### PR TITLE
Support three data sources: daily, hourly, cost optimization

### DIFF
--- a/packages/core/src/sync/s3-client.ts
+++ b/packages/core/src/sync/s3-client.ts
@@ -92,12 +92,20 @@ export async function createS3Handle(profile: string, region?: string): Promise<
   };
 }
 
+export interface FileValidationInfo {
+  readonly file: string;
+  readonly valid: boolean;
+  readonly detectedType: string;
+  readonly message?: string | undefined;
+}
+
 export interface SyncProgress {
-  readonly phase: 'listing' | 'downloading' | 'repartitioning' | 'done';
+  readonly phase: 'listing' | 'downloading' | 'validating' | 'repartitioning' | 'done';
   readonly filesTotal: number;
   readonly filesDone: number;
   readonly bytesTotal: number;
   readonly bytesDone: number;
+  readonly validationResults?: readonly FileValidationInfo[] | undefined;
 }
 
 export type ProgressCallback = (progress: SyncProgress) => void;

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -3,17 +3,102 @@ import { join, basename } from 'node:path';
 import { logger } from '../logger/logger.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { createS3Handle, parseS3Path } from './s3-client.js';
-import type { ProgressCallback } from './s3-client.js';
+import type { ProgressCallback, FileValidationInfo } from './s3-client.js';
 import type { ManifestFileEntry } from './manifest.js';
 import { createLazyDuckDB } from './duckdb-lazy.js';
+
+export type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
 
 export interface SelectiveSyncOptions {
   readonly bucketPath: string;
   readonly profile: string;
   readonly dataDir: string;
   readonly dimensionsConfig: DimensionsConfig;
+  readonly expectedDataType?: ExpectedDataType | undefined;
   readonly files: readonly ManifestFileEntry[];
   readonly onProgress?: ProgressCallback | undefined;
+}
+
+export interface FileValidationResult {
+  readonly file: string;
+  readonly valid: boolean;
+  readonly detectedType: ExpectedDataType | 'unknown';
+  readonly message?: string | undefined;
+}
+
+const REQUIRED_CUR_COLUMNS = [
+  'line_item_usage_start_date',
+  'line_item_usage_account_id',
+  'line_item_unblended_cost',
+  'product_servicecode',
+  'product_product_family',
+  'product_region_code',
+  'resource_tags',
+];
+
+async function validateDownloadedFile(localPath: string, expectedType: ExpectedDataType | undefined): Promise<FileValidationResult> {
+  const fileName = basename(localPath);
+  try {
+    const db = await createLazyDuckDB();
+    const conn = await db.connect();
+
+    // Read parquet schema
+    const schemaResult = await conn.run(`SELECT column_name FROM parquet_schema('${localPath}') LIMIT 100`);
+    const columns: string[] = [];
+    let chunk = await schemaResult.fetchChunk();
+    while (chunk !== null && chunk.rowCount > 0) {
+      for (let r = 0; r < chunk.rowCount; r++) {
+        const val = chunk.getColumnVector(0).getItem(r);
+        if (typeof val === 'string') columns.push(val);
+      }
+      chunk = await schemaResult.fetchChunk();
+    }
+
+    // Detect type from schema
+    if (columns.includes('recommendation_id') || columns.includes('estimated_monthly_savings')) {
+      if (expectedType !== undefined && expectedType !== 'cost-optimization') {
+        return { file: fileName, valid: false, detectedType: 'cost-optimization', message: `Expected ${expectedType} data but file contains cost optimization recommendations` };
+      }
+      return { file: fileName, valid: true, detectedType: 'cost-optimization' };
+    }
+
+    // Check required CUR columns
+    const missingColumns = REQUIRED_CUR_COLUMNS.filter(c => !columns.includes(c));
+    if (missingColumns.length > 0) {
+      return {
+        file: fileName,
+        valid: false,
+        detectedType: 'unknown',
+        message: `Missing required columns: ${missingColumns.join(', ')}`,
+      };
+    }
+
+    // Distinguish daily vs hourly by checking distinct hours
+    const hourResult = await conn.run(
+      `SELECT COUNT(DISTINCT EXTRACT(HOUR FROM line_item_usage_start_date)) as h FROM read_parquet('${localPath}') LIMIT 10000`,
+    );
+    const hourChunk = await hourResult.fetchChunk();
+    const distinctHours = hourChunk !== null && hourChunk.rowCount > 0
+      ? Number(hourChunk.getColumnVector(0).getItem(0))
+      : 0;
+
+    const detectedType: ExpectedDataType = distinctHours > 1 ? 'hourly' : 'daily';
+    const valid = expectedType === undefined || expectedType === detectedType;
+
+    return {
+      file: fileName,
+      valid,
+      detectedType,
+      message: valid ? undefined : `Expected ${expectedType} data but detected ${detectedType} (${String(distinctHours)} distinct hours)`,
+    };
+  } catch (err: unknown) {
+    return {
+      file: fileName,
+      valid: false,
+      detectedType: 'unknown',
+      message: `Validation failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 }
 
 function extractPeriod(key: string): string {
@@ -49,10 +134,12 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
   let totalFilesDownloaded = 0;
   const totalFiles = files.length;
   let globalFilesDone = 0;
+  const allValidationResults: FileValidationInfo[] = [];
+
   for (const [period, periodFiles] of periodList) {
     logger.info(`Processing period ${period}: ${String(periodFiles.length)} files`);
 
-    // Phase 1: Download this period's files to a period-specific staging dir
+    // Phase 1: Download and validate this period's files
     const stagingDir = join(dataDir, 'aws', 'staging', period);
     await mkdir(stagingDir, { recursive: true });
 
@@ -63,6 +150,17 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
       await s3.downloadFile(s3Path.bucket, file.key, localPath);
       globalFilesDone++;
 
+      // Validate downloaded file
+      logger.info(`Validating ${basename(file.key)}...`);
+      const validation = await validateDownloadedFile(localPath, options.expectedDataType);
+      allValidationResults.push(validation);
+
+      if (!validation.valid) {
+        logger.info(`Validation warning for ${validation.file}: ${validation.message ?? 'unknown issue'}`);
+      } else {
+        logger.info(`Validated ${validation.file}: ${validation.detectedType}`);
+      }
+
       if (onProgress !== undefined) {
         onProgress({
           phase: 'downloading',
@@ -70,6 +168,7 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
           filesDone: globalFilesDone,
           bytesTotal: 0,
           bytesDone: 0,
+          validationResults: allValidationResults,
         });
       }
     }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -62,6 +62,7 @@ export interface CostApi {
     providerName: string;
     profile: string;
     dailyBucket: string;
+    retentionDays?: number | undefined;
     hourlyBucket?: string | undefined;
     costOptBucket?: string | undefined;
     tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -56,7 +56,7 @@ export interface CostApi {
   testConnection(params: { profile: string; bucket: string }): Promise<{ ok: boolean; error?: string | undefined }>;
   listAwsProfiles(): Promise<string[]>;
   listS3Buckets(profile: string): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }>;
-  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean }>;
+  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }>;
   scaffoldConfig(): Promise<void>;
   writeConfig(config: {
     providerName: string;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -56,7 +56,7 @@ export interface CostApi {
   testConnection(params: { profile: string; bucket: string }): Promise<{ ok: boolean; error?: string | undefined }>;
   listAwsProfiles(): Promise<string[]>;
   listS3Buckets(profile: string): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }>;
-  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }>;
+  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }>;
   scaffoldConfig(): Promise<void>;
   writeConfig(config: {
     providerName: string;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -63,6 +63,7 @@ export interface CostApi {
     profile: string;
     dailyBucket: string;
     hourlyBucket?: string | undefined;
+    costOptBucket?: string | undefined;
     tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined;
   }): Promise<void>;
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -18,6 +18,7 @@ export interface AwsCredentials {
 export interface SyncConfig {
   readonly daily: SyncTierConfig;
   readonly hourly?: SyncTierConfig | undefined;
+  readonly costOptimization?: SyncTierConfig | undefined;
   readonly intervalMinutes: number;
 }
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -900,6 +900,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
     providerName: string;
     profile: string;
     dailyBucket: string;
+    retentionDays?: number | undefined;
     hourlyBucket?: string | undefined;
     costOptBucket?: string | undefined;
     tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined;
@@ -917,7 +918,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
         type: 'aws',
         credentials: { profile: wizardConfig.profile },
         sync: {
-          daily: { bucket: wizardConfig.dailyBucket, retentionDays: 365 },
+          daily: { bucket: wizardConfig.dailyBucket, retentionDays: wizardConfig.retentionDays ?? 365 },
           ...(wizardConfig.hourlyBucket !== undefined && wizardConfig.hourlyBucket.length > 0
             ? { hourly: { bucket: wizardConfig.hourlyBucket, retentionDays: 30 } }
             : {}),

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -914,30 +914,68 @@ export function registerIpcHandlers(ctx: IpcContext): void {
               if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
                 detectedType = 'cost-optimization';
               } else if (columnNames.includes('line_item_usage_start_date')) {
-                // Check multiple signals for hourly vs daily
-                const manifestStr = JSON.stringify(manifest).toLowerCase();
-                if (manifestStr.includes('hourly')) {
-                  detectedType = 'hourly';
-                } else {
-                  detectedType = 'daily';
+                // CUR report — need to sample data to distinguish daily vs hourly
+                detectedType = 'daily'; // default, refined below by sampling
+              }
+            }
+          }
+          // If it's a CUR, sample data to detect daily vs hourly
+          // Download a parquet file to temp, query with DuckDB for distinct hours
+          if (detectedType === 'daily' && manifestKey !== undefined) {
+            try {
+              const mResp = await client.send(new GetObjectCommand({ Bucket: params.bucket, Key: manifestKey }));
+              const mBody = await mResp.Body?.transformToString();
+              const mJson = mBody !== undefined ? JSON.parse(mBody) as { dataFiles?: string[] } : { dataFiles: [] };
+              const firstFile = mJson.dataFiles?.[0];
+              if (firstFile !== undefined) {
+                const parsed = parseS3Path(firstFile);
+                const os = await import('node:os');
+                const fs = await import('node:fs/promises');
+                const path = await import('node:path');
+                const tmpPath = path.join(os.tmpdir(), 'costgoblin-sample.parquet');
+
+                // Download the full file (parquet needs footer for reading)
+                const getResponse = await client.send(new GetObjectCommand({
+                  Bucket: parsed.bucket,
+                  Key: parsed.prefix,
+                }));
+
+                if (getResponse.Body !== undefined) {
+                  const chunks: Buffer[] = [];
+                  for await (const chunk of getResponse.Body as AsyncIterable<Uint8Array>) {
+                    chunks.push(Buffer.from(chunk));
+                    // Stop after 5MB to avoid downloading huge files
+                    if (chunks.reduce((s, c) => s + c.length, 0) > 5 * 1024 * 1024) break;
+                  }
+                  await fs.writeFile(tmpPath, Buffer.concat(chunks));
+
+                  const { DuckDBInstance } = await import('@duckdb/node-api') as {
+                    DuckDBInstance: { create: () => Promise<{ connect: () => Promise<{ run: (sql: string) => Promise<{ fetchChunk: () => Promise<{ rowCount: number; getColumnVector: (i: number) => { getItem: (r: number) => unknown } } | null> }> }> }> }
+                  };
+                  const sampleDb = await DuckDBInstance.create();
+                  const sampleConn = await sampleDb.connect();
+
+                  const hourResult = await sampleConn.run(
+                    `SELECT COUNT(DISTINCT EXTRACT(HOUR FROM line_item_usage_start_date)) as h FROM read_parquet('${tmpPath}') LIMIT 10000`
+                  );
+                  const sampleChunk = await hourResult.fetchChunk();
+                  if (sampleChunk !== null && sampleChunk.rowCount > 0) {
+                    const distinctHours = Number(sampleChunk.getColumnVector(0).getItem(0));
+                    logger.info(`Data type detection: ${String(distinctHours)} distinct hours found`);
+                    if (distinctHours > 1) {
+                      detectedType = 'hourly';
+                    }
+                  }
+
+                  await fs.rm(tmpPath, { force: true });
                 }
               }
+            } catch (sampleErr: unknown) {
+              logger.info(`Data sampling failed: ${sampleErr instanceof Error ? sampleErr.message : String(sampleErr)}`);
             }
           }
         } catch {
           // manifest detection failed
-        }
-
-        // Fallback: check path for type hints
-        if (detectedType === 'unknown') {
-          const pathLower = params.prefix.toLowerCase();
-          if (pathLower.includes('cost_optimization') || pathLower.includes('cost-optimization') || pathLower.includes('savings')) {
-            detectedType = 'cost-optimization';
-          } else if (pathLower.includes('hourly')) {
-            detectedType = 'hourly';
-          } else {
-            detectedType = 'daily';
-          }
         }
       }
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -901,6 +901,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
     profile: string;
     dailyBucket: string;
     hourlyBucket?: string | undefined;
+    costOptBucket?: string | undefined;
     tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined;
   }): Promise<void> => {
     const fs = await import('node:fs/promises');
@@ -916,9 +917,12 @@ export function registerIpcHandlers(ctx: IpcContext): void {
         type: 'aws',
         credentials: { profile: wizardConfig.profile },
         sync: {
-          daily: { bucket: wizardConfig.dailyBucket, retentionDays: 90 },
+          daily: { bucket: wizardConfig.dailyBucket, retentionDays: 365 },
           ...(wizardConfig.hourlyBucket !== undefined && wizardConfig.hourlyBucket.length > 0
-            ? { hourly: { bucket: wizardConfig.hourlyBucket, retentionDays: 14 } }
+            ? { hourly: { bucket: wizardConfig.hourlyBucket, retentionDays: 30 } }
+            : {}),
+          ...(wizardConfig.costOptBucket !== undefined && wizardConfig.costOptBucket.length > 0
+            ? { costOptimization: { bucket: wizardConfig.costOptBucket, retentionDays: 90 } }
             : {}),
           intervalMinutes: 60,
         },

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -914,10 +914,9 @@ export function registerIpcHandlers(ctx: IpcContext): void {
               if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
                 detectedType = 'cost-optimization';
               } else if (columnNames.includes('line_item_usage_start_date')) {
-                // Check granularity from report name or time_granularity field
-                const reportName = typeof manifest['reportName'] === 'string' ? manifest['reportName'] : '';
-                const contentColumns = typeof manifest['contentColumns'] === 'string' ? manifest['contentColumns'] : '';
-                if (reportName.toLowerCase().includes('hourly') || contentColumns.includes('HOURLY')) {
+                // Check multiple signals for hourly vs daily
+                const manifestStr = JSON.stringify(manifest).toLowerCase();
+                if (manifestStr.includes('hourly')) {
                   detectedType = 'hourly';
                 } else {
                   detectedType = 'daily';
@@ -926,7 +925,19 @@ export function registerIpcHandlers(ctx: IpcContext): void {
             }
           }
         } catch {
-          // manifest detection failed, leave as unknown
+          // manifest detection failed
+        }
+
+        // Fallback: check path for type hints
+        if (detectedType === 'unknown') {
+          const pathLower = params.prefix.toLowerCase();
+          if (pathLower.includes('cost_optimization') || pathLower.includes('cost-optimization') || pathLower.includes('savings')) {
+            detectedType = 'cost-optimization';
+          } else if (pathLower.includes('hourly')) {
+            detectedType = 'hourly';
+          } else {
+            detectedType = 'daily';
+          }
         }
       }
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -914,64 +914,10 @@ export function registerIpcHandlers(ctx: IpcContext): void {
               if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
                 detectedType = 'cost-optimization';
               } else if (columnNames.includes('line_item_usage_start_date')) {
-                // CUR report — need to sample data to distinguish daily vs hourly
-                detectedType = 'daily'; // default, refined below by sampling
+                // CUR report — can't reliably distinguish daily vs hourly from manifest
+              // Validated post-download by checking distinct hours in the data
+                detectedType = 'daily';
               }
-            }
-          }
-          // If it's a CUR, sample data to detect daily vs hourly
-          // Download a parquet file to temp, query with DuckDB for distinct hours
-          if (detectedType === 'daily' && manifestKey !== undefined) {
-            try {
-              const mResp = await client.send(new GetObjectCommand({ Bucket: params.bucket, Key: manifestKey }));
-              const mBody = await mResp.Body?.transformToString();
-              const mJson = mBody !== undefined ? JSON.parse(mBody) as { dataFiles?: string[] } : { dataFiles: [] };
-              const firstFile = mJson.dataFiles?.[0];
-              if (firstFile !== undefined) {
-                const parsed = parseS3Path(firstFile);
-                const os = await import('node:os');
-                const fs = await import('node:fs/promises');
-                const path = await import('node:path');
-                const tmpPath = path.join(os.tmpdir(), 'costgoblin-sample.parquet');
-
-                // Download the full file (parquet needs footer for reading)
-                const getResponse = await client.send(new GetObjectCommand({
-                  Bucket: parsed.bucket,
-                  Key: parsed.prefix,
-                }));
-
-                if (getResponse.Body !== undefined) {
-                  const chunks: Buffer[] = [];
-                  for await (const chunk of getResponse.Body as AsyncIterable<Uint8Array>) {
-                    chunks.push(Buffer.from(chunk));
-                    // Stop after 5MB to avoid downloading huge files
-                    if (chunks.reduce((s, c) => s + c.length, 0) > 5 * 1024 * 1024) break;
-                  }
-                  await fs.writeFile(tmpPath, Buffer.concat(chunks));
-
-                  const { DuckDBInstance } = await import('@duckdb/node-api') as {
-                    DuckDBInstance: { create: () => Promise<{ connect: () => Promise<{ run: (sql: string) => Promise<{ fetchChunk: () => Promise<{ rowCount: number; getColumnVector: (i: number) => { getItem: (r: number) => unknown } } | null> }> }> }> }
-                  };
-                  const sampleDb = await DuckDBInstance.create();
-                  const sampleConn = await sampleDb.connect();
-
-                  const hourResult = await sampleConn.run(
-                    `SELECT COUNT(DISTINCT EXTRACT(HOUR FROM line_item_usage_start_date)) as h FROM read_parquet('${tmpPath}') LIMIT 10000`
-                  );
-                  const sampleChunk = await hourResult.fetchChunk();
-                  if (sampleChunk !== null && sampleChunk.rowCount > 0) {
-                    const distinctHours = Number(sampleChunk.getColumnVector(0).getItem(0));
-                    logger.info(`Data type detection: ${String(distinctHours)} distinct hours found`);
-                    if (distinctHours > 1) {
-                      detectedType = 'hourly';
-                    }
-                  }
-
-                  await fs.rm(tmpPath, { force: true });
-                }
-              }
-            } catch (sampleErr: unknown) {
-              logger.info(`Data sampling failed: ${sampleErr instanceof Error ? sampleErr.message : String(sampleErr)}`);
             }
           }
         } catch {

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -862,7 +862,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
     }
   });
 
-  ipcMain.handle('setup:browse-s3', async (_event, params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }> => {
+  ipcMain.handle('setup:browse-s3', async (_event, params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }> => {
     try {
       const { S3Client, ListObjectsV2Command, GetObjectCommand } = await import('@aws-sdk/client-s3');
       const client = new S3Client({
@@ -891,6 +891,13 @@ export function registerIpcHandlers(ctx: IpcContext): void {
       const isCurReport = hasData && hasMetadata;
 
       let detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' = 'unknown';
+      let missingColumns: string[] = [];
+
+      const requiredCurColumns = [
+        'line_item_usage_start_date', 'line_item_usage_account_id',
+        'line_item_unblended_cost', 'product_servicecode',
+        'product_product_family', 'product_region_code', 'resource_tags',
+      ];
 
       if (isCurReport) {
         try {
@@ -914,9 +921,10 @@ export function registerIpcHandlers(ctx: IpcContext): void {
               if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
                 detectedType = 'cost-optimization';
               } else if (columnNames.includes('line_item_usage_start_date')) {
-                // CUR report — can't reliably distinguish daily vs hourly from manifest
-              // Validated post-download by checking distinct hours in the data
+                // CUR report — daily vs hourly validated post-download
                 detectedType = 'daily';
+                // Check for missing required columns
+                missingColumns = requiredCurColumns.filter(c => !columnNames.includes(c));
               }
             }
           }
@@ -925,9 +933,9 @@ export function registerIpcHandlers(ctx: IpcContext): void {
         }
       }
 
-      return { prefixes, isCurReport, detectedType };
+      return { prefixes, isCurReport, detectedType, missingColumns };
     } catch {
-      return { prefixes: [], isCurReport: false, detectedType: 'unknown' };
+      return { prefixes: [], isCurReport: false, detectedType: 'unknown', missingColumns: [] };
     }
   });
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -862,9 +862,9 @@ export function registerIpcHandlers(ctx: IpcContext): void {
     }
   });
 
-  ipcMain.handle('setup:browse-s3', async (_event, params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean }> => {
+  ipcMain.handle('setup:browse-s3', async (_event, params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }> => {
     try {
-      const { S3Client, ListObjectsV2Command } = await import('@aws-sdk/client-s3');
+      const { S3Client, ListObjectsV2Command, GetObjectCommand } = await import('@aws-sdk/client-s3');
       const client = new S3Client({
         region: 'eu-central-1',
         ...(params.profile !== 'default' ? { profile: params.profile } : {}),
@@ -890,9 +890,49 @@ export function registerIpcHandlers(ctx: IpcContext): void {
       const hasMetadata = prefixes.includes('metadata');
       const isCurReport = hasData && hasMetadata;
 
-      return { prefixes, isCurReport };
+      let detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' = 'unknown';
+
+      if (isCurReport) {
+        try {
+          // Find first manifest to detect report type
+          const metaList = await client.send(new ListObjectsV2Command({
+            Bucket: params.bucket,
+            Prefix: `${params.prefix}metadata/`,
+            MaxKeys: 10,
+          }));
+
+          const manifestKey = (metaList.Contents ?? []).find(c => c.Key?.endsWith('.json'))?.Key;
+          if (manifestKey !== undefined) {
+            const manifestResponse = await client.send(new GetObjectCommand({ Bucket: params.bucket, Key: manifestKey }));
+            const body = await manifestResponse.Body?.transformToString();
+            if (body !== undefined) {
+              const manifest = JSON.parse(body) as Record<string, unknown>;
+              const columns = manifest['columns'] as Array<{ name: string }> | undefined;
+              const columnNames = columns?.map(c => c.name) ?? [];
+
+              // Cost optimization reports have specific columns
+              if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
+                detectedType = 'cost-optimization';
+              } else if (columnNames.includes('line_item_usage_start_date')) {
+                // Check granularity from report name or time_granularity field
+                const reportName = typeof manifest['reportName'] === 'string' ? manifest['reportName'] : '';
+                const contentColumns = typeof manifest['contentColumns'] === 'string' ? manifest['contentColumns'] : '';
+                if (reportName.toLowerCase().includes('hourly') || contentColumns.includes('HOURLY')) {
+                  detectedType = 'hourly';
+                } else {
+                  detectedType = 'daily';
+                }
+              }
+            }
+          }
+        } catch {
+          // manifest detection failed, leave as unknown
+        }
+      }
+
+      return { prefixes, isCurReport, detectedType };
     } catch {
-      return { prefixes: [], isCurReport: false };
+      return { prefixes: [], isCurReport: false, detectedType: 'unknown' };
     }
   });
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -89,7 +89,7 @@ const api: CostApi = {
   scaffoldConfig(): Promise<void> {
     return invoke<undefined>('setup:scaffold-config').then(() => undefined);
   },
-  writeConfig(config: { providerName: string; profile: string; dailyBucket: string; hourlyBucket?: string | undefined; tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined }): Promise<void> {
+  writeConfig(config: { providerName: string; profile: string; dailyBucket: string; hourlyBucket?: string | undefined; costOptBucket?: string | undefined; tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined }): Promise<void> {
     return invoke<undefined>('setup:write-config', config).then(() => undefined);
   },
 };

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -83,8 +83,8 @@ const api: CostApi = {
   listS3Buckets(profile: string): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }> {
     return invoke<{ buckets: { name: string; region: string }[]; error?: string | undefined }>('setup:list-buckets', profile);
   },
-  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }> {
-    return invoke<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }>('setup:browse-s3', params);
+  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }> {
+    return invoke<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }>('setup:browse-s3', params);
   },
   scaffoldConfig(): Promise<void> {
     return invoke<undefined>('setup:scaffold-config').then(() => undefined);

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -89,7 +89,7 @@ const api: CostApi = {
   scaffoldConfig(): Promise<void> {
     return invoke<undefined>('setup:scaffold-config').then(() => undefined);
   },
-  writeConfig(config: { providerName: string; profile: string; dailyBucket: string; hourlyBucket?: string | undefined; costOptBucket?: string | undefined; tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined }): Promise<void> {
+  writeConfig(config: { providerName: string; profile: string; dailyBucket: string; retentionDays?: number | undefined; hourlyBucket?: string | undefined; costOptBucket?: string | undefined; tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined }): Promise<void> {
     return invoke<undefined>('setup:write-config', config).then(() => undefined);
   },
 };

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -83,8 +83,8 @@ const api: CostApi = {
   listS3Buckets(profile: string): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }> {
     return invoke<{ buckets: { name: string; region: string }[]; error?: string | undefined }>('setup:list-buckets', profile);
   },
-  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean }> {
-    return invoke<{ prefixes: string[]; isCurReport: boolean }>('setup:browse-s3', params);
+  browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }> {
+    return invoke<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }>('setup:browse-s3', params);
   },
   scaffoldConfig(): Promise<void> {
     return invoke<undefined>('setup:scaffold-config').then(() => undefined);

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -214,7 +214,7 @@ export class MockCostApi implements CostApi {
   testConnection(): Promise<{ ok: boolean; error?: string | undefined }> { return Promise.resolve({ ok: true }); }
   listAwsProfiles(): Promise<string[]> { return Promise.resolve(['default', 'prod', 'staging']); }
   listS3Buckets(): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }> { return Promise.resolve({ buckets: [{ name: 'my-cur-bucket', region: 'eu-central-1' }] }); }
-  browseS3(): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }> { return Promise.resolve({ prefixes: ['data', 'metadata'], isCurReport: true, detectedType: 'daily' }); }
+  browseS3(): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }> { return Promise.resolve({ prefixes: ['data', 'metadata'], isCurReport: true, detectedType: 'daily', missingColumns: [] }); }
   scaffoldConfig(): Promise<void> { return Promise.resolve(); }
   writeConfig(): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -214,7 +214,7 @@ export class MockCostApi implements CostApi {
   testConnection(): Promise<{ ok: boolean; error?: string | undefined }> { return Promise.resolve({ ok: true }); }
   listAwsProfiles(): Promise<string[]> { return Promise.resolve(['default', 'prod', 'staging']); }
   listS3Buckets(): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }> { return Promise.resolve({ buckets: [{ name: 'my-cur-bucket', region: 'eu-central-1' }] }); }
-  browseS3(): Promise<{ prefixes: string[]; isCurReport: boolean }> { return Promise.resolve({ prefixes: ['data', 'metadata'], isCurReport: true }); }
+  browseS3(): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' }> { return Promise.resolve({ prefixes: ['data', 'metadata'], isCurReport: true, detectedType: 'daily' }); }
   scaffoldConfig(): Promise<void> { return Promise.resolve(); }
   writeConfig(): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -298,10 +298,15 @@ export function DataManagement() {
     configQuery.status === 'success' ? configQuery.data : null;
   const provider = config?.providers[0] ?? null;
 
-  const missingPeriods = inventory?.periods.filter(p => p.localStatus === 'missing') ?? [];
+  const retentionDays = provider?.sync.daily.retentionDays ?? 365;
+  const retentionCutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+  const retentionCutoffPeriod = `${String(retentionCutoff.getFullYear())}-${String(retentionCutoff.getMonth() + 1).padStart(2, '0')}`;
 
-  if (!initialized && inventoryQuery.status === 'success' && missingPeriods.length > 0) {
-    setSelected(new Set(missingPeriods.map(p => p.period)));
+  const missingPeriods = inventory?.periods.filter(p => p.localStatus === 'missing') ?? [];
+  const missingWithinRetention = missingPeriods.filter(p => p.period >= retentionCutoffPeriod);
+
+  if (!initialized && inventoryQuery.status === 'success' && missingWithinRetention.length > 0) {
+    setSelected(new Set(missingWithinRetention.map(p => p.period)));
     setInitialized(true);
   }
 

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -3,6 +3,7 @@ import type { AccountMappingStatus, DataInventoryResult, CostGoblinConfig } from
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
+import { SetupWizard } from './setup-wizard.js';
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${String(bytes)}B`;
@@ -110,13 +111,14 @@ interface TierPanelProps {
   onDownload: () => void;
   onDeletePeriod: (period: string) => void;
   syncState: SyncState;
+  onConfigure?: (() => void) | undefined;
 }
 
 function TierPanel({
   title, configured, bucket, retentionDays,
   localDates, diskBytes, oldestDate, newestDate,
   periods, selected, onToggle, onSelectAll, onDeselectAll, onDownload, onDeletePeriod,
-  syncState,
+  syncState, onConfigure,
 }: TierPanelProps) {
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const missingPeriods = periods.filter(p => p.localStatus === 'missing' || p.localStatus === 'stale');
@@ -131,9 +133,19 @@ function TierPanel({
         <h3 className="text-sm font-semibold text-text-primary mb-4">{title}</h3>
         <div className="rounded-lg border border-dashed border-border p-6 text-center">
           <p className="text-sm text-text-secondary">Not configured</p>
-          <p className="text-xs text-text-muted mt-2">
-            Add a <span className="font-mono text-text-secondary">{title.toLowerCase()}</span> section to your provider sync config in <span className="font-mono text-accent">costgoblin.yaml</span>
-          </p>
+          {onConfigure !== undefined ? (
+            <button
+              type="button"
+              onClick={onConfigure}
+              className="mt-3 rounded-md border border-accent/50 bg-accent/10 px-4 py-1.5 text-xs font-medium text-accent hover:bg-accent/20 transition-colors"
+            >
+              Configure {title.toLowerCase()} data source
+            </button>
+          ) : (
+            <p className="text-xs text-text-muted mt-2">
+              Add a <span className="font-mono text-text-secondary">{title.toLowerCase()}</span> section to your provider sync config in <span className="font-mono text-accent">costgoblin.yaml</span>
+            </p>
+          )}
         </div>
       </div>
     );
@@ -291,6 +303,7 @@ export function DataManagement() {
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
   const [autoSync, setAutoSync] = useState(false);
   const [showDeleteAll, setShowDeleteAll] = useState(false);
+  const [configureSource, setConfigureSource] = useState<'hourly' | 'costOptimization' | null>(null);
 
   const inventory: DataInventoryResult | null =
     inventoryQuery.status === 'success' ? inventoryQuery.data : null;
@@ -374,6 +387,9 @@ export function DataManagement() {
   const dailyRetention = provider?.sync.daily.retentionDays ?? null;
   const hourlyBucket = provider?.sync.hourly?.bucket ?? null;
   const hourlyRetention = provider?.sync.hourly?.retentionDays ?? null;
+  const costOptBucket = provider?.sync.costOptimization?.bucket ?? null;
+  const costOptRetention = provider?.sync.costOptimization?.retentionDays ?? null;
+  const awsProfile = provider?.credentials.profile ?? null;
 
   if (isNotConfigured) {
     return (
@@ -497,6 +513,26 @@ export function DataManagement() {
             onDownload={() => {}}
             onDeletePeriod={() => {}}
             syncState={{ status: 'idle' }}
+            onConfigure={() => { setConfigureSource('hourly'); }}
+          />
+          <TierPanel
+            title="Cost Optimization"
+            configured={costOptBucket !== null}
+            bucket={costOptBucket}
+            retentionDays={costOptRetention}
+            localDates={[]}
+            diskBytes={0}
+            oldestDate={null}
+            newestDate={null}
+            periods={[]}
+            selected={new Set()}
+            onToggle={() => {}}
+            onSelectAll={() => {}}
+            onDeselectAll={() => {}}
+            onDownload={() => {}}
+            onDeletePeriod={() => {}}
+            syncState={{ status: 'idle' }}
+            onConfigure={() => { setConfigureSource('costOptimization'); }}
           />
         </div>
       )}
@@ -510,6 +546,16 @@ export function DataManagement() {
           onConfirm={handleDeleteAll}
           onCancel={() => { setShowDeleteAll(false); }}
         />
+      )}
+
+      {configureSource !== null && awsProfile !== null && (
+        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+          <SetupWizard
+            source={configureSource}
+            profile={awsProfile}
+            onComplete={() => { setConfigureSource(null); setRefreshKey(k => k + 1); }}
+          />
+        </div>
       )}
     </div>
   );

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -15,7 +15,7 @@ type WizardStep =
   | { step: 'welcome' }
   | { step: 'profile'; profiles: string[]; loading: boolean; selected: string }
   | { step: 'bucket'; profile: string; source: DataSource; buckets: { name: string; region: string }[]; loading: boolean; selected: string; error: string }
-  | { step: 'browse'; profile: string; source: DataSource; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; path: string[] }
+  | { step: 'browse'; profile: string; source: DataSource; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; path: string[] }
   | { step: 'confirm'; profile: string; s3Path: string; hourlyPath: string; costOptPath: string; retentionDays: number };
 
 interface SetupWizardProps {
@@ -244,14 +244,31 @@ function BrowseStep({ state, onNavigate, onConfirm, onSkip, onBack }: {
         ))}
       </div>
 
-      {state.isCurReport && (
-        <div className="rounded-lg border border-accent/40 bg-accent/5 px-4 py-3">
-          <p className="text-sm font-medium text-accent">CUR report detected</p>
-          <p className="text-xs text-text-secondary mt-0.5">
-            Found <code className="text-text-primary">data/</code> and <code className="text-text-primary">metadata/</code> folders at this location
-          </p>
-        </div>
-      )}
+      {state.isCurReport && (() => {
+        const TYPE_LABELS: Record<string, string> = { daily: 'Daily CUR', hourly: 'Hourly CUR', 'cost-optimization': 'Cost Optimization', unknown: 'Unknown type' };
+        const SOURCE_TO_EXPECTED: Record<DataSource, string> = { daily: 'daily', hourly: 'hourly', costOptimization: 'cost-optimization' };
+        const expected = SOURCE_TO_EXPECTED[state.source];
+        const detected = state.detectedType;
+        const isMatch = detected === 'unknown' || detected === expected;
+
+        return (
+          <div className={`rounded-lg border px-4 py-3 ${isMatch ? 'border-accent/40 bg-accent/5' : 'border-warning/50 bg-warning-muted'}`}>
+            <p className={`text-sm font-medium ${isMatch ? 'text-accent' : 'text-warning'}`}>
+              {detected !== 'unknown' ? `Detected: ${TYPE_LABELS[detected] ?? detected}` : 'CUR report detected'}
+            </p>
+            {!isMatch && (
+              <p className="text-xs text-warning mt-0.5">
+                You are configuring <strong>{SOURCE_LABELS[state.source].title}</strong> but this looks like <strong>{TYPE_LABELS[detected] ?? detected}</strong> data. Continue anyway?
+              </p>
+            )}
+            {isMatch && detected !== 'unknown' && (
+              <p className="text-xs text-text-secondary mt-0.5">
+                Matches expected type for {SOURCE_LABELS[state.source].title}
+              </p>
+            )}
+          </div>
+        );
+      })()}
 
       {state.loading ? (
         <div className="flex items-center justify-center py-6">
@@ -449,9 +466,9 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
 
   function browseTo(profile: string, source: DataSource, bucket: string, prefix: string) {
     const path = prefix.split('/').filter(s => s.length > 0);
-    setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: [], loading: true, isCurReport: false, path });
+    setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: [], loading: true, isCurReport: false, detectedType: 'unknown', path });
     void api.browseS3({ profile, bucket, prefix }).then(result => {
-      setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: result.prefixes, loading: false, isCurReport: result.isCurReport, path });
+      setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: result.prefixes, loading: false, isCurReport: result.isCurReport, detectedType: result.detectedType, path });
     });
   }
 

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -15,7 +15,7 @@ type WizardStep =
   | { step: 'welcome' }
   | { step: 'profile'; profiles: string[]; loading: boolean; selected: string }
   | { step: 'bucket'; profile: string; source: DataSource; buckets: { name: string; region: string }[]; loading: boolean; selected: string; error: string }
-  | { step: 'browse'; profile: string; source: DataSource; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; path: string[] }
+  | { step: 'browse'; profile: string; source: DataSource; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[]; path: string[] }
   | { step: 'confirm'; profile: string; s3Path: string; hourlyPath: string; costOptPath: string; retentionDays: number };
 
 interface SetupWizardProps {
@@ -270,6 +270,18 @@ function BrowseStep({ state, onNavigate, onConfirm, onSkip, onBack }: {
         );
       })()}
 
+      {state.isCurReport && state.missingColumns.length > 0 && (
+        <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3">
+          <p className="text-sm font-medium text-negative">Missing required columns</p>
+          <p className="text-xs text-text-secondary mt-0.5">
+            {state.missingColumns.join(', ')}
+          </p>
+          <p className="text-xs text-text-muted mt-1">
+            CostGoblin needs these columns. Check your CUR report configuration in the AWS Console.
+          </p>
+        </div>
+      )}
+
       {state.loading ? (
         <div className="flex items-center justify-center py-6">
           <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-border border-t-accent" />
@@ -466,9 +478,9 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
 
   function browseTo(profile: string, source: DataSource, bucket: string, prefix: string) {
     const path = prefix.split('/').filter(s => s.length > 0);
-    setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: [], loading: true, isCurReport: false, detectedType: 'unknown', path });
+    setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: [], loading: true, isCurReport: false, detectedType: 'unknown', missingColumns: [], path });
     void api.browseS3({ profile, bucket, prefix }).then(result => {
-      setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: result.prefixes, loading: false, isCurReport: result.isCurReport, detectedType: result.detectedType, path });
+      setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: result.prefixes, loading: false, isCurReport: result.isCurReport, detectedType: result.detectedType, missingColumns: result.missingColumns, path });
     });
   }
 

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -8,7 +8,7 @@ type WizardStep =
   | { step: 'profile'; profiles: string[]; loading: boolean; selected: string }
   | { step: 'bucket'; profile: string; buckets: { name: string; region: string }[]; loading: boolean; selected: string; error: string }
   | { step: 'browse'; profile: string; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; path: string[] }
-  | { step: 'confirm'; profile: string; s3Path: string; retentionDays: number };
+  | { step: 'confirm'; profile: string; s3Path: string; hourlyPath: string; costOptPath: string; retentionDays: number };
 
 interface SetupWizardProps {
   onComplete: () => void;
@@ -280,13 +280,15 @@ function BrowseStep({ state, onNavigate, onConfirm, onBack }: {
   );
 }
 
-function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
+function ConfirmStep({ state, onUpdate, onRetentionChange, onComplete, onBack }: {
   state: Extract<WizardStep, { step: 'confirm' }>;
+  onUpdate: (updates: Partial<Extract<WizardStep, { step: 'confirm' }>>) => void;
   onRetentionChange: (days: number) => void;
   onComplete: () => void;
   onBack: () => void;
 }) {
   const [saving, setSaving] = useState(false);
+  const [showExtra, setShowExtra] = useState(state.hourlyPath.length > 0 || state.costOptPath.length > 0);
   const api = useCostApi();
 
   const retentionOptions = [
@@ -302,6 +304,8 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
       providerName: 'aws-main',
       profile: state.profile,
       dailyBucket: state.s3Path,
+      ...(state.hourlyPath.length > 0 ? { hourlyBucket: state.hourlyPath } : {}),
+      ...(state.costOptPath.length > 0 ? { costOptBucket: state.costOptPath } : {}),
     }).then(() => {
       onComplete();
     });
@@ -320,9 +324,50 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
           <p className="text-sm font-mono text-text-primary mt-0.5">{state.profile}</p>
         </div>
         <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
-          <p className="text-xs text-text-muted uppercase tracking-wider">CUR Location</p>
+          <p className="text-xs text-text-muted uppercase tracking-wider">Daily CUR</p>
           <p className="text-sm font-mono text-text-primary mt-0.5">{state.s3Path}</p>
         </div>
+
+        {/* Additional data sources */}
+        {!showExtra ? (
+          <button
+            type="button"
+            onClick={() => { setShowExtra(true); }}
+            className="text-xs text-accent hover:text-accent-hover text-left underline underline-offset-2"
+          >
+            + Add hourly CUR or cost optimization data
+          </button>
+        ) : (
+          <>
+            <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
+              <p className="text-xs text-text-muted uppercase tracking-wider mb-1">
+                Hourly CUR <span className="normal-case text-text-muted">(optional)</span>
+              </p>
+              <input
+                type="text"
+                value={state.hourlyPath}
+                onChange={(e) => { onUpdate({ hourlyPath: e.target.value }); }}
+                placeholder="s3://bucket/path/to/hourly-cur/"
+                className="w-full h-8 rounded border border-border bg-bg-primary px-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+              />
+              <p className="text-xs text-text-muted mt-1">For short-term drill-down and incident analysis</p>
+            </div>
+            <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
+              <p className="text-xs text-text-muted uppercase tracking-wider mb-1">
+                Cost Optimization <span className="normal-case text-text-muted">(optional)</span>
+              </p>
+              <input
+                type="text"
+                value={state.costOptPath}
+                onChange={(e) => { onUpdate({ costOptPath: e.target.value }); }}
+                placeholder="s3://bucket/path/to/cost-optimization/"
+                className="w-full h-8 rounded border border-border bg-bg-primary px-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+              />
+              <p className="text-xs text-text-muted mt-1">RI/SP recommendations and rightsizing suggestions</p>
+            </div>
+          </>
+        )}
+
         <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
           <p className="text-xs text-text-muted uppercase tracking-wider mb-2">Data Retention</p>
           <div className="flex gap-2">
@@ -398,7 +443,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element
   function handleBrowseConfirm() {
     if (wizard.step !== 'browse') return;
     const s3Path = `s3://${wizard.bucket}/${wizard.prefix}`;
-    setWizard({ step: 'confirm', profile: wizard.profile, s3Path, retentionDays: 365 });
+    setWizard({ step: 'confirm', profile: wizard.profile, s3Path, hourlyPath: '', costOptPath: '', retentionDays: 365 });
   }
 
   function handleBack() {
@@ -432,6 +477,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element
           {wizard.step === 'confirm' && (
             <ConfirmStep
               state={wizard}
+              onUpdate={(updates) => { setWizard(prev => prev.step === 'confirm' ? { ...prev, ...updates } : prev); }}
               onRetentionChange={(days) => { setWizard(prev => prev.step === 'confirm' ? { ...prev, retentionDays: days } : prev); }}
               onComplete={onComplete}
               onBack={handleBack}

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -3,11 +3,19 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { Card, CardContent } from '../components/ui/card.js';
 import { Button } from '../components/ui/button.js';
 
+type DataSource = 'daily' | 'hourly' | 'costOptimization';
+
+const SOURCE_LABELS: Record<DataSource, { title: string; description: string }> = {
+  daily: { title: 'Daily CUR', description: 'Main billing data — required' },
+  hourly: { title: 'Hourly CUR', description: 'For short-term drill-down and incident analysis' },
+  costOptimization: { title: 'Cost Optimization', description: 'RI/SP recommendations and rightsizing suggestions' },
+};
+
 type WizardStep =
   | { step: 'welcome' }
   | { step: 'profile'; profiles: string[]; loading: boolean; selected: string }
-  | { step: 'bucket'; profile: string; buckets: { name: string; region: string }[]; loading: boolean; selected: string; error: string }
-  | { step: 'browse'; profile: string; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; path: string[] }
+  | { step: 'bucket'; profile: string; source: DataSource; buckets: { name: string; region: string }[]; loading: boolean; selected: string; error: string }
+  | { step: 'browse'; profile: string; source: DataSource; bucket: string; prefix: string; prefixes: string[]; loading: boolean; isCurReport: boolean; path: string[] }
   | { step: 'confirm'; profile: string; s3Path: string; hourlyPath: string; costOptPath: string; retentionDays: number };
 
 interface SetupWizardProps {
@@ -115,22 +123,22 @@ function ProfileStep({ state, onSelect, onSkip, onBack }: {
   );
 }
 
-function BucketStep({ state, onSelect, onBack }: {
+function BucketStep({ state, onSelect, onSkip, onBack }: {
   state: Extract<WizardStep, { step: 'bucket' }>;
   onSelect: (bucket: string) => void;
+  onSkip?: (() => void) | undefined;
   onBack: () => void;
 }) {
   const [filter, setFilter] = useState('');
   const filtered = state.buckets.filter(b => filter.length === 0 || b.name.toLowerCase().includes(filter.toLowerCase()));
+  const sourceLabel = SOURCE_LABELS[state.source];
 
   return (
     <div className="flex flex-col gap-5">
       <div>
-        <h2 className="text-xl font-semibold text-text-primary">S3 Bucket</h2>
-        <p className="text-sm text-text-secondary mt-1">
-          Select the bucket containing your CUR data
-          <span className="text-text-muted"> (profile: {state.profile})</span>
-        </p>
+        <h2 className="text-xl font-semibold text-text-primary">{sourceLabel.title}</h2>
+        <p className="text-sm text-text-secondary mt-1">{sourceLabel.description}</p>
+        <p className="text-xs text-text-muted mt-0.5">Select the S3 bucket</p>
       </div>
 
       {state.error.length > 0 && (
@@ -177,29 +185,38 @@ function BucketStep({ state, onSelect, onBack }: {
 
       <div className="flex items-center justify-between pt-2">
         <button type="button" onClick={onBack} className="text-sm text-text-muted hover:text-text-secondary">← Back</button>
-        <Button
-          onClick={() => { onSelect(state.selected); }}
-          disabled={state.selected.length === 0}
-          className="bg-accent hover:bg-accent-hover text-white px-8"
-        >
-          Next
-        </Button>
+        <div className="flex items-center gap-3">
+          {onSkip !== undefined && (
+            <button type="button" onClick={onSkip} className="text-xs text-text-muted hover:text-text-secondary underline underline-offset-2">Skip</button>
+          )}
+          <Button
+            onClick={() => { onSelect(state.selected); }}
+            disabled={state.selected.length === 0}
+            className="bg-accent hover:bg-accent-hover text-white px-8"
+          >
+            Next
+          </Button>
+        </div>
       </div>
     </div>
   );
 }
 
-function BrowseStep({ state, onNavigate, onConfirm, onBack }: {
+function BrowseStep({ state, onNavigate, onConfirm, onSkip, onBack }: {
   state: Extract<WizardStep, { step: 'browse' }>;
   onNavigate: (prefix: string) => void;
   onConfirm: () => void;
+  onSkip?: (() => void) | undefined;
   onBack: () => void;
 }) {
+  const sourceLabel = SOURCE_LABELS[state.source];
+
   return (
     <div className="flex flex-col gap-5">
       <div>
-        <h2 className="text-xl font-semibold text-text-primary">Locate CUR Report</h2>
+        <h2 className="text-xl font-semibold text-text-primary">{sourceLabel.title}</h2>
         <p className="text-sm text-text-secondary mt-1">Navigate to the folder containing <code className="text-text-primary">data/</code> and <code className="text-text-primary">metadata/</code></p>
+        <p className="text-xs text-text-muted mt-0.5">{sourceLabel.description}</p>
       </div>
 
       {/* Breadcrumb */}
@@ -268,27 +285,30 @@ function BrowseStep({ state, onNavigate, onConfirm, onBack }: {
 
       <div className="flex items-center justify-between pt-2">
         <button type="button" onClick={onBack} className="text-sm text-text-muted hover:text-text-secondary">← Back</button>
-        <Button
-          onClick={onConfirm}
-          disabled={!state.isCurReport}
-          className="bg-accent hover:bg-accent-hover text-white px-8"
-        >
-          {state.isCurReport ? 'Use this location' : 'Select a CUR folder'}
-        </Button>
+        <div className="flex items-center gap-3">
+          {onSkip !== undefined && (
+            <button type="button" onClick={onSkip} className="text-xs text-text-muted hover:text-text-secondary underline underline-offset-2">Skip</button>
+          )}
+          <Button
+            onClick={onConfirm}
+            disabled={!state.isCurReport}
+            className="bg-accent hover:bg-accent-hover text-white px-8"
+          >
+            {state.isCurReport ? 'Use this location' : 'Select a CUR folder'}
+          </Button>
+        </div>
       </div>
     </div>
   );
 }
 
-function ConfirmStep({ state, onUpdate, onRetentionChange, onComplete, onBack }: {
+function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
   state: Extract<WizardStep, { step: 'confirm' }>;
-  onUpdate: (updates: Partial<Extract<WizardStep, { step: 'confirm' }>>) => void;
   onRetentionChange: (days: number) => void;
   onComplete: () => void;
   onBack: () => void;
 }) {
   const [saving, setSaving] = useState(false);
-  const [showExtra, setShowExtra] = useState(state.hourlyPath.length > 0 || state.costOptPath.length > 0);
   const api = useCostApi();
 
   const retentionOptions = [
@@ -304,6 +324,7 @@ function ConfirmStep({ state, onUpdate, onRetentionChange, onComplete, onBack }:
       providerName: 'aws-main',
       profile: state.profile,
       dailyBucket: state.s3Path,
+      retentionDays: state.retentionDays,
       ...(state.hourlyPath.length > 0 ? { hourlyBucket: state.hourlyPath } : {}),
       ...(state.costOptPath.length > 0 ? { costOptBucket: state.costOptPath } : {}),
     }).then(() => {
@@ -328,44 +349,18 @@ function ConfirmStep({ state, onUpdate, onRetentionChange, onComplete, onBack }:
           <p className="text-sm font-mono text-text-primary mt-0.5">{state.s3Path}</p>
         </div>
 
-        {/* Additional data sources */}
-        {!showExtra ? (
-          <button
-            type="button"
-            onClick={() => { setShowExtra(true); }}
-            className="text-xs text-accent hover:text-accent-hover text-left underline underline-offset-2"
-          >
-            + Add hourly CUR or cost optimization data
-          </button>
-        ) : (
-          <>
-            <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
-              <p className="text-xs text-text-muted uppercase tracking-wider mb-1">
-                Hourly CUR <span className="normal-case text-text-muted">(optional)</span>
-              </p>
-              <input
-                type="text"
-                value={state.hourlyPath}
-                onChange={(e) => { onUpdate({ hourlyPath: e.target.value }); }}
-                placeholder="s3://bucket/path/to/hourly-cur/"
-                className="w-full h-8 rounded border border-border bg-bg-primary px-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-              />
-              <p className="text-xs text-text-muted mt-1">For short-term drill-down and incident analysis</p>
-            </div>
-            <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
-              <p className="text-xs text-text-muted uppercase tracking-wider mb-1">
-                Cost Optimization <span className="normal-case text-text-muted">(optional)</span>
-              </p>
-              <input
-                type="text"
-                value={state.costOptPath}
-                onChange={(e) => { onUpdate({ costOptPath: e.target.value }); }}
-                placeholder="s3://bucket/path/to/cost-optimization/"
-                className="w-full h-8 rounded border border-border bg-bg-primary px-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-              />
-              <p className="text-xs text-text-muted mt-1">RI/SP recommendations and rightsizing suggestions</p>
-            </div>
-          </>
+        {/* Additional data sources — shown as read-only summaries */}
+        {state.hourlyPath.length > 0 && (
+          <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
+            <p className="text-xs text-text-muted uppercase tracking-wider">Hourly CUR</p>
+            <p className="text-sm font-mono text-text-primary mt-0.5">{state.hourlyPath}</p>
+          </div>
+        )}
+        {state.costOptPath.length > 0 && (
+          <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
+            <p className="text-xs text-text-muted uppercase tracking-wider">Cost Optimization</p>
+            <p className="text-sm font-mono text-text-primary mt-0.5">{state.costOptPath}</p>
+          </div>
         )}
 
         <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
@@ -408,6 +403,7 @@ function ConfirmStep({ state, onUpdate, onRetentionChange, onComplete, onBack }:
 export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element {
   const api = useCostApi();
   const [wizard, setWizard] = useState<WizardStep>({ step: 'welcome' });
+  const [collectedPaths, setCollectedPaths] = useState({ daily: '', hourly: '', costOpt: '' });
 
   function handleWelcomeNext() {
     setWizard({ step: 'profile', profiles: [], loading: true, selected: '' });
@@ -417,49 +413,90 @@ export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element
   }
 
   function handleProfileSelect(profile: string) {
-    setWizard({ step: 'bucket', profile, buckets: [], loading: true, selected: '', error: '' });
+    startBucketStep(profile, 'daily');
+  }
+
+  function startBucketStep(profile: string, source: DataSource) {
+    setWizard({ step: 'bucket', profile, source, buckets: [], loading: true, selected: '', error: '' });
     void api.listS3Buckets(profile).then(result => {
-      setWizard({ step: 'bucket', profile, buckets: result.buckets, loading: false, selected: '', error: result.error ?? '' });
+      setWizard({ step: 'bucket', profile, source, buckets: result.buckets, loading: false, selected: '', error: result.error ?? '' });
     });
   }
 
   function handleBucketSelect(bucket: string) {
-    browseTo(wizard.step === 'bucket' ? wizard.profile : '', bucket, '');
+    if (wizard.step !== 'bucket') return;
+    browseTo(wizard.profile, wizard.source, bucket, '');
   }
 
-  function browseTo(profile: string, bucket: string, prefix: string) {
+  function browseTo(profile: string, source: DataSource, bucket: string, prefix: string) {
     const path = prefix.split('/').filter(s => s.length > 0);
-    setWizard({ step: 'browse', profile, bucket, prefix, prefixes: [], loading: true, isCurReport: false, path });
+    setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: [], loading: true, isCurReport: false, path });
     void api.browseS3({ profile, bucket, prefix }).then(result => {
-      setWizard({ step: 'browse', profile, bucket, prefix, prefixes: result.prefixes, loading: false, isCurReport: result.isCurReport, path });
+      setWizard({ step: 'browse', profile, source, bucket, prefix, prefixes: result.prefixes, loading: false, isCurReport: result.isCurReport, path });
     });
   }
 
   function handleNavigate(prefix: string) {
     if (wizard.step !== 'browse') return;
-    browseTo(wizard.profile, wizard.bucket, prefix);
+    browseTo(wizard.profile, wizard.source, wizard.bucket, prefix);
   }
 
   function handleBrowseConfirm() {
     if (wizard.step !== 'browse') return;
     const s3Path = `s3://${wizard.bucket}/${wizard.prefix}`;
-    setWizard({ step: 'confirm', profile: wizard.profile, s3Path, hourlyPath: '', costOptPath: '', retentionDays: 365 });
+    const profile = wizard.profile;
+    const source = wizard.source;
+
+    if (source === 'daily') {
+      setCollectedPaths(prev => ({ ...prev, daily: s3Path }));
+      startBucketStep(profile, 'hourly');
+    } else if (source === 'hourly') {
+      setCollectedPaths(prev => ({ ...prev, hourly: s3Path }));
+      startBucketStep(profile, 'costOptimization');
+    } else {
+      setCollectedPaths(prev => ({ ...prev, costOpt: s3Path }));
+      goToConfirm(profile);
+    }
+  }
+
+  function handleBrowseSkip() {
+    if (wizard.step !== 'browse' && wizard.step !== 'bucket') return;
+    const profile = wizard.profile;
+    const source = wizard.step === 'browse' ? wizard.source : wizard.source;
+
+    if (source === 'hourly') {
+      startBucketStep(profile, 'costOptimization');
+    } else {
+      goToConfirm(profile);
+    }
+  }
+
+  function goToConfirm(profile: string) {
+    setWizard({
+      step: 'confirm',
+      profile,
+      s3Path: collectedPaths.daily,
+      hourlyPath: collectedPaths.hourly,
+      costOptPath: collectedPaths.costOpt,
+      retentionDays: 365,
+    });
   }
 
   function handleBack() {
     if (wizard.step === 'profile') {
       setWizard({ step: 'welcome' });
     } else if (wizard.step === 'bucket') {
-      handleWelcomeNext();
+      if (wizard.source === 'daily') {
+        handleWelcomeNext();
+      } else if (wizard.source === 'hourly') {
+        startBucketStep(wizard.profile, 'daily');
+      } else {
+        startBucketStep(wizard.profile, 'hourly');
+      }
     } else if (wizard.step === 'browse') {
-      handleProfileSelect(wizard.profile);
+      startBucketStep(wizard.profile, wizard.source);
     } else if (wizard.step === 'confirm') {
-      const profile = wizard.profile;
-      const parsed = wizard.s3Path.replace(/^s3:\/\//, '');
-      const slashIdx = parsed.indexOf('/');
-      const bucket = slashIdx > 0 ? parsed.slice(0, slashIdx) : parsed;
-      const prefix = slashIdx > 0 ? parsed.slice(slashIdx + 1) : '';
-      browseTo(profile, bucket, prefix);
+      startBucketStep(wizard.profile, 'costOptimization');
     }
   }
 
@@ -472,12 +509,26 @@ export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element
           </div>
           {wizard.step === 'welcome' && <WelcomeStep onNext={handleWelcomeNext} />}
           {wizard.step === 'profile' && <ProfileStep state={wizard} onSelect={handleProfileSelect} onSkip={onComplete} onBack={handleBack} />}
-          {wizard.step === 'bucket' && <BucketStep state={wizard} onSelect={handleBucketSelect} onBack={handleBack} />}
-          {wizard.step === 'browse' && <BrowseStep state={wizard} onNavigate={handleNavigate} onConfirm={handleBrowseConfirm} onBack={handleBack} />}
+          {wizard.step === 'bucket' && (
+            <BucketStep
+              state={wizard}
+              onSelect={handleBucketSelect}
+              onSkip={wizard.source !== 'daily' ? handleBrowseSkip : undefined}
+              onBack={handleBack}
+            />
+          )}
+          {wizard.step === 'browse' && (
+            <BrowseStep
+              state={wizard}
+              onNavigate={handleNavigate}
+              onConfirm={handleBrowseConfirm}
+              onSkip={wizard.source !== 'daily' ? handleBrowseSkip : undefined}
+              onBack={handleBack}
+            />
+          )}
           {wizard.step === 'confirm' && (
             <ConfirmStep
               state={wizard}
-              onUpdate={(updates) => { setWizard(prev => prev.step === 'confirm' ? { ...prev, ...updates } : prev); }}
               onRetentionChange={(days) => { setWizard(prev => prev.step === 'confirm' ? { ...prev, retentionDays: days } : prev); }}
               onComplete={onComplete}
               onBack={handleBack}

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -462,16 +462,16 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     const profile = wizard.profile;
     const source = wizard.source;
 
+    const updated = { ...collectedPaths };
     if (source === 'daily') {
-      setCollectedPaths(prev => ({ ...prev, daily: s3Path }));
-      goToConfirm(profile);
+      updated.daily = s3Path;
     } else if (source === 'hourly') {
-      setCollectedPaths(prev => ({ ...prev, hourly: s3Path }));
-      goToConfirm(profile);
+      updated.hourly = s3Path;
     } else {
-      setCollectedPaths(prev => ({ ...prev, costOpt: s3Path }));
-      goToConfirm(profile);
+      updated.costOpt = s3Path;
     }
+    setCollectedPaths(updated);
+    goToConfirm(profile, updated);
   }
 
   function handleBrowseSkip() {
@@ -486,13 +486,14 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     }
   }
 
-  function goToConfirm(profile: string) {
+  function goToConfirm(profile: string, paths?: { daily: string; hourly: string; costOpt: string }) {
+    const p = paths ?? collectedPaths;
     setWizard({
       step: 'confirm',
       profile,
-      s3Path: collectedPaths.daily,
-      hourlyPath: collectedPaths.hourly,
-      costOptPath: collectedPaths.costOpt,
+      s3Path: p.daily,
+      hourlyPath: p.hourly,
+      costOptPath: p.costOpt,
       retentionDays: 365,
     });
   }

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -313,12 +313,22 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
   const [saving, setSaving] = useState(false);
   const api = useCostApi();
 
-  const retentionOptions = [
-    { days: 90, label: '3 months' },
-    { days: 180, label: '6 months' },
-    { days: 365, label: '12 months' },
-    { days: 730, label: '2 years' },
-  ];
+  const isDaily = state.s3Path.length > 0;
+  const isHourlyOnly = !isDaily && state.hourlyPath.length > 0;
+
+  const retentionOptions = isHourlyOnly
+    ? [
+        { days: 7, label: '7 days' },
+        { days: 14, label: '14 days' },
+        { days: 30, label: '30 days' },
+        { days: 90, label: '90 days' },
+      ]
+    : [
+        { days: 90, label: '3 months' },
+        { days: 180, label: '6 months' },
+        { days: 365, label: '12 months' },
+        { days: 730, label: '2 years' },
+      ];
 
   function handleSave() {
     setSaving(true);
@@ -326,13 +336,18 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
       providerName: 'aws-main',
       profile: state.profile,
       dailyBucket: state.s3Path,
-      retentionDays: state.retentionDays,
+      retentionDays: isDaily ? state.retentionDays : undefined,
       ...(state.hourlyPath.length > 0 ? { hourlyBucket: state.hourlyPath } : {}),
       ...(state.costOptPath.length > 0 ? { costOptBucket: state.costOptPath } : {}),
     }).then(() => {
       onComplete();
     });
   }
+
+  const paths: { label: string; value: string }[] = [];
+  if (state.s3Path.length > 0) paths.push({ label: 'Daily CUR', value: state.s3Path });
+  if (state.hourlyPath.length > 0) paths.push({ label: 'Hourly CUR', value: state.hourlyPath });
+  if (state.costOptPath.length > 0) paths.push({ label: 'Cost Optimization', value: state.costOptPath });
 
   return (
     <div className="flex flex-col gap-5">
@@ -346,24 +361,13 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
           <p className="text-xs text-text-muted uppercase tracking-wider">AWS Profile</p>
           <p className="text-sm font-mono text-text-primary mt-0.5">{state.profile}</p>
         </div>
-        <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
-          <p className="text-xs text-text-muted uppercase tracking-wider">Daily CUR</p>
-          <p className="text-sm font-mono text-text-primary mt-0.5">{state.s3Path}</p>
-        </div>
 
-        {/* Additional data sources — shown as read-only summaries */}
-        {state.hourlyPath.length > 0 && (
-          <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
-            <p className="text-xs text-text-muted uppercase tracking-wider">Hourly CUR</p>
-            <p className="text-sm font-mono text-text-primary mt-0.5">{state.hourlyPath}</p>
+        {paths.map(({ label, value }) => (
+          <div key={label} className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
+            <p className="text-xs text-text-muted uppercase tracking-wider">{label}</p>
+            <p className="text-sm font-mono text-text-primary mt-0.5">{value}</p>
           </div>
-        )}
-        {state.costOptPath.length > 0 && (
-          <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
-            <p className="text-xs text-text-muted uppercase tracking-wider">Cost Optimization</p>
-            <p className="text-sm font-mono text-text-primary mt-0.5">{state.costOptPath}</p>
-          </div>
-        )}
+        ))}
 
         <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3">
           <p className="text-xs text-text-muted uppercase tracking-wider mb-2">Data Retention</p>
@@ -463,15 +467,19 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     const source = wizard.source;
 
     const updated = { ...collectedPaths };
+    let defaultRetention = 365;
     if (source === 'daily') {
       updated.daily = s3Path;
+      defaultRetention = 365;
     } else if (source === 'hourly') {
       updated.hourly = s3Path;
+      defaultRetention = 30;
     } else {
       updated.costOpt = s3Path;
+      defaultRetention = 90;
     }
     setCollectedPaths(updated);
-    goToConfirm(profile, updated);
+    goToConfirm(profile, updated, defaultRetention);
   }
 
   function handleBrowseSkip() {
@@ -486,7 +494,7 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     }
   }
 
-  function goToConfirm(profile: string, paths?: { daily: string; hourly: string; costOpt: string }) {
+  function goToConfirm(profile: string, paths?: { daily: string; hourly: string; costOpt: string }, retention?: number) {
     const p = paths ?? collectedPaths;
     setWizard({
       step: 'confirm',
@@ -494,7 +502,7 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
       s3Path: p.daily,
       hourlyPath: p.hourly,
       costOptPath: p.costOpt,
-      retentionDays: 365,
+      retentionDays: retention ?? 365,
     });
   }
 

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -20,6 +20,8 @@ type WizardStep =
 
 interface SetupWizardProps {
   onComplete: () => void;
+  source?: DataSource | undefined;
+  profile?: string | undefined;
 }
 
 function WelcomeStep({ onNext }: { onNext: () => void }) {
@@ -400,10 +402,23 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
   );
 }
 
-export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element {
+export function SetupWizard({ onComplete, source: initialSource, profile: initialProfile }: SetupWizardProps): React.JSX.Element {
   const api = useCostApi();
-  const [wizard, setWizard] = useState<WizardStep>({ step: 'welcome' });
+  const isSourceMode = initialSource !== undefined && initialProfile !== undefined;
+  const [wizard, setWizard] = useState<WizardStep>(
+    isSourceMode
+      ? { step: 'bucket', profile: initialProfile, source: initialSource, buckets: [], loading: true, selected: '', error: '' }
+      : { step: 'welcome' },
+  );
   const [collectedPaths, setCollectedPaths] = useState({ daily: '', hourly: '', costOpt: '' });
+  const [bucketsLoaded, setBucketsLoaded] = useState(false);
+
+  if (isSourceMode && !bucketsLoaded) {
+    setBucketsLoaded(true);
+    void api.listS3Buckets(initialProfile).then(result => {
+      setWizard({ step: 'bucket', profile: initialProfile, source: initialSource, buckets: result.buckets, loading: false, selected: '', error: result.error ?? '' });
+    });
+  }
 
   function handleWelcomeNext() {
     setWizard({ step: 'profile', profiles: [], loading: true, selected: '' });
@@ -449,10 +464,10 @@ export function SetupWizard({ onComplete }: SetupWizardProps): React.JSX.Element
 
     if (source === 'daily') {
       setCollectedPaths(prev => ({ ...prev, daily: s3Path }));
-      startBucketStep(profile, 'hourly');
+      goToConfirm(profile);
     } else if (source === 'hourly') {
       setCollectedPaths(prev => ({ ...prev, hourly: s3Path }));
-      startBucketStep(profile, 'costOptimization');
+      goToConfirm(profile);
     } else {
       setCollectedPaths(prev => ({ ...prev, costOpt: s3Path }));
       goToConfirm(profile);


### PR DESCRIPTION
## Summary
- Add `costOptimization` tier to `SyncConfig` (alongside daily and hourly)
- Wizard confirm step has expandable section for optional hourly + cost-optimization S3 paths
- `writeConfig` writes all three tiers to `costgoblin.yaml`
- Default retention: daily 365d, hourly 30d, cost-optimization 90d
- Data ingestion ready for cost-optimization dataset (query/UI integration later)