### PR TITLE
Fix browse warning and config merge on tier add

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -954,25 +954,44 @@ export function registerIpcHandlers(ctx: IpcContext): void {
 
     const configDir = path.dirname(ctx.configPath);
     await fs.mkdir(configDir, { recursive: true });
+    const { parse: parseYaml } = await import('yaml');
+
+    // Load existing config if present, then merge
+    let existing: Record<string, unknown> = {};
+    try {
+      const raw = await fs.readFile(ctx.configPath, 'utf-8');
+      existing = parseYaml(raw) as Record<string, unknown>;
+    } catch {
+      // no existing config
+    }
+
+    const existingProviders = Array.isArray(existing['providers']) ? existing['providers'] as Record<string, unknown>[] : [];
+    const existingProvider = existingProviders[0] ?? {};
+    const existingSync = (existingProvider['sync'] ?? {}) as Record<string, unknown>;
+
+    const sync: Record<string, unknown> = { ...existingSync, intervalMinutes: 60 };
+
+    // Only update tiers that have values — preserve existing for others
+    if (wizardConfig.dailyBucket.length > 0) {
+      sync['daily'] = { bucket: wizardConfig.dailyBucket, retentionDays: wizardConfig.retentionDays ?? 365 };
+    }
+    if (wizardConfig.hourlyBucket !== undefined && wizardConfig.hourlyBucket.length > 0) {
+      sync['hourly'] = { bucket: wizardConfig.hourlyBucket, retentionDays: 30 };
+    }
+    if (wizardConfig.costOptBucket !== undefined && wizardConfig.costOptBucket.length > 0) {
+      sync['costOptimization'] = { bucket: wizardConfig.costOptBucket, retentionDays: 90 };
+    }
 
     const costgoblinYaml = {
+      ...existing,
       providers: [{
         name: wizardConfig.providerName,
         type: 'aws',
         credentials: { profile: wizardConfig.profile },
-        sync: {
-          daily: { bucket: wizardConfig.dailyBucket, retentionDays: wizardConfig.retentionDays ?? 365 },
-          ...(wizardConfig.hourlyBucket !== undefined && wizardConfig.hourlyBucket.length > 0
-            ? { hourly: { bucket: wizardConfig.hourlyBucket, retentionDays: 30 } }
-            : {}),
-          ...(wizardConfig.costOptBucket !== undefined && wizardConfig.costOptBucket.length > 0
-            ? { costOptimization: { bucket: wizardConfig.costOptBucket, retentionDays: 90 } }
-            : {}),
-          intervalMinutes: 60,
-        },
+        sync,
       }],
-      defaults: { periodDays: 30, costMetric: 'UnblendedCost', lagDays: 2 },
-      cache: { ttlMinutes: 15 },
+      defaults: (existing['defaults'] as Record<string, unknown> | undefined) ?? { periodDays: 30, costMetric: 'UnblendedCost', lagDays: 2 },
+      cache: (existing['cache'] as Record<string, unknown> | undefined) ?? { ttlMinutes: 15 },
     };
 
     await fs.writeFile(ctx.configPath, stringify(costgoblinYaml), 'utf-8');

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -245,27 +245,32 @@ function BrowseStep({ state, onNavigate, onConfirm, onSkip, onBack }: {
       </div>
 
       {state.isCurReport && (() => {
-        const TYPE_LABELS: Record<string, string> = { daily: 'Daily CUR', hourly: 'Hourly CUR', 'cost-optimization': 'Cost Optimization', unknown: 'Unknown type' };
-        const SOURCE_TO_EXPECTED: Record<DataSource, string> = { daily: 'daily', hourly: 'hourly', costOptimization: 'cost-optimization' };
-        const expected = SOURCE_TO_EXPECTED[state.source];
         const detected = state.detectedType;
-        const isMatch = detected === 'unknown' || detected === expected;
+        const isCostOptMismatch = detected === 'cost-optimization' && state.source !== 'costOptimization';
+        const isCurForCostOpt = detected !== 'cost-optimization' && detected !== 'unknown' && state.source === 'costOptimization';
+
+        if (isCostOptMismatch || isCurForCostOpt) {
+          return (
+            <div className="rounded-lg border border-warning/50 bg-warning-muted px-4 py-3">
+              <p className="text-sm font-medium text-warning">Data type mismatch</p>
+              <p className="text-xs text-warning mt-0.5">
+                {isCostOptMismatch
+                  ? 'This looks like a Cost Optimization report, not a CUR.'
+                  : 'This looks like a CUR report, not a Cost Optimization export.'}
+                {' '}Continue anyway?
+              </p>
+            </div>
+          );
+        }
 
         return (
-          <div className={`rounded-lg border px-4 py-3 ${isMatch ? 'border-accent/40 bg-accent/5' : 'border-warning/50 bg-warning-muted'}`}>
-            <p className={`text-sm font-medium ${isMatch ? 'text-accent' : 'text-warning'}`}>
-              {detected !== 'unknown' ? `Detected: ${TYPE_LABELS[detected] ?? detected}` : 'CUR report detected'}
+          <div className="rounded-lg border border-accent/40 bg-accent/5 px-4 py-3">
+            <p className="text-sm font-medium text-accent">
+              {detected === 'cost-optimization' ? 'Cost Optimization report detected' : 'CUR report detected'}
             </p>
-            {!isMatch && (
-              <p className="text-xs text-warning mt-0.5">
-                You are configuring <strong>{SOURCE_LABELS[state.source].title}</strong> but this looks like <strong>{TYPE_LABELS[detected] ?? detected}</strong> data. Continue anyway?
-              </p>
-            )}
-            {isMatch && detected !== 'unknown' && (
-              <p className="text-xs text-text-secondary mt-0.5">
-                Matches expected type for {SOURCE_LABELS[state.source].title}
-              </p>
-            )}
+            <p className="text-xs text-text-secondary mt-0.5">
+              Found <code className="text-text-primary">data/</code> and <code className="text-text-primary">metadata/</code> folders
+            </p>
           </div>
         );
       })()}


### PR DESCRIPTION
## Summary
- Remove false daily/hourly mismatch warning from browse step (manifest can't distinguish them)
- Only warn on CUR vs cost-optimization mismatch (reliably detectable)
- Fix empty bucket error when adding hourly/cost-opt from Data tab — writeConfig now merges with existing config instead of overwriting