### PR TITLE
Add Savings tab for cost optimization recommendations

### DIFF
--- a/packages/core/src/__fixtures__/setup.ts
+++ b/packages/core/src/__fixtures__/setup.ts
@@ -35,8 +35,9 @@ function weightedPick<T extends { costShare: number }>(arr: readonly T[], rand: 
 }
 
 export async function setup(): Promise<void> {
+  const dailyParquet = join(SYNTHETIC_DIR, 'aws', 'raw', 'daily-2026-01', 'data.parquet');
   try {
-    await access(MARKER);
+    await access(dailyParquet);
     return;
   } catch {
     // needs generation

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -8,6 +8,7 @@ import type {
   EntityDetailResult,
   MissingTagsParams,
   MissingTagsResult,
+  SavingsResult,
   SyncStatus,
   TrendQueryParams,
   TrendResult,
@@ -40,6 +41,7 @@ export interface CostApi {
   queryDailyCosts(params: DailyCostsParams): Promise<DailyCostsResult>;
   queryTrends(params: TrendQueryParams): Promise<TrendResult>;
   queryMissingTags(params: MissingTagsParams): Promise<MissingTagsResult>;
+  querySavings(): Promise<SavingsResult>;
   queryEntityDetail(params: EntityDetailParams): Promise<EntityDetailResult>;
   getSyncStatus(syncId?: string): Promise<SyncStatus>;
   triggerSync(): Promise<void>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -52,6 +52,8 @@ export type {
   DailyCost,
   DistributionSlice,
   EntityDetailResult,
+  SavingsRecommendation,
+  SavingsResult,
   SyncStatus,
   QueryState,
 } from './query.js';

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -127,6 +127,33 @@ export interface DailyCostsResult {
   readonly totalCost: Dollars;
 }
 
+export type ImplementationEffort = 'VeryLow' | 'Low' | 'Medium' | 'High';
+
+export interface SavingsRecommendation {
+  readonly accountId: string;
+  readonly accountName: string;
+  readonly actionType: string;
+  readonly resourceType: string;
+  readonly summary: string;
+  readonly region: string;
+  readonly monthlySavings: Dollars;
+  readonly monthlyCost: Dollars;
+  readonly savingsPercentage: number;
+  readonly effort: ImplementationEffort;
+  readonly resourceArn: string;
+  readonly currentDetails: string;
+  readonly recommendedDetails: string;
+  readonly currentSummary: string;
+  readonly restartNeeded: boolean;
+  readonly rollbackPossible: boolean;
+  readonly recommendationSource: string;
+}
+
+export interface SavingsResult {
+  readonly recommendations: readonly SavingsRecommendation[];
+  readonly totalMonthlySavings: Dollars;
+}
+
 export type SyncPhase = 'downloading' | 'repartitioning';
 
 export type SyncStatus =

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -48,6 +48,7 @@ import type {
   EntityDetailResult,
   DailyCost,
   DistributionSlice,
+  SavingsResult,
   SyncStatus,
   DateRange,
   Dollars,
@@ -576,6 +577,72 @@ export function registerIpcHandlers(ctx: IpcContext): void {
           accountName: resolveEntityName(r.accountId, accountMap) || r.accountName,
         })),
       };
+    });
+  });
+
+  ipcMain.handle('query:savings', async (): Promise<SavingsResult> => {
+    const config = await getConfig();
+    const provider = config.providers[0];
+    if (provider?.sync.costOptimization === undefined) {
+      return { recommendations: [], totalMonthlySavings: asDollars(0) };
+    }
+
+    return withConnection(async (conn) => {
+      let rows: RawRow[];
+      try {
+        rows = await queryAll(conn, `
+          SELECT
+            account_id,
+            account_name,
+            action_type,
+            current_resource_type,
+            COALESCE(recommended_resource_summary, '') AS summary,
+            COALESCE(region, '') AS region,
+            COALESCE(estimated_monthly_savings_after_discount, 0) AS monthly_savings,
+            COALESCE(estimated_monthly_cost_after_discount, 0) AS monthly_cost,
+            COALESCE(estimated_savings_percentage_after_discount, 0) AS savings_pct,
+            COALESCE(implementation_effort, '') AS effort,
+            COALESCE(resource_arn, '') AS resource_arn,
+            COALESCE(current_resource_details, '') AS current_details,
+            COALESCE(recommended_resource_details, '') AS recommended_details,
+            COALESCE(current_resource_summary, '') AS current_summary,
+            COALESCE(restart_needed, false) AS restart_needed,
+            COALESCE(rollback_possible, false) AS rollback_possible,
+            COALESCE(recommendation_source, '') AS recommendation_source
+          FROM read_parquet('${ctx.dataDir}/aws/raw/cost-opt-*/*.parquet', filename=true)
+          QUALIFY ROW_NUMBER() OVER (PARTITION BY recommendation_id ORDER BY filename DESC) = 1
+          ORDER BY monthly_savings DESC
+        `);
+      } catch {
+        return { recommendations: [], totalMonthlySavings: asDollars(0) };
+      }
+
+      let totalSavings = 0;
+      const recommendations = rows.map(r => {
+        const savings = toNum(r['monthly_savings']);
+        totalSavings += savings;
+        return {
+          accountId: toStr(r['account_id']),
+          accountName: toStr(r['account_name']),
+          actionType: toStr(r['action_type']),
+          resourceType: toStr(r['current_resource_type']),
+          summary: toStr(r['summary']),
+          region: toStr(r['region']),
+          monthlySavings: asDollars(savings),
+          monthlyCost: asDollars(toNum(r['monthly_cost'])),
+          savingsPercentage: toNum(r['savings_pct']),
+          effort: toStr(r['effort']) as 'VeryLow' | 'Low' | 'Medium' | 'High',
+          resourceArn: toStr(r['resource_arn']),
+          currentDetails: toStr(r['current_details']),
+          recommendedDetails: toStr(r['recommended_details']),
+          currentSummary: toStr(r['current_summary']),
+          restartNeeded: r['restart_needed'] === true || r['restart_needed'] === 1,
+          rollbackPossible: r['rollback_possible'] === true || r['rollback_possible'] === 1,
+          recommendationSource: toStr(r['recommendation_source']),
+        };
+      });
+
+      return { recommendations, totalMonthlySavings: asDollars(totalSavings) };
     });
   });
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -14,6 +14,7 @@ import type {
   EntityDetailParams,
   EntityDetailResult,
   SyncStatus,
+  SavingsResult,
   DataInventoryResult,
   DataTier,
   AccountMappingStatus,
@@ -35,6 +36,9 @@ const api: CostApi = {
   },
   queryMissingTags(params: MissingTagsParams): Promise<MissingTagsResult> {
     return invoke<MissingTagsResult>('query:missing-tags', params);
+  },
+  querySavings(): Promise<SavingsResult> {
+    return invoke<SavingsResult>('query:savings');
   },
   queryEntityDetail(params: EntityDetailParams): Promise<EntityDetailResult> {
     return invoke<EntityDetailResult>('query:entity-detail', params);

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { CostOverview, CostTrends, MissingTags, EntityDetail, DataManagement, CostApiProvider, SetupWizard } from '@costgoblin/ui';
+import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, CostApiProvider, SetupWizard } from '@costgoblin/ui';
 import type { CostApi } from '@costgoblin/core/browser';
 
 function getApi(): CostApi {
@@ -11,6 +11,7 @@ type View =
   | { page: 'overview' }
   | { page: 'trends' }
   | { page: 'missing-tags' }
+  | { page: 'savings' }
   | { page: 'data' }
   | { page: 'entity-detail'; entity: string; dimension: string };
 
@@ -18,6 +19,7 @@ const LEFT_NAV: { id: string; label: string }[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'trends', label: 'Trends' },
   { id: 'missing-tags', label: 'Missing Tags' },
+  { id: 'savings', label: 'Savings' },
 ];
 
 function getStoredTheme(): 'dark' | 'light' {
@@ -100,6 +102,7 @@ export function App(): React.JSX.Element {
       case 'overview': setView({ page: 'overview' }); break;
       case 'trends': setView({ page: 'trends' }); break;
       case 'missing-tags': setView({ page: 'missing-tags' }); break;
+      case 'savings': setView({ page: 'savings' }); break;
       case 'data': setView({ page: 'data' }); break;
     }
   }
@@ -198,6 +201,7 @@ export function App(): React.JSX.Element {
         {view.page === 'overview' && <CostOverview />}
         {view.page === 'trends' && <CostTrends onEntityClick={handleEntityClick} />}
         {view.page === 'missing-tags' && <MissingTags />}
+        {view.page === 'savings' && <Savings />}
         <div className={view.page === 'data' ? '' : 'hidden'}>
           <DataManagement />
         </div>

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -15,6 +15,7 @@ import type {
   EntityDetailResult,
   MissingTagsResult,
   OrgNode,
+  SavingsResult,
   SyncStatus,
   TrendResult,
   CostGoblinConfig,
@@ -198,6 +199,7 @@ export class MockCostApi implements CostApi {
   }
   queryTrends(): Promise<TrendResult> { return Promise.resolve(trendResult); }
   queryMissingTags(): Promise<MissingTagsResult> { return Promise.resolve(missingTagsResult); }
+  querySavings(): Promise<SavingsResult> { return Promise.resolve({ recommendations: [], totalMonthlySavings: asDollars(0) }); }
   queryEntityDetail(): Promise<EntityDetailResult> { return Promise.resolve(entityDetailResult); }
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
   triggerSync(): Promise<void> { return Promise.resolve(); }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -31,6 +31,7 @@ export { useCostFocus, useCostFocusDispatch, useCostFocusReducer, CostFocusProvi
 export { CostOverview } from './views/cost-overview.js';
 export { CostTrends } from './views/cost-trends.js';
 export { MissingTags } from './views/missing-tags.js';
+export { Savings } from './views/savings.js';
 export { EntityDetail } from './views/entity-detail.js';
 export { DataManagement } from './views/data-management.js';
 export { SetupWizard } from './views/setup-wizard.js';

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -1,0 +1,332 @@
+import type { SavingsResult, SavingsRecommendation } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useQuery } from '../hooks/use-query.js';
+import { formatDollars } from '../components/format.js';
+import { useState, useMemo } from 'react';
+
+type SortField = 'monthlySavings' | 'savingsPercentage' | 'monthlyCost' | 'effort' | 'accountName';
+
+const EFFORT_ORDER: Record<string, number> = { 'VeryLow': 0, 'Low': 1, 'Medium': 2, 'High': 3 };
+
+function effortLabel(effort: string): string {
+  if (effort === 'VeryLow') return 'Very Low';
+  return effort;
+}
+
+function effortColor(effort: string): string {
+  switch (effort) {
+    case 'VeryLow':
+    case 'Low':
+      return 'text-accent bg-accent/10 border-accent/30';
+    case 'Medium':
+      return 'text-warning bg-warning/10 border-warning/30';
+    case 'High':
+      return 'text-negative bg-negative/10 border-negative/30';
+    default:
+      return 'text-text-muted bg-bg-tertiary/30 border-border';
+  }
+}
+
+function humanizeAction(action: string): string {
+  return action.replace(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+interface ParsedDetails {
+  config: Record<string, string>;
+  usages: { type: string; amount: string; unit: string }[];
+}
+
+function parseResourceDetails(json: string): ParsedDetails | null {
+  if (json.length === 0) return null;
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const topKey = Object.keys(parsed)[0];
+    if (topKey === undefined) return null;
+    const inner = (parsed as Record<string, unknown>)[topKey];
+    if (typeof inner !== 'object' || inner === null) return null;
+    const obj = inner as Record<string, unknown>;
+
+    const config: Record<string, string> = {};
+    const rawConfig = obj['configuration'];
+    if (typeof rawConfig === 'object' && rawConfig !== null) {
+      for (const [section, value] of Object.entries(rawConfig as Record<string, unknown>)) {
+        if (typeof value === 'object' && value !== null) {
+          for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+            config[`${section}.${k}`] = String(v);
+          }
+        } else {
+          config[section] = String(value);
+        }
+      }
+    }
+
+    const usages: ParsedDetails['usages'] = [];
+    const costCalc = obj['costCalculation'];
+    if (typeof costCalc === 'object' && costCalc !== null) {
+      const rawUsages = (costCalc as Record<string, unknown>)['usages'];
+      if (Array.isArray(rawUsages)) {
+        for (const u of rawUsages) {
+          if (typeof u === 'object' && u !== null) {
+            const usage = u as Record<string, unknown>;
+            const uType = usage['usageType'];
+            const uAmount = usage['usageAmount'];
+            const uUnit = usage['unit'];
+            usages.push({
+              type: typeof uType === 'string' ? uType : '',
+              amount: typeof uAmount === 'number' ? String(uAmount) : typeof uAmount === 'string' ? uAmount : '',
+              unit: typeof uUnit === 'string' ? uUnit : '',
+            });
+          }
+        }
+      }
+    }
+
+    return { config, usages };
+  } catch {
+    return null;
+  }
+}
+
+export function Savings() {
+  const api = useCostApi();
+  const savingsQuery = useQuery(() => api.querySavings(), [api]);
+  const [sortField, setSortField] = useState<SortField>('monthlySavings');
+  const [sortAsc, setSortAsc] = useState(false);
+  const [activeFilter, setActiveFilter] = useState<string | null>(null);
+  const [expandedRow, setExpandedRow] = useState<number | null>(null);
+
+  const data: SavingsResult | null =
+    savingsQuery.status === 'success' ? savingsQuery.data : null;
+
+  const actionTypes = useMemo(() => {
+    if (data === null) return [];
+    const map = new Map<string, { count: number; savings: number }>();
+    for (const rec of data.recommendations) {
+      const existing = map.get(rec.actionType);
+      if (existing !== undefined) {
+        existing.count++;
+        existing.savings += rec.monthlySavings;
+      } else {
+        map.set(rec.actionType, { count: 1, savings: rec.monthlySavings });
+      }
+    }
+    return [...map.entries()]
+      .sort((a, b) => b[1].savings - a[1].savings)
+      .map(([type, info]) => ({ type, ...info }));
+  }, [data]);
+
+  const filtered = useMemo(() => {
+    if (data === null) return [];
+    const recs = activeFilter !== null
+      ? data.recommendations.filter(r => r.actionType === activeFilter)
+      : [...data.recommendations];
+    return recs.sort((a, b) => {
+      let cmp: number;
+      switch (sortField) {
+        case 'monthlySavings': cmp = a.monthlySavings - b.monthlySavings; break;
+        case 'savingsPercentage': cmp = a.savingsPercentage - b.savingsPercentage; break;
+        case 'monthlyCost': cmp = a.monthlyCost - b.monthlyCost; break;
+        case 'effort': cmp = (EFFORT_ORDER[a.effort] ?? 4) - (EFFORT_ORDER[b.effort] ?? 4); break;
+        case 'accountName': cmp = a.accountName.localeCompare(b.accountName); break;
+        default: cmp = 0;
+      }
+      return sortAsc ? cmp : -cmp;
+    });
+  }, [data, activeFilter, sortField, sortAsc]);
+
+  const filteredSavings = filtered.reduce((s, r) => s + r.monthlySavings, 0);
+
+  function handleSort(field: SortField) {
+    if (sortField === field) {
+      setSortAsc(prev => !prev);
+    } else {
+      setSortField(field);
+      setSortAsc(false);
+    }
+  }
+
+  function sortIndicator(field: SortField): string {
+    if (sortField !== field) return '';
+    return sortAsc ? ' \u25B2' : ' \u25BC';
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div>
+        <h2 className="text-xl font-semibold text-text-primary">Savings Opportunities</h2>
+        <p className="text-sm text-text-secondary mt-1">AWS cost optimization recommendations</p>
+      </div>
+
+      {data !== null && (
+        <div className="flex items-center gap-6">
+          <div className="rounded-xl border border-border bg-bg-secondary/50 px-6 py-4">
+            <p className="text-xs text-text-muted uppercase tracking-wider">Potential Monthly Savings</p>
+            <p className="text-2xl font-bold text-accent mt-1">{formatDollars(filteredSavings)}</p>
+          </div>
+          <div className="rounded-xl border border-border bg-bg-secondary/50 px-6 py-4">
+            <p className="text-xs text-text-muted uppercase tracking-wider">Recommendations</p>
+            <p className="text-2xl font-bold text-text-primary mt-1">{String(filtered.length)}</p>
+          </div>
+        </div>
+      )}
+
+      {actionTypes.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => { setActiveFilter(null); }}
+            className={[
+              'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+              activeFilter === null
+                ? 'border-accent/50 bg-accent/10 text-accent'
+                : 'border-border bg-bg-tertiary/30 text-text-secondary hover:text-text-primary',
+            ].join(' ')}
+          >
+            All ({String(data?.recommendations.length ?? 0)})
+          </button>
+          {actionTypes.map(at => (
+            <button
+              key={at.type}
+              type="button"
+              onClick={() => { setActiveFilter(activeFilter === at.type ? null : at.type); }}
+              className={[
+                'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                activeFilter === at.type
+                  ? 'border-accent/50 bg-accent/10 text-accent'
+                  : 'border-border bg-bg-tertiary/30 text-text-secondary hover:text-text-primary',
+              ].join(' ')}
+            >
+              {humanizeAction(at.type)} ({String(at.count)}) &mdash; {formatDollars(at.savings)}/mo
+            </button>
+          ))}
+        </div>
+      )}
+
+      {savingsQuery.status === 'loading' && (
+        <div className="text-sm text-text-secondary">Loading recommendations...</div>
+      )}
+      {savingsQuery.status === 'error' && (
+        <div className="rounded-lg border border-negative bg-negative-muted px-4 py-3 text-sm text-negative">
+          {savingsQuery.error.message}
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-text-secondary">
+                <th className="px-4 pb-3 pt-4 font-medium">Recommendation</th>
+                <th className="px-4 pb-3 pt-4 font-medium cursor-pointer hover:text-text-primary" onClick={() => { handleSort('accountName'); }}>
+                  Account{sortIndicator('accountName')}
+                </th>
+                <th className="px-4 pb-3 pt-4 font-medium">Region</th>
+                <th className="px-4 pb-3 pt-4 text-right font-medium cursor-pointer hover:text-text-primary" onClick={() => { handleSort('monthlyCost'); }}>
+                  Monthly Cost{sortIndicator('monthlyCost')}
+                </th>
+                <th className="px-4 pb-3 pt-4 text-right font-medium cursor-pointer hover:text-text-primary" onClick={() => { handleSort('monthlySavings'); }}>
+                  Savings/mo{sortIndicator('monthlySavings')}
+                </th>
+                <th className="px-4 pb-3 pt-4 text-right font-medium cursor-pointer hover:text-text-primary" onClick={() => { handleSort('savingsPercentage'); }}>
+                  %{sortIndicator('savingsPercentage')}
+                </th>
+                <th className="px-4 pb-3 pt-4 font-medium cursor-pointer hover:text-text-primary" onClick={() => { handleSort('effort'); }}>
+                  Effort{sortIndicator('effort')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((rec: SavingsRecommendation, i: number) => {
+                const isExpanded = expandedRow === i;
+                const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
+                const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
+                return (
+                  <>
+                  <tr key={`row-${String(i)}`} className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
+                    <td className="px-4 py-3 max-w-lg">
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-text-primary text-xs font-medium shrink-0">{humanizeAction(rec.actionType)}</span>
+                        {rec.resourceArn.length > 0 && (
+                          <span className="text-text-muted text-[10px] font-mono truncate" title={rec.resourceArn}>{rec.resourceArn.split(':').pop() ?? rec.resourceArn}</span>
+                        )}
+                      </div>
+                      <p className="text-text-muted text-xs mt-0.5 truncate" title={rec.summary}>{rec.summary}</p>
+                    </td>
+                    <td className="px-4 py-3">
+                      <p className="text-text-secondary text-xs">{rec.accountName}</p>
+                      <p className="text-text-muted text-[10px] font-mono">{rec.accountId}</p>
+                    </td>
+                    <td className="px-4 py-3 text-text-secondary text-xs">{rec.region}</td>
+                    <td className="px-4 py-3 text-right tabular-nums text-text-secondary">{formatDollars(rec.monthlyCost)}</td>
+                    <td className="px-4 py-3 text-right tabular-nums font-medium text-accent">{formatDollars(rec.monthlySavings)}</td>
+                    <td className="px-4 py-3 text-right tabular-nums text-text-secondary">{String(Math.round(rec.savingsPercentage))}%</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-medium ${effortColor(rec.effort)}`}>
+                        {effortLabel(rec.effort)}
+                      </span>
+                    </td>
+                  </tr>
+                  {isExpanded && (
+                    <tr key={`detail-${String(i)}`} className="border-b border-border bg-bg-tertiary/10">
+                      <td colSpan={7} className="px-6 py-4">
+                        <div className="grid grid-cols-2 gap-6 text-xs">
+                          <div className="space-y-3">
+                            <h4 className="text-text-muted uppercase tracking-wider text-[10px] font-medium">Current</h4>
+                            {rec.currentSummary.length > 0 && (
+                              <p className="text-text-secondary font-mono text-xs">{rec.currentSummary}</p>
+                            )}
+                            {current !== null && Object.keys(current.config).length > 0 && (
+                              <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+                                {Object.entries(current.config).map(([k, v]) => (
+                                  <><span key={`k-${k}`} className="text-text-muted">{k}</span><span key={`v-${k}`} className="text-text-secondary">{v}</span></>
+                                ))}
+                              </div>
+                            )}
+                            {current !== null && current.usages.length > 0 && (
+                              <div className="space-y-1 pt-1">
+                                <p className="text-text-muted text-[10px] uppercase tracking-wider">Usage</p>
+                                {current.usages.map((u, ui) => (
+                                  <p key={ui} className="text-text-secondary">{u.amount} {u.unit} <span className="text-text-muted">({u.type.split('-').pop() ?? u.type})</span></p>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                          <div className="space-y-3">
+                            <h4 className="text-accent uppercase tracking-wider text-[10px] font-medium">Recommended</h4>
+                            <p className="text-text-secondary">{rec.summary}</p>
+                            {recommended !== null && Object.keys(recommended.config).length > 0 && (
+                              <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+                                {Object.entries(recommended.config).map(([k, v]) => (
+                                  <><span key={`k-${k}`} className="text-text-muted">{k}</span><span key={`v-${k}`} className="text-accent">{v}</span></>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-6 mt-4 pt-3 border-t border-border-subtle text-xs text-text-muted">
+                          {rec.resourceArn.length > 0 && <span className="font-mono">{rec.resourceArn}</span>}
+                          <span>{rec.resourceType}</span>
+                          <span>{rec.recommendationSource}</span>
+                          <span>Restart: <span className={rec.restartNeeded ? 'text-warning' : 'text-text-secondary'}>{rec.restartNeeded ? 'Yes' : 'No'}</span></span>
+                          <span>Rollback: <span className={rec.rollbackPossible ? 'text-accent' : 'text-text-secondary'}>{rec.rollbackPossible ? 'Yes' : 'No'}</span></span>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {data !== null && data.recommendations.length === 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center text-text-secondary">
+          No cost optimization data available. Download cost optimization data from the Data tab.
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Savings** tab in the nav bar showing AWS cost optimization recommendations
- Queries `cost-opt-*/*.parquet` directly with DuckDB, deduplicates by `recommendation_id` keeping only the latest date
- **Filter badges** by action type (Purchase RI, Delete, Rightsize, Upgrade, Stop, Purchase Savings Plans) with counts and savings totals
- **Sortable columns**: savings, %, monthly cost, effort, account
- **Expandable rows** showing full context: current config vs recommended config side-by-side, usage metrics explaining _why_ the recommendation was made, ARN, resource type, restart/rollback flags
- Summary cards (total savings + count) update to reflect active filter
- Graceful handling when cost optimization data isn't configured or downloaded