### PR TITLE
Add tests for Savings, CostTrends, MissingTags + fix React key warnings

### DIFF
--- a/packages/core/src/logger/logger.ts
+++ b/packages/core/src/logger/logger.ts
@@ -17,7 +17,7 @@ const LOG_LEVELS: Record<LogLevel, number> = {
 };
 
 export class Logger {
-  private handlers: LogHandler[] = [];
+  private readonly handlers: LogHandler[] = [];
   private minLevel: LogLevel = 'info';
 
   setLevel(level: LogLevel): void {

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -60,7 +60,7 @@ async function listRawPeriods(rawDir: string, tierPrefix: string): Promise<strin
     const raw = entries
       .filter(e => e.startsWith(`${tierPrefix}-`))
       .map(e => e.slice(tierPrefix.length + 1).slice(0, 7));
-    return [...new Set(raw)].sort();
+    return [...new Set(raw)].sort((a, b) => a.localeCompare(b));
   } catch {
     return [];
   }

--- a/packages/core/src/sync/s3-client.ts
+++ b/packages/core/src/sync/s3-client.ts
@@ -56,15 +56,10 @@ export async function createS3Handle(profile: string, region?: string): Promise<
         });
         const response = await client.send(command);
 
-        if (response.Contents !== undefined) {
-          for (const obj of response.Contents) {
-            if (obj.Key === undefined || obj.Size === undefined) continue;
-            if (!obj.Key.endsWith('.parquet')) continue;
-            entries.push({
-              key: obj.Key,
-              contentHash: obj.ETag ?? '',
-              size: obj.Size,
-            });
+        for (const obj of response.Contents ?? []) {
+          if (obj.Key === undefined || obj.Size === undefined) continue;
+          if (obj.Key.endsWith('.parquet')) {
+            entries.push({ key: obj.Key, contentHash: obj.ETag ?? '', size: obj.Size });
           }
         }
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -55,6 +55,13 @@ import type {
 } from '@costgoblin/core';
 
 type RawRow = Readonly<Record<string, unknown>>;
+type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
+
+function resolveDataType(syncId: string): ExpectedDataType {
+  if (syncId === 'hourly') return 'hourly';
+  if (syncId === 'cost-optimization') return 'cost-optimization';
+  return 'daily';
+}
 
 async function queryAll(conn: DuckDBConnection, sql: string): Promise<RawRow[]> {
   const result = await conn.run(sql);
@@ -509,9 +516,14 @@ export function registerIpcHandlers(ctx: IpcContext): void {
       for (const row of rows) {
         const rawDate = row['date'];
         const rawGroup = row['group_name'];
-        const date = rawDate instanceof Date
-          ? rawDate.toISOString().slice(0, 10)
-          : typeof rawDate === 'string' ? rawDate : '';
+        let date: string;
+        if (rawDate instanceof Date) {
+          date = rawDate.toISOString().slice(0, 10);
+        } else if (typeof rawDate === 'string') {
+          date = rawDate;
+        } else {
+          date = '';
+        }
         const group = typeof rawGroup === 'string' ? rawGroup : '';
         const cost = Number(row['cost'] ?? 0);
 
@@ -862,7 +874,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
         bucketPath,
         profile: provider.credentials.profile,
         dataDir: ctx.dataDir,
-        expectedDataType: id === 'hourly' ? 'hourly' : id === 'cost-optimization' ? 'cost-optimization' : 'daily',
+        expectedDataType: resolveDataType(id),
         files: fileEntries,
         signal: controller.signal,
         onProgress: (progress) => {

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -199,7 +199,16 @@ export class MockCostApi implements CostApi {
   }
   queryTrends(): Promise<TrendResult> { return Promise.resolve(trendResult); }
   queryMissingTags(): Promise<MissingTagsResult> { return Promise.resolve(missingTagsResult); }
-  querySavings(): Promise<SavingsResult> { return Promise.resolve({ recommendations: [], totalMonthlySavings: asDollars(0) }); }
+  querySavings(): Promise<SavingsResult> {
+    return Promise.resolve({
+      recommendations: [
+        { accountId: '111111111111', accountName: 'Production', actionType: 'PurchaseReservedInstances', resourceType: 'RdsReservedInstances', summary: '10 db.t4g.micro MariaDB in eu-central-1', region: 'eu-central-1', monthlySavings: asDollars(3000), monthlyCost: asDollars(5500), savingsPercentage: 55, effort: 'VeryLow', resourceArn: '', currentDetails: '', recommendedDetails: '', currentSummary: '', restartNeeded: false, rollbackPossible: false, recommendationSource: 'CostExplorer' },
+        { accountId: '222222222222', accountName: 'Staging', actionType: 'Delete', resourceType: 'EbsVolume', summary: 'Detach and delete unused volume', region: 'us-east-1', monthlySavings: asDollars(800), monthlyCost: asDollars(800), savingsPercentage: 100, effort: 'Low', resourceArn: 'arn:aws:ec2:us-east-1:222222222222:volume/vol-abc123', currentDetails: '{"ebsVolume":{"configuration":{"storage":{"type":"gp3","sizeInGb":1024}}}}', recommendedDetails: '', currentSummary: 'vol-abc123', restartNeeded: false, rollbackPossible: false, recommendationSource: 'ComputeOptimizer' },
+        { accountId: '111111111111', accountName: 'Production', actionType: 'Rightsize', resourceType: 'Ec2Instance', summary: 'Downsize to t3.medium', region: 'eu-central-1', monthlySavings: asDollars(150), monthlyCost: asDollars(400), savingsPercentage: 37, effort: 'Medium', resourceArn: 'arn:aws:ec2:eu-central-1:111111111111:instance/i-xyz789', currentDetails: '{"ec2Instance":{"configuration":{"instance":{"type":"m5.xlarge"}}}}', recommendedDetails: '{"ec2Instance":{"configuration":{"instance":{"type":"t3.medium"}}}}', currentSummary: 'i-xyz789', restartNeeded: true, rollbackPossible: true, recommendationSource: 'ComputeOptimizer' },
+      ],
+      totalMonthlySavings: asDollars(3950),
+    });
+  }
   queryEntityDetail(): Promise<EntityDetailResult> { return Promise.resolve(entityDetailResult); }
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
   triggerSync(): Promise<void> { return Promise.resolve(); }

--- a/packages/ui/src/__tests__/cost-trends.test.tsx
+++ b/packages/ui/src/__tests__/cost-trends.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { CostTrends } from '../views/cost-trends.js';
+
+function renderTrends() {
+  const api = new MockCostApi();
+  const onEntityClick = vi.fn();
+  return {
+    api,
+    onEntityClick,
+    ...render(
+      <CostApiProvider value={api}>
+        <CostTrends onEntityClick={onEntityClick} />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('CostTrends', () => {
+  it('renders heading', () => {
+    renderTrends();
+    expect(screen.getByText('Cost Trends')).toBeDefined();
+  });
+
+  it('shows trend data after loading', async () => {
+    renderTrends();
+    await waitFor(() => {
+      expect(screen.getByText(/platform/)).toBeDefined();
+    });
+  });
+
+  it('shows delta and percent change columns', async () => {
+    renderTrends();
+    await waitFor(() => {
+      expect(screen.getByText('Entity')).toBeDefined();
+      expect(screen.getByText('Current')).toBeDefined();
+      expect(screen.getByText('Previous')).toBeDefined();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/missing-tags.test.tsx
+++ b/packages/ui/src/__tests__/missing-tags.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { MissingTags } from '../views/missing-tags.js';
+
+function renderMissingTags() {
+  const api = new MockCostApi();
+  return {
+    api,
+    ...render(
+      <CostApiProvider value={api}>
+        <MissingTags />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('MissingTags', () => {
+  it('renders heading', () => {
+    renderMissingTags();
+    expect(screen.getByText('Missing Tags')).toBeDefined();
+  });
+
+  it('shows untagged cost summary after loading', async () => {
+    renderMissingTags();
+    await waitFor(() => {
+      expect(screen.getByText(/resources/)).toBeDefined();
+    });
+  });
+
+  it('shows table with resource columns', async () => {
+    renderMissingTags();
+    await waitFor(() => {
+      expect(screen.getByText('Account')).toBeDefined();
+      expect(screen.getByText('Resource')).toBeDefined();
+      expect(screen.getByText('Service')).toBeDefined();
+    });
+  });
+
+  it('has min cost filter input', () => {
+    renderMissingTags();
+    const input = screen.getByDisplayValue('50');
+    expect(input).toBeDefined();
+  });
+});

--- a/packages/ui/src/__tests__/savings.test.tsx
+++ b/packages/ui/src/__tests__/savings.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { Savings } from '../views/savings.js';
+
+function renderSavings() {
+  const api = new MockCostApi();
+  const user = userEvent.setup();
+  return {
+    api,
+    user,
+    ...render(
+      <CostApiProvider value={api}>
+        <Savings />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('Savings', () => {
+  it('renders heading', () => {
+    renderSavings();
+    expect(screen.getByText('Savings Opportunities')).toBeDefined();
+  });
+
+  it('shows recommendations after loading', async () => {
+    renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText('$4.0k')).toBeDefined();
+    });
+    expect(screen.getByText('3')).toBeDefined();
+  });
+
+  it('displays action type filter badges', async () => {
+    renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText(/All \(3\)/)).toBeDefined();
+    });
+    expect(screen.getByText(/Purchase Reserved Instances \(1\)/)).toBeDefined();
+    expect(screen.getByText(/Delete \(1\)/)).toBeDefined();
+    expect(screen.getByText(/Rightsize \(1\)/)).toBeDefined();
+  });
+
+  it('filters by action type when badge clicked', async () => {
+    const { user } = renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText(/Delete \(1\)/)).toBeDefined();
+    });
+    await user.click(screen.getByText(/Delete \(1\)/));
+    await waitFor(() => {
+      expect(screen.getByText('Potential Monthly Savings')).toBeDefined();
+    });
+  });
+
+  it('shows resource ARN in recommendation column', async () => {
+    renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText('volume/vol-abc123')).toBeDefined();
+    });
+  });
+
+  it('shows account name and ID', async () => {
+    renderSavings();
+    await waitFor(() => {
+      expect(screen.getAllByText('Production').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('111111111111').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('expands row on click to show details', async () => {
+    const { user } = renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    });
+    const row = screen.getByText(/Detach and delete/).closest('tr');
+    expect(row).not.toBeNull();
+    await user.click(row as HTMLElement);
+    await waitFor(() => {
+      expect(screen.getByText('vol-abc123')).toBeDefined();
+    });
+  });
+
+  it('shows effort badges with correct labels', async () => {
+    renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText('Very Low')).toBeDefined();
+      expect(screen.getByText('Low')).toBeDefined();
+      expect(screen.getByText('Medium')).toBeDefined();
+    });
+  });
+});

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -2,7 +2,7 @@ import type { SavingsResult, SavingsRecommendation } from '@costgoblin/core/brow
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { formatDollars } from '../components/format.js';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, Fragment } from 'react';
 
 type SortField = 'monthlySavings' | 'savingsPercentage' | 'monthlyCost' | 'effort' | 'accountName';
 
@@ -236,14 +236,13 @@ export function Savings() {
                 </th>
               </tr>
             </thead>
-            <tbody>
               {filtered.map((rec: SavingsRecommendation, i: number) => {
                 const isExpanded = expandedRow === i;
                 const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
                 const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
                 return (
-                  <>
-                  <tr key={`row-${String(i)}`} className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
+                  <tbody key={`group-${String(i)}`}>
+                  <tr className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
                     <td className="px-4 py-3 max-w-lg">
                       <div className="flex items-baseline gap-2">
                         <span className="text-text-primary text-xs font-medium shrink-0">{humanizeAction(rec.actionType)}</span>
@@ -279,7 +278,7 @@ export function Savings() {
                             {current !== null && Object.keys(current.config).length > 0 && (
                               <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
                                 {Object.entries(current.config).map(([k, v]) => (
-                                  <><span key={`k-${k}`} className="text-text-muted">{k}</span><span key={`v-${k}`} className="text-text-secondary">{v}</span></>
+                                  <Fragment key={`c-${k}`}><span className="text-text-muted">{k}</span><span className="text-text-secondary">{v}</span></Fragment>
                                 ))}
                               </div>
                             )}
@@ -298,7 +297,7 @@ export function Savings() {
                             {recommended !== null && Object.keys(recommended.config).length > 0 && (
                               <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
                                 {Object.entries(recommended.config).map(([k, v]) => (
-                                  <><span key={`k-${k}`} className="text-text-muted">{k}</span><span key={`v-${k}`} className="text-accent">{v}</span></>
+                                  <Fragment key={`r-${k}`}><span className="text-text-muted">{k}</span><span className="text-accent">{v}</span></Fragment>
                                 ))}
                               </div>
                             )}
@@ -314,10 +313,9 @@ export function Savings() {
                       </td>
                     </tr>
                   )}
-                  </>
+                  </tbody>
                 );
               })}
-            </tbody>
           </table>
         </div>
       )}

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -501,7 +501,7 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     const source = wizard.source;
 
     const updated = { ...collectedPaths };
-    let defaultRetention = 365;
+    let defaultRetention: number;
     if (source === 'daily') {
       updated.daily = s3Path;
       defaultRetention = 365;
@@ -519,7 +519,7 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
   function handleBrowseSkip() {
     if (wizard.step !== 'browse' && wizard.step !== 'bucket') return;
     const profile = wizard.profile;
-    const source = wizard.step === 'browse' ? wizard.source : wizard.source;
+    const source = wizard.source;
 
     if (source === 'hourly') {
       startBucketStep(profile, 'costOptimization');


### PR DESCRIPTION
## Summary
- Add 15 new tests covering 3 previously untested views: Savings (8), CostTrends (3), MissingTags (4)
- Fix React key warnings in Savings view (Fragment keys, tbody grouping)
- Mock API updated with realistic savings fixture data for tests
- Total test count: 82 → 97