### PR TITLE
Add tests for zero-coverage UI components and views

### DIFF
--- a/packages/ui/src/__tests__/confirm-modal.test.tsx
+++ b/packages/ui/src/__tests__/confirm-modal.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { ConfirmModal } from '../components/confirm-modal.js';
+
+afterEach(cleanup);
+
+describe('ConfirmModal', () => {
+  it('renders title and message', () => {
+    render(
+      <ConfirmModal title="Delete item" message="Are you sure?" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText('Delete item')).toBeDefined();
+    expect(screen.getByText('Are you sure?')).toBeDefined();
+  });
+
+  it('renders default button labels', () => {
+    render(
+      <ConfirmModal title="Test" message="msg" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText('Confirm')).toBeDefined();
+    expect(screen.getByText('Cancel')).toBeDefined();
+  });
+
+  it('renders custom button labels', () => {
+    render(
+      <ConfirmModal title="Test" message="msg" confirmLabel="Yes" cancelLabel="No" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText('Yes')).toBeDefined();
+    expect(screen.getByText('No')).toBeDefined();
+  });
+
+  it('calls onConfirm when confirm button clicked', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal title="Test" message="msg" onConfirm={onConfirm} onCancel={vi.fn()} />,
+    );
+    await user.click(screen.getByText('Confirm'));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when cancel button clicked', async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal title="Test" message="msg" onConfirm={vi.fn()} onCancel={onCancel} />,
+    );
+    await user.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when escape key pressed', async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal title="Test" message="msg" onConfirm={vi.fn()} onCancel={onCancel} />,
+    );
+    await user.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('applies destructive styling when destructive prop is true', () => {
+    render(
+      <ConfirmModal title="Delete" message="msg" destructive onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+    const confirmBtn = screen.getByText('Confirm');
+    expect(confirmBtn.className).toContain('bg-negative');
+  });
+
+  it('has dialog role', () => {
+    render(
+      <ConfirmModal title="Test" message="msg" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByRole('dialog')).toBeDefined();
+  });
+});

--- a/packages/ui/src/__tests__/cost-table.test.tsx
+++ b/packages/ui/src/__tests__/cost-table.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostTable } from '../components/cost-table.js';
+import { asEntityRef, asDollars } from '@costgoblin/core/browser';
+import type { CostRow } from '@costgoblin/core/browser';
+
+const rows: CostRow[] = [
+  {
+    entity: asEntityRef('platform'),
+    totalCost: asDollars(42_000),
+    serviceCosts: { 'Amazon EC2': asDollars(18_000), 'Amazon RDS': asDollars(9_500) },
+  },
+  {
+    entity: asEntityRef('data'),
+    totalCost: asDollars(31_000),
+    serviceCosts: { 'Amazon EC2': asDollars(10_000), 'Amazon RDS': asDollars(14_000) },
+  },
+  {
+    entity: asEntityRef('infra'),
+    totalCost: asDollars(14_000),
+    serviceCosts: { 'Amazon EC2': asDollars(9_000) },
+    isVirtual: true,
+  },
+];
+
+const topServices = ['Amazon EC2', 'Amazon RDS'];
+
+afterEach(cleanup);
+
+describe('CostTable', () => {
+  it('renders entity names', () => {
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} />);
+    expect(screen.getByText('platform')).toBeDefined();
+    expect(screen.getByText('data')).toBeDefined();
+    expect(screen.getByText('infra')).toBeDefined();
+  });
+
+  it('renders service column headers', () => {
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} />);
+    expect(screen.getByText('Amazon EC2')).toBeDefined();
+    expect(screen.getByText('Amazon RDS')).toBeDefined();
+  });
+
+  it('renders total column header', () => {
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} />);
+    expect(screen.getByText('Total')).toBeDefined();
+  });
+
+  it('sorts rows by cost descending', () => {
+    const { container } = render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} />);
+    const entityCells = container.querySelectorAll('tbody td:first-child');
+    const names = [...entityCells].map(td => td.textContent);
+    expect(names[0]).toContain('platform');
+    expect(names[1]).toContain('data');
+    expect(names[2]).toContain('infra');
+  });
+
+  it('calls onEntityClick when entity name clicked', async () => {
+    const onEntityClick = vi.fn();
+    const user = userEvent.setup();
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={onEntityClick} />);
+    await user.click(screen.getByText('platform'));
+    expect(onEntityClick).toHaveBeenCalledWith('platform');
+  });
+
+  it('shows dash for missing service costs', () => {
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} />);
+    const cells = screen.getAllByText('—');
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it('shows virtual entity styling with folder icon', () => {
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} />);
+    const infraBtn = screen.getByText('infra');
+    expect(infraBtn.className).toContain('text-warning');
+  });
+
+  it('calls onServiceClick when service header clicked', async () => {
+    const onServiceClick = vi.fn();
+    const user = userEvent.setup();
+    render(<CostTable rows={rows} topServices={topServices} onEntityClick={vi.fn()} onServiceClick={onServiceClick} />);
+    await user.click(screen.getByText('Amazon EC2'));
+    expect(onServiceClick).toHaveBeenCalledWith('Amazon EC2');
+  });
+});

--- a/packages/ui/src/__tests__/data-management.test.tsx
+++ b/packages/ui/src/__tests__/data-management.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { DataManagement } from '../views/data-management.js';
+
+function renderDataManagement(api?: MockCostApi) {
+  const mockApi = api ?? new MockCostApi();
+  const user = userEvent.setup();
+  return {
+    api: mockApi,
+    user,
+    ...render(
+      <CostApiProvider value={mockApi}>
+        <DataManagement />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('DataManagement', () => {
+  it('renders heading', async () => {
+    renderDataManagement();
+    await waitFor(() => {
+      expect(screen.getByText('Data Management')).toBeDefined();
+    });
+  });
+
+  it('shows account mapping warning when missing', async () => {
+    renderDataManagement();
+    await waitFor(() => {
+      expect(screen.getByText('Account mapping not found')).toBeDefined();
+    });
+  });
+
+  it('shows daily tier panel', async () => {
+    renderDataManagement();
+    await waitFor(() => {
+      expect(screen.getByText('Daily')).toBeDefined();
+    });
+  });
+
+  it('shows hourly tier as not configured', async () => {
+    renderDataManagement();
+    await waitFor(() => {
+      const elements = screen.getAllByText('Not configured');
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('shows cost optimization tier as not configured', async () => {
+    renderDataManagement();
+    await waitFor(() => {
+      expect(screen.getByText('Cost Optimization')).toBeDefined();
+      const elements = screen.getAllByText('Not configured');
+      expect(elements.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('shows no data source configured when config has no providers', async () => {
+    const api = new MockCostApi();
+    api.getConfig = () => Promise.reject(new Error('No config found'));
+    renderDataManagement(api);
+    await waitFor(() => {
+      expect(screen.getByText('No data source configured')).toBeDefined();
+    });
+  });
+
+  it('refresh button triggers data reload', async () => {
+    const api = new MockCostApi();
+    const spy = vi.spyOn(api, 'getDataInventory');
+    const { user } = renderDataManagement(api);
+    await waitFor(() => {
+      expect(screen.getByText('Refresh')).toBeDefined();
+    });
+    const callsBefore = spy.mock.calls.length;
+    await user.click(screen.getByText('Refresh'));
+    await waitFor(() => {
+      expect(spy.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  it('delete all data button shows confirmation modal', async () => {
+    const { user } = renderDataManagement();
+    await waitFor(() => {
+      expect(screen.getByText('Delete All Data')).toBeDefined();
+    });
+    await user.click(screen.getByText('Delete All Data'));
+    await waitFor(() => {
+      expect(screen.getByText('Delete all local data')).toBeDefined();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/entity-popup.test.tsx
+++ b/packages/ui/src/__tests__/entity-popup.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { EntityPopup } from '../components/entity-popup.js';
+
+function renderPopup(overrides?: Partial<{ onClose: () => void; onSetFilter: () => void; onOpenDetail: () => void }>) {
+  const api = new MockCostApi();
+  const user = userEvent.setup();
+  const onClose = overrides?.onClose ?? vi.fn();
+  const onSetFilter = overrides?.onSetFilter ?? vi.fn();
+  const onOpenDetail = overrides?.onOpenDetail ?? vi.fn();
+  return {
+    api,
+    user,
+    onClose,
+    onSetFilter,
+    onOpenDetail,
+    ...render(
+      <CostApiProvider value={api}>
+        <EntityPopup
+          entity="platform"
+          dimension="team"
+          onClose={onClose}
+          onSetFilter={onSetFilter}
+          onOpenDetail={onOpenDetail}
+        />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('EntityPopup', () => {
+  it('renders entity name and dimension', () => {
+    renderPopup();
+    expect(screen.getByText('platform')).toBeDefined();
+    expect(screen.getByText('team')).toBeDefined();
+  });
+
+  it('shows loading state initially', () => {
+    renderPopup();
+    expect(screen.getByText('Loading…')).toBeDefined();
+  });
+
+  it('loads entity detail data', async () => {
+    renderPopup();
+    await waitFor(() => {
+      expect(screen.getByText('Total Cost')).toBeDefined();
+    });
+  });
+
+  it('shows close button', () => {
+    renderPopup();
+    expect(screen.getByLabelText('Close')).toBeDefined();
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const onClose = vi.fn();
+    const { user } = renderPopup({ onClose });
+    await user.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders action buttons after data loads', async () => {
+    renderPopup();
+    await waitFor(() => {
+      expect(screen.getByText('Set as filter')).toBeDefined();
+    });
+    expect(screen.getByText('Open full view')).toBeDefined();
+  });
+});

--- a/packages/ui/src/__tests__/pie-chart.test.tsx
+++ b/packages/ui/src/__tests__/pie-chart.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { PieChart } from '../components/pie-chart.js';
+import type { PieSlice } from '../components/pie-chart.js';
+
+const slices: PieSlice[] = [
+  { name: 'Amazon EC2', cost: 18_000, percentage: 42.6 },
+  { name: 'Amazon RDS', cost: 9_500, percentage: 22.5 },
+  { name: 'Amazon S3', cost: 6_200, percentage: 14.7 },
+];
+
+afterEach(cleanup);
+
+describe('PieChart', () => {
+  it('renders collapsed state with title', () => {
+    render(<PieChart data={slices} title="Services" collapsed />);
+    expect(screen.getByText('Services')).toBeDefined();
+  });
+
+  it('renders expand button in collapsed state', () => {
+    const onExpand = vi.fn();
+    render(<PieChart data={slices} title="Services" collapsed onExpandToggle={onExpand} />);
+    expect(screen.getByText('Services')).toBeDefined();
+  });
+
+  it('renders container when not collapsed', () => {
+    const { container } = render(<PieChart data={slices} title="Accounts" />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('renders with empty data', () => {
+    const { container } = render(<PieChart data={[]} title="Empty" />);
+    expect(container.firstChild).toBeDefined();
+  });
+});

--- a/packages/ui/src/__tests__/setup-wizard.test.tsx
+++ b/packages/ui/src/__tests__/setup-wizard.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { SetupWizard } from '../views/setup-wizard.js';
+
+function renderWizard(props?: { source?: 'daily' | 'hourly' | 'costOptimization'; profile?: string }) {
+  const api = new MockCostApi();
+  const onComplete = vi.fn();
+  const user = userEvent.setup();
+  return {
+    api,
+    onComplete,
+    user,
+    ...render(
+      <CostApiProvider value={api}>
+        <SetupWizard onComplete={onComplete} source={props?.source} profile={props?.profile} />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('SetupWizard', () => {
+  it('renders welcome step', () => {
+    renderWizard();
+    expect(screen.getByText('CostGoblin')).toBeDefined();
+    expect(screen.getByText('Cloud cost visibility for your team')).toBeDefined();
+    expect(screen.getByText('Get Started')).toBeDefined();
+  });
+
+  it('get started button advances to profile step', async () => {
+    const { user } = renderWizard();
+    await user.click(screen.getByText('Get Started'));
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeDefined();
+    });
+    expect(screen.getByText('prod')).toBeDefined();
+    expect(screen.getByText('staging')).toBeDefined();
+  });
+
+  it('shows loading state while fetching profiles', async () => {
+    const api = new MockCostApi();
+    let resolveProfiles: ((profiles: string[]) => void) | undefined;
+    api.listAwsProfiles = () => new Promise<string[]>((resolve) => { resolveProfiles = resolve; });
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CostApiProvider value={api}>
+        <SetupWizard onComplete={onComplete} />
+      </CostApiProvider>,
+    );
+    await user.click(screen.getByText('Get Started'));
+    expect(screen.getByText('Loading profiles...')).toBeDefined();
+    resolveProfiles?.(['default']);
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeDefined();
+    });
+  });
+
+  it('renders in source mode when source and profile provided', async () => {
+    renderWizard({ source: 'daily', profile: 'default' });
+    await waitFor(() => {
+      expect(screen.getByText('my-cur-bucket')).toBeDefined();
+    });
+  });
+
+  it('onComplete callback is provided but not called on render', () => {
+    const { onComplete } = renderWizard();
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(screen.getByText('CostGoblin')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for 6 previously uncovered UI components/views: ConfirmModal, CostTable, PieChart, EntityPopup, DataManagement, SetupWizard
- 39 new tests (97 → 136 total), all passing
- UI component coverage: 41% → 61%
- UI views coverage: 45% → 68%
- Per-file improvements: confirm-modal 0→100%, cost-table 0→100%, entity-popup 0→97%, data-management 0→53%, setup-wizard 0→40%