### PR TITLE
Handle expired AWS SSO credentials gracefully

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -307,6 +307,20 @@ interface OrgTreeConfig {
   readonly tree: readonly OrgNode[];
 }
 
+function isCredentialError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const name = err.name;
+  if (name === 'CredentialsProviderError' || name === 'TokenProviderError') return true;
+  return err.message.includes('Token is expired') || err.message.includes('SSO session') || err.message.includes('credentials');
+}
+
+function toUserFriendlyError(err: unknown, profile: string): Error {
+  if (isCredentialError(err)) {
+    return new Error(`AWS credentials expired for profile "${profile}". Run: aws sso login --profile ${profile}`);
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
 function isOwnerGroupBy(groupBy: string, dimensions: DimensionsConfig): boolean {
   return dimensions.tags.some(
     t => t.concept === 'owner' && `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === groupBy,
@@ -777,7 +791,9 @@ export function registerIpcHandlers(ctx: IpcContext): void {
         filesDownloaded: result.filesDownloaded,
       };
     } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
+      const provider = (await getConfig()).providers[0];
+      const profile = provider?.credentials.profile ?? 'default';
+      const error = isCredentialError(err) ? toUserFriendlyError(err, profile) : err instanceof Error ? err : new Error(String(err));
       logger.error(`Sync failed: ${error.message}`);
       state.syncStatuses['default'] = {
         status: 'failed',
@@ -830,7 +846,11 @@ export function registerIpcHandlers(ctx: IpcContext): void {
     } else {
       bucket = provider.sync.daily.bucket;
     }
-    return getDataInventory(bucket, provider.credentials.profile, ctx.dataDir, t);
+    try {
+      return await getDataInventory(bucket, provider.credentials.profile, ctx.dataDir, t);
+    } catch (err: unknown) {
+      throw toUserFriendlyError(err, provider.credentials.profile);
+    }
   });
 
   ipcMain.handle('data:delete-period', async (_event, period: string, tier: 'daily' | 'hourly' | 'cost-optimization' = 'daily'): Promise<void> => {
@@ -899,11 +919,12 @@ export function registerIpcHandlers(ctx: IpcContext): void {
       return result;
     } catch (err: unknown) {
       syncAbortControllers.delete(id);
-      const error = err instanceof Error ? err : new Error(String(err));
-      if (error.message === 'Download cancelled') {
+      const raw = err instanceof Error ? err : new Error(String(err));
+      if (raw.message === 'Download cancelled') {
         state.syncStatuses[id] = { status: 'idle', lastSync: null };
         return { filesDownloaded: 0, rowsProcessed: 0 };
       }
+      const error = isCredentialError(err) ? toUserFriendlyError(err, provider.credentials.profile) : raw;
       logger.error(`Selective sync '${id}' failed: ${error.message}`);
       state.syncStatuses[id] = { status: 'failed', error, lastSync: null };
       throw error;

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, CostApiProvider, SetupWizard } from '@costgoblin/ui';
+import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, CostApiProvider, SetupWizard, ErrorBoundary } from '@costgoblin/ui';
 import type { CostApi } from '@costgoblin/core/browser';
 
 function getApi(): CostApi {
@@ -141,6 +141,7 @@ export function App(): React.JSX.Element {
   }
 
   return (
+    <ErrorBoundary>
     <CostApiProvider value={api}>
       <div className="min-h-screen bg-bg-primary text-text-primary">
         {/* Title bar + nav */}
@@ -214,5 +215,6 @@ export function App(): React.JSX.Element {
         )}
       </div>
     </CostApiProvider>
+    </ErrorBoundary>
   );
 }

--- a/packages/ui/src/components/error-boundary.tsx
+++ b/packages/ui/src/components/error-boundary.tsx
@@ -1,0 +1,53 @@
+import { Component } from 'react';
+import type { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  render(): ReactNode {
+    if (this.state.error !== null) {
+      return (
+        <div className="min-h-screen bg-bg-primary flex items-center justify-center p-8">
+          <div className="max-w-lg w-full rounded-xl border border-negative/50 bg-negative-muted p-6">
+            <h2 className="text-lg font-semibold text-negative">Something went wrong</h2>
+            <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+              {this.state.error.message}
+            </p>
+            {this.state.error.message.includes('aws sso login') && (
+              <div className="mt-3 rounded-lg bg-bg-primary/50 border border-border px-3 py-2">
+                <p className="text-xs text-text-muted">Run this in your terminal:</p>
+                <code className="text-sm text-accent font-mono">
+                  {this.state.error.message.split('Run: ')[1] ?? 'aws sso login'}
+                </code>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={() => { this.setState({ error: null }); }}
+              className="mt-4 rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -75,15 +75,36 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         </div>
       </div>
 
-      {days.length > 0 ? (
-        <div>
-          {/* Y axis label */}
-          <div className="flex items-center gap-2 mb-1">
-            <span className="text-[10px] text-text-muted w-10 text-right">{formatDollars(maxCost)}</span>
-            <div className="flex-1 border-b border-border-subtle" />
+      {days.length > 0 ? (() => {
+        const chartHeight = expanded ? 360 : 180;
+        const ticks = [1, 0.75, 0.5, 0.25, 0];
+        return (
+        <div className="relative">
+          {/* Y axis ticks */}
+          <div className="absolute left-0 top-0 w-10 h-full" style={{ height: `${String(chartHeight)}px` }}>
+            {ticks.map(pct => (
+              <div
+                key={pct}
+                className="absolute right-0 flex items-center"
+                style={{ top: `${String((1 - pct) * 100)}%`, transform: 'translateY(-50%)' }}
+              >
+                <span className="text-[10px] text-text-muted tabular-nums">{formatDollars(maxCost * pct)}</span>
+              </div>
+            ))}
           </div>
 
-          <div className="flex items-end ml-12" style={{ height: expanded ? '360px' : '180px', gap: '2px' }}>
+          {/* Grid lines */}
+          <div className="absolute left-12 right-0 top-0" style={{ height: `${String(chartHeight)}px` }}>
+            {ticks.map(pct => (
+              <div
+                key={pct}
+                className="absolute left-0 right-0 border-b border-border-subtle/50"
+                style={{ top: `${String((1 - pct) * 100)}%` }}
+              />
+            ))}
+          </div>
+
+          <div className="flex items-end ml-12 relative z-10" style={{ height: `${String(chartHeight)}px`, gap: '2px' }}>
             {days.map((day) => {
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys
@@ -167,16 +188,20 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
 
           {/* X axis */}
           <div className="flex ml-12 mt-1" style={{ gap: '2px' }}>
-            {days.map((day, idx) => (
-              <div key={day.date} className="flex-1 min-w-0 text-center">
-                {idx % Math.max(1, Math.floor(days.length / 6)) === 0 ? (
-                  <span className="text-[10px] text-text-muted">{day.date.slice(5)}</span>
+            {days.map((day, idx) => {
+              const step = Math.max(1, Math.ceil(days.length / 7));
+              return (
+              <div key={day.date} className="flex-1 min-w-0 text-center overflow-hidden">
+                {idx % step === 0 ? (
+                  <span className="text-[10px] text-text-muted whitespace-nowrap">{day.date.slice(5)}</span>
                 ) : null}
               </div>
-            ))}
+              );
+            })}
           </div>
         </div>
-      ) : (
+        );
+      })() : (
         <div className="flex items-center justify-center h-40 text-sm text-text-muted">No daily data</div>
       )}
     </div>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,7 @@ export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
 export { Button, buttonVariants } from './components/ui/button.js';
 export type { ButtonProps } from './components/ui/button.js';
 
+export { ErrorBoundary } from './components/error-boundary.js';
 export { BubbleChart } from './components/bubble-chart.js';
 export { CostTable } from './components/cost-table.js';
 export { EntityPopup } from './components/entity-popup.js';

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -658,8 +658,11 @@ export function DataManagement() {
       )}
 
       {inventoryQuery.status === 'error' && (
-        <div className="rounded-lg border border-negative bg-negative-muted px-4 py-3 text-sm text-negative">
-          {inventoryQuery.error.message}
+        <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3">
+          <p className="text-sm font-medium text-negative">{inventoryQuery.error.message}</p>
+          {inventoryQuery.error.message.includes('aws sso login') && (
+            <p className="text-xs text-text-secondary mt-1">Refresh this page after logging in.</p>
+          )}
         </div>
       )}
 

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -184,7 +184,7 @@ export function Savings() {
         <div className="flex flex-wrap items-center gap-2">
           <button
             type="button"
-            onClick={() => { setActiveFilter(null); }}
+            onClick={() => { setActiveFilter(null); setExpandedRow(null); }}
             className={[
               'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
               activeFilter === null
@@ -198,7 +198,7 @@ export function Savings() {
             <button
               key={at.type}
               type="button"
-              onClick={() => { setActiveFilter(activeFilter === at.type ? null : at.type); }}
+              onClick={() => { setActiveFilter(activeFilter === at.type ? null : at.type); setExpandedRow(null); }}
               className={[
                 'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
                 activeFilter === at.type
@@ -250,7 +250,7 @@ export function Savings() {
                 const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
                 const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
                 return (
-                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}`}>
+                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}-${String(i)}`}>
                   <tr className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
                     <td className="px-4 py-3 max-w-lg">
                       <div className="flex items-baseline gap-2">


### PR DESCRIPTION
## Summary
- Detect `CredentialsProviderError` / `TokenProviderError` in IPC handlers and convert to user-friendly message with the exact `aws sso login --profile <name>` command to run
- Add `ErrorBoundary` component to prevent black screen on any uncaught render error — shows error message + "Try Again" button
- Wrap the Electron App with ErrorBoundary
- Improve data-management error display with SSO-specific hint ("Refresh this page after logging in")

Before: expired SSO token → black screen, raw stack trace in console
After: clear error message with actionable command, app stays functional