### PR TITLE
Add weekly histogram aggregation + coin rain loader

### DIFF
--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Coin {
+  id: number;
+  x: number;
+  y: number;
+  vy: number;
+  vx: number;
+  rotation: number;
+  rotationSpeed: number;
+  scale: number;
+}
+
+function createCoin(id: number, containerWidth: number, containerHeight: number): Coin {
+  return {
+    id,
+    x: Math.random() * (containerWidth - 24),
+    y: -30 - Math.random() * containerHeight * 0.6,
+    vy: 0.5 + Math.random() * 1.5,
+    vx: (Math.random() - 0.5) * 0.3,
+    rotation: Math.random() * 360,
+    rotationSpeed: (Math.random() - 0.5) * 6,
+    scale: 0.7 + Math.random() * 0.5,
+  };
+}
+
+export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: number; count?: number }>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [coins, setCoins] = useState<Coin[]>([]);
+  const frameRef = useRef(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el === null) return;
+    setCoins(Array.from({ length: count }, (_, i) => createCoin(i, el.offsetWidth, height)));
+  }, [count, height]);
+
+  useEffect(() => {
+    if (coins.length === 0) return;
+    const el = containerRef.current;
+    if (el === null) return;
+
+    const w = el.offsetWidth;
+
+    const tick = () => {
+      setCoins(prev => prev.map(c => {
+        let { x, y, vx, vy, rotation, rotationSpeed, scale } = c;
+        vy += 0.12;
+        vx += Math.sin(Date.now() / 800 + c.id * 2) * 0.04;
+        vx *= 0.98;
+        x += vx;
+        y += vy;
+        rotation += rotationSpeed;
+
+        if (x < 0) { x = 0; vx = Math.abs(vx) * 0.5; }
+        if (x > w - 24 * scale) { x = w - 24 * scale; vx = -Math.abs(vx) * 0.5; }
+
+        if (y > height + 30) {
+          return createCoin(c.id, w, height);
+        }
+
+        return { ...c, x, y, vx, vy, rotation, scale };
+      }));
+      frameRef.current = requestAnimationFrame(tick);
+    };
+
+    frameRef.current = requestAnimationFrame(tick);
+    return () => { cancelAnimationFrame(frameRef.current); };
+  }, [coins.length, height]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative overflow-hidden"
+      style={{ height, perspective: '600px' }}
+    >
+      {coins.map(c => (
+        <div
+          key={c.id}
+          className="absolute pointer-events-none select-none"
+          style={{
+            left: c.x,
+            top: c.y,
+            transform: `rotateZ(${String(c.rotation)}deg) scale(${String(c.scale)})`,
+            fontSize: 22,
+            willChange: 'transform',
+            transition: 'transform 0.03s linear',
+          }}
+        >
+          🪙
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { PALETTE_STANDARD } from '../lib/palette.js';
 import { formatDollars } from './format.js';
+import { CoinRainLoader } from './coin-rain-loader.js';
 
 export interface BarDay {
   readonly date: string;
@@ -18,9 +19,10 @@ interface StackedBarChartProps {
   expanded?: boolean | undefined;
   onExpandToggle?: (() => void) | undefined;
   title?: string | undefined;
+  loading?: boolean | undefined;
 }
 
-export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title }: StackedBarChartProps) {
+export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading }: StackedBarChartProps) {
   const [hoveredDay, setHoveredDay] = useState<string | null>(null);
 
   const allKeys = new Set<string>();
@@ -202,7 +204,13 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         </div>
         );
       })() : (
-        <div className="flex items-center justify-center flex-1 min-h-40 text-sm text-text-muted">No daily data</div>
+        loading === true ? (
+          <div className="flex-1 min-h-40 flex items-center justify-center">
+            <CoinRainLoader height={expanded ? 340 : 160} count={6} />
+          </div>
+        ) : (
+          <div className="flex items-center justify-center flex-1 min-h-40 text-sm text-text-muted">No daily data</div>
+        )
       )}
     </div>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,6 +27,7 @@ export { DimensionSelector } from './components/dimension-selector.js';
 export { PieChart } from './components/pie-chart.js';
 export { StackedBarChart } from './components/stacked-bar-chart.js';
 export { FilterActiveBanner } from './components/filter-active-banner.js';
+export { CoinRainLoader } from './components/coin-rain-loader.js';
 export { useCostFocus, useCostFocusDispatch, useCostFocusReducer, CostFocusProvider, CostFocusDispatchProvider } from './hooks/use-cost-focus.js';
 
 export { CostOverview } from './views/cost-overview.js';

--- a/packages/ui/src/views/cost-overview.tsx
+++ b/packages/ui/src/views/cost-overview.tsx
@@ -40,13 +40,41 @@ function costRowsToSlices(data: CostResult | null): PieSlice[] {
   }));
 }
 
-function dailyCostsToBarDays(data: DailyCostsResult | null): BarDay[] {
+function getISOWeekStart(dateStr: string): string {
+  const d = new Date(dateStr);
+  const day = d.getUTCDay();
+  const diff = (day === 0 ? -6 : 1) - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+function aggregateToWeekly(days: BarDay[]): BarDay[] {
+  const weeks = new Map<string, { total: number; breakdown: Record<string, number> }>();
+  for (const day of days) {
+    const weekStart = getISOWeekStart(day.date);
+    let week = weeks.get(weekStart);
+    if (week === undefined) {
+      week = { total: 0, breakdown: {} };
+      weeks.set(weekStart, week);
+    }
+    week.total += day.total;
+    for (const [key, val] of Object.entries(day.breakdown)) {
+      week.breakdown[key] = (week.breakdown[key] ?? 0) + val;
+    }
+  }
+  return [...weeks.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, data]) => ({ date, total: data.total, breakdown: data.breakdown }));
+}
+
+function dailyCostsToBarDays(data: DailyCostsResult | null, useWeekly: boolean): BarDay[] {
   if (data === null) return [];
-  return data.days.map(d => ({
+  const daily = data.days.map(d => ({
     date: d.date,
     total: d.total,
     breakdown: { ...d.breakdown },
   }));
+  return useWeekly ? aggregateToWeekly(daily) : daily;
 }
 
 function getProductDimensionId(dimensions: Dimension[]): DimensionId | null {
@@ -185,7 +213,9 @@ function OverviewInner() {
     [histogramDimId, dateRangeKey, filterKey, granularity, api],
   );
 
-  const barDays = dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null);
+  const useWeekly = periodDays > 90;
+  const barDays = dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null, useWeekly);
+  const histogramLoading = dailyQuery.status === 'loading';
 
   // Click a pie slice → set as dimension filter
   function handlePieSliceClick(dimId: DimensionId, name: string) {
@@ -299,7 +329,8 @@ function OverviewInner() {
             onTabChange={setHistogramTab}
             expanded={histogramExpanded}
             onExpandToggle={() => { setHistogramExpanded(prev => !prev); }}
-            title={granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs'}
+            title={granularity === 'hourly' ? 'Hourly Costs' : useWeekly ? 'Weekly Costs' : 'Daily Costs'}
+            loading={histogramLoading}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Aggregate daily costs into weekly buckets when date range exceeds 90 days — fixes 365-day histogram rendering invisible 1px bars
- Title dynamically changes to "Weekly Costs" when weekly aggregation is active
- Add CoinRainLoader component with falling coin physics animation (gravity, sway, boundary bounce, respawn)
- Show coin rain animation while histogram query is loading