### PR TITLE
Fix savings filter showing wrong rows

### DIFF
--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -250,7 +250,7 @@ export function Savings() {
                 const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
                 const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
                 return (
-                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}`}>
+                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}-${rec.summary}`}>
                   <tr className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
                     <td className="px-4 py-3 max-w-lg">
                       <div className="flex items-baseline gap-2">


### PR DESCRIPTION
## Summary
- Fix filter badges not working in Savings view — clicking a filter pill showed stale rows from the wrong category
- Root cause: duplicate React keys after removing array index in PR #22 — multiple recommendations for the same resource had identical keys, causing React DOM reuse bugs
- Fix: include `rec.summary` in the key to disambiguate