### PR TITLE
Fix savings filter — restore index in key

### DIFF
--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -250,7 +250,7 @@ export function Savings() {
                 const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
                 const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
                 return (
-                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}-${rec.summary}`}>
+                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}-${String(i)}`}>
                   <tr className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
                     <td className="px-4 py-3 max-w-lg">
                       <div className="flex items-baseline gap-2">


### PR DESCRIPTION
## Summary
- Previous fix (PR #25) still had key collisions — multiple recommendations share the same actionType+resourceArn+accountId+summary
- Restore the array index as part of the composite key — safe here because the list is fully re-filtered on each badge click (not reordered)