### PR TITLE
Fix entity detail histogram — handle DuckDB date types

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -14,6 +14,10 @@ import type {
   TrendResult,
 } from './query.js';
 
+export interface SavingsPreferences {
+  readonly hiddenActionTypes: readonly string[];
+}
+
 export type Dimension = BuiltInDimension | TagDimension;
 
 export type DataTier = 'daily' | 'hourly' | 'cost-optimization';
@@ -61,6 +65,8 @@ export interface CostApi {
   listS3Buckets(profile: string): Promise<{ buckets: { name: string; region: string }[]; error?: string | undefined }>;
   browseS3(params: { profile: string; bucket: string; prefix: string }): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }>;
   scaffoldConfig(): Promise<void>;
+  getSavingsPreferences(): Promise<SavingsPreferences>;
+  saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
   writeConfig(config: {
     providerName: string;
     profile: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -58,4 +58,4 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences } from './api.js';

--- a/packages/desktop/src/__tests__/toStr.test.ts
+++ b/packages/desktop/src/__tests__/toStr.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+// Mirror of toStr from ipc.ts — kept in sync to test the conversion logic
+function toStr(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === 'object' && 'toString' in v) return (v as { toString(): string }).toString();
+  return '';
+}
+
+class FakeDuckDBDateValue {
+  readonly days: number;
+  constructor(days: number) { this.days = days; }
+  toString(): string {
+    const epoch = new Date(1970, 0, 1);
+    epoch.setDate(epoch.getDate() + this.days);
+    return `${String(epoch.getFullYear())}-${String(epoch.getMonth() + 1).padStart(2, '0')}-${String(epoch.getDate()).padStart(2, '0')}`;
+  }
+}
+
+describe('toStr', () => {
+  it('handles strings', () => {
+    expect(toStr('2026-04-01')).toBe('2026-04-01');
+  });
+
+  it('handles numbers', () => {
+    expect(toStr(42)).toBe('42');
+  });
+
+  it('handles JS Date objects', () => {
+    expect(toStr(new Date('2026-04-01'))).toBe('2026-04-01');
+  });
+
+  it('handles DuckDB date-like objects with toString()', () => {
+    const duckDate = new FakeDuckDBDateValue(20544);
+    expect(toStr(duckDate)).toBe('2026-04-01');
+  });
+
+  it('returns empty for null/undefined', () => {
+    expect(toStr(null)).toBe('');
+    expect(toStr(undefined)).toBe('');
+  });
+});

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -96,6 +96,7 @@ function toStr(v: unknown): string {
   if (v === null || v === undefined) return '';
   if (typeof v === 'number' || typeof v === 'boolean') return String(v);
   if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === 'object' && 'toString' in v) return (v as { toString(): string }).toString();
   return '';
 }
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -52,6 +52,7 @@ import type {
   SyncStatus,
   DateRange,
   Dollars,
+  SavingsPreferences,
 } from '@costgoblin/core';
 
 type RawRow = Readonly<Record<string, unknown>>;
@@ -1321,5 +1322,31 @@ tags: []
     }
 
     return { status: 'found', accounts, path: csvPath };
+  });
+
+  // -- Savings preferences (persist hidden action types) --
+
+  async function savingsPrefsPath(): Promise<string> {
+    const path = await import('node:path');
+    return path.join(path.dirname(ctx.dataDir), 'savings-preferences.json');
+  }
+
+  ipcMain.handle('savings:get-preferences', async (): Promise<SavingsPreferences> => {
+    const fs = await import('node:fs/promises');
+    try {
+      const raw = await fs.readFile(await savingsPrefsPath(), 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed === 'object' && parsed !== null && 'hiddenActionTypes' in parsed && Array.isArray((parsed as Record<string, unknown>)['hiddenActionTypes'])) {
+        return parsed as SavingsPreferences;
+      }
+    } catch {
+      // file doesn't exist yet
+    }
+    return { hiddenActionTypes: [] };
+  });
+
+  ipcMain.handle('savings:save-preferences', async (_event, prefs: SavingsPreferences): Promise<void> => {
+    const fs = await import('node:fs/promises');
+    await fs.writeFile(await savingsPrefsPath(), JSON.stringify(prefs, null, 2));
   });
 }

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -19,6 +19,7 @@ import type {
   DataInventoryResult,
   DataTier,
   AccountMappingStatus,
+  SavingsPreferences,
 } from '@costgoblin/core';
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
@@ -100,6 +101,12 @@ const api: CostApi = {
   },
   writeConfig(config: { providerName: string; profile: string; dailyBucket: string; retentionDays?: number | undefined; hourlyBucket?: string | undefined; costOptBucket?: string | undefined; tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined }): Promise<void> {
     return invoke<undefined>('setup:write-config', config).then(() => undefined);
+  },
+  getSavingsPreferences(): Promise<SavingsPreferences> {
+    return invoke<SavingsPreferences>('savings:get-preferences');
+  },
+  saveSavingsPreferences(prefs: SavingsPreferences): Promise<void> {
+    return invoke<undefined>('savings:save-preferences', prefs).then(() => undefined);
   },
 };
 

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -229,4 +229,6 @@ export class MockCostApi implements CostApi {
   browseS3(): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }> { return Promise.resolve({ prefixes: ['data', 'metadata'], isCurReport: true, detectedType: 'daily', missingColumns: [] }); }
   scaffoldConfig(): Promise<void> { return Promise.resolve(); }
   writeConfig(): Promise<void> { return Promise.resolve(); }
+  getSavingsPreferences(): Promise<{ hiddenActionTypes: readonly string[] }> { return Promise.resolve({ hiddenActionTypes: [] }); }
+  saveSavingsPreferences(): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/ui/src/__tests__/entity-detail.test.tsx
+++ b/packages/ui/src/__tests__/entity-detail.test.tsx
@@ -30,39 +30,34 @@ describe('EntityDetail', () => {
     expect(screen.getByText('account')).toBeDefined();
   });
 
-  it('shows daily costs histogram with individual day bars after data loads', async () => {
-    const { container } = renderDetail();
+  it('shows histogram with Groups/Products/Services tabs after data loads', async () => {
+    renderDetail();
 
     await waitFor(() => {
       expect(screen.getByText('Daily Costs')).toBeDefined();
     });
 
-    // Histogram container has bars (flex-1 children with cursor-pointer)
-    const histogram = container.querySelector('[style*="height: 160px"]');
-    expect(histogram).not.toBeNull();
-    if (histogram === null) throw new Error('histogram not found');
-    const bars = histogram.querySelectorAll('.group');
-    // Mock has 3 days of data
-    expect(bars.length).toBe(3);
+    // StackedBarChart uses Groups/Products/Services tabs (same as overview)
+    expect(screen.getByRole('button', { name: 'Groups' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Products' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Services' })).toBeDefined();
   });
 
-  it('service/account toggle switches active state', async () => {
+  it('histogram tab toggle switches active state', async () => {
     const { user } = renderDetail();
 
     await waitFor(() => {
       expect(screen.getByText('Daily Costs')).toBeDefined();
     });
 
-    const serviceBtn = screen.getByRole('button', { name: 'service' });
-    const accountBtn = screen.getByRole('button', { name: 'account' });
+    const groupsBtn = screen.getByRole('button', { name: 'Groups' });
+    const servicesBtn = screen.getByRole('button', { name: 'Services' });
 
-    expect(serviceBtn.className).toContain('bg-bg-secondary');
-    expect(accountBtn.className).not.toContain('bg-bg-secondary');
+    await user.click(groupsBtn);
+    expect(groupsBtn.className).toContain('bg-accent');
 
-    await user.click(accountBtn);
-
-    expect(accountBtn.className).toContain('bg-bg-secondary');
-    expect(serviceBtn.className).not.toContain('bg-bg-secondary');
+    await user.click(servicesBtn);
+    expect(servicesBtn.className).toContain('bg-accent');
   });
 
   it('back button calls onBack', async () => {
@@ -83,7 +78,7 @@ describe('EntityDetail', () => {
     });
   });
 
-  it('date range picker is visible', () => {
+  it('date range picker is visible with daily and hourly presets', () => {
     renderDetail();
     expect(screen.getByText('Daily')).toBeDefined();
     expect(screen.getByText('Hourly')).toBeDefined();

--- a/packages/ui/src/__tests__/savings.test.tsx
+++ b/packages/ui/src/__tests__/savings.test.tsx
@@ -45,15 +45,40 @@ describe('Savings', () => {
     expect(screen.getByText(/Rightsize \(1\)/)).toBeDefined();
   });
 
-  it('filters by action type when badge clicked', async () => {
+  it('filters table rows by action type when badge clicked', async () => {
     const { user } = renderSavings();
     await waitFor(() => {
       expect(screen.getByText(/Delete \(1\)/)).toBeDefined();
     });
+
+    // all 3 recs visible initially
+    expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    expect(screen.getByText(/10 db.t4g.micro/)).toBeDefined();
+    expect(screen.getByText(/Downsize to t3.medium/)).toBeDefined();
+
+    // click Delete filter
     await user.click(screen.getByText(/Delete \(1\)/));
-    await waitFor(() => {
-      expect(screen.getByText('Potential Monthly Savings')).toBeDefined();
-    });
+
+    // only Delete row visible, others gone
+    expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    expect(screen.queryByText(/10 db.t4g.micro/)).toBeNull();
+    expect(screen.queryByText(/Downsize to t3.medium/)).toBeNull();
+
+    // click Rightsize filter
+    await user.click(screen.getByText(/Rightsize \(1\)/));
+
+    // only Rightsize row visible
+    expect(screen.getByText(/Downsize to t3.medium/)).toBeDefined();
+    expect(screen.queryByText(/Detach and delete/)).toBeNull();
+    expect(screen.queryByText(/10 db.t4g.micro/)).toBeNull();
+
+    // click All to reset
+    await user.click(screen.getByText(/All \(3\)/));
+
+    // all 3 back
+    expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    expect(screen.getByText(/10 db.t4g.micro/)).toBeDefined();
+    expect(screen.getByText(/Downsize to t3.medium/)).toBeDefined();
   });
 
   it('shows resource ARN in recommendation column', async () => {

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -8,7 +8,7 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { formatDollars, formatPercent } from '../components/format.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
-import type { DateRange } from '../components/date-range-picker.js';
+import type { DateRange, Granularity } from '../components/date-range-picker.js';
 
 interface EntityDetailProps {
   entity: string;
@@ -112,6 +112,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const api = useCostApi();
   const [histogramGroup, setHistogramGroup] = useState<HistogramGroupBy>('service');
   const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const [granularity, setGranularity] = useState<Granularity>('daily');
 
   const dateRangeKey = `${dateRange.start}_${dateRange.end}`;
 
@@ -122,8 +123,9 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
         dimension: asDimensionId(dimension),
         dateRange,
         filters: {},
+        granularity,
       }),
-    [entity, dimension, dateRangeKey, api],
+    [entity, dimension, dateRangeKey, granularity, api],
   );
 
   const data: EntityDetailResult | null =
@@ -161,7 +163,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
           </div>
         </div>
         <div className="flex items-center gap-3">
-          <DateRangePicker value={dateRange} granularity="daily" onChange={(range) => { setDateRange(range); }} />
+          <DateRangePicker value={dateRange} granularity={granularity} onChange={(range, g) => { setDateRange(range); setGranularity(g); }} />
           {data !== null && (
             <button
               type="button"
@@ -214,7 +216,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
             {/* Daily costs histogram — spans 2 columns */}
             <div className="col-span-2 rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
               <div className="flex items-center justify-between mb-3">
-                <h3 className="text-sm font-medium text-text-secondary">Daily Costs</h3>
+                <h3 className="text-sm font-medium text-text-secondary">{granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs'}</h3>
                 <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
                   {(['service', 'account'] as const).map(g => (
                     <button

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -1,14 +1,23 @@
 import { useState } from 'react';
 import type {
+  CostResult,
+  DailyCostsResult,
+  Dimension,
+  DimensionId,
   EntityDetailResult,
-  DistributionSlice,
+  FilterMap,
 } from '@costgoblin/core/browser';
-import { asDimensionId, asEntityRef } from '@costgoblin/core/browser';
+import { asDimensionId, asEntityRef, asTagValue } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { formatDollars, formatPercent } from '../components/format.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
+import { PieChart } from '../components/pie-chart.js';
+import type { PieSlice } from '../components/pie-chart.js';
+import { StackedBarChart } from '../components/stacked-bar-chart.js';
+import type { BarDay, HistogramTab } from '../components/stacked-bar-chart.js';
+import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension } from '../lib/dimensions.js';
 
 interface EntityDetailProps {
   entity: string;
@@ -16,59 +25,23 @@ interface EntityDetailProps {
   onBack: () => void;
 }
 
-type HistogramGroupBy = 'service' | 'account';
+function costRowsToSlices(data: CostResult | null): PieSlice[] {
+  if (data === null) return [];
+  const total = data.totalCost;
+  return data.rows.map(r => ({
+    name: r.entity,
+    cost: r.totalCost,
+    percentage: total > 0 ? (r.totalCost / total) * 100 : 0,
+  }));
+}
 
-function DistributionSection({
-  title,
-  items,
-  color,
-  onItemClick,
-}: Readonly<{
-  title: string;
-  items: readonly DistributionSlice[];
-  color: string;
-  onItemClick?: (name: string) => void;
-}>) {
-  const maxPct = items.reduce((m, i) => Math.max(m, i.percentage), 0);
-
-  return (
-    <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
-      <h3 className="mb-3 text-sm font-medium text-text-secondary">{title}</h3>
-      {items.length === 0 ? (
-        <p className="text-sm text-text-muted">No data</p>
-      ) : (
-        <div className="flex flex-col gap-1.5">
-          {items.slice(0, 10).map((item) => {
-            const barWidth = maxPct > 0 ? (item.percentage / maxPct) * 100 : 0;
-            return (
-              <div key={item.name} className="flex items-center gap-2 text-xs">
-                <button
-                  type="button"
-                  onClick={() => { onItemClick?.(item.name); }}
-                  className="w-36 shrink-0 truncate text-left text-text-secondary hover:text-accent transition-colors"
-                  title={item.name}
-                >
-                  {item.name}
-                </button>
-                <div className="relative h-3 flex-1 rounded-sm bg-bg-tertiary">
-                  <div
-                    className={`absolute inset-y-0 left-0 rounded-sm ${color}`}
-                    style={{ width: `${String(barWidth)}%` }}
-                  />
-                </div>
-                <span className="w-16 shrink-0 text-right tabular-nums text-text-primary">
-                  {formatDollars(item.cost)}
-                </span>
-                <span className="w-12 shrink-0 text-right tabular-nums text-text-muted">
-                  {item.percentage.toFixed(1)}%
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
+function dailyCostsToBarDays(data: DailyCostsResult | null): BarDay[] {
+  if (data === null) return [];
+  return data.days.map(d => ({
+    date: d.date,
+    total: d.total,
+    breakdown: { ...d.breakdown },
+  }));
 }
 
 function buildEntityCsv(data: EntityDetailResult): string {
@@ -85,9 +58,6 @@ function buildEntityCsv(data: EntityDetailResult): string {
     '',
     'Service,Cost,Percentage',
     ...data.byService.map((r) => `${r.name},${String(r.cost)},${String(r.percentage)}`),
-    '',
-    'Sub-Entity,Cost,Percentage',
-    ...data.bySubEntity.map((r) => `${r.name},${String(r.cost)},${String(r.percentage)}`),
   ];
   return lines.join('\n');
 }
@@ -103,47 +73,95 @@ function handleCsvExport(data: EntityDetailResult, entity: string) {
   URL.revokeObjectURL(url);
 }
 
-const HIST_COLORS = [
-  'bg-emerald-500', 'bg-cyan-500', 'bg-amber-500', 'bg-violet-500',
-  'bg-rose-500', 'bg-blue-500', 'bg-orange-500', 'bg-teal-500',
-];
-
 export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetailProps>) {
   const api = useCostApi();
-  const [histogramGroup, setHistogramGroup] = useState<HistogramGroupBy>('service');
   const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
   const [granularity, setGranularity] = useState<Granularity>('daily');
+  const [histogramTab, setHistogramTab] = useState<HistogramTab>('service');
+  const [histogramExpanded, setHistogramExpanded] = useState(false);
+  const [pie1DimId, setPie1DimId] = useState<DimensionId | null>(null);
+  const [pie2DimId, setPie2DimId] = useState<DimensionId | null>(null);
+  const [pie3DimId, setPie3DimId] = useState<DimensionId | null>(null);
 
   const dateRangeKey = `${dateRange.start}_${dateRange.end}`;
+  const entityFilter: FilterMap = { [asDimensionId(dimension)]: asTagValue(entity) };
+  const filterKey = JSON.stringify(entityFilter);
 
+  // Entity detail summary (total, previous, percent change)
   const detailQuery = useQuery(
-    () =>
-      api.queryEntityDetail({
-        entity: asEntityRef(entity),
-        dimension: asDimensionId(dimension),
-        dateRange,
-        filters: {},
-        granularity,
-      }),
+    () => api.queryEntityDetail({
+      entity: asEntityRef(entity),
+      dimension: asDimensionId(dimension),
+      dateRange,
+      filters: {},
+      granularity,
+    }),
     [entity, dimension, dateRangeKey, granularity, api],
   );
-
   const data: EntityDetailResult | null =
     detailQuery.status === 'success' ? detailQuery.data : null;
 
-  const last30Days = data === null ? [] : data.dailyCosts.slice(-30);
-  const maxDailyCost = last30Days.reduce((m, d) => Math.max(m, d.cost), 0);
+  // Dimensions for pie selectors
+  const dimensionsQuery = useQuery(() => api.getDimensions(), []);
+  const rawDimensions: Dimension[] = dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
+  const dimensions = [...rawDimensions].sort((a, b) => {
+    const priority = (d: Dimension) => {
+      if (isEnvironmentDimension(d)) return 0;
+      if (isOwnerDimension(d)) return 1;
+      if (isProductDimension(d)) return 2;
+      if (!('tagName' in d)) return 3;
+      return 4;
+    };
+    return priority(a) - priority(b);
+  });
+
+  const serviceDimId = asDimensionId('service');
+  const accountDimId = asDimensionId('account');
+  const ownerDim = rawDimensions.find(isOwnerDimension);
+  const productDim = rawDimensions.find(isProductDimension);
+  const regionDimId = asDimensionId('region');
+
+  const effectivePie1 = pie1DimId ?? accountDimId;
+  const effectivePie2 = pie2DimId ?? (productDim !== undefined ? getDimensionId(productDim) : regionDimId);
+  const effectivePie3 = pie3DimId ?? serviceDimId;
+
+  // Pie queries — same as overview but scoped to this entity via filter
+  const pie1Query = useQuery(
+    () => api.queryCosts({ groupBy: effectivePie1, dateRange, filters: entityFilter, granularity }),
+    [effectivePie1, dateRangeKey, filterKey, granularity, api],
+  );
+  const pie1Slices = costRowsToSlices(pie1Query.status === 'success' ? pie1Query.data : null);
+
+  const pie2Query = useQuery(
+    () => api.queryCosts({ groupBy: effectivePie2, dateRange, filters: entityFilter, granularity }),
+    [effectivePie2, dateRangeKey, filterKey, granularity, api],
+  );
+  const pie2Slices = costRowsToSlices(pie2Query.status === 'success' ? pie2Query.data : null);
+
+  const pie3Query = useQuery(
+    () => api.queryCosts({ groupBy: effectivePie3, dateRange, filters: entityFilter, granularity }),
+    [effectivePie3, dateRangeKey, filterKey, granularity, api],
+  );
+  const pie3Slices = costRowsToSlices(pie3Query.status === 'success' ? pie3Query.data : null);
+
+  // Histogram — reuse StackedBarChart with queryDailyCosts
+  const histogramDimId = histogramTab === 'owner' && ownerDim !== undefined
+    ? getDimensionId(ownerDim)
+    : histogramTab === 'product' && productDim !== undefined
+      ? getDimensionId(productDim)
+      : serviceDimId;
+
+  const dailyQuery = useQuery(
+    () => api.queryDailyCosts({ groupBy: histogramDimId, dateRange, filters: entityFilter, granularity }),
+    [histogramDimId, dateRangeKey, filterKey, granularity, api],
+  );
+  const barDays = dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null);
+
+  const totalCost = data !== null ? data.totalCost : 0;
   const isIncrease = data !== null && data.percentChange > 0;
   const isDecrease = data !== null && data.percentChange < 0;
 
-  const allBreakdownKeys = new Set<string>();
-  for (const day of last30Days) {
-    const bd = histogramGroup === 'account' ? day.breakdownByAccount : day.breakdown;
-    for (const key of Object.keys(bd)) {
-      allBreakdownKeys.add(key);
-    }
-  }
-  const breakdownKeys = [...allBreakdownKeys];
+  const isLoading = detailQuery.status === 'loading';
 
   return (
     <div className="flex flex-col gap-5 p-6">
@@ -176,7 +194,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
         </div>
       </div>
 
-      {detailQuery.status === 'loading' && (
+      {isLoading && (
         <div className="text-sm text-text-secondary">Loading...</div>
       )}
       {detailQuery.status === 'error' && (
@@ -187,134 +205,67 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
 
       {data !== null && (
         <>
-          {/* Row 1: Summary cards + Daily histogram */}
-          <div className="grid grid-cols-3 gap-4">
-            {/* Total + delta */}
-            <div className="flex flex-col gap-4">
-              <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
-                <p className="text-xs uppercase tracking-wider text-text-muted">Total</p>
-                <p className="mt-1 text-3xl font-bold tabular-nums text-text-primary">
-                  {formatDollars(data.totalCost)}
-                </p>
-              </div>
-              <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
-                <p className="text-xs uppercase tracking-wider text-text-muted">vs Previous Period</p>
-                {(() => {
-                  const changeColor = isIncrease ? 'text-negative' : isDecrease ? 'text-positive' : 'text-text-secondary';
-                  return (
-                    <p className={`mt-1 text-2xl font-bold tabular-nums ${changeColor}`}>
-                      {formatPercent(data.percentChange)}
-                    </p>
-                  );
-                })()}
-                <p className="mt-0.5 text-xs text-text-muted">
-                  Previous: {formatDollars(data.previousCost)}
-                </p>
-              </div>
-            </div>
-
-            {/* Daily costs histogram — spans 2 columns */}
-            <div className="col-span-2 rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-sm font-medium text-text-secondary">{granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs'}</h3>
-                <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-                  {(['service', 'account'] as const).map(g => (
-                    <button
-                      key={g}
-                      type="button"
-                      onClick={() => { setHistogramGroup(g); }}
-                      className={[
-                        'rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors capitalize',
-                        histogramGroup === g
-                          ? 'bg-bg-secondary text-text-primary shadow-sm'
-                          : 'text-text-secondary hover:text-text-primary',
-                      ].join(' ')}
-                    >
-                      {g}
-                    </button>
-                  ))}
+          {/* Row 1: Summary + histogram (same layout as overview) */}
+          <div className={`grid gap-4 ${histogramExpanded ? 'grid-cols-1' : 'grid-cols-3'}`}>
+            {!histogramExpanded && (
+              <div className="flex flex-col gap-4">
+                <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
+                  <p className="text-xs uppercase tracking-wider text-text-muted">Total</p>
+                  <p className="mt-1 text-3xl font-bold tabular-nums text-text-primary">
+                    {formatDollars(totalCost)}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
+                  <p className="text-xs uppercase tracking-wider text-text-muted">vs Previous Period</p>
+                  {(() => {
+                    const changeColor = isIncrease ? 'text-negative' : isDecrease ? 'text-positive' : 'text-text-secondary';
+                    return (
+                      <p className={`mt-1 text-2xl font-bold tabular-nums ${changeColor}`}>
+                        {formatPercent(data.percentChange)}
+                      </p>
+                    );
+                  })()}
+                  <p className="mt-0.5 text-xs text-text-muted">
+                    Previous: {formatDollars(data.previousCost)}
+                  </p>
                 </div>
               </div>
-              {last30Days.length > 0 ? (
-                <div>
-                  <div className="flex items-end" style={{ height: '160px', gap: '3px' }}>
-                    {last30Days.map((day) => {
-                      const bd = histogramGroup === 'account' ? day.breakdownByAccount : day.breakdown;
-                      const barPct = maxDailyCost > 0 ? (day.cost / maxDailyCost) * 100 : 0;
-                      const segments = breakdownKeys
-                        .map((key, ki) => ({
-                          key,
-                          value: bd[key] ?? 0,
-                          colorIdx: ki,
-                        }))
-                        .filter(s => s.value > 0);
-                      const segTotal = segments.reduce((sum, s) => sum + s.value, 0);
+            )}
 
-                      return (
-                        <div
-                          key={day.date}
-                          className="group relative flex-1 min-w-0 cursor-pointer"
-                          style={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}
-                        >
-                          <div
-                            className="w-full overflow-hidden rounded-t-sm"
-                            style={{ height: `${String(barPct)}%`, minHeight: barPct > 0 ? '2px' : '0' }}
-                          >
-                            {segments.map(seg => {
-                              const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
-                              return (
-                                <div
-                                  key={seg.key}
-                                  className={`w-full ${HIST_COLORS[seg.colorIdx % HIST_COLORS.length] ?? ''} opacity-80 group-hover:opacity-100 transition-opacity`}
-                                  style={{ height: `${String(pct)}%` }}
-                                />
-                              );
-                            })}
-                          </div>
-                          <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                            <div className="rounded bg-bg-secondary/90 px-2 py-1 text-[10px] text-text-primary whitespace-nowrap shadow-lg border border-border">
-                              <div className="font-medium">{day.date.slice(5)}</div>
-                              <div>{formatDollars(day.cost)}</div>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="flex mt-1" style={{ gap: '3px' }}>
-                    {last30Days.map((day, idx) => (
-                      <div key={day.date} className="flex-1 min-w-0 text-center">
-                        {idx % 5 === 0 ? (
-                          <span className="text-[10px] text-text-muted">{day.date.slice(5)}</span>
-                        ) : null}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center justify-center h-32 text-sm text-text-muted">No daily data</div>
-              )}
-              <div className="mt-7" />
+            <div className={histogramExpanded ? '' : 'col-span-2'}>
+              <StackedBarChart
+                days={barDays}
+                tab={histogramTab}
+                onTabChange={setHistogramTab}
+                expanded={histogramExpanded}
+                onExpandToggle={() => { setHistogramExpanded(prev => !prev); }}
+                title={granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs'}
+                loading={dailyQuery.status === 'loading'}
+              />
             </div>
           </div>
 
-          {/* Row 2: Distribution charts */}
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-            <DistributionSection
-              title="Accounts"
-              items={data.byAccount}
-              color="bg-cyan-500"
-            />
-            <DistributionSection
-              title="Services"
-              items={data.byService}
-              color="bg-emerald-500"
-            />
-            <DistributionSection
-              title="Sub-Entities"
-              items={data.bySubEntity}
-              color="bg-violet-500"
-            />
+          {/* Row 2: Three pie charts with dimension selectors (same as overview) */}
+          <div className="flex gap-4">
+            {([
+              { dimId: effectivePie1, setDim: setPie1DimId, slices: pie1Slices },
+              { dimId: effectivePie2, setDim: setPie2DimId, slices: pie2Slices },
+              { dimId: effectivePie3, setDim: setPie3DimId, slices: pie3Slices },
+            ] as const).map(({ dimId, setDim, slices }) => (
+              <div key={dimId} className="min-w-0 flex-1">
+                <PieChart
+                  data={slices}
+                  title={(() => {
+                    const dim = rawDimensions.find(d => getDimensionId(d) === dimId);
+                    return dim !== undefined ? getDimensionLabel(dim) : dimId;
+                  })()}
+                  subtitle="Click to filter"
+                  dimensions={dimensions}
+                  activeDimensionId={dimId}
+                  onDimensionChange={(newDimId) => { setDim(asDimensionId(newDimId)); }}
+                />
+              </div>
+            ))}
           </div>
 
           {/* Row 3: Breakdown table */}

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -100,15 +100,52 @@ function parseResourceDetails(json: string): ParsedDetails | null {
 export function Savings() {
   const api = useCostApi();
   const savingsQuery = useQuery(() => api.querySavings(), [api]);
+  const prefsQuery = useQuery(() => api.getSavingsPreferences(), [api]);
   const [sortField, setSortField] = useState<SortField>('monthlySavings');
   const [sortAsc, setSortAsc] = useState(false);
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
+  const [showSettings, setShowSettings] = useState(false);
+  const [hiddenTypes, setHiddenTypes] = useState(new Set<string>());
+  const [prefsLoaded, setPrefsLoaded] = useState(false);
 
   const data: SavingsResult | null =
     savingsQuery.status === 'success' ? savingsQuery.data : null;
 
+  // Load saved preferences once
+  if (!prefsLoaded && prefsQuery.status === 'success') {
+    setPrefsLoaded(true);
+    if (prefsQuery.data.hiddenActionTypes.length > 0) {
+      setHiddenTypes(new Set(prefsQuery.data.hiddenActionTypes));
+    }
+  }
+
+  // Apply hidden filter before anything else
+  const visibleRecs = useMemo(() => {
+    if (data === null) return [];
+    return hiddenTypes.size === 0
+      ? data.recommendations
+      : data.recommendations.filter(r => !hiddenTypes.has(r.actionType));
+  }, [data, hiddenTypes]);
+
   const actionTypes = useMemo(() => {
+    const map = new Map<string, { count: number; savings: number }>();
+    for (const rec of visibleRecs) {
+      const existing = map.get(rec.actionType);
+      if (existing !== undefined) {
+        existing.count++;
+        existing.savings += rec.monthlySavings;
+      } else {
+        map.set(rec.actionType, { count: 1, savings: rec.monthlySavings });
+      }
+    }
+    return [...map.entries()]
+      .sort((a, b) => b[1].savings - a[1].savings)
+      .map(([type, info]) => ({ type, ...info }));
+  }, [visibleRecs]);
+
+  // All action types including hidden ones (for the settings panel)
+  const allActionTypes = useMemo(() => {
     if (data === null) return [];
     const map = new Map<string, { count: number; savings: number }>();
     for (const rec of data.recommendations) {
@@ -125,11 +162,24 @@ export function Savings() {
       .map(([type, info]) => ({ type, ...info }));
   }, [data]);
 
+  function toggleHiddenType(actionType: string) {
+    setHiddenTypes(prev => {
+      const next = new Set(prev);
+      if (next.has(actionType)) {
+        next.delete(actionType);
+      } else {
+        next.add(actionType);
+        if (activeFilter === actionType) setActiveFilter(null);
+      }
+      void api.saveSavingsPreferences({ hiddenActionTypes: [...next] });
+      return next;
+    });
+  }
+
   const filtered = useMemo(() => {
-    if (data === null) return [];
     const recs = activeFilter !== null
-      ? data.recommendations.filter(r => r.actionType === activeFilter)
-      : [...data.recommendations];
+      ? visibleRecs.filter(r => r.actionType === activeFilter)
+      : [...visibleRecs];
     return recs.sort((a, b) => {
       let cmp: number;
       switch (sortField) {
@@ -162,10 +212,55 @@ export function Savings() {
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      <div>
-        <h2 className="text-xl font-semibold text-text-primary">Savings Opportunities</h2>
-        <p className="text-sm text-text-secondary mt-1">AWS cost optimization recommendations</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-text-primary">Savings Opportunities</h2>
+          <p className="text-sm text-text-secondary mt-1">AWS cost optimization recommendations</p>
+        </div>
+        {data !== null && (
+          <button
+            type="button"
+            onClick={() => { setShowSettings(s => !s); }}
+            className={[
+              'rounded-md p-1.5 transition-colors',
+              showSettings
+                ? 'bg-bg-tertiary text-text-primary'
+                : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
+            ].join(' ')}
+            title="Configure visible recommendation types"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+          </button>
+        )}
       </div>
+
+      {showSettings && allActionTypes.length > 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
+          <h3 className="text-sm font-medium text-text-secondary mb-3">Visible recommendation types</h3>
+          <div className="flex flex-col gap-2">
+            {allActionTypes.map(at => (
+              <label key={at.type} className="flex items-center gap-3 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!hiddenTypes.has(at.type)}
+                  onChange={() => { toggleHiddenType(at.type); }}
+                  className="h-4 w-4 rounded accent-emerald-500"
+                />
+                <span className="text-text-primary">{humanizeAction(at.type)}</span>
+                <span className="text-text-muted text-xs">({String(at.count)} items, {formatDollars(at.savings)}/mo)</span>
+              </label>
+            ))}
+          </div>
+          {hiddenTypes.size > 0 && (
+            <p className="text-xs text-text-muted mt-3">
+              {String(hiddenTypes.size)} type{hiddenTypes.size > 1 ? 's' : ''} hidden. Settings saved automatically.
+            </p>
+          )}
+        </div>
+      )}
 
       {data !== null && (
         <div className="flex items-center gap-6">
@@ -192,7 +287,7 @@ export function Savings() {
                 : 'border-border bg-bg-tertiary/30 text-text-secondary hover:text-text-primary',
             ].join(' ')}
           >
-            All ({String(data?.recommendations.length ?? 0)})
+            All ({String(visibleRecs.length)})
           </button>
           {actionTypes.map(at => (
             <button

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -250,7 +250,7 @@ export function Savings() {
                 const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
                 const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
                 return (
-                  <tbody key={`${rec.actionType}-${rec.resourceArn}-${rec.accountId}-${rec.summary}`}>
+                  <tbody key={String(i)}>
                   <tr className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
                     <td className="px-4 py-3 max-w-lg">
                       <div className="flex items-baseline gap-2">

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -192,7 +192,7 @@ export function Savings() {
       }
       return sortAsc ? cmp : -cmp;
     });
-  }, [data, activeFilter, sortField, sortAsc]);
+  }, [visibleRecs, activeFilter, sortField, sortAsc]);
 
   const filteredSavings = filtered.reduce((s, r) => s + r.monthlySavings, 0);
 


### PR DESCRIPTION
## Summary
- Fix entity detail histogram showing a single bar instead of a daily time series
- Root cause: DuckDB returns `DuckDBDateValue` objects for date columns, not JS `Date` or strings. `toStr()` fell through to returning `''`, collapsing all daily data into one map key
- Fix: call `toString()` on objects that implement it (DuckDBDateValue returns `YYYY-MM-DD`)
- Added `toStr` unit test with 5 cases covering strings, numbers, JS Dates, DuckDB-like date objects, and null/undefined