### PR TITLE
Add AWS Organizations integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,6 +306,56 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-organizations": {
+      "version": "3.1029.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.1029.0.tgz",
+      "integrity": "sha512-6Ag8ozoVc80+XVNjOwNtR3obCV+Bn3Svc9Ha7T+YApH6HwNUUC9WgnOXfbgXeVBhnaFxGSrf8kWj4XeM4d/tIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1025.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1025.0.tgz",
@@ -373,22 +423,22 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
-      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -410,15 +460,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
-      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -426,20 +476,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
-      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -447,24 +497,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
-      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-login": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -472,18 +522,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
-      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -491,22 +541,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
-      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-ini": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -514,16 +564,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
-      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -531,18 +581,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
-      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/token-providers": "3.1021.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -550,17 +600,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
-      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -626,14 +676,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -655,13 +705,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -669,15 +719,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/types": "^3.973.7",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -724,18 +774,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
-      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-retry": "^4.2.13",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-retry": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -743,47 +793,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
-      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -792,15 +842,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -825,17 +875,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
-      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -843,12 +893,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -868,15 +918,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-endpoints": "^3.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -896,27 +946,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
-      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -933,12 +983,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
@@ -8438,9 +8488,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -9252,9 +9302,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -10079,6 +10129,7 @@
       "name": "@costgoblin/desktop",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-organizations": "^3.1029.0",
         "@aws-sdk/client-s3": "^3.1025.0",
         "@costgoblin/core": "*",
         "@costgoblin/ui": "*",

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -18,6 +18,28 @@ export interface SavingsPreferences {
   readonly hiddenActionTypes: readonly string[];
 }
 
+export interface OrgAccount {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly status: string;
+  readonly joinedTimestamp: string;
+  readonly ouPath: string;
+  readonly tags: Readonly<Record<string, string>>;
+}
+
+export interface OrgSyncResult {
+  readonly accounts: readonly OrgAccount[];
+  readonly orgId: string;
+  readonly syncedAt: string;
+}
+
+export interface OrgSyncProgress {
+  readonly phase: 'accounts' | 'ous' | 'tags';
+  readonly done: number;
+  readonly total: number;
+}
+
 export type Dimension = BuiltInDimension | TagDimension;
 
 export type DataTier = 'daily' | 'hourly' | 'cost-optimization';
@@ -67,6 +89,9 @@ export interface CostApi {
   scaffoldConfig(): Promise<void>;
   getSavingsPreferences(): Promise<SavingsPreferences>;
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
+  syncOrgAccounts(profile: string): Promise<OrgSyncResult>;
+  getOrgSyncResult(): Promise<OrgSyncResult | null>;
+  getOrgSyncProgress(): Promise<OrgSyncProgress | null>;
   writeConfig(config: {
     providerName: string;
     profile: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -58,4 +58,4 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -10,6 +10,7 @@
     "dev": "electron-vite dev"
   },
   "dependencies": {
+    "@aws-sdk/client-organizations": "^3.1029.0",
     "@aws-sdk/client-s3": "^3.1025.0",
     "@costgoblin/core": "*",
     "@costgoblin/ui": "*",
@@ -17,17 +18,17 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
-    "electron": "^34.0.0",
-    "electron-vite": "^3.0.0",
-    "vite": "^6.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
-    "vitest": "^3.0.0",
-    "typescript": "^5.7.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "@tailwindcss/vite": "^4.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "electron": "^34.0.0",
+    "electron-vite": "^3.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0"
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/desktop/src/main/aws-org-client.ts
+++ b/packages/desktop/src/main/aws-org-client.ts
@@ -1,0 +1,180 @@
+import { logger } from '@costgoblin/core';
+
+interface OrgAccount {
+  id: string;
+  name: string;
+  email: string;
+  status: string;
+  joinedTimestamp: string;
+  ouPath: string;
+  tags: Record<string, string>;
+}
+
+interface OrgSyncProgress {
+  phase: 'accounts' | 'ous' | 'tags';
+  done: number;
+  total: number;
+}
+
+interface OrgSyncResult {
+  accounts: OrgAccount[];
+  orgId: string;
+  syncedAt: string;
+}
+
+interface OUNode {
+  id: string;
+  name: string;
+  parentId: string;
+}
+
+async function getOrganizationsModule(): Promise<typeof import('@aws-sdk/client-organizations')> {
+  return import('@aws-sdk/client-organizations');
+}
+
+export async function syncOrgAccounts(
+  profile: string,
+  onProgress?: (progress: OrgSyncProgress) => void,
+): Promise<OrgSyncResult> {
+  const {
+    OrganizationsClient,
+    ListAccountsCommand,
+    ListRootsCommand,
+    ListOrganizationalUnitsForParentCommand,
+    ListAccountsForParentCommand,
+    ListTagsForResourceCommand,
+    DescribeOrganizationCommand,
+  } = await getOrganizationsModule();
+
+  const config = profile === 'default' ? {} : { profile };
+  const client = new OrganizationsClient(config);
+
+  // Get org ID
+  const orgResp = await client.send(new DescribeOrganizationCommand({}));
+  const orgId = orgResp.Organization?.Id ?? 'unknown';
+
+  // 1. List all accounts
+  onProgress?.({ phase: 'accounts', done: 0, total: 0 });
+  const allAccounts: { id: string; name: string; email: string; status: string; joinedTimestamp: string }[] = [];
+  let nextToken: string | undefined;
+  do {
+    const resp = await client.send(new ListAccountsCommand({ NextToken: nextToken }));
+    for (const acct of resp.Accounts ?? []) {
+      allAccounts.push({
+        id: acct.Id ?? '',
+        name: acct.Name ?? '',
+        email: acct.Email ?? '',
+        status: acct.Status ?? 'UNKNOWN',
+        joinedTimestamp: acct.JoinedTimestamp?.toISOString() ?? '',
+      });
+    }
+    nextToken = resp.NextToken;
+    onProgress?.({ phase: 'accounts', done: allAccounts.length, total: allAccounts.length });
+  } while (nextToken !== undefined);
+
+  logger.info(`Discovered ${String(allAccounts.length)} accounts`);
+
+  // 2. Build OU tree to resolve paths
+  onProgress?.({ phase: 'ous', done: 0, total: 0 });
+  const roots = await client.send(new ListRootsCommand({}));
+  const rootId = roots.Roots?.[0]?.Id ?? '';
+
+  const ouNodes: OUNode[] = [];
+  const queue = [rootId];
+  while (queue.length > 0) {
+    const parentId = queue.shift();
+    if (parentId === undefined) break;
+    let ouToken: string | undefined;
+    do {
+      const resp = await client.send(new ListOrganizationalUnitsForParentCommand({
+        ParentId: parentId,
+        NextToken: ouToken,
+      }));
+      for (const ou of resp.OrganizationalUnits ?? []) {
+        if (ou.Id !== undefined) {
+          ouNodes.push({ id: ou.Id, name: ou.Name ?? '', parentId });
+          queue.push(ou.Id);
+        }
+      }
+      ouToken = resp.NextToken;
+    } while (ouToken !== undefined);
+    onProgress?.({ phase: 'ous', done: ouNodes.length, total: ouNodes.length });
+  }
+
+  // Build a map of account → parent OU
+  const accountParentMap = new Map<string, string>();
+  const parentsToScan = [rootId, ...ouNodes.map(ou => ou.id)];
+  for (const parentId of parentsToScan) {
+    let acctToken: string | undefined;
+    do {
+      const resp = await client.send(new ListAccountsForParentCommand({
+        ParentId: parentId,
+        NextToken: acctToken,
+      }));
+      for (const acct of resp.Accounts ?? []) {
+        if (acct.Id !== undefined) {
+          accountParentMap.set(acct.Id, parentId);
+        }
+      }
+      acctToken = resp.NextToken;
+    } while (acctToken !== undefined);
+  }
+
+  // Resolve OU path for each account
+  const ouMap = new Map(ouNodes.map(ou => [ou.id, ou]));
+  function resolveOuPath(accountId: string): string {
+    const parts: string[] = [];
+    let current = accountParentMap.get(accountId);
+    while (current !== undefined && current !== rootId) {
+      const ou = ouMap.get(current);
+      if (ou === undefined) break;
+      parts.unshift(ou.name);
+      current = ou.parentId;
+    }
+    return parts.join(' / ');
+  }
+
+  // 3. Fetch tags for each account
+  const results: OrgAccount[] = [];
+  for (let i = 0; i < allAccounts.length; i++) {
+    const acct = allAccounts[i];
+    if (acct === undefined) continue;
+    onProgress?.({ phase: 'tags', done: i, total: allAccounts.length });
+
+    const tags: Record<string, string> = {};
+    try {
+      let tagToken: string | undefined;
+      do {
+        const resp = await client.send(new ListTagsForResourceCommand({
+          ResourceId: acct.id,
+          NextToken: tagToken,
+        }));
+        for (const tag of resp.Tags ?? []) {
+          if (tag.Key !== undefined && tag.Value !== undefined) {
+            tags[tag.Key] = tag.Value;
+          }
+        }
+        tagToken = resp.NextToken;
+      } while (tagToken !== undefined);
+    } catch {
+      logger.info(`Failed to fetch tags for ${acct.id}, skipping`);
+    }
+
+    results.push({
+      ...acct,
+      ouPath: resolveOuPath(acct.id),
+      tags,
+    });
+  }
+  onProgress?.({ phase: 'tags', done: allAccounts.length, total: allAccounts.length });
+
+  logger.info(`Org sync complete: ${String(results.length)} accounts with tags`);
+
+  return {
+    accounts: results,
+    orgId,
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+export type { OrgAccount, OrgSyncProgress, OrgSyncResult };

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -53,7 +53,10 @@ import type {
   DateRange,
   Dollars,
   SavingsPreferences,
+  OrgSyncResult,
+  OrgSyncProgress,
 } from '@costgoblin/core';
+import { syncOrgAccounts } from './aws-org-client.js';
 
 type RawRow = Readonly<Record<string, unknown>>;
 type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
@@ -1348,5 +1351,42 @@ tags: []
   ipcMain.handle('savings:save-preferences', async (_event, prefs: SavingsPreferences): Promise<void> => {
     const fs = await import('node:fs/promises');
     await fs.writeFile(await savingsPrefsPath(), JSON.stringify(prefs, null, 2));
+  });
+
+  // -- AWS Organizations sync --
+
+  let orgSyncProgress: OrgSyncProgress | null = null;
+
+  async function orgResultPath(): Promise<string> {
+    const path = await import('node:path');
+    return path.join(path.dirname(ctx.dataDir), 'org-accounts.json');
+  }
+
+  ipcMain.handle('org:sync-accounts', async (_event, profile: string): Promise<OrgSyncResult> => {
+    orgSyncProgress = { phase: 'accounts', done: 0, total: 0 };
+    try {
+      const result = await syncOrgAccounts(profile, (p) => { orgSyncProgress = p; });
+      const fs = await import('node:fs/promises');
+      await fs.writeFile(await orgResultPath(), JSON.stringify(result, null, 2));
+      orgSyncProgress = null;
+      return result;
+    } catch (err: unknown) {
+      orgSyncProgress = null;
+      throw err;
+    }
+  });
+
+  ipcMain.handle('org:get-result', async (): Promise<OrgSyncResult | null> => {
+    const fs = await import('node:fs/promises');
+    try {
+      const raw = await fs.readFile(await orgResultPath(), 'utf-8');
+      return JSON.parse(raw) as OrgSyncResult;
+    } catch {
+      return null;
+    }
+  });
+
+  ipcMain.handle('org:get-progress', (): OrgSyncProgress | null => {
+    return orgSyncProgress;
   });
 }

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -20,6 +20,8 @@ import type {
   DataTier,
   AccountMappingStatus,
   SavingsPreferences,
+  OrgSyncResult,
+  OrgSyncProgress,
 } from '@costgoblin/core';
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
@@ -107,6 +109,15 @@ const api: CostApi = {
   },
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void> {
     return invoke<undefined>('savings:save-preferences', prefs).then(() => undefined);
+  },
+  syncOrgAccounts(profile: string): Promise<OrgSyncResult> {
+    return invoke<OrgSyncResult>('org:sync-accounts', profile);
+  },
+  getOrgSyncResult(): Promise<OrgSyncResult | null> {
+    return invoke<OrgSyncResult | null>('org:get-result');
+  },
+  getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
+    return invoke<OrgSyncProgress | null>('org:get-progress');
   },
 };
 

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -231,4 +231,7 @@ export class MockCostApi implements CostApi {
   writeConfig(): Promise<void> { return Promise.resolve(); }
   getSavingsPreferences(): Promise<{ hiddenActionTypes: readonly string[] }> { return Promise.resolve({ hiddenActionTypes: [] }); }
   saveSavingsPreferences(): Promise<void> { return Promise.resolve(); }
+  syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
+  getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
+  getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
 }

--- a/packages/ui/src/__tests__/data-management.test.tsx
+++ b/packages/ui/src/__tests__/data-management.test.tsx
@@ -29,10 +29,10 @@ describe('DataManagement', () => {
     });
   });
 
-  it('shows account mapping warning when missing', async () => {
+  it('shows org sync prompt when not synced', async () => {
     renderDataManagement();
     await waitFor(() => {
-      expect(screen.getByText('Account mapping not found')).toBeDefined();
+      expect(screen.getByText('AWS Organizations not synced')).toBeDefined();
     });
   });
 

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -39,8 +39,12 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
   const [expanded, setExpanded] = useState(false);
   const [syncState, setSyncState] = useState<OrgSyncState>({ status: 'idle' });
   const [tagFilter, setTagFilter] = useState('');
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
 
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
+  const selectedAccount = orgData !== null && selectedAccountId !== null
+    ? orgData.accounts.find(a => a.id === selectedAccountId) ?? null
+    : null;
 
   async function handleSync() {
     if (profile === null) return;
@@ -178,7 +182,11 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
               </thead>
               <tbody className="divide-y divide-border-subtle">
                 {orgData.accounts.map(a => (
-                  <tr key={a.id} className="hover:bg-bg-tertiary/20">
+                  <tr
+                    key={a.id}
+                    className={`cursor-pointer transition-colors ${selectedAccountId === a.id ? 'bg-bg-tertiary/40' : 'hover:bg-bg-tertiary/20'}`}
+                    onClick={() => { setSelectedAccountId(selectedAccountId === a.id ? null : a.id); }}
+                  >
                     <td className="px-4 py-1.5 font-mono text-text-secondary">{a.id}</td>
                     <td className="px-4 py-1.5 text-text-primary">{a.name}</td>
                     <td className="px-4 py-1.5 text-text-muted">{a.ouPath.length > 0 ? a.ouPath : '—'}</td>
@@ -189,6 +197,57 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
               </tbody>
             </table>
           </div>
+
+          {selectedAccount !== null && (
+            <div className="border-t border-accent/30 bg-bg-tertiary/10 px-5 py-4">
+              <div className="flex items-center justify-between mb-3">
+                <div>
+                  <h4 className="text-sm font-semibold text-text-primary">{selectedAccount.name}</h4>
+                  <p className="text-xs text-text-muted font-mono mt-0.5">{selectedAccount.id}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => { setSelectedAccountId(null); }}
+                  className="rounded-md p-1 text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-x-8 gap-y-2 text-xs mb-4">
+                <div className="flex justify-between">
+                  <span className="text-text-muted">Email</span>
+                  <span className="text-text-secondary">{selectedAccount.email}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-muted">Status</span>
+                  <span className="text-text-secondary">{selectedAccount.status}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-muted">OU Path</span>
+                  <span className="text-text-secondary">{selectedAccount.ouPath.length > 0 ? selectedAccount.ouPath : '—'}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-muted">Joined</span>
+                  <span className="text-text-secondary">{selectedAccount.joinedTimestamp.length > 0 ? new Date(selectedAccount.joinedTimestamp).toLocaleDateString() : '—'}</span>
+                </div>
+              </div>
+              {Object.keys(selectedAccount.tags).length > 0 ? (
+                <div>
+                  <h5 className="text-xs font-medium text-text-secondary mb-2">Tags ({String(Object.keys(selectedAccount.tags).length)})</h5>
+                  <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+                    {Object.entries(selectedAccount.tags).sort((a, b) => a[0].localeCompare(b[0])).map(([key, value]) => (
+                      <div key={key} className="contents">
+                        <span className="text-text-muted font-mono">{key}</span>
+                        <span className="text-text-primary">{value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-text-muted">No tags</p>
+              )}
+            </div>
+          )}
 
           {allTagKeys.length > 0 && (
             <div className="border-t border-border px-4 py-3">

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { AccountMappingStatus, DataInventoryResult, CostGoblinConfig } from '@costgoblin/core/browser';
+import type { DataInventoryResult, CostGoblinConfig } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
@@ -27,29 +27,96 @@ type SyncState =
   | { status: 'done'; filesDownloaded: number }
   | { status: 'error'; message: string };
 
-function AccountMappingSection({ status, loading }: Readonly<{ status: AccountMappingStatus | null; loading: boolean }>) {
+type OrgSyncState =
+  | { status: 'idle' }
+  | { status: 'syncing'; phase: string; done: number; total: number }
+  | { status: 'done'; count: number }
+  | { status: 'error'; message: string };
+
+function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
+  const api = useCostApi();
+  const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
   const [expanded, setExpanded] = useState(false);
+  const [syncState, setSyncState] = useState<OrgSyncState>({ status: 'idle' });
+  const [tagFilter, setTagFilter] = useState('');
 
-  if (loading) return null;
+  const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
 
-  if (status === null || status.status === 'missing') {
+  async function handleSync() {
+    if (profile === null) return;
+    setSyncState({ status: 'syncing', phase: 'accounts', done: 0, total: 0 });
+
+    const pollInterval = setInterval(() => {
+      void api.getOrgSyncProgress().then(p => {
+        if (p !== null) {
+          setSyncState({ status: 'syncing', phase: p.phase, done: p.done, total: p.total });
+        }
+      }).catch(() => { /* transient */ });
+    }, 500);
+
+    try {
+      const result = await api.syncOrgAccounts(profile);
+      clearInterval(pollInterval);
+      setSyncState({ status: 'done', count: result.accounts.length });
+    } catch (err: unknown) {
+      clearInterval(pollInterval);
+      setSyncState({ status: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  // Collect all unique tag keys across accounts
+  const allTagKeys = orgData !== null
+    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort()
+    : [];
+
+  const filteredTagKeys = tagFilter.length > 0
+    ? allTagKeys.filter(k => k.toLowerCase().includes(tagFilter.toLowerCase()))
+    : allTagKeys;
+
+  if (orgData === null) {
     return (
       <div className="rounded-xl border border-warning/50 bg-warning-muted p-4">
         <div className="flex items-start gap-3">
           <span className="text-warning text-lg">&#9888;</span>
-          <div>
-            <p className="text-sm font-medium text-warning">Account mapping not found</p>
+          <div className="flex-1">
+            <p className="text-sm font-medium text-warning">AWS Organizations not synced</p>
             <p className="text-xs text-text-secondary mt-1 leading-relaxed">
-              CostGoblin uses an AWS Organizations account export to map Account IDs to friendly names.
+              Sync your AWS Organization to discover accounts, their OU placement, and tags.
+              This replaces the manual CSV export.
             </p>
-            <div className="mt-3 rounded-lg border border-border bg-bg-primary/50 p-3 text-xs text-text-secondary leading-relaxed">
-              <p className="font-medium text-text-secondary mb-1">How to export:</p>
-              <ol className="list-decimal list-inside space-y-1">
-                <li>Go to <span className="text-text-primary">AWS Organizations → AWS accounts</span></li>
-                <li>Click <span className="text-text-primary">Actions → Export account list</span></li>
-                <li>Save the CSV to <span className="font-mono text-accent">data/raw/</span></li>
-              </ol>
-            </div>
+
+            {syncState.status === 'syncing' && (
+              <div className="mt-3 rounded-lg border border-accent/50 bg-positive-muted px-3 py-2">
+                <div className="flex items-center gap-2 text-xs text-accent">
+                  <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+                  <span className="capitalize">{syncState.phase}</span>
+                  {syncState.total > 0 && <span>— {String(syncState.done)}/{String(syncState.total)}</span>}
+                </div>
+              </div>
+            )}
+            {syncState.status === 'error' && (
+              <div className="mt-3 rounded-lg border border-negative/50 bg-negative-muted px-3 py-2 text-xs text-negative">
+                {syncState.message}
+              </div>
+            )}
+            {syncState.status === 'done' && (
+              <div className="mt-3 rounded-lg border border-accent/50 bg-positive-muted px-3 py-2 text-xs text-accent">
+                Synced {String(syncState.count)} accounts
+              </div>
+            )}
+
+            {profile !== null && syncState.status !== 'syncing' && (
+              <button
+                type="button"
+                onClick={() => { void handleSync(); }}
+                className="mt-3 rounded-md border border-accent/50 bg-accent/10 px-4 py-1.5 text-xs font-medium text-accent hover:bg-accent/20 transition-colors"
+              >
+                Sync from AWS Organizations
+              </button>
+            )}
+            {profile === null && (
+              <p className="text-xs text-text-muted mt-2">Configure an AWS profile first via the setup wizard.</p>
+            )}
           </div>
         </div>
       </div>
@@ -58,36 +125,92 @@ function AccountMappingSection({ status, loading }: Readonly<{ status: AccountMa
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
-      <button
-        type="button"
-        onClick={() => { setExpanded(v => !v); }}
-        className="flex items-center gap-2 w-full px-4 py-3 text-left hover:bg-bg-tertiary/30 transition-colors"
-      >
-        <div className="h-2 w-2 rounded-full bg-accent" />
-        <span className="text-sm font-medium text-text-primary">Account mapping</span>
-        <span className="text-xs text-text-secondary">{String(status.accounts.length)} accounts</span>
-        <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>
-      </button>
+      <div className="flex items-center gap-2 px-4 py-3">
+        <button
+          type="button"
+          onClick={() => { setExpanded(v => !v); }}
+          className="flex items-center gap-2 flex-1 text-left hover:bg-bg-tertiary/30 transition-colors rounded -mx-1 px-1"
+        >
+          <div className="h-2 w-2 rounded-full bg-accent" />
+          <span className="text-sm font-medium text-text-primary">AWS Organization</span>
+          <span className="text-xs text-text-secondary">{String(orgData.accounts.length)} accounts</span>
+          <span className="text-xs text-text-muted">{String(allTagKeys.length)} tag keys</span>
+          <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>
+        </button>
+        {profile !== null && (
+          <button
+            type="button"
+            onClick={() => { void handleSync(); }}
+            disabled={syncState.status === 'syncing'}
+            className="text-xs text-text-muted hover:text-accent transition-colors disabled:opacity-50"
+            title="Re-sync"
+          >
+            ↻
+          </button>
+        )}
+      </div>
+
+      {syncState.status === 'syncing' && (
+        <div className="px-4 pb-2">
+          <div className="flex items-center gap-2 text-xs text-accent">
+            <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+            <span className="capitalize">{syncState.phase}</span>
+            {syncState.total > 0 && <span>— {String(syncState.done)}/{String(syncState.total)}</span>}
+          </div>
+        </div>
+      )}
+
       {expanded && (
-        <div className="border-t border-border max-h-48 overflow-y-auto">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="text-left text-text-muted">
-                <th className="px-4 py-2 font-medium">Account ID</th>
-                <th className="px-4 py-2 font-medium">Name</th>
-                <th className="px-4 py-2 font-medium">State</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border-subtle">
-              {status.accounts.map(a => (
-                <tr key={a.accountId} className="hover:bg-bg-tertiary/20">
-                  <td className="px-4 py-1.5 font-mono text-text-secondary">{a.accountId}</td>
-                  <td className="px-4 py-1.5 text-text-primary">{a.name}</td>
-                  <td className="px-4 py-1.5 text-text-muted">{a.state}</td>
+        <div className="border-t border-border">
+          <div className="px-4 py-2 text-[10px] text-text-muted">
+            Synced {new Date(orgData.syncedAt).toLocaleDateString()} · Org {orgData.orgId}
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-left text-text-muted sticky top-0 bg-bg-secondary">
+                  <th className="px-4 py-2 font-medium">Account ID</th>
+                  <th className="px-4 py-2 font-medium">Name</th>
+                  <th className="px-4 py-2 font-medium">OU Path</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Tags</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="divide-y divide-border-subtle">
+                {orgData.accounts.map(a => (
+                  <tr key={a.id} className="hover:bg-bg-tertiary/20">
+                    <td className="px-4 py-1.5 font-mono text-text-secondary">{a.id}</td>
+                    <td className="px-4 py-1.5 text-text-primary">{a.name}</td>
+                    <td className="px-4 py-1.5 text-text-muted">{a.ouPath.length > 0 ? a.ouPath : '—'}</td>
+                    <td className="px-4 py-1.5 text-text-muted">{a.status}</td>
+                    <td className="px-4 py-1.5 text-text-muted">{String(Object.keys(a.tags).length)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {allTagKeys.length > 0 && (
+            <div className="border-t border-border px-4 py-3">
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-xs font-medium text-text-secondary">Discovered Tags</h4>
+                <input
+                  type="text"
+                  placeholder="Filter tags..."
+                  value={tagFilter}
+                  onChange={e => { setTagFilter(e.target.value); }}
+                  className="w-40 rounded border border-border bg-bg-primary px-2 py-1 text-[10px] text-text-primary outline-none focus:border-accent"
+                />
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {filteredTagKeys.map(key => (
+                  <span key={key} className="rounded-full border border-border bg-bg-tertiary/30 px-2 py-0.5 text-[10px] text-text-secondary">
+                    {key}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -328,7 +451,6 @@ export function DataManagement() {
   const [costOptRefreshKey, setCostOptRefreshKey] = useState(0);
   const configQuery = useQuery(() => api.getConfig(), [configRefreshKey]);
   const inventoryQuery = useQuery(() => api.getDataInventory(), [dailyRefreshKey]);
-  const accountQuery = useQuery(() => api.getAccountMapping(), [configRefreshKey]);
   const [selected, setSelected] = useState(new Set<string>());
   const [hourlySelected, setHourlySelected] = useState(new Set<string>());
   const [costOptSelected, setCostOptSelected] = useState(new Set<string>());
@@ -649,7 +771,7 @@ export function DataManagement() {
       </div>
 
       {/* Account mapping */}
-      <AccountMappingSection status={accountQuery.status === 'success' ? accountQuery.data : null} loading={accountQuery.status === 'loading'} />
+      <OrgAccountsSection profile={awsProfile} />
 
       {inventoryQuery.status === 'loading' && (
         <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center text-text-secondary">

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -517,7 +517,9 @@ export function DataManagement() {
   const [dailySyncState, setDailySyncState] = useState<SyncState>({ status: 'idle' });
   const [hourlySyncState, setHourlySyncState] = useState<SyncState>({ status: 'idle' });
   const [costOptSyncState, setCostOptSyncState] = useState<SyncState>({ status: 'idle' });
-  const [autoSync, setAutoSync] = useState(false);
+  const [autoSync, setAutoSync] = useState(() => {
+    try { return localStorage.getItem('costgoblin-auto-sync') === 'true'; } catch { return false; }
+  });
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
 
@@ -534,12 +536,22 @@ export function DataManagement() {
   const missingPeriods = inventory?.periods.filter(p => p.localStatus === 'missing') ?? [];
   const missingWithinRetention = missingPeriods.filter(p => p.period >= retentionCutoffPeriod);
 
+  const [autoSyncTriggered, setAutoSyncTriggered] = useState(false);
+
   useEffect(() => {
     if (!initialized && inventoryQuery.status === 'success' && missingWithinRetention.length > 0) {
       setSelected(new Set(missingWithinRetention.map(p => p.period)));
       setInitialized(true);
     }
   }, [initialized, inventoryQuery.status, missingWithinRetention]);
+
+  // Auto-sync: trigger daily sync when toggle is on and missing periods exist
+  useEffect(() => {
+    if (autoSync && !autoSyncTriggered && initialized && missingWithinRetention.length > 0 && dailySyncState.status === 'idle') {
+      setAutoSyncTriggered(true);
+      void handleSync();
+    }
+  }, [autoSync, autoSyncTriggered, initialized, missingWithinRetention.length, dailySyncState.status]);
 
   function togglePeriod(period: string) {
     setSelected(prev => {
@@ -811,7 +823,7 @@ export function DataManagement() {
             <span className="text-xs text-text-secondary">Auto-sync</span>
             <button
               type="button"
-              onClick={() => { setAutoSync(v => !v); }}
+              onClick={() => { setAutoSync(v => { const next = !v; try { localStorage.setItem('costgoblin-auto-sync', String(next)); } catch { /* */ } return next; }); }}
               className={['relative h-5 w-9 rounded-full transition-colors', autoSync ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
             >
               <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -38,7 +38,7 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
   const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
   const [expanded, setExpanded] = useState(false);
   const [syncState, setSyncState] = useState<OrgSyncState>({ status: 'idle' });
-  const [tagFilter, setTagFilter] = useState('');
+  const [accountSearch, setAccountSearch] = useState('');
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
 
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
@@ -73,9 +73,13 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
     ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort()
     : [];
 
-  const filteredTagKeys = tagFilter.length > 0
-    ? allTagKeys.filter(k => k.toLowerCase().includes(tagFilter.toLowerCase()))
-    : allTagKeys;
+  // Filter accounts by search
+  const filteredAccounts = orgData !== null && accountSearch.length > 0
+    ? orgData.accounts.filter(a =>
+      a.id.includes(accountSearch) ||
+      a.name.toLowerCase().includes(accountSearch.toLowerCase()) ||
+      a.ouPath.toLowerCase().includes(accountSearch.toLowerCase()))
+    : orgData?.accounts ?? [];
 
   if (orgData === null) {
     return (
@@ -166,8 +170,17 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
 
       {expanded && (
         <div className="border-t border-border">
-          <div className="px-4 py-2 text-[10px] text-text-muted">
-            Synced {new Date(orgData.syncedAt).toLocaleDateString()} · Org {orgData.orgId}
+          <div className="flex items-center justify-between px-4 py-2">
+            <span className="text-[10px] text-text-muted">
+              Synced {new Date(orgData.syncedAt).toLocaleDateString()} · Org {orgData.orgId}
+            </span>
+            <input
+              type="text"
+              placeholder="Search accounts..."
+              value={accountSearch}
+              onChange={e => { setAccountSearch(e.target.value); }}
+              className="w-48 rounded border border-border bg-bg-primary px-2 py-1 text-[10px] text-text-primary outline-none focus:border-accent"
+            />
           </div>
           <div className="max-h-64 overflow-y-auto">
             <table className="w-full text-xs">
@@ -181,7 +194,7 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
                 </tr>
               </thead>
               <tbody className="divide-y divide-border-subtle">
-                {orgData.accounts.map(a => (
+                {filteredAccounts.map(a => (
                   <tr
                     key={a.id}
                     className={`cursor-pointer transition-colors ${selectedAccountId === a.id ? 'bg-bg-tertiary/40' : 'hover:bg-bg-tertiary/20'}`}
@@ -251,18 +264,9 @@ function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
 
           {allTagKeys.length > 0 && (
             <div className="border-t border-border px-4 py-3">
-              <div className="flex items-center justify-between mb-2">
-                <h4 className="text-xs font-medium text-text-secondary">Discovered Tags</h4>
-                <input
-                  type="text"
-                  placeholder="Filter tags..."
-                  value={tagFilter}
-                  onChange={e => { setTagFilter(e.target.value); }}
-                  className="w-40 rounded border border-border bg-bg-primary px-2 py-1 text-[10px] text-text-primary outline-none focus:border-accent"
-                />
-              </div>
+              <h4 className="text-xs font-medium text-text-secondary mb-2">Discovered Tags</h4>
               <div className="flex flex-wrap gap-1.5">
-                {filteredTagKeys.map(key => (
+                {allTagKeys.map(key => (
                   <span key={key} className="rounded-full border border-border bg-bg-tertiary/30 px-2 py-0.5 text-[10px] text-text-secondary">
                     {key}
                   </span>


### PR DESCRIPTION
## Summary
- Discover all accounts from AWS Organizations API (ListAccounts, ListRoots, ListOrganizationalUnitsForParent, ListAccountsForParent, ListTagsForResource)
- Build OU tree and resolve account OU paths (e.g. "Infrastructure / Production")
- Fetch all tags for each account
- Persist results to org-accounts.json for offline use
- Replace manual CSV export workflow with one-click "Sync from AWS Organizations"
- Progress reporting during sync (accounts → OUs → tags)
- Expandable table showing all accounts with metadata
- Tag key discovery with filterable pill display