### PR TITLE
Implement background auto-sync

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -34,6 +34,13 @@ export interface OrgSyncResult {
   readonly syncedAt: string;
 }
 
+export type AutoSyncStatus =
+  | { readonly state: 'disabled' }
+  | { readonly state: 'idle'; readonly lastRun: string | null; readonly nextRun: string | null }
+  | { readonly state: 'checking' }
+  | { readonly state: 'syncing'; readonly tier: string; readonly filesDone: number; readonly filesTotal: number }
+  | { readonly state: 'error'; readonly message: string; readonly lastRun: string | null };
+
 export interface OrgSyncProgress {
   readonly phase: 'accounts' | 'ous' | 'tags';
   readonly done: number;
@@ -89,6 +96,9 @@ export interface CostApi {
   scaffoldConfig(): Promise<void>;
   getSavingsPreferences(): Promise<SavingsPreferences>;
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
+  getAutoSyncEnabled(): Promise<boolean>;
+  setAutoSyncEnabled(enabled: boolean): Promise<void>;
+  getAutoSyncStatus(): Promise<AutoSyncStatus>;
   syncOrgAccounts(profile: string): Promise<OrgSyncResult>;
   getOrgSyncResult(): Promise<OrgSyncResult | null>;
   getOrgSyncProgress(): Promise<OrgSyncProgress | null>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -58,4 +58,4 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -1,0 +1,150 @@
+import { logger } from '@costgoblin/core';
+import type { AutoSyncStatus } from '@costgoblin/core';
+
+export interface AutoSyncDeps {
+  getPrefsPath: () => Promise<string>;
+  getConfig: () => Promise<{ providers: { sync: { daily: { retentionDays?: number | undefined }; hourly?: { retentionDays?: number | undefined } | undefined } }[] }>;
+  getInventory: (tier: string) => Promise<{ periods: { period: string; localStatus: string; files: { key: string; contentHash: string; size: number }[] }[] }>;
+  syncPeriods: (files: { key: string; contentHash: string; size: number }[], tier: string) => Promise<{ filesDownloaded: number }>;
+}
+
+let status: AutoSyncStatus = { state: 'disabled' };
+let timer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+export function getAutoSyncStatus(): AutoSyncStatus {
+  return status;
+}
+
+export async function readAutoSyncEnabled(prefsPath: string): Promise<boolean> {
+  const fs = await import('node:fs/promises');
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && 'autoSync' in parsed) {
+      return (parsed as Record<string, unknown>)['autoSync'] === true;
+    }
+  } catch {
+    // file doesn't exist
+  }
+  return false;
+}
+
+export async function writeAutoSyncEnabled(prefsPath: string, enabled: boolean): Promise<void> {
+  const fs = await import('node:fs/promises');
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null) {
+      existing = parsed as Record<string, unknown>;
+    }
+  } catch { /* */ }
+  existing['autoSync'] = enabled;
+  await fs.writeFile(prefsPath, JSON.stringify(existing, null, 2));
+}
+
+function retentionCutoff(days: number): string {
+  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return `${String(d.getFullYear())}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+async function runOnce(deps: AutoSyncDeps): Promise<void> {
+  if (running) return;
+  running = true;
+
+  try {
+    const prefsPath = await deps.getPrefsPath();
+    const enabled = await readAutoSyncEnabled(prefsPath);
+    if (!enabled) {
+      status = { state: 'disabled' };
+      running = false;
+      return;
+    }
+
+    status = { state: 'checking' };
+    logger.info('Auto-sync: checking for missing data');
+
+    const config = await deps.getConfig();
+    const provider = config.providers[0];
+    if (provider === undefined) {
+      status = { state: 'idle', lastRun: new Date().toISOString(), nextRun: null };
+      running = false;
+      return;
+    }
+
+    const tiers: { name: string; retention: number }[] = [
+      { name: 'daily', retention: provider.sync.daily.retentionDays ?? 365 },
+    ];
+    if (provider.sync.hourly !== undefined) {
+      tiers.push({ name: 'hourly', retention: provider.sync.hourly.retentionDays ?? 30 });
+    }
+
+    for (const tier of tiers) {
+      const cutoff = retentionCutoff(tier.retention);
+      let inventory: Awaited<ReturnType<typeof deps.getInventory>>;
+      try {
+        inventory = await deps.getInventory(tier.name);
+      } catch (err: unknown) {
+        logger.info(`Auto-sync: failed to get ${tier.name} inventory — ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+
+      const missing = inventory.periods
+        .filter(p => (p.localStatus === 'missing' || p.localStatus === 'stale') && p.period >= cutoff);
+
+      if (missing.length === 0) {
+        logger.info(`Auto-sync: ${tier.name} — nothing to sync`);
+        continue;
+      }
+
+      const files = missing.flatMap(p => [...p.files]);
+      logger.info(`Auto-sync: ${tier.name} — syncing ${String(missing.length)} periods (${String(files.length)} files)`);
+
+      status = { state: 'syncing', tier: tier.name, filesDone: 0, filesTotal: files.length };
+
+      try {
+        const result = await deps.syncPeriods(files, tier.name);
+        logger.info(`Auto-sync: ${tier.name} — synced ${String(result.filesDownloaded)} files`);
+      } catch (err: unknown) {
+        logger.info(`Auto-sync: ${tier.name} — sync failed: ${err instanceof Error ? err.message : String(err)}`);
+        status = { state: 'error', message: err instanceof Error ? err.message : String(err), lastRun: new Date().toISOString() };
+        running = false;
+        return;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const intervalMs = (provider.sync.daily.retentionDays !== undefined ? 60 : 60) * 60 * 1000;
+    status = { state: 'idle', lastRun: now, nextRun: new Date(Date.now() + intervalMs).toISOString() };
+  } catch (err: unknown) {
+    status = { state: 'error', message: err instanceof Error ? err.message : String(err), lastRun: new Date().toISOString() };
+  }
+
+  running = false;
+}
+
+export function startAutoSync(deps: AutoSyncDeps, intervalMinutes: number): void {
+  stopAutoSync();
+
+  const intervalMs = intervalMinutes * 60 * 1000;
+
+  // initial run after short delay (let the app finish loading)
+  timer = setTimeout(() => {
+    void runOnce(deps).then(() => {
+      // schedule recurring
+      timer = setInterval(() => { void runOnce(deps); }, intervalMs);
+    });
+  }, 5000);
+
+  logger.info(`Auto-sync: scheduled every ${String(intervalMinutes)} minutes`);
+}
+
+export function stopAutoSync(): void {
+  if (timer !== null) {
+    clearTimeout(timer);
+    clearInterval(timer);
+    timer = null;
+  }
+  status = { state: 'disabled' };
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -55,8 +55,10 @@ import type {
   SavingsPreferences,
   OrgSyncResult,
   OrgSyncProgress,
+  AutoSyncStatus,
 } from '@costgoblin/core';
 import { syncOrgAccounts } from './aws-org-client.js';
+import { startAutoSync, stopAutoSync, getAutoSyncStatus, readAutoSyncEnabled, writeAutoSyncEnabled } from './auto-sync.js';
 
 type RawRow = Readonly<Record<string, unknown>>;
 type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
@@ -1389,4 +1391,81 @@ tags: []
   ipcMain.handle('org:get-progress', (): OrgSyncProgress | null => {
     return orgSyncProgress;
   });
+
+  // -- Auto-sync --
+
+  async function autoSyncPrefsPath(): Promise<string> {
+    const path = await import('node:path');
+    return path.join(path.dirname(ctx.dataDir), 'app-preferences.json');
+  }
+
+  function buildAutoSyncDeps() {
+    return {
+      getPrefsPath: autoSyncPrefsPath,
+      getConfig: async () => {
+        const config = await getConfig();
+        return { providers: [...config.providers] };
+      },
+      getInventory: async (tier: string) => {
+        const config = await getConfig();
+        const provider = config.providers[0];
+        if (provider === undefined) return { periods: [] };
+        const bucket = tier === 'hourly'
+          ? provider.sync.hourly?.bucket ?? provider.sync.daily.bucket
+          : tier === 'cost-optimization'
+            ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
+            : provider.sync.daily.bucket;
+        const inv = await getDataInventory(bucket, provider.credentials.profile, ctx.dataDir, tier as 'daily' | 'hourly' | 'cost-optimization');
+        return {
+          periods: inv.periods.map(p => ({
+            period: p.period,
+            localStatus: p.localStatus,
+            files: [...p.files],
+          })),
+        };
+      },
+      syncPeriods: async (files: { key: string; contentHash: string; size: number }[], tier: string) => {
+        const config = await getConfig();
+        const provider = config.providers[0];
+        if (provider === undefined) return { filesDownloaded: 0 };
+        const bucket = tier === 'hourly'
+          ? provider.sync.hourly?.bucket ?? provider.sync.daily.bucket
+          : tier === 'cost-optimization'
+            ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
+            : provider.sync.daily.bucket;
+        return syncSelectedFiles({
+          bucketPath: bucket,
+          profile: provider.credentials.profile,
+          dataDir: ctx.dataDir,
+          expectedDataType: tier as 'daily' | 'hourly' | 'cost-optimization',
+          files,
+        });
+      },
+    };
+  }
+
+  ipcMain.handle('auto-sync:get-enabled', async (): Promise<boolean> => {
+    return readAutoSyncEnabled(await autoSyncPrefsPath());
+  });
+
+  ipcMain.handle('auto-sync:set-enabled', async (_event, enabled: boolean): Promise<void> => {
+    await writeAutoSyncEnabled(await autoSyncPrefsPath(), enabled);
+    if (enabled) {
+      startAutoSync(buildAutoSyncDeps(), 60);
+    } else {
+      stopAutoSync();
+    }
+  });
+
+  ipcMain.handle('auto-sync:get-status', (): AutoSyncStatus => {
+    return getAutoSyncStatus();
+  });
+
+  // Start auto-sync on launch if previously enabled
+  void autoSyncPrefsPath().then(async (prefsPath) => {
+    const enabled = await readAutoSyncEnabled(prefsPath);
+    if (enabled) {
+      startAutoSync(buildAutoSyncDeps(), 60);
+    }
+  }).catch(() => { /* auto-sync startup failure is non-fatal */ });
 }

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -22,6 +22,7 @@ import type {
   SavingsPreferences,
   OrgSyncResult,
   OrgSyncProgress,
+  AutoSyncStatus,
 } from '@costgoblin/core';
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
@@ -118,6 +119,15 @@ const api: CostApi = {
   },
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
+  },
+  getAutoSyncEnabled(): Promise<boolean> {
+    return invoke<boolean>('auto-sync:get-enabled');
+  },
+  setAutoSyncEnabled(enabled: boolean): Promise<void> {
+    return invoke<undefined>('auto-sync:set-enabled', enabled).then(() => undefined);
+  },
+  getAutoSyncStatus(): Promise<AutoSyncStatus> {
+    return invoke<AutoSyncStatus>('auto-sync:get-status');
   },
 };
 

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -234,4 +234,7 @@ export class MockCostApi implements CostApi {
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
+  getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }
+  setAutoSyncEnabled(): Promise<void> { return Promise.resolve(); }
+  getAutoSyncStatus(): Promise<{ state: 'disabled' }> { return Promise.resolve({ state: 'disabled' }); }
 }

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -521,9 +521,14 @@ export function DataManagement() {
   const [dailySyncState, setDailySyncState] = useState<SyncState>({ status: 'idle' });
   const [hourlySyncState, setHourlySyncState] = useState<SyncState>({ status: 'idle' });
   const [costOptSyncState, setCostOptSyncState] = useState<SyncState>({ status: 'idle' });
-  const [autoSync, setAutoSync] = useState(() => {
-    try { return localStorage.getItem('costgoblin-auto-sync') === 'true'; } catch { return false; }
-  });
+  const autoSyncQuery = useQuery(() => api.getAutoSyncEnabled(), []);
+  const [autoSync, setAutoSync] = useState(false);
+  const [autoSyncLoaded, setAutoSyncLoaded] = useState(false);
+
+  if (!autoSyncLoaded && autoSyncQuery.status === 'success') {
+    setAutoSyncLoaded(true);
+    setAutoSync(autoSyncQuery.data);
+  }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
 
@@ -540,22 +545,12 @@ export function DataManagement() {
   const missingPeriods = inventory?.periods.filter(p => p.localStatus === 'missing') ?? [];
   const missingWithinRetention = missingPeriods.filter(p => p.period >= retentionCutoffPeriod);
 
-  const [autoSyncTriggered, setAutoSyncTriggered] = useState(false);
-
   useEffect(() => {
     if (!initialized && inventoryQuery.status === 'success' && missingWithinRetention.length > 0) {
       setSelected(new Set(missingWithinRetention.map(p => p.period)));
       setInitialized(true);
     }
   }, [initialized, inventoryQuery.status, missingWithinRetention]);
-
-  // Auto-sync: trigger daily sync when toggle is on and missing periods exist
-  useEffect(() => {
-    if (autoSync && !autoSyncTriggered && initialized && missingWithinRetention.length > 0 && dailySyncState.status === 'idle') {
-      setAutoSyncTriggered(true);
-      void handleSync();
-    }
-  }, [autoSync, autoSyncTriggered, initialized, missingWithinRetention.length, dailySyncState.status]);
 
   function togglePeriod(period: string) {
     setSelected(prev => {
@@ -827,7 +822,7 @@ export function DataManagement() {
             <span className="text-xs text-text-secondary">Auto-sync</span>
             <button
               type="button"
-              onClick={() => { setAutoSync(v => { const next = !v; try { localStorage.setItem('costgoblin-auto-sync', String(next)); } catch { /* */ } return next; }); }}
+              onClick={() => { const next = !autoSync; setAutoSync(next); void api.setAutoSyncEnabled(next); }}
               className={['relative h-5 w-9 rounded-full transition-colors', autoSync ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
             >
               <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />


### PR DESCRIPTION
## Summary
- Auto-sync now actually works: runs in the main process on app startup
- Checks S3 for missing/stale daily and hourly periods, downloads them automatically
- Preference persisted to `app-preferences.json` (survives restarts)
- Runs every 60 minutes after initial sync
- Toggle in Data Management immediately starts/stops the background loop
- Status reporting: disabled → checking → syncing (with tier/progress) → idle (with timestamps)