### PR TITLE
Rename Data → Sync, add Dimensions view

### DIFF
--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -183,6 +183,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
       ...(normalize !== undefined ? { normalize } : {}),
       ...(separator !== undefined ? { separator } : {}),
       ...(aliases !== undefined ? { aliases } : {}),
+      ...(typeof tag['accountTagFallback'] === 'string' ? { accountTagFallback: tag['accountTagFallback'] } : {}),
     };
   });
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -33,11 +33,21 @@ function buildFilterClauses(filters: FilterMap, dimensions: DimensionsConfig): s
   return clauses;
 }
 
-export function buildSource(dataDir: string, tier: string, dimensions: DimensionsConfig): string {
+export function buildSource(dataDir: string, tier: string, dimensions: DimensionsConfig, orgAccountsPath?: string): string {
+  const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
+  const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
+
   const tagSelects = dimensions.tags.map(t => {
     const curKey = `user_${t.tagName}`;
     const colName = `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
-    return `element_at(resource_tags, '${curKey}')[1] AS ${colName}`;
+    const resourceExpr = `element_at(resource_tags, '${curKey}')[1]`;
+
+    if (t.accountTagFallback !== undefined && needsOrgJoin) {
+      const fallbackKey = t.accountTagFallback.replaceAll("'", "''");
+      return `COALESCE(NULLIF(${resourceExpr}, ''), element_at(acct_tags.tags, '${fallbackKey}')[1]) AS ${colName}`;
+    }
+
+    return `${resourceExpr} AS ${colName}`;
   });
 
   const tagClause = tagSelects.length > 0 ? `,\n      ${tagSelects.join(',\n      ')}` : '';
@@ -46,23 +56,33 @@ export function buildSource(dataDir: string, tier: string, dimensions: Dimension
     ? 'line_item_usage_start_date AS usage_date'
     : 'line_item_usage_start_date::DATE AS usage_date';
 
+  const parquetSource = `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
+
+  const fromClause = needsOrgJoin
+    ? `${parquetSource} AS cur
+      LEFT JOIN (
+        SELECT id, tags::MAP(VARCHAR, VARCHAR) AS tags
+        FROM read_json_auto('${orgAccountsPath}', format='array', records='true', columns={id: 'VARCHAR', tags: 'JSON'})
+      ) AS acct_tags ON cur.line_item_usage_account_id = acct_tags.id`
+    : parquetSource;
+
   return `(
     SELECT
       ${dateExpr},
-      line_item_usage_account_id AS account_id,
-      COALESCE(line_item_usage_account_name, '') AS account_name,
-      COALESCE(product_region_code, '') AS region,
-      COALESCE(product_servicecode, '') AS service,
-      COALESCE(product_product_family, '') AS service_family,
-      COALESCE(line_item_line_item_description, '') AS description,
-      COALESCE(line_item_resource_id, '') AS resource_id,
-      COALESCE(line_item_usage_amount, 0) AS usage_amount,
-      COALESCE(line_item_unblended_cost, 0) AS cost,
-      COALESCE(pricing_public_on_demand_cost, 0) AS list_cost,
-      COALESCE(line_item_line_item_type, '') AS line_item_type,
-      COALESCE(line_item_operation, '') AS operation,
-      COALESCE(line_item_usage_type, '') AS usage_type${tagClause}
-    FROM read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')
+      ${needsOrgJoin ? 'cur.' : ''}line_item_usage_account_id AS account_id,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_account_name, '') AS account_name,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}product_region_code, '') AS region,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}product_servicecode, '') AS service,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}product_product_family, '') AS service_family,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_line_item_description, '') AS description,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_resource_id, '') AS resource_id,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_amount, 0) AS usage_amount,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_unblended_cost, 0) AS cost,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}pricing_public_on_demand_cost, 0) AS list_cost,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_line_item_type, '') AS line_item_type,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_operation, '') AS operation,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_type, '') AS usage_type${tagClause}
+    FROM ${fromClause}
   )`;
 }
 
@@ -71,11 +91,12 @@ export function buildCostQuery(
   dataDir: string,
   dimensions: DimensionsConfig,
   topN: number = 5,
+  orgAccountsPath?: string,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const source = buildSource(dataDir, costTier, dimensions);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -135,10 +156,11 @@ export function buildTrendQuery(
   params: TrendQueryParams,
   dataDir: string,
   dimensions: DimensionsConfig,
+  orgAccountsPath?: string,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
-  const source = buildSource(dataDir, 'daily', dimensions);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
@@ -187,10 +209,11 @@ export function buildMissingTagsQuery(
   params: MissingTagsParams,
   dataDir: string,
   dimensions: DimensionsConfig,
+  orgAccountsPath?: string,
 ): string {
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
-  const source = buildSource(dataDir, 'daily', dimensions);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -218,11 +241,12 @@ export function buildDailyCostsQuery(
   params: DailyCostsParams,
   dataDir: string,
   dimensions: DimensionsConfig,
+  orgAccountsPath?: string,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const source = buildSource(dataDir, dailyTier, dimensions);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -249,12 +273,13 @@ export function buildEntityDetailQuery(
   params: EntityDetailParams,
   dataDir: string,
   dimensions: DimensionsConfig,
+  orgAccountsPath?: string,
 ): string {
   const dimResolved = resolveField(params.dimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
-  const source = buildSource(dataDir, tier, dimensions);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,4 +1,4 @@
-import type { BuiltInDimension, CostGoblinConfig, OrgNode, TagDimension } from './config.js';
+import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, OrgNode, TagDimension } from './config.js';
 import type {
   CostQueryParams,
   CostResult,
@@ -96,6 +96,9 @@ export interface CostApi {
   scaffoldConfig(): Promise<void>;
   getSavingsPreferences(): Promise<SavingsPreferences>;
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
+  discoverTagKeys(): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]>;
+  getDimensionsConfig(): Promise<DimensionsConfig>;
+  saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;
   setAutoSyncEnabled(enabled: boolean): Promise<void>;
   getAutoSyncStatus(): Promise<AutoSyncStatus>;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -57,6 +57,7 @@ export interface TagDimension {
   readonly normalize?: NormalizationRule | undefined;
   readonly separator?: string | undefined;
   readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
+  readonly accountTagFallback?: string | undefined;
 }
 
 export interface DimensionsConfig {

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -391,6 +391,18 @@ export function registerIpcHandlers(ctx: IpcContext): void {
     return dimensions;
   }
 
+  async function getOrgAccountsPath(): Promise<string | undefined> {
+    const path = await import('node:path');
+    const fs = await import('node:fs/promises');
+    const p = path.join(path.dirname(ctx.dataDir), 'org-accounts.json');
+    try {
+      await fs.access(p);
+      return p;
+    } catch {
+      return undefined;
+    }
+  }
+
   async function getOrgTreeConfig(): Promise<OrgTreeConfig> {
     if (state.orgTree !== null) return state.orgTree;
     const orgTree = await loadOrgTree(ctx.orgTreePath);
@@ -504,7 +516,8 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   ipcMain.handle('query:costs', async (_event, params: CostQueryParams): Promise<CostResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions);
+    const orgPath = await getOrgAccountsPath();
+    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath);
     logger.info('query:costs', { groupBy: params.groupBy });
 
     return withConnection(async (conn) => {
@@ -531,7 +544,8 @@ export function registerIpcHandlers(ctx: IpcContext): void {
 
   ipcMain.handle('query:daily-costs', async (_event, params: DailyCostsParams): Promise<DailyCostsResult> => {
     const dimensions = await getDimensions();
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions);
+    const orgPath = await getOrgAccountsPath();
+    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
     return withConnection(async (conn) => {
@@ -584,7 +598,8 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   ipcMain.handle('query:trends', async (_event, params: TrendQueryParams): Promise<TrendResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions);
+    const orgPath = await getOrgAccountsPath();
+    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:trends', { groupBy: params.groupBy });
 
     return withConnection(async (conn) => {
@@ -604,7 +619,8 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   ipcMain.handle('query:missing-tags', async (_event, params: MissingTagsParams): Promise<MissingTagsResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
-    const sql = buildMissingTagsQuery(params, ctx.dataDir, dimensions);
+    const orgPath = await getOrgAccountsPath();
+    const sql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
     return withConnection(async (conn) => {
@@ -689,7 +705,8 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   ipcMain.handle('query:entity-detail', async (_event, params: EntityDetailParams): Promise<EntityDetailResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions);
+    const orgPath = await getOrgAccountsPath();
+    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:entity-detail', { entity: params.entity });
 
     return withConnection(async (conn) => {
@@ -736,7 +753,8 @@ export function registerIpcHandlers(ctx: IpcContext): void {
 
     const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
 
-    const source = buildSource(ctx.dataDir, 'daily', dimensions);
+    const orgPath = await getOrgAccountsPath();
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath);
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
       FROM ${source}
@@ -1424,6 +1442,7 @@ tags: []
         ...(t.normalize === undefined ? {} : { normalize: t.normalize }),
         ...(t.separator === undefined ? {} : { separator: t.separator }),
         ...(t.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(t.aliases).map(([k, v]) => [k, [...v]])) }),
+        ...(t.accountTagFallback === undefined ? {} : { accountTagFallback: t.accountTagFallback }),
       })),
     });
     await fs.writeFile(ctx.dimensionsPath, output);

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1384,37 +1384,58 @@ tags: []
 
     const conn = await ctx.db.connect();
     try {
-      const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
+      // Only scan the most recent month for speed
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const dailyDir = path.join(ctx.dataDir, 'aws', 'raw');
+      let dirs: string[] = [];
+      try {
+        dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort();
+      } catch { /* no data */ }
+      const recentDir = dirs.length > 0 ? dirs[dirs.length - 1] : 'daily-*';
+      const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/${recentDir ?? 'daily-*'}/*.parquet')`;
+
+      // Single query: get all tag keys with counts AND sample values
       const sql = `
-        SELECT tag_key, COUNT(*) AS cnt
-        FROM (
-          SELECT unnest(map_keys(resource_tags)) AS tag_key
+        WITH tags AS (
+          SELECT unnest(map_keys(resource_tags)) AS tag_key,
+                 unnest(map_values(resource_tags)) AS tag_val
           FROM ${rawParquet}
           WHERE resource_tags IS NOT NULL
+        ),
+        ranked AS (
+          SELECT tag_key, tag_val,
+                 COUNT(*) AS val_cnt,
+                 COUNT(*) OVER (PARTITION BY tag_key) AS key_cnt,
+                 ROW_NUMBER() OVER (PARTITION BY tag_key ORDER BY COUNT(*) DESC) AS rn
+          FROM tags
+          WHERE tag_val IS NOT NULL AND tag_val != ''
+          GROUP BY tag_key, tag_val
         )
-        GROUP BY tag_key
-        ORDER BY cnt DESC
+        SELECT tag_key, key_cnt, tag_val, val_cnt
+        FROM ranked
+        WHERE rn <= 10
+        ORDER BY key_cnt DESC, tag_key, rn
       `;
       const rows = await queryAll(conn, sql);
-      const tagKeys: { key: string; sampleValues: string[]; rowCount: number }[] = [];
 
+      const tagMap = new Map<string, { rowCount: number; values: { val: string; cnt: number }[] }>();
       for (const row of rows) {
         const key = toStr(row['tag_key']);
-        const cnt = toNum(row['cnt']);
         if (key.length === 0) continue;
-
-        const sampleSql = `
-          SELECT DISTINCT element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] AS val
-          FROM ${rawParquet}
-          WHERE element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] IS NOT NULL
-            AND element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] != ''
-          LIMIT 10
-        `;
-        const sampleRows = await queryAll(conn, sampleSql);
-        const samples = sampleRows.map(r => toStr(r['val'])).filter(v => v.length > 0);
-
-        tagKeys.push({ key, sampleValues: samples, rowCount: cnt });
+        let entry = tagMap.get(key);
+        if (entry === undefined) {
+          entry = { rowCount: toNum(row['key_cnt']), values: [] };
+          tagMap.set(key, entry);
+        }
+        entry.values.push({ val: toStr(row['tag_val']), cnt: toNum(row['val_cnt']) });
       }
+
+      const tagKeys = [...tagMap.entries()].map(([key, data]) => ({
+        key,
+        sampleValues: data.values.map(v => v.val),
+        rowCount: data.rowCount,
+      }));
 
       return tagKeys;
     } finally {

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1357,6 +1357,80 @@ tags: []
 
   // -- AWS Organizations sync --
 
+  // -- Tag discovery + Dimensions config --
+
+  ipcMain.handle('dimensions:discover-tags', async (): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]> => {
+    const config = await getConfig();
+    const provider = config.providers[0];
+    if (provider === undefined) return [];
+
+    const conn = await ctx.db.connect();
+    try {
+      const source = buildSource(ctx.dataDir, 'daily', await getDimensions());
+      const sql = `
+        SELECT
+          unnest(map_keys(resource_tags)) AS tag_key,
+          COUNT(*) AS cnt
+        FROM ${source}
+        GROUP BY tag_key
+        ORDER BY cnt DESC
+      `;
+      const rows = await queryAll(conn, sql);
+      const tagKeys: { key: string; sampleValues: string[]; rowCount: number }[] = [];
+
+      for (const row of rows) {
+        const key = toStr(row['tag_key']);
+        const cnt = toNum(row['cnt']);
+        if (key.length === 0) continue;
+
+        // fetch sample values for each key
+        const sampleSql = `
+          SELECT DISTINCT element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] AS val
+          FROM ${source}
+          WHERE element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] IS NOT NULL
+          LIMIT 10
+        `;
+        const sampleRows = await queryAll(conn, sampleSql);
+        const samples = sampleRows.map(r => toStr(r['val'])).filter(v => v.length > 0);
+
+        tagKeys.push({ key, sampleValues: samples, rowCount: cnt });
+      }
+
+      return tagKeys;
+    } finally {
+      conn.disconnectSync();
+    }
+  });
+
+  ipcMain.handle('dimensions:get-config', async (): Promise<DimensionsConfig> => {
+    return getDimensions();
+  });
+
+  ipcMain.handle('dimensions:save-config', async (_event, config: DimensionsConfig): Promise<void> => {
+    const yaml = await import('yaml');
+    const fs = await import('node:fs/promises');
+    const output = yaml.stringify({
+      builtIn: config.builtIn.map(d => ({
+        name: d.name,
+        label: d.label,
+        field: d.field,
+        ...(d.displayField === undefined ? {} : { displayField: d.displayField }),
+      })),
+      tags: config.tags.map(t => ({
+        tagName: t.tagName,
+        label: t.label,
+        ...(t.concept === undefined ? {} : { concept: t.concept }),
+        ...(t.normalize === undefined ? {} : { normalize: t.normalize }),
+        ...(t.separator === undefined ? {} : { separator: t.separator }),
+        ...(t.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(t.aliases).map(([k, v]) => [k, [...v]])) }),
+      })),
+    });
+    await fs.writeFile(ctx.dimensionsPath, output);
+    state.dimensions = null; // invalidate cache
+  });
+
+  // -- AWS Organizations sync --
+
   let orgSyncProgress: OrgSyncProgress | null = null;
 
   async function orgResultPath(): Promise<string> {

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1366,12 +1366,13 @@ tags: []
 
     const conn = await ctx.db.connect();
     try {
-      const source = buildSource(ctx.dataDir, 'daily', await getDimensions());
+      const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
       const sql = `
         SELECT
           unnest(map_keys(resource_tags)) AS tag_key,
           COUNT(*) AS cnt
-        FROM ${source}
+        FROM ${rawParquet}
+        WHERE resource_tags IS NOT NULL
         GROUP BY tag_key
         ORDER BY cnt DESC
       `;
@@ -1383,11 +1384,11 @@ tags: []
         const cnt = toNum(row['cnt']);
         if (key.length === 0) continue;
 
-        // fetch sample values for each key
         const sampleSql = `
           SELECT DISTINCT element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] AS val
-          FROM ${source}
+          FROM ${rawParquet}
           WHERE element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] IS NOT NULL
+            AND element_at(resource_tags, '${key.replaceAll("'", "''")}')[1] != ''
           LIMIT 10
         `;
         const sampleRows = await queryAll(conn, sampleSql);

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1386,11 +1386,12 @@ tags: []
     try {
       const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
       const sql = `
-        SELECT
-          unnest(map_keys(resource_tags)) AS tag_key,
-          COUNT(*) AS cnt
-        FROM ${rawParquet}
-        WHERE resource_tags IS NOT NULL
+        SELECT tag_key, COUNT(*) AS cnt
+        FROM (
+          SELECT unnest(map_keys(resource_tags)) AS tag_key
+          FROM ${rawParquet}
+          WHERE resource_tags IS NOT NULL
+        )
         GROUP BY tag_key
         ORDER BY cnt DESC
       `;

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -20,6 +20,7 @@ import type {
   DataTier,
   AccountMappingStatus,
   SavingsPreferences,
+  DimensionsConfig,
   OrgSyncResult,
   OrgSyncProgress,
   AutoSyncStatus,
@@ -119,6 +120,15 @@ const api: CostApi = {
   },
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
+  },
+  discoverTagKeys(): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]> {
+    return invoke<{ key: string; sampleValues: string[]; rowCount: number }[]>('dimensions:discover-tags');
+  },
+  getDimensionsConfig(): Promise<DimensionsConfig> {
+    return invoke<DimensionsConfig>('dimensions:get-config');
+  },
+  saveDimensionsConfig(config: DimensionsConfig): Promise<void> {
+    return invoke<undefined>('dimensions:save-config', config).then(() => undefined);
   },
   getAutoSyncEnabled(): Promise<boolean> {
     return invoke<boolean>('auto-sync:get-enabled');

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, CostApiProvider, SetupWizard, ErrorBoundary } from '@costgoblin/ui';
+import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostApiProvider, SetupWizard, ErrorBoundary } from '@costgoblin/ui';
 import type { CostApi } from '@costgoblin/core/browser';
 
 function getApi(): CostApi {
@@ -12,7 +12,8 @@ type View =
   | { page: 'trends' }
   | { page: 'missing-tags' }
   | { page: 'savings' }
-  | { page: 'data' }
+  | { page: 'dimensions' }
+  | { page: 'sync' }
   | { page: 'entity-detail'; entity: string; dimension: string };
 
 const LEFT_NAV: { id: string; label: string }[] = [
@@ -20,6 +21,11 @@ const LEFT_NAV: { id: string; label: string }[] = [
   { id: 'trends', label: 'Trends' },
   { id: 'missing-tags', label: 'Missing Tags' },
   { id: 'savings', label: 'Savings' },
+];
+
+const RIGHT_NAV: { id: string; label: string }[] = [
+  { id: 'dimensions', label: 'Dimensions' },
+  { id: 'sync', label: 'Sync' },
 ];
 
 function getStoredTheme(): 'dark' | 'light' {
@@ -103,7 +109,8 @@ export function App(): React.JSX.Element {
       case 'trends': setView({ page: 'trends' }); break;
       case 'missing-tags': setView({ page: 'missing-tags' }); break;
       case 'savings': setView({ page: 'savings' }); break;
-      case 'data': setView({ page: 'data' }); break;
+      case 'dimensions': setView({ page: 'dimensions' }); break;
+      case 'sync': setView({ page: 'sync' }); break;
     }
   }
 
@@ -121,7 +128,7 @@ export function App(): React.JSX.Element {
 
   function handleSetupComplete() {
     setSetupCheck({ status: 'ready' });
-    setView({ page: 'data' });
+    setView({ page: 'sync' });
   }
 
   if (setupCheck.status === 'checking') {
@@ -177,23 +184,26 @@ export function App(): React.JSX.Element {
               >
                 {isDark ? <SunIcon /> : <MoonIcon />}
               </button>
-              <button
-                type="button"
-                onClick={() => { handleNavClick('data'); }}
-                className={[
-                  'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
-                  view.page === 'data'
-                    ? 'bg-bg-tertiary text-text-primary'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
-                ].join(' ')}
-              >
-                Data
-                {missingPeriods > 0 && view.page !== 'data' && (
-                  <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-bold text-bg-primary">
-                    {String(missingPeriods)}
-                  </span>
-                )}
-              </button>
+              {RIGHT_NAV.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => { handleNavClick(item.id); }}
+                  className={[
+                    'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+                    view.page === item.id
+                      ? 'bg-bg-tertiary text-text-primary'
+                      : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
+                  ].join(' ')}
+                >
+                  {item.label}
+                  {item.id === 'sync' && missingPeriods > 0 && view.page !== 'sync' && (
+                    <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-bold text-bg-primary">
+                      {String(missingPeriods)}
+                    </span>
+                  )}
+                </button>
+              ))}
             </div>
           </nav>
         </div>
@@ -203,7 +213,8 @@ export function App(): React.JSX.Element {
         {view.page === 'trends' && <CostTrends onEntityClick={handleEntityClick} />}
         {view.page === 'missing-tags' && <MissingTags />}
         {view.page === 'savings' && <Savings />}
-        <div className={view.page === 'data' ? '' : 'hidden'}>
+        {view.page === 'dimensions' && <DimensionsView />}
+        <div className={view.page === 'sync' ? '' : 'hidden'}>
           <DataManagement />
         </div>
         {view.page === 'entity-detail' && (

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -95,8 +95,11 @@ export function App(): React.JSX.Element {
 
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
-    void api.getDataInventory().then((inv) => {
-      const missing = inv.periods.filter(p => p.localStatus === 'missing').length;
+    void Promise.all([api.getDataInventory(), api.getConfig()]).then(([inv, config]) => {
+      const retentionDays = config.providers[0]?.sync.daily.retentionDays ?? 365;
+      const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+      const cutoffPeriod = `${String(cutoff.getFullYear())}-${String(cutoff.getMonth() + 1).padStart(2, '0')}`;
+      const missing = inv.periods.filter(p => p.localStatus === 'missing' && p.period >= cutoffPeriod).length;
       setMissingPeriods(missing);
     }).catch(() => {
       // ignore — S3 may not be configured yet

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -19,6 +19,7 @@ import type {
   SyncStatus,
   TrendResult,
   CostGoblinConfig,
+  DimensionsConfig,
 } from '@costgoblin/core/browser';
 
 const costResult: CostResult = {
@@ -234,6 +235,9 @@ export class MockCostApi implements CostApi {
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
+  discoverTagKeys(): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]> { return Promise.resolve([{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400 }]); }
+  getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }
+  saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }
   setAutoSyncEnabled(): Promise<void> { return Promise.resolve(); }
   getAutoSyncStatus(): Promise<{ state: 'disabled' }> { return Promise.resolve({ state: 'disabled' }); }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -36,6 +36,7 @@ export { MissingTags } from './views/missing-tags.js';
 export { Savings } from './views/savings.js';
 export { EntityDetail } from './views/entity-detail.js';
 export { DataManagement } from './views/data-management.js';
+export { DimensionsView } from './views/dimensions.js';
 export { SetupWizard } from './views/setup-wizard.js';
 
 export { getDimensionId, isTagDimension, isEnvironmentDimension, isOwnerDimension, isProductDimension } from './lib/dimensions.js';

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -209,7 +209,6 @@ export function DimensionsView() {
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [addingNew, setAddingNew] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [tagSearch, setTagSearch] = useState('');
 
   const discoveredTags = tagsQuery.status === 'success' ? tagsQuery.data : [];
   const config: DimensionsConfig | null = configQuery.status === 'success' ? configQuery.data : null;
@@ -228,11 +227,6 @@ export function DimensionsView() {
     .map(t => t.key)
     .filter(k => !mappedTagNames.has(k))
     .sort();
-
-  // Filter discovered tags
-  const filteredDiscovered = tagSearch.length > 0
-    ? discoveredTags.filter(t => t.key.toLowerCase().includes(tagSearch.toLowerCase()))
-    : discoveredTags;
 
   function editingToTagDimension(editing: EditingTag): TagDimension {
     const base: { tagName: string; label: string } = { tagName: editing.tagName, label: editing.label };
@@ -269,20 +263,6 @@ export function DimensionsView() {
   }
 
   // Quick-add a discovered tag as a dimension
-  function handleQuickAdd(tagKey: string) {
-    const label = tagKey
-      .replace(/^(user:|aws:|resource_tags_user_)/i, '')
-      .replaceAll('_', ' ')
-      .replaceAll('-', ' ')
-      .replace(/\b\w/g, c => c.toUpperCase());
-
-    setAddingNew(true);
-    setEditingIdx(null);
-    // The TagEditor will be shown with pre-filled values
-    // We need to pass the initial state — using a key trick
-    setQuickAddState({ tagName: tagKey, label, concept: '', normalize: '', aliases: '', fallbackTag: undefined });
-  }
-
   const [quickAddState, setQuickAddState] = useState<EditingTag | null>(null);
 
   void refreshKey; // used as useQuery dep to force re-fetch
@@ -389,87 +369,107 @@ export function DimensionsView() {
         </div>
       )}
 
-      {/* Discovered tags from billing data */}
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-text-secondary">
-            Discovered Resource Tags
-            {discoveredTags.length > 0 && <span className="text-text-muted ml-1">({String(discoveredTags.length)})</span>}
-          </h3>
-          <input
-            type="text"
-            placeholder="Search tags..."
-            value={tagSearch}
-            onChange={e => { setTagSearch(e.target.value); }}
-            className="w-48 rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
-          />
-        </div>
-
-        {tagsQuery.status === 'loading' && (
-          <div className="text-sm text-text-secondary">Scanning billing data for tags...</div>
-        )}
-
-        {filteredDiscovered.length > 0 && (
-          <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
-            <table className="w-full text-xs">
+      {/* Resource tags pivot table — columns are tag keys, rows are top values */}
+      {discoveredTags.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-text-secondary">
+              Resource Tags
+              <span className="text-text-muted ml-1">({String(discoveredTags.length)} keys found in billing data)</span>
+            </h3>
+          </div>
+          <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
+            <table className="text-xs">
               <thead>
                 <tr className="border-b border-border text-left text-text-muted">
-                  <th className="px-4 py-2 font-medium">Tag Key</th>
-                  <th className="px-4 py-2 font-medium">Rows</th>
-                  <th className="px-4 py-2 font-medium">Sample Values</th>
-                  <th className="px-4 py-2 font-medium w-24"></th>
+                  {discoveredTags.map(t => (
+                    <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-mono">{t.key}</span>
+                        <span className="text-[9px] text-text-muted font-normal">{t.rowCount.toLocaleString()} rows</span>
+                      </div>
+                    </th>
+                  ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-border-subtle">
-                {filteredDiscovered.map(tag => (
-                  <tr key={tag.key} className="hover:bg-bg-tertiary/20">
-                    <td className="px-4 py-2 font-mono text-text-primary">{tag.key}</td>
-                    <td className="px-4 py-2 tabular-nums text-text-secondary">{tag.rowCount.toLocaleString()}</td>
-                    <td className="px-4 py-2 text-text-muted">
-                      <div className="flex flex-wrap gap-1">
-                        {tag.sampleValues.slice(0, 5).map(v => (
-                          <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px]">{v}</span>
-                        ))}
-                        {tag.sampleValues.length > 5 && <span className="text-[10px] text-text-muted">+{String(tag.sampleValues.length - 5)}</span>}
-                      </div>
-                    </td>
-                    <td className="px-4 py-2">
-                      {mappedTagNames.has(tag.key) ? (
-                        <span className="text-[10px] text-accent">Mapped</span>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={() => { handleQuickAdd(tag.key); }}
-                          className="rounded px-2 py-0.5 text-[10px] font-medium text-accent hover:bg-accent/10 transition-colors"
-                        >
-                          + Add
-                        </button>
-                      )}
-                    </td>
+              <tbody>
+                {Array.from({ length: Math.max(...discoveredTags.map(t => t.sampleValues.length), 0) }, (_, rowIdx) => (
+                  <tr key={rowIdx} className="border-b border-border-subtle">
+                    {discoveredTags.map(t => {
+                      const val = t.sampleValues[rowIdx];
+                      return (
+                        <td key={t.key} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
+                          {val !== undefined ? val : ''}
+                        </td>
+                      );
+                    })}
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
-      {/* Account tags from AWS Organizations */}
-      {accountTagKeys.length > 0 && (
+      {tagsQuery.status === 'loading' && (
+        <div className="text-sm text-text-secondary">Scanning billing data for tags...</div>
+      )}
+
+      {/* Account tags pivot table */}
+      {accountTagKeys.length > 0 && orgData !== null && (
         <div className="flex flex-col gap-3">
-          <h3 className="text-sm font-medium text-text-secondary">
-            Account Tags (from AWS Organizations)
-            <span className="text-text-muted ml-1">({String(accountTagKeys.length)} keys)</span>
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-text-secondary">
+              Account Tags
+              <span className="text-text-muted ml-1">({String(accountTagKeys.length)} keys from AWS Organizations)</span>
+            </h3>
+          </div>
           <p className="text-xs text-text-muted">
-            These tags are set at the account level in AWS Organizations. They can be used as fallback values when resource-level tags are missing.
+            Values sorted by frequency. Can be used as fallback when resource-level tags are missing.
           </p>
-          <div className="flex flex-wrap gap-1.5">
-            {accountTagKeys.map(key => (
-              <span key={key} className="rounded-full border border-border bg-bg-tertiary/30 px-2.5 py-0.5 text-[10px] text-text-secondary">
-                {key}
-              </span>
-            ))}
+          <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
+            <table className="text-xs">
+              <thead>
+                <tr className="border-b border-border text-left text-text-muted">
+                  {accountTagKeys.map(key => {
+                    const count = orgData.accounts.filter(a => a.tags[key] !== undefined && a.tags[key] !== '').length;
+                    return (
+                      <th key={key} className="px-3 py-2 font-medium whitespace-nowrap">
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-mono">{key}</span>
+                          <span className="text-[9px] text-text-muted font-normal">{String(count)}/{String(orgData.accounts.length)} accounts</span>
+                        </div>
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {(() => {
+                  // For each tag key, compute sorted unique values by frequency
+                  const columnValues = accountTagKeys.map(key => {
+                    const counts = new Map<string, number>();
+                    for (const acct of orgData.accounts) {
+                      const val = acct.tags[key];
+                      if (val !== undefined && val.length > 0) {
+                        counts.set(val, (counts.get(val) ?? 0) + 1);
+                      }
+                    }
+                    return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([v, c]) => `${v} (${String(c)})`);
+                  });
+                  const maxRows = Math.max(...columnValues.map(c => c.length), 0);
+                  return Array.from({ length: Math.min(maxRows, 15) }, (_, rowIdx) => (
+                    <tr key={rowIdx} className="border-b border-border-subtle">
+                      {columnValues.map((vals, colIdx) => (
+                        <td key={accountTagKeys[colIdx]} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
+                          {vals[rowIdx] ?? ''}
+                        </td>
+                      ))}
+                    </tr>
+                  ));
+                })()}
+              </tbody>
+            </table>
           </div>
         </div>
       )}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1,0 +1,390 @@
+import { useState } from 'react';
+import type { DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useQuery } from '../hooks/use-query.js';
+
+const CONCEPTS: { value: ConceptType; label: string }[] = [
+  { value: 'owner', label: 'Owner (team)' },
+  { value: 'product', label: 'Product (system)' },
+  { value: 'environment', label: 'Environment' },
+];
+
+const NORMALIZE_RULES: { value: NormalizationRule; label: string }[] = [
+  { value: 'lowercase', label: 'lowercase' },
+  { value: 'uppercase', label: 'UPPERCASE' },
+  { value: 'lowercase-kebab', label: 'kebab-case' },
+];
+
+interface EditingTag {
+  tagName: string;
+  label: string;
+  concept: string;
+  normalize: string;
+  aliases: string; // "canonical: alias1, alias2\n..."
+  accountTagFallback: boolean;
+}
+
+function aliasesToText(aliases: Readonly<Record<string, readonly string[]>> | undefined): string {
+  if (aliases === undefined) return '';
+  return Object.entries(aliases)
+    .map(([canonical, alts]) => `${canonical}: ${alts.join(', ')}`)
+    .join('\n');
+}
+
+function textToAliases(text: string): Record<string, readonly string[]> | undefined {
+  if (text.trim().length === 0) return undefined;
+  const result: Record<string, string[]> = {};
+  for (const line of text.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const canonical = line.slice(0, idx).trim();
+    const alts = line.slice(idx + 1).split(',').map(s => s.trim()).filter(s => s.length > 0);
+    if (canonical.length > 0 && alts.length > 0) {
+      result[canonical] = alts;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function TagEditor({ tag, onSave, onCancel, onRemove }: Readonly<{
+  tag: EditingTag;
+  onSave: (tag: EditingTag) => void;
+  onCancel: () => void;
+  onRemove: (() => void) | undefined;
+}>) {
+  const [state, setState] = useState(tag);
+
+  return (
+    <div className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Tag Name (CUR column)</span>
+          <input
+            type="text"
+            value={state.tagName}
+            onChange={e => { setState(s => ({ ...s, tagName: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+            placeholder="e.g. team"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Display Label</span>
+          <input
+            type="text"
+            value={state.label}
+            onChange={e => { setState(s => ({ ...s, label: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+            placeholder="e.g. Team"
+          />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Concept (dimension role)</span>
+          <select
+            value={state.concept}
+            onChange={e => { setState(s => ({ ...s, concept: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            <option value="">None</option>
+            {CONCEPTS.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Normalization</span>
+          <select
+            value={state.normalize}
+            onChange={e => { setState(s => ({ ...s, normalize: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            <option value="">None</option>
+            {NORMALIZE_RULES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+          </select>
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Alias Rules (one per line: canonical: alias1, alias2)</span>
+        <textarea
+          value={state.aliases}
+          onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
+          rows={4}
+          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-xs text-text-primary font-mono outline-none focus:border-accent resize-y"
+          placeholder="production: prod, prd, Production&#10;staging: stg, stage"
+        />
+      </label>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button type="button" onClick={() => { onSave(state); }} className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white hover:bg-accent-hover transition-colors">
+            Save
+          </button>
+          <button type="button" onClick={onCancel} className="rounded-md px-4 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary transition-colors">
+            Cancel
+          </button>
+        </div>
+        {onRemove !== undefined && (
+          <button type="button" onClick={onRemove} className="rounded-md px-4 py-1.5 text-xs font-medium text-negative hover:bg-negative-muted transition-colors">
+            Remove Dimension
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function DimensionsView() {
+  const api = useCostApi();
+  const tagsQuery = useQuery(() => api.discoverTagKeys(), []);
+  const configQuery = useQuery(() => api.getDimensionsConfig(), []);
+  const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [addingNew, setAddingNew] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [tagSearch, setTagSearch] = useState('');
+
+  const discoveredTags = tagsQuery.status === 'success' ? tagsQuery.data : [];
+  const config: DimensionsConfig | null = configQuery.status === 'success' ? configQuery.data : null;
+  const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
+
+  // Account tag keys from org sync
+  const accountTagKeys = orgData !== null
+    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort()
+    : [];
+
+  // Which resource tags are already mapped as dimensions
+  const mappedTagNames = new Set(config?.tags.map(t => t.tagName) ?? []);
+
+  // Filter discovered tags
+  const filteredDiscovered = tagSearch.length > 0
+    ? discoveredTags.filter(t => t.key.toLowerCase().includes(tagSearch.toLowerCase()))
+    : discoveredTags;
+
+  function editingToTagDimension(editing: EditingTag): TagDimension {
+    const base: { tagName: string; label: string } = { tagName: editing.tagName, label: editing.label };
+    const concept = editing.concept.length > 0 ? editing.concept as ConceptType : undefined;
+    const normalize = editing.normalize.length > 0 ? editing.normalize as NormalizationRule : undefined;
+    const aliases = textToAliases(editing.aliases);
+    return { ...base, concept, normalize, aliases };
+  }
+
+  async function handleSaveTag(idx: number, editing: EditingTag) {
+    if (config === null) return;
+    const tags = [...config.tags];
+    tags[idx] = editingToTagDimension(editing);
+    await api.saveDimensionsConfig({ ...config, tags });
+    setEditingIdx(null);
+    setRefreshKey(k => k + 1);
+  }
+
+  async function handleAddTag(editing: EditingTag) {
+    if (config === null) return;
+    const newTag = editingToTagDimension(editing);
+    await api.saveDimensionsConfig({ ...config, tags: [...config.tags, newTag] });
+    setAddingNew(false);
+    setRefreshKey(k => k + 1);
+  }
+
+  async function handleRemoveTag(idx: number) {
+    if (config === null) return;
+    const tags = config.tags.filter((_, i) => i !== idx);
+    await api.saveDimensionsConfig({ ...config, tags });
+    setEditingIdx(null);
+    setRefreshKey(k => k + 1);
+  }
+
+  // Quick-add a discovered tag as a dimension
+  function handleQuickAdd(tagKey: string) {
+    const label = tagKey
+      .replace(/^(user:|aws:|resource_tags_user_)/i, '')
+      .replaceAll('_', ' ')
+      .replaceAll('-', ' ')
+      .replace(/\b\w/g, c => c.toUpperCase());
+
+    setAddingNew(true);
+    setEditingIdx(null);
+    // The TagEditor will be shown with pre-filled values
+    // We need to pass the initial state — using a key trick
+    setQuickAddState({ tagName: tagKey, label, concept: '', normalize: '', aliases: '', accountTagFallback: false });
+  }
+
+  const [quickAddState, setQuickAddState] = useState<EditingTag | null>(null);
+
+  void refreshKey; // used as useQuery dep to force re-fetch
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div>
+        <h2 className="text-xl font-semibold text-text-primary">Dimensions</h2>
+        <p className="text-sm text-text-secondary mt-1">Map tags to cost allocation dimensions</p>
+      </div>
+
+      {/* Current dimension mappings */}
+      {config !== null && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-text-secondary">Active Dimensions</h3>
+            <button
+              type="button"
+              onClick={() => { setAddingNew(true); setEditingIdx(null); setQuickAddState(null); }}
+              className="rounded-md border border-accent/50 bg-accent/10 px-3 py-1 text-xs font-medium text-accent hover:bg-accent/20 transition-colors"
+            >
+              + Add Dimension
+            </button>
+          </div>
+
+          {/* Built-in dimensions (read-only) */}
+          {config.builtIn.map(d => (
+            <div key={d.name} className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between">
+              <div>
+                <span className="text-sm font-medium text-text-primary">{d.label}</span>
+                <span className="text-xs text-text-muted ml-2">built-in · {d.field}</span>
+              </div>
+              <span className="text-[10px] text-text-muted uppercase tracking-wider">Built-in</span>
+            </div>
+          ))}
+
+          {/* Tag dimensions (editable) */}
+          {config.tags.map((tag, idx) => (
+            <div key={tag.tagName}>
+              {editingIdx === idx ? (
+                <TagEditor
+                  tag={{
+                    tagName: tag.tagName,
+                    label: tag.label,
+                    concept: tag.concept ?? '',
+                    normalize: tag.normalize ?? '',
+                    aliases: aliasesToText(tag.aliases),
+                    accountTagFallback: false,
+                  }}
+                  onSave={(edited) => { void handleSaveTag(idx, edited); }}
+                  onCancel={() => { setEditingIdx(null); }}
+                  onRemove={() => { void handleRemoveTag(idx); }}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => { setEditingIdx(idx); setAddingNew(false); }}
+                  className="w-full rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between text-left hover:bg-bg-tertiary/30 transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium text-text-primary">{tag.label}</span>
+                    <span className="text-xs text-text-muted font-mono">tag:{tag.tagName}</span>
+                    {tag.concept !== undefined && (
+                      <span className="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
+                        {tag.concept}
+                      </span>
+                    )}
+                    {tag.normalize !== undefined && (
+                      <span className="text-[10px] text-text-muted">{tag.normalize}</span>
+                    )}
+                    {tag.aliases !== undefined && (
+                      <span className="text-[10px] text-text-muted">{String(Object.keys(tag.aliases).length)} alias rules</span>
+                    )}
+                  </div>
+                  <span className="text-xs text-text-muted">Edit →</span>
+                </button>
+              )}
+            </div>
+          ))}
+
+          {/* Add new dimension form */}
+          {addingNew && (
+            <TagEditor
+              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', accountTagFallback: false }}
+              onSave={(edited) => { void handleAddTag(edited); }}
+              onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
+              onRemove={undefined}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Discovered tags from billing data */}
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-text-secondary">
+            Discovered Resource Tags
+            {discoveredTags.length > 0 && <span className="text-text-muted ml-1">({String(discoveredTags.length)})</span>}
+          </h3>
+          <input
+            type="text"
+            placeholder="Search tags..."
+            value={tagSearch}
+            onChange={e => { setTagSearch(e.target.value); }}
+            className="w-48 rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
+          />
+        </div>
+
+        {tagsQuery.status === 'loading' && (
+          <div className="text-sm text-text-secondary">Scanning billing data for tags...</div>
+        )}
+
+        {filteredDiscovered.length > 0 && (
+          <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border text-left text-text-muted">
+                  <th className="px-4 py-2 font-medium">Tag Key</th>
+                  <th className="px-4 py-2 font-medium">Rows</th>
+                  <th className="px-4 py-2 font-medium">Sample Values</th>
+                  <th className="px-4 py-2 font-medium w-24"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border-subtle">
+                {filteredDiscovered.map(tag => (
+                  <tr key={tag.key} className="hover:bg-bg-tertiary/20">
+                    <td className="px-4 py-2 font-mono text-text-primary">{tag.key}</td>
+                    <td className="px-4 py-2 tabular-nums text-text-secondary">{tag.rowCount.toLocaleString()}</td>
+                    <td className="px-4 py-2 text-text-muted">
+                      <div className="flex flex-wrap gap-1">
+                        {tag.sampleValues.slice(0, 5).map(v => (
+                          <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px]">{v}</span>
+                        ))}
+                        {tag.sampleValues.length > 5 && <span className="text-[10px] text-text-muted">+{String(tag.sampleValues.length - 5)}</span>}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2">
+                      {mappedTagNames.has(tag.key) ? (
+                        <span className="text-[10px] text-accent">Mapped</span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => { handleQuickAdd(tag.key); }}
+                          className="rounded px-2 py-0.5 text-[10px] font-medium text-accent hover:bg-accent/10 transition-colors"
+                        >
+                          + Add
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Account tags from AWS Organizations */}
+      {accountTagKeys.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium text-text-secondary">
+            Account Tags (from AWS Organizations)
+            <span className="text-text-muted ml-1">({String(accountTagKeys.length)} keys)</span>
+          </h3>
+          <p className="text-xs text-text-muted">
+            These tags are set at the account level in AWS Organizations. They can be used as fallback values when resource-level tags are missing.
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {accountTagKeys.map(key => (
+              <span key={key} className="rounded-full border border-border bg-bg-tertiary/30 px-2.5 py-0.5 text-[10px] text-text-secondary">
+                {key}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -46,13 +46,15 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, accountTagKeys: acctTags, isNew }: Readonly<{
+function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredTags: discovered, accountTagKeys: acctTags, orgAccounts, isNew }: Readonly<{
   tag: EditingTag;
   onSave: (tag: EditingTag) => void;
   onCancel: () => void;
   onRemove: (() => void) | undefined;
   availableTags: readonly string[];
+  discoveredTags: readonly { key: string; sampleValues: string[]; rowCount: number }[];
   accountTagKeys: readonly string[];
+  orgAccounts: readonly { tags: Readonly<Record<string, string>> }[];
   isNew: boolean;
 }>) {
   const [state, setState] = useState(tag);
@@ -89,6 +91,18 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, accountTagK
               placeholder="e.g. team"
             />
           )}
+          {state.tagName.length > 0 && (() => {
+            const match = discovered.find(t => t.key === state.tagName);
+            if (match === undefined) return null;
+            return (
+              <div className="flex flex-wrap gap-1 mt-1">
+                <span className="text-[10px] text-text-muted">{match.rowCount.toLocaleString()} rows:</span>
+                {match.sampleValues.map(v => (
+                  <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">{v}</span>
+                ))}
+              </div>
+            );
+          })()}
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Display Label</span>
@@ -128,7 +142,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, accountTagK
       </div>
 
       {acctTags.length > 0 && (
-        <label className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Fallback account tag (used when resource tag is missing)</span>
           <select
             value={state.fallbackTag ?? ''}
@@ -138,7 +152,27 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, accountTagK
             <option value="">No fallback</option>
             {acctTags.map(t => <option key={t} value={t}>{t}</option>)}
           </select>
-        </label>
+          {state.fallbackTag !== undefined && state.fallbackTag.length > 0 && (() => {
+            const counts = new Map<string, number>();
+            for (const acct of orgAccounts) {
+              const val = acct.tags[state.fallbackTag];
+              if (val !== undefined && val.length > 0) {
+                counts.set(val, (counts.get(val) ?? 0) + 1);
+              }
+            }
+            const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+            if (sorted.length === 0) return null;
+            return (
+              <div className="flex flex-wrap gap-1 mt-1">
+                {sorted.map(([val, cnt]) => (
+                  <span key={val} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">
+                    {val} <span className="text-text-muted">({String(cnt)})</span>
+                  </span>
+                ))}
+              </div>
+            );
+          })()}
+        </div>
       )}
 
       <label className="flex flex-col gap-1">
@@ -309,7 +343,9 @@ export function DimensionsView() {
                   onCancel={() => { setEditingIdx(null); }}
                   onRemove={() => { void handleRemoveTag(idx); }}
                   availableTags={[]}
+                  discoveredTags={discoveredTags}
                   accountTagKeys={accountTagKeys}
+                  orgAccounts={orgData?.accounts ?? []}
                   isNew={false}
                 />
               ) : (
@@ -350,7 +386,9 @@ export function DimensionsView() {
               onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
               onRemove={undefined}
               availableTags={unmappedTagKeys}
+              discoveredTags={discoveredTags}
               accountTagKeys={accountTagKeys}
+              orgAccounts={orgData?.accounts ?? []}
               isNew
             />
           )}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -20,8 +20,8 @@ interface EditingTag {
   label: string;
   concept: string;
   normalize: string;
-  aliases: string; // "canonical: alias1, alias2\n..."
-  accountTagFallback: boolean;
+  aliases: string;
+  fallbackTag: string | undefined;
 }
 
 function aliasesToText(aliases: Readonly<Record<string, readonly string[]>> | undefined): string {
@@ -46,12 +46,13 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, isNew }: Readonly<{
+function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, accountTagKeys: acctTags, isNew }: Readonly<{
   tag: EditingTag;
   onSave: (tag: EditingTag) => void;
   onCancel: () => void;
   onRemove: (() => void) | undefined;
   availableTags: readonly string[];
+  accountTagKeys: readonly string[];
   isNew: boolean;
 }>) {
   const [state, setState] = useState(tag);
@@ -126,6 +127,20 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, isNew }: Re
         </label>
       </div>
 
+      {acctTags.length > 0 && (
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Fallback account tag (used when resource tag is missing)</span>
+          <select
+            value={state.fallbackTag ?? ''}
+            onChange={e => { setState(s => ({ ...s, fallbackTag: e.target.value.length > 0 ? e.target.value : undefined })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            <option value="">No fallback</option>
+            {acctTags.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </label>
+      )}
+
       <label className="flex flex-col gap-1">
         <span className="text-xs text-text-muted">Alias Rules (one per line: canonical: alias1, alias2)</span>
         <textarea
@@ -195,7 +210,8 @@ export function DimensionsView() {
     const concept = editing.concept.length > 0 ? editing.concept as ConceptType : undefined;
     const normalize = editing.normalize.length > 0 ? editing.normalize as NormalizationRule : undefined;
     const aliases = textToAliases(editing.aliases);
-    return { ...base, concept, normalize, aliases };
+    const accountTagFallback = editing.fallbackTag !== undefined && editing.fallbackTag.length > 0 ? editing.fallbackTag : undefined;
+    return { ...base, concept, normalize, aliases, accountTagFallback };
   }
 
   async function handleSaveTag(idx: number, editing: EditingTag) {
@@ -235,7 +251,7 @@ export function DimensionsView() {
     setEditingIdx(null);
     // The TagEditor will be shown with pre-filled values
     // We need to pass the initial state — using a key trick
-    setQuickAddState({ tagName: tagKey, label, concept: '', normalize: '', aliases: '', accountTagFallback: false });
+    setQuickAddState({ tagName: tagKey, label, concept: '', normalize: '', aliases: '', fallbackTag: undefined });
   }
 
   const [quickAddState, setQuickAddState] = useState<EditingTag | null>(null);
@@ -266,9 +282,12 @@ export function DimensionsView() {
           {/* Built-in dimensions (read-only) */}
           {config.builtIn.map(d => (
             <div key={d.name} className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between">
-              <div>
+              <div className="flex items-center gap-3">
                 <span className="text-sm font-medium text-text-primary">{d.label}</span>
-                <span className="text-xs text-text-muted ml-2">built-in · {d.field}</span>
+                <span className="text-xs text-text-muted font-mono">{d.field}</span>
+                {d.displayField !== undefined && (
+                  <span className="text-[10px] text-text-muted">display: {d.displayField}</span>
+                )}
               </div>
               <span className="text-[10px] text-text-muted uppercase tracking-wider">Built-in</span>
             </div>
@@ -285,12 +304,13 @@ export function DimensionsView() {
                     concept: tag.concept ?? '',
                     normalize: tag.normalize ?? '',
                     aliases: aliasesToText(tag.aliases),
-                    accountTagFallback: false,
+                    fallbackTag: tag.accountTagFallback,
                   }}
                   onSave={(edited) => { void handleSaveTag(idx, edited); }}
                   onCancel={() => { setEditingIdx(null); }}
                   onRemove={() => { void handleRemoveTag(idx); }}
                   availableTags={[]}
+                  accountTagKeys={accountTagKeys}
                   isNew={false}
                 />
               ) : (
@@ -313,6 +333,9 @@ export function DimensionsView() {
                     {tag.aliases !== undefined && (
                       <span className="text-[10px] text-text-muted">{String(Object.keys(tag.aliases).length)} alias rules</span>
                     )}
+                    {tag.accountTagFallback !== undefined && (
+                      <span className="text-[10px] text-text-muted">fallback: {tag.accountTagFallback}</span>
+                    )}
                   </div>
                   <span className="text-xs text-text-muted">Edit →</span>
                 </button>
@@ -323,11 +346,12 @@ export function DimensionsView() {
           {/* Add new dimension form */}
           {addingNew && (
             <TagEditor
-              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', accountTagFallback: false }}
+              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined }}
               onSave={(edited) => { void handleAddTag(edited); }}
               onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
               onRemove={undefined}
               availableTags={unmappedTagKeys}
+              accountTagKeys={accountTagKeys}
               isNew
             />
           )}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -193,12 +193,11 @@ export function DimensionsView() {
   // Which resource tags are already mapped as dimensions
   const mappedTagNames = new Set(config?.tags.map(t => t.tagName) ?? []);
 
-  // Tags discovered in billing data + account tags, minus already-mapped ones
-  const allKnownTags = [...new Set([
-    ...discoveredTags.map(t => t.key),
-    ...accountTagKeys,
-  ])].sort();
-  const unmappedTagKeys = allKnownTags.filter(k => !mappedTagNames.has(k));
+  // Only CUR resource tags for the primary dropdown (not account tags)
+  const unmappedTagKeys = discoveredTags
+    .map(t => t.key)
+    .filter(k => !mappedTagNames.has(k))
+    .sort();
 
   // Filter discovered tags
   const filteredDiscovered = tagSearch.length > 0

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -46,11 +46,13 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function TagEditor({ tag, onSave, onCancel, onRemove }: Readonly<{
+function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, isNew }: Readonly<{
   tag: EditingTag;
   onSave: (tag: EditingTag) => void;
   onCancel: () => void;
   onRemove: (() => void) | undefined;
+  availableTags: readonly string[];
+  isNew: boolean;
 }>) {
   const [state, setState] = useState(tag);
 
@@ -59,13 +61,33 @@ function TagEditor({ tag, onSave, onCancel, onRemove }: Readonly<{
       <div className="grid grid-cols-2 gap-4">
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Tag Name (CUR column)</span>
-          <input
-            type="text"
-            value={state.tagName}
-            onChange={e => { setState(s => ({ ...s, tagName: e.target.value })); }}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-            placeholder="e.g. team"
-          />
+          {isNew && availableTags.length > 0 ? (
+            <select
+              value={state.tagName}
+              onChange={e => {
+                const name = e.target.value;
+                const label = name
+                  .replace(/^user_/i, '')
+                  .replaceAll('_', ' ')
+                  .replaceAll('-', ' ')
+                  .replace(/\b\w/g, c => c.toUpperCase());
+                setState(s => ({ ...s, tagName: name, label: s.label.length === 0 ? label : s.label }));
+              }}
+              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+            >
+              <option value="">Select a tag...</option>
+              {availableTags.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          ) : (
+            <input
+              type="text"
+              value={state.tagName}
+              readOnly={!isNew}
+              onChange={e => { setState(s => ({ ...s, tagName: e.target.value })); }}
+              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+              placeholder="e.g. team"
+            />
+          )}
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Display Label</span>
@@ -155,6 +177,13 @@ export function DimensionsView() {
 
   // Which resource tags are already mapped as dimensions
   const mappedTagNames = new Set(config?.tags.map(t => t.tagName) ?? []);
+
+  // Tags discovered in billing data + account tags, minus already-mapped ones
+  const allKnownTags = [...new Set([
+    ...discoveredTags.map(t => t.key),
+    ...accountTagKeys,
+  ])].sort();
+  const unmappedTagKeys = allKnownTags.filter(k => !mappedTagNames.has(k));
 
   // Filter discovered tags
   const filteredDiscovered = tagSearch.length > 0
@@ -261,6 +290,8 @@ export function DimensionsView() {
                   onSave={(edited) => { void handleSaveTag(idx, edited); }}
                   onCancel={() => { setEditingIdx(null); }}
                   onRemove={() => { void handleRemoveTag(idx); }}
+                  availableTags={[]}
+                  isNew={false}
                 />
               ) : (
                 <button
@@ -296,6 +327,8 @@ export function DimensionsView() {
               onSave={(edited) => { void handleAddTag(edited); }}
               onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
               onRemove={undefined}
+              availableTags={unmappedTagKeys}
+              isNew
             />
           )}
         </div>

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -46,7 +46,7 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredTags: discovered, accountTagKeys: acctTags, orgAccounts, isNew }: Readonly<{
+function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredTags: discovered, accountTagKeys: acctTags, orgAccounts }: Readonly<{
   tag: EditingTag;
   onSave: (tag: EditingTag) => void;
   onCancel: () => void;
@@ -55,42 +55,38 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   discoveredTags: readonly { key: string; sampleValues: string[]; rowCount: number }[];
   accountTagKeys: readonly string[];
   orgAccounts: readonly { tags: Readonly<Record<string, string>> }[];
-  isNew: boolean;
 }>) {
   const [state, setState] = useState(tag);
 
   return (
     <div className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-4">
-        <label className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Tag Name (CUR column)</span>
-          {isNew && availableTags.length > 0 ? (
-            <select
-              value={state.tagName}
-              onChange={e => {
-                const name = e.target.value;
-                const label = name
-                  .replace(/^user_/i, '')
-                  .replaceAll('_', ' ')
-                  .replaceAll('-', ' ')
-                  .replace(/\b\w/g, c => c.toUpperCase());
-                setState(s => ({ ...s, tagName: name, label: s.label.length === 0 ? label : s.label }));
-              }}
-              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-            >
-              <option value="">Select a tag...</option>
-              {availableTags.map(t => <option key={t} value={t}>{t}</option>)}
-            </select>
-          ) : (
-            <input
-              type="text"
-              value={state.tagName}
-              readOnly={!isNew}
-              onChange={e => { setState(s => ({ ...s, tagName: e.target.value })); }}
-              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-              placeholder="e.g. team"
-            />
-          )}
+          {(() => {
+            // Build option list: current tag (if set) + all unmapped tags
+            const options = state.tagName.length > 0 && !availableTags.includes(state.tagName)
+              ? [state.tagName, ...availableTags]
+              : [...availableTags];
+            return (
+              <select
+                value={state.tagName}
+                onChange={e => {
+                  const name = e.target.value;
+                  const label = name
+                    .replace(/^user_/i, '')
+                    .replaceAll('_', ' ')
+                    .replaceAll('-', ' ')
+                    .replace(/\b\w/g, c => c.toUpperCase());
+                  setState(s => ({ ...s, tagName: name, label: s.label.length === 0 ? label : s.label }));
+                }}
+                className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+              >
+                <option value="">Select a tag...</option>
+                {options.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+            );
+          })()}
           {state.tagName.length > 0 && (() => {
             const match = discovered.find(t => t.key === state.tagName);
             if (match === undefined) return null;
@@ -103,7 +99,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               </div>
             );
           })()}
-        </label>
+        </div>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Display Label</span>
           <input
@@ -342,11 +338,10 @@ export function DimensionsView() {
                   onSave={(edited) => { void handleSaveTag(idx, edited); }}
                   onCancel={() => { setEditingIdx(null); }}
                   onRemove={() => { void handleRemoveTag(idx); }}
-                  availableTags={[]}
+                  availableTags={unmappedTagKeys}
                   discoveredTags={discoveredTags}
                   accountTagKeys={accountTagKeys}
                   orgAccounts={orgData?.accounts ?? []}
-                  isNew={false}
                 />
               ) : (
                 <button
@@ -389,7 +384,6 @@ export function DimensionsView() {
               discoveredTags={discoveredTags}
               accountTagKeys={accountTagKeys}
               orgAccounts={orgData?.accounts ?? []}
-              isNew
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- Rename "Data" nav button to "Sync" — it handles S3 sync, org discovery, auto-sync
- Add new "Dimensions" nav button for tag and dimension management
- Dimensions view: edit tag dimensions (concept, normalization, aliases), discover tags from billing data via DuckDB, see account tags from AWS Organizations
- Changes write directly to dimensions.yaml
- DuckDB-powered tag key discovery with sample values and row counts