### PR TITLE
Polish dimensions editor layout + column toggle badges

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -100,7 +100,7 @@ test.describe('App shell', () => {
   });
 
   test('shows all navigation buttons', async () => {
-    for (const label of ['Overview', 'Trends', 'Missing Tags', 'Savings', 'Data']) {
+    for (const label of ['Overview', 'Trends', 'Missing Tags', 'Savings', 'Dimensions', 'Sync']) {
       await expect(page.getByRole('button', { name: label })).toBeVisible();
     }
   });
@@ -130,7 +130,8 @@ test.describe('App shell', () => {
       { button: 'Trends', heading: 'Cost Trends' },
       { button: 'Missing Tags', heading: 'Missing Tags' },
       { button: 'Savings', heading: 'Savings Opportunities' },
-      { button: 'Data', heading: 'Data Management' },
+      { button: 'Dimensions', heading: 'Dimensions' },
+      { button: 'Sync', heading: 'Data Management' },
     ];
 
     for (const { button, heading } of views) {
@@ -860,7 +861,7 @@ test.describe('Data Management', () => {
     app = await launchApp();
     page = await app.firstWindow();
     await expect(page).toHaveTitle('CostGoblin');
-    await page.getByRole('button', { name: 'Data' }).click();
+    await page.getByRole('button', { name: 'Sync' }).click();
     await expect(page.getByRole('heading', { name: 'Data Management' })).toBeVisible();
     // Data management loads S3 inventory which can be slow — wait longer
     await waitForQuerySettle(page);
@@ -1001,6 +1002,138 @@ test.describe('Data Management', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Dimensions
+// ---------------------------------------------------------------------------
+test.describe('Dimensions', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    app = await launchApp();
+    page = await app.firstWindow();
+    await expect(page).toHaveTitle('CostGoblin');
+    await startCoverage(page);
+    await page.getByRole('button', { name: 'Dimensions' }).click();
+    await expect(page.getByRole('heading', { name: 'Dimensions' })).toBeVisible();
+    await waitForQuerySettle(page);
+  });
+
+  test.afterAll(async () => { await stopAndCollectCoverage(page); await app.close(); });
+
+  test('shows heading and subtitle', async () => {
+    await expect(page.getByText('Map tags to cost allocation dimensions')).toBeVisible();
+  });
+
+  test('shows Active Dimensions section with built-in dimensions', async () => {
+    await expect(page.getByText('Active Dimensions')).toBeVisible();
+    await expect(page.getByText('Account')).toBeVisible();
+    await expect(page.getByText('Region')).toBeVisible();
+    await expect(page.getByText('Service', { exact: true }).first()).toBeVisible();
+  });
+
+  test('shows Add Dimension button', async () => {
+    await expect(page.getByRole('button', { name: '+ Add Dimension' })).toBeVisible();
+  });
+
+  test('clicking a tag dimension opens the editor', async () => {
+    // find a tag dimension (not built-in) and click it
+    const editBtn = page.locator('button').filter({ hasText: 'Edit →' }).first();
+    const exists = await editBtn.isVisible().catch(() => false);
+
+    if (exists) {
+      await editBtn.click();
+
+      // editor should show concept, label, normalization dropdowns
+      await expect(page.getByText('Concept')).toBeVisible();
+      await expect(page.getByText('Display Label')).toBeVisible();
+      await expect(page.getByText('Normalization')).toBeVisible();
+      await expect(page.getByText('Resource Tag')).toBeVisible();
+
+      // Save and Cancel buttons
+      await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+
+      await screenshot(page, 'dimensions-editor');
+
+      // Cancel to close
+      await page.getByRole('button', { name: 'Cancel' }).click();
+    }
+  });
+
+  test('Add Dimension opens editor with tag dropdown', async () => {
+    await page.getByRole('button', { name: '+ Add Dimension' }).click();
+
+    // should show a select for tag name
+    await expect(page.getByText('Resource Tag')).toBeVisible();
+    await expect(page.getByText('Select a tag...')).toBeVisible();
+
+    await screenshot(page, 'dimensions-add-new');
+
+    // Cancel
+    await page.getByRole('button', { name: 'Cancel' }).click();
+  });
+
+  test('Resource Tags table loads or shows loading state', async () => {
+    const hasTable = await page.getByText('Resource Tags').isVisible().catch(() => false);
+    const hasLoading = await page.getByText('Scanning billing data').isVisible().catch(() => false);
+
+    // one of them should be visible
+    expect(hasTable || hasLoading).toBe(true);
+
+    if (hasTable) {
+      // badges should be visible
+      const badges = page.locator('button.rounded-full');
+      const badgeCount = await badges.count();
+      expect(badgeCount).toBeGreaterThan(0);
+
+      // table should not show "undefined"
+      const tableText = await page.locator('table').first().textContent();
+      expect(tableText).not.toContain('undefined');
+
+      await screenshot(page, 'dimensions-resource-tags');
+    }
+  });
+
+  test('Account Tags table shows when org data exists', async () => {
+    const hasAccountTags = await page.getByText('Account Tags').isVisible().catch(() => false);
+
+    if (hasAccountTags) {
+      // badges should be visible
+      const badges = page.locator('button.rounded-full');
+      const badgeCount = await badges.count();
+      expect(badgeCount).toBeGreaterThan(0);
+
+      await screenshot(page, 'dimensions-account-tags');
+    }
+  });
+
+  test('tag table badges toggle columns', async () => {
+    const badges = page.locator('button.rounded-full.border-accent\\/40');
+    const count = await badges.count();
+
+    if (count > 2) {
+      // click first badge to hide a column
+      const firstBadge = badges.first();
+      await firstBadge.click();
+
+      // it should now have strikethrough styling
+      await screenshot(page, 'dimensions-badge-toggled');
+
+      // click again to restore
+      const hiddenBadge = page.locator('button.rounded-full.line-through').first();
+      const isHidden = await hiddenBadge.isVisible().catch(() => false);
+      if (isHidden) {
+        await hiddenBadge.click();
+      }
+    }
+  });
+
+  test('no React crash on Dimensions view', async () => {
+    await assertNoReactCrash(page);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cross-view navigation — full user journey
 // ---------------------------------------------------------------------------
 test.describe('Full user journey', () => {
@@ -1036,11 +1169,15 @@ test.describe('Full user journey', () => {
     await expect(page.getByRole('heading', { name: 'Savings Opportunities' })).toBeVisible();
     await waitForQuerySettle(page);
 
-    // 5. Data
-    await page.getByRole('button', { name: 'Data' }).click();
+    // 5. Dimensions
+    await page.getByRole('button', { name: 'Dimensions' }).click();
+    await expect(page.getByRole('heading', { name: 'Dimensions' })).toBeVisible();
+
+    // 6. Sync
+    await page.getByRole('button', { name: 'Sync' }).click();
     await expect(page.getByRole('heading', { name: 'Data Management' })).toBeVisible();
 
-    // 6. Back to Overview
+    // 7. Back to Overview
     await page.getByRole('button', { name: 'Overview' }).click();
     await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible();
 
@@ -1048,7 +1185,7 @@ test.describe('Full user journey', () => {
   });
 
   test('rapid navigation between views does not crash', async () => {
-    const views = ['Trends', 'Overview', 'Missing Tags', 'Savings', 'Data', 'Overview', 'Trends', 'Missing Tags'];
+    const views = ['Trends', 'Overview', 'Missing Tags', 'Savings', 'Dimensions', 'Sync', 'Overview', 'Trends', 'Missing Tags'];
     for (const view of views) {
       await page.getByRole('button', { name: view }).click();
     }

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -44,7 +44,7 @@ function assertNumber(value: unknown, context: string): asserts value is number 
 }
 
 function isValidNormalizationRule(value: string): value is NormalizationRule {
-  return value === 'lowercase' || value === 'uppercase' || value === 'lowercase-kebab';
+  return value === 'lowercase' || value === 'uppercase' || value === 'lowercase-kebab' || value === 'lowercase-underscore' || value === 'camelCase';
 }
 
 function validateSyncTier(raw: unknown, context: string): SyncTierConfig {
@@ -155,7 +155,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     const normalize = tag['normalize'] !== undefined ? (() => {
       assertString(tag['normalize'], `${ctx}.normalize`);
       if (!isValidNormalizationRule(tag['normalize'])) {
-        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', or 'lowercase-kebab'`);
+        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
       }
       return tag['normalize'];
     })() : undefined;

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -184,6 +184,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
       ...(separator !== undefined ? { separator } : {}),
       ...(aliases !== undefined ? { aliases } : {}),
       ...(typeof tag['accountTagFallback'] === 'string' ? { accountTagFallback: tag['accountTagFallback'] } : {}),
+      ...(typeof tag['missingValueTemplate'] === 'string' ? { missingValueTemplate: tag['missingValueTemplate'] } : {}),
     };
   });
 

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -13,6 +13,15 @@ export function applyNormalizationRule(value: string, rule: NormalizationRule): 
         .replace(/([a-z])([A-Z])/g, '$1-$2')
         .replace(/[_\s]+/g, '-')
         .toLowerCase();
+    case 'lowercase-underscore':
+      return value
+        .replace(/([a-z])([A-Z])/g, '$1_$2')
+        .replace(/[-\s]+/g, '_')
+        .toLowerCase();
+    case 'camelCase':
+      return value
+        .replace(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase())
+        .replace(/^(.)/, (_, c: string) => c.toLowerCase());
   }
 }
 
@@ -63,6 +72,13 @@ export function buildAliasSqlCase(
         break;
       case 'lowercase-kebab':
         fieldExpr = `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${fieldExpr}, '([a-z])([A-Z])', '\\1-\\2'), '[_\\s]+', '-', 'g'))`;
+        break;
+      case 'lowercase-underscore':
+        fieldExpr = `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${fieldExpr}, '([a-z])([A-Z])', '\\1_\\2'), '[-\\s]+', '_', 'g'))`;
+        break;
+      case 'camelCase':
+        // SQL approximation for grouping — true camelCase applied in TypeScript
+        fieldExpr = `LOWER(REPLACE(REPLACE(REPLACE(${fieldExpr}, '-', ''), '_', ''), ' ', ''))`;
         break;
     }
   }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -96,7 +96,7 @@ export interface CostApi {
   scaffoldConfig(): Promise<void>;
   getSavingsPreferences(): Promise<SavingsPreferences>;
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
-  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }>;
+  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -96,7 +96,7 @@ export interface CostApi {
   scaffoldConfig(): Promise<void>;
   getSavingsPreferences(): Promise<SavingsPreferences>;
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
-  discoverTagKeys(): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]>;
+  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -58,6 +58,7 @@ export interface TagDimension {
   readonly separator?: string | undefined;
   readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
   readonly accountTagFallback?: string | undefined;
+  readonly missingValueTemplate?: string | undefined;
 }
 
 export interface DimensionsConfig {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { BucketPath, DimensionId } from './branded.js';
 
-export type NormalizationRule = 'lowercase' | 'uppercase' | 'lowercase-kebab';
+export type NormalizationRule = 'lowercase' | 'uppercase' | 'lowercase-kebab' | 'lowercase-underscore' | 'camelCase';
 
 export type ConceptType = 'owner' | 'product' | 'environment';
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1384,7 +1384,7 @@ tags: []
 
     const conn = await ctx.db.connect();
     try {
-      // Only scan the most recent month for speed
+      // Scan last 2 partitions (~30 days) with a date filter
       const fs = await import('node:fs/promises');
       const path = await import('node:path');
       const dailyDir = path.join(ctx.dataDir, 'aws', 'raw');
@@ -1392,8 +1392,10 @@ tags: []
       try {
         dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort();
       } catch { /* no data */ }
-      const recentDir = dirs.length > 0 ? dirs[dirs.length - 1] : 'daily-*';
-      const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/${recentDir ?? 'daily-*'}/*.parquet')`;
+      const recentDirs = dirs.slice(-2);
+      const globPattern = recentDirs.length > 0 ? `{${recentDirs.join(',')}}` : 'daily-*';
+      const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/${globPattern}/*.parquet')`;
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
       // Single query: get all tag keys with counts AND sample values
       const sql = `
@@ -1402,6 +1404,7 @@ tags: []
                  unnest(map_values(resource_tags)) AS tag_val
           FROM ${rawParquet}
           WHERE resource_tags IS NOT NULL
+            AND line_item_usage_start_date >= '${thirtyDaysAgo}'
         ),
         ranked AS (
           SELECT tag_key, tag_val,
@@ -1437,8 +1440,7 @@ tags: []
         rowCount: data.rowCount,
       }));
 
-      // Extract period from dir name (e.g. "daily-2026-04" → "2026-04")
-      const samplePeriod = (recentDir ?? '').replace(/^daily-/, '');
+      const samplePeriod = `last 30 days (since ${thirtyDaysAgo})`;
       return { tags: tagKeys, samplePeriod };
     } finally {
       conn.disconnectSync();

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1377,10 +1377,10 @@ tags: []
 
   // -- Tag discovery + Dimensions config --
 
-  ipcMain.handle('dimensions:discover-tags', async (): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]> => {
+  ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
     const provider = config.providers[0];
-    if (provider === undefined) return [];
+    if (provider === undefined) return { tags: [], samplePeriod: '' };
 
     const conn = await ctx.db.connect();
     try {
@@ -1437,7 +1437,9 @@ tags: []
         rowCount: data.rowCount,
       }));
 
-      return tagKeys;
+      // Extract period from dir name (e.g. "daily-2026-04" → "2026-04")
+      const samplePeriod = (recentDir ?? '').replace(/^daily-/, '');
+      return { tags: tagKeys, samplePeriod };
     } finally {
       conn.disconnectSync();
     }

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1377,7 +1377,7 @@ tags: []
 
   // -- Tag discovery + Dimensions config --
 
-  ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }> => {
+  ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
     const provider = config.providers[0];
     if (provider === undefined) return { tags: [], samplePeriod: '' };
@@ -1412,18 +1412,21 @@ tags: []
           WHERE resource_tags IS NOT NULL
             AND line_item_usage_start_date >= '${thirtyDaysAgo}'
         ),
-        ranked AS (
-          SELECT tag_key, tag_val,
-                 COUNT(*) AS val_cnt,
-                 SUM(COUNT(*)) OVER (PARTITION BY tag_key) AS key_cnt,
-                 COUNT(*) OVER (PARTITION BY tag_key) AS distinct_cnt,
-                 ROW_NUMBER() OVER (PARTITION BY tag_key ORDER BY COUNT(*) DESC) AS rn
+        grouped AS (
+          SELECT tag_key, tag_val, COUNT(*) AS val_cnt
           FROM tags
           WHERE tag_val IS NOT NULL AND tag_val != ''
           GROUP BY tag_key, tag_val
+        ),
+        with_stats AS (
+          SELECT *,
+                 SUM(val_cnt) OVER (PARTITION BY tag_key) AS key_cnt,
+                 COUNT(*) OVER (PARTITION BY tag_key) AS distinct_cnt,
+                 ROW_NUMBER() OVER (PARTITION BY tag_key ORDER BY val_cnt DESC) AS rn
+          FROM grouped
         )
         SELECT tag_key, key_cnt, distinct_cnt, tag_val, val_cnt
-        FROM ranked
+        FROM with_stats
         WHERE rn <= 10
         ORDER BY key_cnt DESC, tag_key, rn
       `;

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1393,8 +1393,9 @@ tags: []
         dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort();
       } catch { /* no data */ }
       const recentDirs = dirs.slice(-2);
-      const globPattern = recentDirs.length > 0 ? `{${recentDirs.join(',')}}` : 'daily-*';
-      const rawParquet = `read_parquet('${ctx.dataDir}/aws/raw/${globPattern}/*.parquet')`;
+      const rawParquet = recentDirs.length > 0
+        ? `read_parquet([${recentDirs.map(d => `'${ctx.dataDir}/aws/raw/${d}/*.parquet'`).join(', ')}])`
+        : `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
       const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
       // Single query: get all tag keys with counts AND sample values

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1427,7 +1427,6 @@ tags: []
         )
         SELECT tag_key, key_cnt, distinct_cnt, tag_val, val_cnt
         FROM with_stats
-        WHERE rn <= 10
         ORDER BY key_cnt DESC, tag_key, rn
       `;
       const rows = await queryAll(conn, sql);

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1480,6 +1480,7 @@ tags: []
         ...(t.separator === undefined ? {} : { separator: t.separator }),
         ...(t.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(t.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(t.accountTagFallback === undefined ? {} : { accountTagFallback: t.accountTagFallback }),
+        ...(t.missingValueTemplate === undefined ? {} : { missingValueTemplate: t.missingValueTemplate }),
       })),
     });
     await fs.writeFile(ctx.dimensionsPath, output);

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1398,7 +1398,12 @@ tags: []
         : `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
       const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
-      // Single query: get all tag keys with counts AND sample values
+      // Get total row count for coverage %
+      const totalSql = `SELECT COUNT(*) AS total FROM ${rawParquet} WHERE line_item_usage_start_date >= '${thirtyDaysAgo}'`;
+      const totalRows = await queryAll(conn, totalSql);
+      const totalRowCount = totalRows[0] !== undefined ? toNum(totalRows[0]['total']) : 0;
+
+      // Single query: get all tag keys with counts, distinct values, AND top values
       const sql = `
         WITH tags AS (
           SELECT unnest(map_keys(resource_tags)) AS tag_key,
@@ -1410,26 +1415,27 @@ tags: []
         ranked AS (
           SELECT tag_key, tag_val,
                  COUNT(*) AS val_cnt,
-                 COUNT(*) OVER (PARTITION BY tag_key) AS key_cnt,
+                 SUM(COUNT(*)) OVER (PARTITION BY tag_key) AS key_cnt,
+                 COUNT(*) OVER (PARTITION BY tag_key) AS distinct_cnt,
                  ROW_NUMBER() OVER (PARTITION BY tag_key ORDER BY COUNT(*) DESC) AS rn
           FROM tags
           WHERE tag_val IS NOT NULL AND tag_val != ''
           GROUP BY tag_key, tag_val
         )
-        SELECT tag_key, key_cnt, tag_val, val_cnt
+        SELECT tag_key, key_cnt, distinct_cnt, tag_val, val_cnt
         FROM ranked
         WHERE rn <= 10
         ORDER BY key_cnt DESC, tag_key, rn
       `;
       const rows = await queryAll(conn, sql);
 
-      const tagMap = new Map<string, { rowCount: number; values: { val: string; cnt: number }[] }>();
+      const tagMap = new Map<string, { rowCount: number; distinctCount: number; values: { val: string; cnt: number }[] }>();
       for (const row of rows) {
         const key = toStr(row['tag_key']);
         if (key.length === 0) continue;
         let entry = tagMap.get(key);
         if (entry === undefined) {
-          entry = { rowCount: toNum(row['key_cnt']), values: [] };
+          entry = { rowCount: toNum(row['key_cnt']), distinctCount: toNum(row['distinct_cnt']), values: [] };
           tagMap.set(key, entry);
         }
         entry.values.push({ val: toStr(row['tag_val']), cnt: toNum(row['val_cnt']) });
@@ -1439,6 +1445,8 @@ tags: []
         key,
         sampleValues: data.values.map(v => v.val),
         rowCount: data.rowCount,
+        distinctCount: data.distinctCount,
+        coveragePct: totalRowCount > 0 ? Math.round((data.rowCount / totalRowCount) * 100) : 0,
       }));
 
       const samplePeriod = `last 30 days (since ${thirtyDaysAgo})`;

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -121,8 +121,8 @@ const api: CostApi = {
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
   },
-  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }> {
-    return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }>('dimensions:discover-tags');
+  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
+    return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {
     return invoke<DimensionsConfig>('dimensions:get-config');

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -121,8 +121,8 @@ const api: CostApi = {
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
   },
-  discoverTagKeys(): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]> {
-    return invoke<{ key: string; sampleValues: string[]; rowCount: number }[]>('dimensions:discover-tags');
+  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }> {
+    return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {
     return invoke<DimensionsConfig>('dimensions:get-config');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -235,7 +235,7 @@ export class MockCostApi implements CostApi {
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
-  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400 }], samplePeriod: '2026-04' }); }
+  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500, distinctCount: 8, coveragePct: 45 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400, distinctCount: 4, coveragePct: 36 }], samplePeriod: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }
   saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -235,7 +235,7 @@ export class MockCostApi implements CostApi {
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
-  discoverTagKeys(): Promise<{ key: string; sampleValues: string[]; rowCount: number }[]> { return Promise.resolve([{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400 }]); }
+  discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400 }], samplePeriod: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }
   saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -218,9 +218,30 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         // Collect values with source tracking
         const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
         const accountVals = fallbackValues.map(([v]) => v);
+        const hasTemplate = state.missingValueTemplate.length > 0;
+
+        // When a template is set, account fallback values are replaced by template-generated values
+        const templateVals: string[] = [];
+        if (hasTemplate) {
+          // Generate template values by substituting each account fallback value
+          const templateHasVar = /\{[^}]+\}/.test(state.missingValueTemplate);
+          if (templateHasVar) {
+            for (const acctVal of accountVals) {
+              templateVals.push(state.missingValueTemplate.replaceAll(/\{[^}]+\}/g, acctVal));
+            }
+          } else {
+            // Static template — just one value
+            templateVals.push(state.missingValueTemplate);
+          }
+        }
+
         const resourceSet = new Set(resourceVals);
-        const accountSet = new Set(accountVals);
-        const allRaw = [...new Set([...resourceVals, ...accountVals])];
+        const templateSet = new Set(templateVals);
+        // When template is set, don't include raw account vals — they're replaced by template vals
+        const allRaw = hasTemplate
+          ? [...new Set([...resourceVals, ...templateVals])]
+          : [...new Set([...resourceVals, ...accountVals])];
+        const accountSet = hasTemplate ? new Set<string>() : new Set(accountVals);
         if (allRaw.length === 0) return null;
 
         // Apply normalization
@@ -247,13 +268,18 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         }
 
         // Transform: normalize → alias resolve → track source
-        type Source = 'resource' | 'account' | 'both';
+        type Source = 'resource' | 'account' | 'both' | 'template';
         const transformed = allRaw.map(raw => {
           const normalized = normalize(raw);
           const resolved = aliasMap.get(normalized) ?? normalized;
           const fromResource = resourceSet.has(raw);
           const fromAccount = accountSet.has(raw);
-          const source: Source = fromResource && fromAccount ? 'both' : fromResource ? 'resource' : 'account';
+          const fromTemplate = templateSet.has(raw);
+          let source: Source;
+          if (fromTemplate) source = 'template';
+          else if (fromResource && fromAccount) source = 'both';
+          else if (fromResource) source = 'resource';
+          else source = 'account';
           return { raw, resolved, changed: resolved !== raw, source };
         });
 
@@ -288,15 +314,17 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
-              {state.missingValueTemplate.length > 0 && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> missing</span>}
+              {hasTemplate && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> template</span>}
             </div>
             <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
               {unique.map(({ resolved, changed, source }) => {
-                const colors = source === 'both'
-                  ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
-                  : source === 'account'
-                    ? 'bg-violet-500/10 border-violet-500/30 text-violet-300'
-                    : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
+                const colors = source === 'template'
+                  ? 'bg-warning/10 border-warning/30 text-warning italic'
+                  : source === 'both'
+                    ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+                    : source === 'account'
+                      ? 'bg-violet-500/10 border-violet-500/30 text-violet-300'
+                      : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
                 return (
                 <span
                   key={resolved}
@@ -306,11 +334,6 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
                 </span>
                 );
               })}
-              {state.missingValueTemplate.length > 0 && (
-                <span className="rounded border px-1.5 py-0.5 text-[10px] font-mono bg-warning/10 border-warning/30 text-warning italic">
-                  {state.missingValueTemplate}
-                </span>
-              )}
             </div>
           </div>
         );

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -254,7 +254,9 @@ export function DimensionsView() {
   const [addingNew, setAddingNew] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const discoveredTags = tagsQuery.status === 'success' ? tagsQuery.data : [];
+  const tagsResult = tagsQuery.status === 'success' ? tagsQuery.data : null;
+  const discoveredTags = tagsResult?.tags ?? [];
+  const samplePeriod = tagsResult?.samplePeriod ?? '';
   const config: DimensionsConfig | null = configQuery.status === 'success' ? configQuery.data : null;
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
 
@@ -420,7 +422,7 @@ export function DimensionsView() {
         <div className="flex flex-col gap-3">
           <h3 className="text-sm font-medium text-text-secondary">
             Resource Tags
-            <span className="text-text-muted ml-1">({String(discoveredTags.length)} keys)</span>
+            <span className="text-text-muted ml-1">({String(discoveredTags.length)} keys{samplePeriod.length > 0 ? ` · sampled from ${samplePeriod}` : ''})</span>
           </h3>
           <div className="flex flex-wrap gap-1.5">
             {[...discoveredTags].sort((a, b) => {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -186,19 +186,17 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 
       {/* Row: Missing value template */}
       <label className="flex flex-col gap-1">
-        <span className="text-xs text-text-muted">When value is missing (after fallback)</span>
+        <span className="text-xs text-text-muted">Fallback format</span>
         <input
           type="text"
           value={state.missingValueTemplate}
           onChange={e => { setState(s => ({ ...s, missingValueTemplate: e.target.value })); }}
           className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
-          placeholder={state.fallbackTag !== undefined && state.fallbackTag.length > 0 ? `e.g. unknown-{${state.fallbackTag}}` : 'e.g. unknown-{owner}'}
+          placeholder="{fallback}"
         />
-        {state.missingValueTemplate.length > 0 && (
-          <span className="text-[10px] text-text-muted">
-            Example: {state.missingValueTemplate.replaceAll(/\{[^}]+\}/g, 'some-value')} — variables in {'{ }'} are resolved from other dimensions
-          </span>
-        )}
+        <span className="text-[10px] text-text-muted">
+          {'{fallback}'} = account tag value. Example: unknown-{'{fallback}'} → unknown-payments
+        </span>
       </label>
 
       {/* Row 4: Alias rules (compact) */}
@@ -218,30 +216,30 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         // Collect values with source tracking
         const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
         const accountVals = fallbackValues.map(([v]) => v);
-        const hasTemplate = state.missingValueTemplate.length > 0;
+        // Fallback format: {fallback} = raw account value, or custom like "unknown-{fallback}"
+        const fallbackFormat = state.missingValueTemplate.length > 0 ? state.missingValueTemplate : '{fallback}';
+        const isPassthrough = fallbackFormat === '{fallback}';
 
-        // When a template is set, account fallback values are replaced by template-generated values
+        // Generate formatted fallback values
         const templateVals: string[] = [];
-        if (hasTemplate) {
-          // Generate template values by substituting each account fallback value
-          const templateHasVar = /\{[^}]+\}/.test(state.missingValueTemplate);
-          if (templateHasVar) {
+        if (!isPassthrough && accountVals.length > 0) {
+          if (fallbackFormat.includes('{fallback}')) {
             for (const acctVal of accountVals) {
-              templateVals.push(state.missingValueTemplate.replaceAll(/\{[^}]+\}/g, acctVal));
+              templateVals.push(fallbackFormat.replaceAll('{fallback}', acctVal));
             }
           } else {
-            // Static template — just one value
-            templateVals.push(state.missingValueTemplate);
+            // Static string, no variable
+            templateVals.push(fallbackFormat);
           }
         }
 
         const resourceSet = new Set(resourceVals);
         const templateSet = new Set(templateVals);
-        // When template is set, don't include raw account vals — they're replaced by template vals
-        const allRaw = hasTemplate
-          ? [...new Set([...resourceVals, ...templateVals])]
-          : [...new Set([...resourceVals, ...accountVals])];
-        const accountSet = hasTemplate ? new Set<string>() : new Set(accountVals);
+        // When format changes the value, show template vals instead of raw account vals
+        const allRaw = isPassthrough
+          ? [...new Set([...resourceVals, ...accountVals])]
+          : [...new Set([...resourceVals, ...templateVals])];
+        const accountSet = isPassthrough ? new Set(accountVals) : new Set<string>();
         if (allRaw.length === 0) return null;
 
         // Apply normalization
@@ -314,7 +312,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
-              {hasTemplate && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> template</span>}
+              {!isPassthrough && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> formatted</span>}
             </div>
             <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
               {unique.map(({ resolved, changed, source }) => {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -53,7 +53,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   onCancel: () => void;
   onRemove: (() => void) | undefined;
   availableTags: readonly string[];
-  discoveredTags: readonly { key: string; sampleValues: string[]; rowCount: number }[];
+  discoveredTags: readonly { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[];
   accountTagKeys: readonly string[];
   orgAccounts: readonly { tags: Readonly<Record<string, string>> }[];
 }>) {
@@ -139,7 +139,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         <div className="flex flex-col gap-1">
           {tagMatch !== undefined && (
             <>
-              <span className="text-xs text-text-muted">{tagMatch.rowCount.toLocaleString()} rows — top values</span>
+              <span className="text-xs text-text-muted">{String(tagMatch.coveragePct)}% coverage · {String(tagMatch.distinctCount)} distinct values</span>
               <div className="flex flex-wrap gap-1">
                 {tagMatch.sampleValues.map(v => (
                   <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">{v}</span>
@@ -508,7 +508,7 @@ export function DimensionsView() {
                       <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
                         <div className="flex flex-col gap-0.5">
                           <span className="font-mono">{t.key}</span>
-                          <span className="text-[9px] text-text-muted font-normal">{t.rowCount.toLocaleString()} rows</span>
+                          <span className="text-[9px] text-text-muted font-normal">{String(t.coveragePct)}% · {String(t.distinctCount)} values</span>
                         </div>
                       </th>
                     ))}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -58,48 +58,52 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 }>) {
   const [state, setState] = useState(tag);
 
+  const tagOptions = state.tagName.length > 0 && !availableTags.includes(state.tagName)
+    ? [state.tagName, ...availableTags]
+    : [...availableTags];
+
+  const tagMatch = discovered.find(t => t.key === state.tagName);
+
+  const fallbackValues = (() => {
+    if (state.fallbackTag === undefined || state.fallbackTag.length === 0) return [];
+    const counts = new Map<string, number>();
+    for (const acct of orgAccounts) {
+      const val = acct.tags[state.fallbackTag];
+      if (val !== undefined && val.length > 0) {
+        counts.set(val, (counts.get(val) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  })();
+
+  // Compute alias preview: show what each alias resolves to
+  const aliasPreview = (() => {
+    const parsed = textToAliases(state.aliases);
+    if (parsed === undefined) return [];
+    const result: { from: string; to: string }[] = [];
+    for (const [canonical, alts] of Object.entries(parsed)) {
+      for (const alt of alts) {
+        result.push({ from: alt, to: canonical });
+      }
+    }
+    return result;
+  })();
+
   return (
     <div className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
-      <div className="grid grid-cols-2 gap-4">
-        <div className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Tag Name (CUR column)</span>
-          {(() => {
-            // Build option list: current tag (if set) + all unmapped tags
-            const options = state.tagName.length > 0 && !availableTags.includes(state.tagName)
-              ? [state.tagName, ...availableTags]
-              : [...availableTags];
-            return (
-              <select
-                value={state.tagName}
-                onChange={e => {
-                  const name = e.target.value;
-                  const label = name
-                    .replace(/^user_/i, '')
-                    .replaceAll('_', ' ')
-                    .replaceAll('-', ' ')
-                    .replace(/\b\w/g, c => c.toUpperCase());
-                  setState(s => ({ ...s, tagName: name, label: s.label.length === 0 ? label : s.label }));
-                }}
-                className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-              >
-                <option value="">Select a tag...</option>
-                {options.map(t => <option key={t} value={t}>{t}</option>)}
-              </select>
-            );
-          })()}
-          {state.tagName.length > 0 && (() => {
-            const match = discovered.find(t => t.key === state.tagName);
-            if (match === undefined) return null;
-            return (
-              <div className="flex flex-wrap gap-1 mt-1">
-                <span className="text-[10px] text-text-muted">{match.rowCount.toLocaleString()} rows:</span>
-                {match.sampleValues.map(v => (
-                  <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">{v}</span>
-                ))}
-              </div>
-            );
-          })()}
-        </div>
+      {/* Row 1: Concept + Display Label + Normalization */}
+      <div className="grid grid-cols-3 gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Concept</span>
+          <select
+            value={state.concept}
+            onChange={e => { setState(s => ({ ...s, concept: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            <option value="">None</option>
+            {CONCEPTS.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
+          </select>
+        </label>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Display Label</span>
           <input
@@ -109,20 +113,6 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
             placeholder="e.g. Team"
           />
-        </label>
-      </div>
-
-      <div className="grid grid-cols-2 gap-4">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Concept (dimension role)</span>
-          <select
-            value={state.concept}
-            onChange={e => { setState(s => ({ ...s, concept: e.target.value })); }}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-          >
-            <option value="">None</option>
-            {CONCEPTS.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
-          </select>
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Normalization</span>
@@ -137,50 +127,102 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         </label>
       </div>
 
-      {acctTags.length > 0 && (
+      {/* Row 2: Tag Name + preview */}
+      <div className="grid grid-cols-[1fr_2fr] gap-4 items-start">
         <div className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Fallback account tag (used when resource tag is missing)</span>
+          <span className="text-xs text-text-muted">Resource Tag</span>
           <select
-            value={state.fallbackTag ?? ''}
-            onChange={e => { setState(s => ({ ...s, fallbackTag: e.target.value.length > 0 ? e.target.value : undefined })); }}
+            value={state.tagName}
+            onChange={e => {
+              const name = e.target.value;
+              const label = name
+                .replace(/^user_/i, '')
+                .replaceAll('_', ' ')
+                .replaceAll('-', ' ')
+                .replace(/\b\w/g, c => c.toUpperCase());
+              setState(s => ({ ...s, tagName: name, label: s.label.length === 0 ? label : s.label }));
+            }}
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
           >
-            <option value="">No fallback</option>
-            {acctTags.map(t => <option key={t} value={t}>{t}</option>)}
+            <option value="">Select a tag...</option>
+            {tagOptions.map(t => <option key={t} value={t}>{t}</option>)}
           </select>
-          {state.fallbackTag !== undefined && state.fallbackTag.length > 0 && (() => {
-            const counts = new Map<string, number>();
-            for (const acct of orgAccounts) {
-              const val = acct.tags[state.fallbackTag];
-              if (val !== undefined && val.length > 0) {
-                counts.set(val, (counts.get(val) ?? 0) + 1);
-              }
-            }
-            const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
-            if (sorted.length === 0) return null;
-            return (
-              <div className="flex flex-wrap gap-1 mt-1">
-                {sorted.map(([val, cnt]) => (
-                  <span key={val} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">
-                    {val} <span className="text-text-muted">({String(cnt)})</span>
-                  </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          {tagMatch !== undefined && (
+            <>
+              <span className="text-xs text-text-muted">{tagMatch.rowCount.toLocaleString()} rows — top values</span>
+              <div className="flex flex-wrap gap-1">
+                {tagMatch.sampleValues.map(v => (
+                  <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">{v}</span>
                 ))}
               </div>
-            );
-          })()}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Row 3: Fallback + preview */}
+      {acctTags.length > 0 && (
+        <div className="grid grid-cols-[1fr_2fr] gap-4 items-start">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-text-muted">Fallback (account tag)</span>
+            <select
+              value={state.fallbackTag ?? ''}
+              onChange={e => { setState(s => ({ ...s, fallbackTag: e.target.value.length > 0 ? e.target.value : undefined })); }}
+              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+            >
+              <option value="">No fallback</option>
+              {acctTags.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            {fallbackValues.length > 0 && (
+              <>
+                <span className="text-xs text-text-muted">{String(fallbackValues.length)} distinct values</span>
+                <div className="flex flex-wrap gap-1">
+                  {fallbackValues.slice(0, 12).map(([val, cnt]) => (
+                    <span key={val} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">
+                      {val} <span className="text-text-muted">({String(cnt)})</span>
+                    </span>
+                  ))}
+                  {fallbackValues.length > 12 && <span className="text-[10px] text-text-muted">+{String(fallbackValues.length - 12)}</span>}
+                </div>
+              </>
+            )}
+          </div>
         </div>
       )}
 
-      <label className="flex flex-col gap-1">
-        <span className="text-xs text-text-muted">Alias Rules (one per line: canonical: alias1, alias2)</span>
-        <textarea
-          value={state.aliases}
-          onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
-          rows={4}
-          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-xs text-text-primary font-mono outline-none focus:border-accent resize-y"
-          placeholder="production: prod, prd, Production&#10;staging: stg, stage"
-        />
-      </label>
+      {/* Row 4: Alias rules + resolved preview */}
+      <div className="grid grid-cols-[1fr_1fr] gap-4 items-start">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Alias Rules</span>
+          <textarea
+            value={state.aliases}
+            onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
+            rows={3}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-xs text-text-primary font-mono outline-none focus:border-accent resize-y"
+            placeholder="production: prod, prd&#10;staging: stg, stage"
+          />
+        </label>
+        <div className="flex flex-col gap-1">
+          {aliasPreview.length > 0 && (
+            <>
+              <span className="text-xs text-text-muted">Resolved mappings</span>
+              <div className="flex flex-col gap-0.5 text-xs">
+                {aliasPreview.map(({ from, to }) => (
+                  <div key={from} className="flex items-center gap-2">
+                    <span className="text-text-muted font-mono">{from}</span>
+                    <span className="text-text-muted">→</span>
+                    <span className="text-accent font-mono">{to}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -207,6 +249,8 @@ export function DimensionsView() {
   const configQuery = useQuery(() => api.getDimensionsConfig(), []);
   const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [hiddenResourceCols, setHiddenResourceCols] = useState(new Set<string>());
+  const [hiddenAccountCols, setHiddenAccountCols] = useState(new Set<string>());
   const [addingNew, setAddingNew] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -369,110 +413,149 @@ export function DimensionsView() {
         </div>
       )}
 
-      {/* Resource tags pivot table — columns are tag keys, rows are top values */}
-      {discoveredTags.length > 0 && (
+      {/* Resource tags pivot table */}
+      {discoveredTags.length > 0 && (() => {
+        const visibleTags = discoveredTags.filter(t => !hiddenResourceCols.has(t.key));
+        return (
         <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-text-secondary">
-              Resource Tags
-              <span className="text-text-muted ml-1">({String(discoveredTags.length)} keys found in billing data)</span>
-            </h3>
+          <h3 className="text-sm font-medium text-text-secondary">
+            Resource Tags
+            <span className="text-text-muted ml-1">({String(discoveredTags.length)} keys)</span>
+          </h3>
+          <div className="flex flex-wrap gap-1.5">
+            {discoveredTags.map(t => {
+              const hidden = hiddenResourceCols.has(t.key);
+              return (
+                <button
+                  key={t.key}
+                  type="button"
+                  onClick={() => { setHiddenResourceCols(prev => { const next = new Set(prev); if (hidden) { next.delete(t.key); } else { next.add(t.key); } return next; }); }}
+                  className={[
+                    'rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors',
+                    hidden
+                      ? 'border-border bg-bg-tertiary/20 text-text-muted line-through'
+                      : 'border-accent/40 bg-accent/10 text-accent',
+                  ].join(' ')}
+                >
+                  {t.key}
+                </button>
+              );
+            })}
           </div>
-          <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
-            <table className="text-xs">
-              <thead>
-                <tr className="border-b border-border text-left text-text-muted">
-                  {discoveredTags.map(t => (
-                    <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
-                      <div className="flex flex-col gap-0.5">
-                        <span className="font-mono">{t.key}</span>
-                        <span className="text-[9px] text-text-muted font-normal">{t.rowCount.toLocaleString()} rows</span>
-                      </div>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {Array.from({ length: Math.max(...discoveredTags.map(t => t.sampleValues.length), 0) }, (_, rowIdx) => (
-                  <tr key={rowIdx} className="border-b border-border-subtle">
-                    {discoveredTags.map(t => {
-                      const val = t.sampleValues[rowIdx];
-                      return (
-                        <td key={t.key} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
-                          {val !== undefined ? val : ''}
-                        </td>
-                      );
-                    })}
+          {visibleTags.length > 0 && (
+            <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
+              <table className="text-xs">
+                <thead>
+                  <tr className="border-b border-border text-left text-text-muted">
+                    {visibleTags.map(t => (
+                      <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-mono">{t.key}</span>
+                          <span className="text-[9px] text-text-muted font-normal">{t.rowCount.toLocaleString()} rows</span>
+                        </div>
+                      </th>
+                    ))}
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {Array.from({ length: Math.max(...visibleTags.map(t => t.sampleValues.length), 0) }, (_, rowIdx) => (
+                    <tr key={rowIdx} className="border-b border-border-subtle">
+                      {visibleTags.map(t => (
+                        <td key={t.key} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
+                          {t.sampleValues[rowIdx] ?? ''}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
-      )}
+        );
+      })()}
 
       {tagsQuery.status === 'loading' && (
         <div className="text-sm text-text-secondary">Scanning billing data for tags...</div>
       )}
 
       {/* Account tags pivot table */}
-      {accountTagKeys.length > 0 && orgData !== null && (
+      {accountTagKeys.length > 0 && orgData !== null && (() => {
+        const visibleKeys = accountTagKeys.filter(k => !hiddenAccountCols.has(k));
+        return (
         <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-text-secondary">
-              Account Tags
-              <span className="text-text-muted ml-1">({String(accountTagKeys.length)} keys from AWS Organizations)</span>
-            </h3>
+          <h3 className="text-sm font-medium text-text-secondary">
+            Account Tags
+            <span className="text-text-muted ml-1">({String(accountTagKeys.length)} keys)</span>
+          </h3>
+          <div className="flex flex-wrap gap-1.5">
+            {accountTagKeys.map(key => {
+              const hidden = hiddenAccountCols.has(key);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => { setHiddenAccountCols(prev => { const next = new Set(prev); if (hidden) { next.delete(key); } else { next.add(key); } return next; }); }}
+                  className={[
+                    'rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors',
+                    hidden
+                      ? 'border-border bg-bg-tertiary/20 text-text-muted line-through'
+                      : 'border-accent/40 bg-accent/10 text-accent',
+                  ].join(' ')}
+                >
+                  {key}
+                </button>
+              );
+            })}
           </div>
-          <p className="text-xs text-text-muted">
-            Values sorted by frequency. Can be used as fallback when resource-level tags are missing.
-          </p>
-          <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
-            <table className="text-xs">
-              <thead>
-                <tr className="border-b border-border text-left text-text-muted">
-                  {accountTagKeys.map(key => {
-                    const count = orgData.accounts.filter(a => a.tags[key] !== undefined && a.tags[key] !== '').length;
-                    return (
-                      <th key={key} className="px-3 py-2 font-medium whitespace-nowrap">
-                        <div className="flex flex-col gap-0.5">
-                          <span className="font-mono">{key}</span>
-                          <span className="text-[9px] text-text-muted font-normal">{String(count)}/{String(orgData.accounts.length)} accounts</span>
-                        </div>
-                      </th>
-                    );
-                  })}
-                </tr>
-              </thead>
-              <tbody>
-                {(() => {
-                  // For each tag key, compute sorted unique values by frequency
-                  const columnValues = accountTagKeys.map(key => {
-                    const counts = new Map<string, number>();
-                    for (const acct of orgData.accounts) {
-                      const val = acct.tags[key];
-                      if (val !== undefined && val.length > 0) {
-                        counts.set(val, (counts.get(val) ?? 0) + 1);
+          {visibleKeys.length > 0 && (
+            <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
+              <table className="text-xs">
+                <thead>
+                  <tr className="border-b border-border text-left text-text-muted">
+                    {visibleKeys.map(key => {
+                      const count = orgData.accounts.filter(a => a.tags[key] !== undefined && a.tags[key] !== '').length;
+                      return (
+                        <th key={key} className="px-3 py-2 font-medium whitespace-nowrap">
+                          <div className="flex flex-col gap-0.5">
+                            <span className="font-mono">{key}</span>
+                            <span className="text-[9px] text-text-muted font-normal">{String(count)}/{String(orgData.accounts.length)} accts</span>
+                          </div>
+                        </th>
+                      );
+                    })}
+                  </tr>
+                </thead>
+                <tbody>
+                  {(() => {
+                    const columnValues = visibleKeys.map(key => {
+                      const counts = new Map<string, number>();
+                      for (const acct of orgData.accounts) {
+                        const val = acct.tags[key];
+                        if (val !== undefined && val.length > 0) {
+                          counts.set(val, (counts.get(val) ?? 0) + 1);
+                        }
                       }
-                    }
-                    return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([v, c]) => `${v} (${String(c)})`);
-                  });
-                  const maxRows = Math.max(...columnValues.map(c => c.length), 0);
-                  return Array.from({ length: Math.min(maxRows, 15) }, (_, rowIdx) => (
-                    <tr key={rowIdx} className="border-b border-border-subtle">
-                      {columnValues.map((vals, colIdx) => (
-                        <td key={accountTagKeys[colIdx]} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
-                          {vals[rowIdx] ?? ''}
-                        </td>
-                      ))}
-                    </tr>
-                  ));
-                })()}
-              </tbody>
-            </table>
-          </div>
+                      return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([v, c]) => `${v} (${String(c)})`);
+                    });
+                    const maxRows = Math.max(...columnValues.map(c => c.length), 0);
+                    return Array.from({ length: Math.min(maxRows, 15) }, (_, rowIdx) => (
+                      <tr key={rowIdx} className="border-b border-border-subtle">
+                        {columnValues.map((vals, colIdx) => (
+                          <td key={visibleKeys[colIdx]} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
+                            {vals[rowIdx] ?? ''}
+                          </td>
+                        ))}
+                      </tr>
+                    ));
+                  })()}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -278,10 +278,11 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           else if (fromResource && fromAccount) source = 'both';
           else if (fromResource) source = 'resource';
           else source = 'account';
-          return { raw, resolved, changed: resolved !== raw, source };
+          const aliased = aliasMap.has(normalized);
+          return { raw, resolved, aliased, source };
         });
 
-        const aliasPreviewCount = transformed.filter(t => t.changed).length;
+        const aliasPreviewCount = transformed.filter(t => t.aliased).length;
 
         // Deduplicate by resolved value, merge sources, sort alphabetically
         const resolvedMap = new Map<string, Source>();
@@ -296,7 +297,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         const unique = [...resolvedMap.entries()]
           .map(([resolved, source]) => ({
             resolved,
-            changed: transformed.some(t => t.resolved === resolved && t.changed),
+            aliased: transformed.some(t => t.resolved === resolved && t.aliased),
             source,
           }))
           .sort((a, b) => a.resolved.localeCompare(b.resolved));
@@ -316,8 +317,8 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               {!isPassthrough && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> formatted</span>}
             </div>
             <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
-              {unique.map(({ resolved, changed, source }) => {
-                const colors = changed
+              {unique.map(({ resolved, aliased, source }) => {
+                const colors = aliased
                   ? 'bg-rose-500/10 border-rose-500/30 text-rose-300'
                   : source === 'template'
                     ? 'bg-warning/10 border-warning/30 text-warning italic'

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -312,21 +312,24 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
+              {aliasPreviewCount > 0 && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-rose-500/30 border border-rose-500/50" /> aliased</span>}
               {!isPassthrough && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> formatted</span>}
             </div>
             <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
               {unique.map(({ resolved, changed, source }) => {
-                const colors = source === 'template'
-                  ? 'bg-warning/10 border-warning/30 text-warning italic'
-                  : source === 'both'
-                    ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
-                    : source === 'account'
-                      ? 'bg-violet-500/10 border-violet-500/30 text-violet-300'
-                      : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
+                const colors = changed
+                  ? 'bg-rose-500/10 border-rose-500/30 text-rose-300'
+                  : source === 'template'
+                    ? 'bg-warning/10 border-warning/30 text-warning italic'
+                    : source === 'both'
+                      ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+                      : source === 'account'
+                        ? 'bg-violet-500/10 border-violet-500/30 text-violet-300'
+                        : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
                 return (
                 <span
                   key={resolved}
-                  className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${changed ? 'ring-1 ring-accent/50' : ''} ${colors}`}
+                  className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${colors}`}
                 >
                   {resolved}
                 </span>

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -25,6 +25,7 @@ interface EditingTag {
   normalize: string;
   aliases: string;
   fallbackTag: string | undefined;
+  missingValueTemplate: string;
 }
 
 function aliasesToText(aliases: Readonly<Record<string, readonly string[]>> | undefined): string {
@@ -183,6 +184,23 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         </div>
       )}
 
+      {/* Row: Missing value template */}
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">When value is missing (after fallback)</span>
+        <input
+          type="text"
+          value={state.missingValueTemplate}
+          onChange={e => { setState(s => ({ ...s, missingValueTemplate: e.target.value })); }}
+          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
+          placeholder={state.fallbackTag !== undefined && state.fallbackTag.length > 0 ? `e.g. unknown-{${state.fallbackTag}}` : 'e.g. unknown-{owner}'}
+        />
+        {state.missingValueTemplate.length > 0 && (
+          <span className="text-[10px] text-text-muted">
+            Example: {state.missingValueTemplate.replaceAll(/\{[^}]+\}/g, 'some-value')} — variables in {'{ }'} are resolved from other dimensions
+          </span>
+        )}
+      </label>
+
       {/* Row 4: Alias rules (compact) */}
       <label className="flex flex-col gap-1">
         <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
@@ -319,7 +337,8 @@ export function DimensionsView() {
     const normalize = editing.normalize.length > 0 ? editing.normalize as NormalizationRule : undefined;
     const aliases = textToAliases(editing.aliases);
     const accountTagFallback = editing.fallbackTag !== undefined && editing.fallbackTag.length > 0 ? editing.fallbackTag : undefined;
-    return { ...base, concept, normalize, aliases, accountTagFallback };
+    const missingValueTemplate = editing.missingValueTemplate.length > 0 ? editing.missingValueTemplate : undefined;
+    return { ...base, concept, normalize, aliases, accountTagFallback, missingValueTemplate };
   }
 
   async function handleSaveTag(idx: number, editing: EditingTag) {
@@ -397,6 +416,7 @@ export function DimensionsView() {
                     normalize: tag.normalize ?? '',
                     aliases: aliasesToText(tag.aliases),
                     fallbackTag: tag.accountTagFallback,
+                    missingValueTemplate: tag.missingValueTemplate ?? '',
                   }}
                   onSave={(edited) => { void handleSaveTag(idx, edited); }}
                   onCancel={() => { setEditingIdx(null); }}
@@ -429,6 +449,9 @@ export function DimensionsView() {
                     {tag.accountTagFallback !== undefined && (
                       <span className="text-[10px] text-text-muted">fallback: {tag.accountTagFallback}</span>
                     )}
+                    {tag.missingValueTemplate !== undefined && (
+                      <span className="text-[10px] text-text-muted font-mono">missing: {tag.missingValueTemplate}</span>
+                    )}
                   </div>
                   <span className="text-xs text-text-muted">Edit →</span>
                 </button>
@@ -439,7 +462,7 @@ export function DimensionsView() {
           {/* Add new dimension form */}
           {addingNew && (
             <TagEditor
-              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined }}
+              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined, missingValueTemplate: '' }}
               onSave={(edited) => { void handleAddTag(edited); }}
               onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
               onRemove={undefined}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -215,9 +215,11 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 
       {/* Row 5: Merged + normalized preview of all values */}
       {(() => {
-        // Collect all raw values from both sources
+        // Collect values with source tracking
         const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
         const accountVals = fallbackValues.map(([v]) => v);
+        const resourceSet = new Set(resourceVals);
+        const accountSet = new Set(accountVals);
         const allRaw = [...new Set([...resourceVals, ...accountVals])];
         if (allRaw.length === 0) return null;
 
@@ -244,22 +246,36 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           }
         }
 
-        // Transform: normalize → alias resolve → deduplicate
+        // Transform: normalize → alias resolve → track source
+        type Source = 'resource' | 'account' | 'both';
         const transformed = allRaw.map(raw => {
           const normalized = normalize(raw);
           const resolved = aliasMap.get(normalized) ?? normalized;
-          return { raw, resolved, changed: resolved !== raw };
+          const fromResource = resourceSet.has(raw);
+          const fromAccount = accountSet.has(raw);
+          const source: Source = fromResource && fromAccount ? 'both' : fromResource ? 'resource' : 'account';
+          return { raw, resolved, changed: resolved !== raw, source };
         });
 
         const aliasPreviewCount = transformed.filter(t => t.changed).length;
 
-        // Deduplicate by resolved value, sort alphabetically
-        const seen = new Set<string>();
-        const unique = transformed.filter(t => {
-          if (seen.has(t.resolved)) return false;
-          seen.add(t.resolved);
-          return true;
-        }).sort((a, b) => a.resolved.localeCompare(b.resolved));
+        // Deduplicate by resolved value, merge sources, sort alphabetically
+        const resolvedMap = new Map<string, Source>();
+        for (const t of transformed) {
+          const existing = resolvedMap.get(t.resolved);
+          if (existing === undefined) {
+            resolvedMap.set(t.resolved, t.source);
+          } else if (existing !== 'both' && existing !== t.source) {
+            resolvedMap.set(t.resolved, 'both');
+          }
+        }
+        const unique = [...resolvedMap.entries()]
+          .map(([resolved, source]) => ({
+            resolved,
+            changed: transformed.some(t => t.resolved === resolved && t.changed),
+            source,
+          }))
+          .sort((a, b) => a.resolved.localeCompare(b.resolved));
 
         return (
           <div className="flex flex-col gap-1">
@@ -268,15 +284,27 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               {state.normalize.length > 0 ? ` (${state.normalize})` : ''}
               {aliasPreviewCount > 0 ? ` · ${String(aliasPreviewCount)} aliased` : ''}
             </span>
+            <div className="flex items-center gap-3 text-[9px] text-text-muted mb-1">
+              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
+              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
+              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
+            </div>
             <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
-              {unique.map(({ resolved, changed }) => (
+              {unique.map(({ resolved, changed, source }) => {
+                const colors = source === 'both'
+                  ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+                  : source === 'account'
+                    ? 'bg-violet-500/10 border-violet-500/30 text-violet-300'
+                    : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
+                return (
                 <span
                   key={resolved}
-                  className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${changed ? 'bg-accent/15 text-accent' : 'bg-bg-tertiary/50 text-text-secondary'}`}
+                  className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${changed ? 'ring-1 ring-accent/50' : ''} ${colors}`}
                 >
                   {resolved}
                 </span>
-              ))}
+                );
+              })}
             </div>
           </div>
         );

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
+import { CoinRainLoader } from '../components/coin-rain-loader.js';
 
 const CONCEPTS: { value: ConceptType; label: string }[] = [
   { value: 'owner', label: 'Owner (team)' },
@@ -416,6 +417,23 @@ export function DimensionsView() {
       )}
 
       {/* Resource tags pivot table */}
+      {tagsQuery.status === 'loading' && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium text-text-secondary">Resource Tags</h3>
+          <div className="rounded-xl border border-border bg-bg-secondary/50 p-8 text-center">
+            <CoinRainLoader height={80} count={4} />
+            <p className="text-xs text-text-muted mt-2">Scanning billing data for tags...</p>
+          </div>
+        </div>
+      )}
+      {tagsQuery.status === 'error' && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium text-text-secondary">Resource Tags</h3>
+          <div className="rounded-xl border border-negative/50 bg-negative-muted p-4 text-sm text-negative">
+            {tagsQuery.error.message}
+          </div>
+        </div>
+      )}
       {discoveredTags.length > 0 && (() => {
         const visibleTags = discoveredTags.filter(t => !hiddenResourceCols.has(t.key));
         return (
@@ -480,10 +498,6 @@ export function DimensionsView() {
         </div>
         );
       })()}
-
-      {tagsQuery.status === 'loading' && (
-        <div className="text-sm text-text-secondary">Scanning billing data for tags...</div>
-      )}
 
       {/* Account tags pivot table */}
       {accountTagKeys.length > 0 && orgData !== null && (() => {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -13,7 +13,9 @@ const CONCEPTS: { value: ConceptType; label: string }[] = [
 const NORMALIZE_RULES: { value: NormalizationRule; label: string }[] = [
   { value: 'lowercase', label: 'lowercase' },
   { value: 'uppercase', label: 'UPPERCASE' },
-  { value: 'lowercase-kebab', label: 'kebab-case' },
+  { value: 'lowercase-kebab', label: 'kebab-case (a-b-c)' },
+  { value: 'lowercase-underscore', label: 'snake_case (a_b_c)' },
+  { value: 'camelCase', label: 'camelCase' },
 ];
 
 interface EditingTag {
@@ -206,7 +208,9 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           switch (state.normalize) {
             case 'lowercase': return v.toLowerCase();
             case 'uppercase': return v.toUpperCase();
-            case 'lowercase-kebab': return v.toLowerCase().replaceAll('_', '-').replaceAll(' ', '-');
+            case 'lowercase-kebab': return v.replace(/([a-z])([A-Z])/g, '$1-$2').replaceAll('_', '-').replaceAll(' ', '-').toLowerCase();
+            case 'lowercase-underscore': return v.replace(/([a-z])([A-Z])/g, '$1_$2').replaceAll('-', '_').replaceAll(' ', '_').toLowerCase();
+            case 'camelCase': return v.replaceAll(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, (_, c: string) => c.toLowerCase());
             default: return v;
           }
         };

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -304,11 +304,10 @@ export function DimensionsView() {
   // Which resource tags are already mapped as dimensions
   const mappedTagNames = new Set(config?.tags.map(t => t.tagName) ?? []);
 
-  // Only CUR resource tags for the primary dropdown (not account tags)
+  // CUR resource tags for the primary dropdown — same order as table, exclude hidden columns
   const unmappedTagKeys = discoveredTags
     .map(t => t.key)
-    .filter(k => !mappedTagNames.has(k))
-    .sort();
+    .filter(k => !mappedTagNames.has(k) && !hiddenResourceCols.has(k));
 
   function editingToTagDimension(editing: EditingTag): TagDimension {
     const base: { tagName: string; label: string } = { tagName: editing.tagName, label: editing.label };

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -77,19 +77,6 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
     return [...counts.entries()].sort((a, b) => b[1] - a[1]);
   })();
 
-  // Compute alias preview: show what each alias resolves to
-  const aliasPreview = (() => {
-    const parsed = textToAliases(state.aliases);
-    if (parsed === undefined) return [];
-    const result: { from: string; to: string }[] = [];
-    for (const [canonical, alts] of Object.entries(parsed)) {
-      for (const alt of alts) {
-        result.push({ from: alt, to: canonical });
-      }
-    }
-    return result;
-  })();
-
   return (
     <div className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
       {/* Row 1: Concept + Display Label + Normalization */}
@@ -195,35 +182,81 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         </div>
       )}
 
-      {/* Row 4: Alias rules + resolved preview */}
-      <div className="grid grid-cols-[1fr_1fr] gap-4 items-start">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Alias Rules</span>
-          <textarea
-            value={state.aliases}
-            onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
-            rows={3}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-xs text-text-primary font-mono outline-none focus:border-accent resize-y"
-            placeholder="production: prod, prd&#10;staging: stg, stage"
-          />
-        </label>
-        <div className="flex flex-col gap-1">
-          {aliasPreview.length > 0 && (
-            <>
-              <span className="text-xs text-text-muted">Resolved mappings</span>
-              <div className="flex flex-col gap-0.5 text-xs">
-                {aliasPreview.map(({ from, to }) => (
-                  <div key={from} className="flex items-center gap-2">
-                    <span className="text-text-muted font-mono">{from}</span>
-                    <span className="text-text-muted">→</span>
-                    <span className="text-accent font-mono">{to}</span>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-        </div>
-      </div>
+      {/* Row 4: Alias rules (compact) */}
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
+        <textarea
+          value={state.aliases}
+          onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
+          rows={2}
+          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-[11px] text-text-primary font-mono outline-none focus:border-accent resize-y"
+          placeholder="production: prod, prd&#10;staging: stg, stage"
+        />
+      </label>
+
+      {/* Row 5: Merged + normalized preview of all values */}
+      {(() => {
+        // Collect all raw values from both sources
+        const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
+        const accountVals = fallbackValues.map(([v]) => v);
+        const allRaw = [...new Set([...resourceVals, ...accountVals])];
+        if (allRaw.length === 0) return null;
+
+        // Apply normalization
+        const normalize = (v: string): string => {
+          switch (state.normalize) {
+            case 'lowercase': return v.toLowerCase();
+            case 'uppercase': return v.toUpperCase();
+            case 'lowercase-kebab': return v.toLowerCase().replaceAll('_', '-').replaceAll(' ', '-');
+            default: return v;
+          }
+        };
+
+        // Build alias reverse map
+        const aliasMap = new Map<string, string>();
+        const parsed = textToAliases(state.aliases);
+        if (parsed !== undefined) {
+          for (const [canonical, alts] of Object.entries(parsed)) {
+            for (const alt of alts) {
+              aliasMap.set(normalize(alt), canonical);
+            }
+          }
+        }
+
+        // Transform: normalize → alias resolve → deduplicate
+        const transformed = allRaw.map(raw => {
+          const normalized = normalize(raw);
+          const resolved = aliasMap.get(normalized) ?? normalized;
+          return { raw, resolved, changed: resolved !== raw };
+        });
+
+        // Deduplicate by resolved value, sort alphabetically
+        const seen = new Set<string>();
+        const unique = transformed.filter(t => {
+          if (seen.has(t.resolved)) return false;
+          seen.add(t.resolved);
+          return true;
+        }).sort((a, b) => a.resolved.localeCompare(b.resolved));
+
+        return (
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-text-muted">
+              Preview — {String(unique.length)} resolved values
+              {state.normalize.length > 0 ? ` (${state.normalize})` : ''}
+            </span>
+            <div className="flex flex-wrap gap-1">
+              {unique.map(({ resolved, changed }) => (
+                <span
+                  key={resolved}
+                  className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${changed ? 'bg-accent/15 text-accent' : 'bg-bg-tertiary/50 text-text-secondary'}`}
+                >
+                  {resolved}
+                </span>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -184,32 +184,32 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         </div>
       )}
 
-      {/* Row: Missing value template */}
-      <label className="flex flex-col gap-1">
-        <span className="text-xs text-text-muted">Fallback format</span>
-        <input
-          type="text"
-          value={state.missingValueTemplate}
-          onChange={e => { setState(s => ({ ...s, missingValueTemplate: e.target.value })); }}
-          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
-          placeholder="{fallback}"
-        />
-        <span className="text-[10px] text-text-muted">
-          {'{fallback}'} = account tag value. Example: unknown-{'{fallback}'} → unknown-payments
-        </span>
-      </label>
-
-      {/* Row 4: Alias rules (compact) */}
-      <label className="flex flex-col gap-1">
-        <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
-        <textarea
-          value={state.aliases}
-          onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
-          rows={2}
-          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-[11px] text-text-primary font-mono outline-none focus:border-accent resize-y"
-          placeholder="production: prod, prd&#10;staging: stg, stage"
-        />
-      </label>
+      {/* Row 4: Fallback format + Alias rules side by side */}
+      <div className="grid grid-cols-[1fr_2fr] gap-4 items-start">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Fallback format</span>
+          <input
+            type="text"
+            value={state.missingValueTemplate}
+            onChange={e => { setState(s => ({ ...s, missingValueTemplate: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
+            placeholder="{fallback}"
+          />
+          <span className="text-[10px] text-text-muted">
+            {'{fallback}'} = account tag value
+          </span>
+        </div>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
+          <textarea
+            value={state.aliases}
+            onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
+            rows={2}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-[11px] text-text-primary font-mono outline-none focus:border-accent resize-y"
+            placeholder="production: prod, prd&#10;staging: stg, stage"
+          />
+        </label>
+      </div>
 
       {/* Row 5: Merged + normalized preview of all values */}
       {(() => {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -423,7 +423,11 @@ export function DimensionsView() {
             <span className="text-text-muted ml-1">({String(discoveredTags.length)} keys)</span>
           </h3>
           <div className="flex flex-wrap gap-1.5">
-            {discoveredTags.map(t => {
+            {[...discoveredTags].sort((a, b) => {
+              const aHidden = hiddenResourceCols.has(a.key) ? 1 : 0;
+              const bHidden = hiddenResourceCols.has(b.key) ? 1 : 0;
+              return aHidden - bHidden;
+            }).map(t => {
               const hidden = hiddenResourceCols.has(t.key);
               return (
                 <button
@@ -489,7 +493,11 @@ export function DimensionsView() {
             <span className="text-text-muted ml-1">({String(accountTagKeys.length)} keys)</span>
           </h3>
           <div className="flex flex-wrap gap-1.5">
-            {accountTagKeys.map(key => {
+            {[...accountTagKeys].sort((a, b) => {
+              const aH = hiddenAccountCols.has(a) ? 1 : 0;
+              const bH = hiddenAccountCols.has(b) ? 1 : 0;
+              return aH - bH;
+            }).map(key => {
               const hidden = hiddenAccountCols.has(key);
               return (
                 <button

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -467,10 +467,10 @@ export function DimensionsView() {
             })}
           </div>
           {visibleTags.length > 0 && (
-            <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
+            <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-auto max-h-96">
               <table className="text-xs">
                 <thead>
-                  <tr className="border-b border-border text-left text-text-muted">
+                  <tr className="border-b border-border text-left text-text-muted sticky top-0 bg-bg-secondary z-10">
                     {visibleTags.map(t => (
                       <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
                         <div className="flex flex-col gap-0.5">
@@ -533,10 +533,10 @@ export function DimensionsView() {
             })}
           </div>
           {visibleKeys.length > 0 && (
-            <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-x-auto">
+            <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-auto max-h-96">
               <table className="text-xs">
                 <thead>
-                  <tr className="border-b border-border text-left text-text-muted">
+                  <tr className="border-b border-border text-left text-text-muted sticky top-0 bg-bg-secondary z-10">
                     {visibleKeys.map(key => {
                       const count = orgData.accounts.filter(a => a.tags[key] !== undefined && a.tags[key] !== '').length;
                       return (

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -140,7 +140,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           {tagMatch !== undefined && (
             <>
               <span className="text-xs text-text-muted">{String(tagMatch.coveragePct)}% coverage · {String(tagMatch.distinctCount)} distinct values</span>
-              <div className="flex flex-wrap gap-1">
+              <div className="flex flex-wrap gap-1 max-h-20 overflow-y-auto">
                 {tagMatch.sampleValues.map(v => (
                   <span key={v} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">{v}</span>
                 ))}
@@ -168,13 +168,12 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             {fallbackValues.length > 0 && (
               <>
                 <span className="text-xs text-text-muted">{String(fallbackValues.length)} distinct values</span>
-                <div className="flex flex-wrap gap-1">
-                  {fallbackValues.slice(0, 12).map(([val, cnt]) => (
+                <div className="flex flex-wrap gap-1 max-h-20 overflow-y-auto">
+                  {fallbackValues.map(([val, cnt]) => (
                     <span key={val} className="rounded bg-bg-tertiary/50 px-1.5 py-0.5 text-[10px] text-text-secondary">
                       {val} <span className="text-text-muted">({String(cnt)})</span>
                     </span>
                   ))}
-                  {fallbackValues.length > 12 && <span className="text-[10px] text-text-muted">+{String(fallbackValues.length - 12)}</span>}
                 </div>
               </>
             )}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -281,14 +281,14 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 
 export function DimensionsView() {
   const api = useCostApi();
-  const tagsQuery = useQuery(() => api.discoverTagKeys(), []);
-  const configQuery = useQuery(() => api.getDimensionsConfig(), []);
-  const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [hiddenResourceCols, setHiddenResourceCols] = useState(new Set<string>());
   const [hiddenAccountCols, setHiddenAccountCols] = useState(new Set<string>());
   const [addingNew, setAddingNew] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const tagsQuery = useQuery(() => api.discoverTagKeys(), []);
+  const configQuery = useQuery(() => api.getDimensionsConfig(), [refreshKey]);
+  const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
 
   const tagsResult = tagsQuery.status === 'success' ? tagsQuery.data : null;
   const discoveredTags = tagsResult?.tags ?? [];
@@ -346,8 +346,6 @@ export function DimensionsView() {
 
   // Quick-add a discovered tag as a dimension
   const [quickAddState, setQuickAddState] = useState<EditingTag | null>(null);
-
-  void refreshKey; // used as useQuery dep to force re-fetch
 
   return (
     <div className="flex flex-col gap-6 p-6">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -229,6 +229,8 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           return { raw, resolved, changed: resolved !== raw };
         });
 
+        const aliasPreviewCount = transformed.filter(t => t.changed).length;
+
         // Deduplicate by resolved value, sort alphabetically
         const seen = new Set<string>();
         const unique = transformed.filter(t => {
@@ -240,10 +242,11 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         return (
           <div className="flex flex-col gap-1">
             <span className="text-xs text-text-muted">
-              Preview — {String(unique.length)} resolved values
+              Preview — {String(allRaw.length)} raw → {String(unique.length)} resolved
               {state.normalize.length > 0 ? ` (${state.normalize})` : ''}
+              {aliasPreviewCount > 0 ? ` · ${String(aliasPreviewCount)} aliased` : ''}
             </span>
-            <div className="flex flex-wrap gap-1">
+            <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
               {unique.map(({ resolved, changed }) => (
                 <span
                   key={resolved}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -288,6 +288,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
+              {state.missingValueTemplate.length > 0 && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> missing</span>}
             </div>
             <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
               {unique.map(({ resolved, changed, source }) => {
@@ -305,6 +306,11 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
                 </span>
                 );
               })}
+              {state.missingValueTemplate.length > 0 && (
+                <span className="rounded border px-1.5 py-0.5 text-[10px] font-mono bg-warning/10 border-warning/30 text-warning italic">
+                  {state.missingValueTemplate}
+                </span>
+              )}
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary
- Reorganize tag editor into 4 clear rows with previews on the right
- Row 1: Concept + Label + Normalization
- Row 2: Resource tag dropdown + top values preview
- Row 3: Fallback tag dropdown + account value frequency preview
- Row 4: Alias rules textarea + resolved mappings (from → to)
- Add clickable badges above both tag tables to toggle column visibility