### PR TITLE
Add JSON codecs + sync utility tests

### DIFF
--- a/packages/core/src/__tests__/json.test.ts
+++ b/packages/core/src/__tests__/json.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { isStringRecord, parseJsonObject } from '../utils/json.js';
+
+describe('isStringRecord', () => {
+  it('accepts plain objects', () => {
+    expect(isStringRecord({})).toBe(true);
+    expect(isStringRecord({ a: 1 })).toBe(true);
+  });
+
+  it('rejects arrays', () => {
+    expect(isStringRecord([])).toBe(false);
+    expect(isStringRecord([1, 2, 3])).toBe(false);
+  });
+
+  it('rejects null and primitives', () => {
+    expect(isStringRecord(null)).toBe(false);
+    expect(isStringRecord(undefined)).toBe(false);
+    expect(isStringRecord('string')).toBe(false);
+    expect(isStringRecord(42)).toBe(false);
+    expect(isStringRecord(true)).toBe(false);
+  });
+});
+
+describe('parseJsonObject', () => {
+  it('parses a JSON object', () => {
+    const result = parseJsonObject('{"theme":"dark","autoSync":true}');
+    expect(result).not.toBeNull();
+    expect(result?.['theme']).toBe('dark');
+    expect(result?.['autoSync']).toBe(true);
+  });
+
+  it('returns null on invalid JSON', () => {
+    expect(parseJsonObject('not json')).toBeNull();
+    expect(parseJsonObject('')).toBeNull();
+  });
+
+  it('returns null when top-level is an array', () => {
+    expect(parseJsonObject('[1,2,3]')).toBeNull();
+  });
+
+  it('returns null when top-level is null or a primitive', () => {
+    expect(parseJsonObject('null')).toBeNull();
+    expect(parseJsonObject('"string"')).toBeNull();
+    expect(parseJsonObject('42')).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/sync-utils.test.ts
+++ b/packages/core/src/__tests__/sync-utils.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractDate,
+  extractPeriod,
+  extractPeriodPrefix,
+  getEtagFileName,
+  groupByPeriod,
+  parseEtagsJson,
+} from '../sync/sync-utils.js';
+import type { ManifestFileEntry } from '../sync/manifest.js';
+
+const file = (key: string, hash = 'h', size = 1): ManifestFileEntry => ({ key, contentHash: hash, size });
+
+describe('extractPeriod', () => {
+  it('extracts BILLING_PERIOD from CUR keys', () => {
+    expect(extractPeriod('cur/data/BILLING_PERIOD=2026-03/file.parquet')).toBe('2026-03');
+  });
+
+  it('extracts year-month from date= keys (cost optimization)', () => {
+    expect(extractPeriod('cost-opt/date=2026-03-15/file.parquet')).toBe('2026-03');
+  });
+
+  it('returns "unknown" for unrecognized keys', () => {
+    expect(extractPeriod('random/path/file.parquet')).toBe('unknown');
+  });
+});
+
+describe('extractPeriodPrefix', () => {
+  it('extracts the path up to and including BILLING_PERIOD=', () => {
+    expect(extractPeriodPrefix('cur/data/BILLING_PERIOD=2026-03/file.parquet'))
+      .toBe('cur/data/BILLING_PERIOD=2026-03/');
+  });
+
+  it('extracts the path up to and including date= for cost optimization', () => {
+    expect(extractPeriodPrefix('cost-opt/data/date=2026-03-15/file.parquet'))
+      .toBe('cost-opt/data/date=2026-03-15/');
+  });
+
+  it('returns empty string when no period marker found', () => {
+    expect(extractPeriodPrefix('random/path/file.parquet')).toBe('');
+  });
+});
+
+describe('extractDate', () => {
+  it('extracts date from date= prefix', () => {
+    expect(extractDate('cost-opt/date=2026-03-15/file.parquet')).toBe('2026-03-15');
+  });
+
+  it('returns undefined when no date marker found', () => {
+    expect(extractDate('cur/BILLING_PERIOD=2026-03/file.parquet')).toBeUndefined();
+  });
+});
+
+describe('groupByPeriod', () => {
+  it('groups files by their billing period', () => {
+    const files = [
+      file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+      file('cur/BILLING_PERIOD=2026-01/b.parquet'),
+      file('cur/BILLING_PERIOD=2026-02/c.parquet'),
+    ];
+    const groups = groupByPeriod(files);
+    expect(groups.size).toBe(2);
+    expect(groups.get('2026-01')).toHaveLength(2);
+    expect(groups.get('2026-02')).toHaveLength(1);
+  });
+
+  it('places unrecognized keys under "unknown"', () => {
+    const groups = groupByPeriod([file('random/file.parquet')]);
+    expect(groups.get('unknown')).toHaveLength(1);
+  });
+
+  it('returns empty map for empty input', () => {
+    expect(groupByPeriod([]).size).toBe(0);
+  });
+});
+
+describe('getEtagFileName', () => {
+  it('returns the per-tier filename', () => {
+    expect(getEtagFileName('daily')).toBe('sync-etags.json');
+    expect(getEtagFileName('hourly')).toBe('sync-etags-hourly.json');
+    expect(getEtagFileName('cost-optimization')).toBe('sync-etags-cost-optimization.json');
+  });
+
+  it('falls back to the daily filename for unknown tiers', () => {
+    expect(getEtagFileName('bogus')).toBe('sync-etags.json');
+  });
+});
+
+describe('parseEtagsJson', () => {
+  it('parses a well-formed nested record', () => {
+    const json = JSON.stringify({
+      '2026-01': { 'a.parquet': 'h1', 'b.parquet': 'h2' },
+      '2026-02': { 'c.parquet': 'h3' },
+    });
+    const result = parseEtagsJson(json);
+    expect(result['2026-01']).toEqual({ 'a.parquet': 'h1', 'b.parquet': 'h2' });
+    expect(result['2026-02']).toEqual({ 'c.parquet': 'h3' });
+  });
+
+  it('returns empty record on invalid JSON', () => {
+    expect(parseEtagsJson('not json')).toEqual({});
+  });
+
+  it('returns empty record when top-level is not an object', () => {
+    expect(parseEtagsJson('[]')).toEqual({});
+    expect(parseEtagsJson('null')).toEqual({});
+    expect(parseEtagsJson('"string"')).toEqual({});
+  });
+
+  it('skips period entries that are not objects', () => {
+    const json = JSON.stringify({
+      '2026-01': { 'a.parquet': 'h1' },
+      '2026-02': 'not-an-object',
+    });
+    const result = parseEtagsJson(json);
+    expect(result['2026-01']).toEqual({ 'a.parquet': 'h1' });
+    expect(result['2026-02']).toBeUndefined();
+  });
+
+  it('drops non-string hash values within a period', () => {
+    const json = JSON.stringify({
+      '2026-01': { 'a.parquet': 'h1', 'b.parquet': 42, 'c.parquet': null },
+    });
+    const result = parseEtagsJson(json);
+    expect(result['2026-01']).toEqual({ 'a.parquet': 'h1' });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from './models/index.js';
 export * from './query/index.js';
 export * from './sync/index.js';
 export * from './logger/index.js';
+export * from './utils/index.js';

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -4,6 +4,7 @@ import { createS3Handle, parseS3Path } from './s3-client.js';
 import type { S3Handle } from './s3-client.js';
 import type { ManifestFileEntry } from './manifest.js';
 import type { DataTier } from '../types/api.js';
+import { parseEtagsJson } from './sync-utils.js';
 
 export type PeriodStatus = 'missing' | 'repartitioned' | 'stale';
 
@@ -127,7 +128,7 @@ export async function getDataInventory(
   let savedEtags: Record<string, Record<string, string>> = {};
   try {
     const raw = await readFile(join(dataDir, ETAG_FILES[tier]), 'utf-8');
-    savedEtags = JSON.parse(raw) as Record<string, Record<string, string>>;
+    savedEtags = parseEtagsJson(raw);
   } catch {
     // no saved etags yet
   }

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -26,3 +26,13 @@ export {
   type SelectiveSyncOptions,
   syncSelectedFiles,
 } from './selective-sync.js';
+
+export {
+  type ExpectedDataType,
+  extractDate,
+  extractPeriod,
+  extractPeriodPrefix,
+  getEtagFileName,
+  groupByPeriod,
+  parseEtagsJson,
+} from './sync-utils.js';

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -5,8 +5,16 @@ import { logger } from '../logger/logger.js';
 import { parseS3Path } from './s3-client.js';
 import type { ProgressCallback } from './s3-client.js';
 import type { ManifestFileEntry } from './manifest.js';
+import {
+  type ExpectedDataType,
+  extractDate,
+  extractPeriodPrefix,
+  getEtagFileName,
+  groupByPeriod,
+  parseEtagsJson,
+} from './sync-utils.js';
 
-export type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
+export type { ExpectedDataType };
 
 export interface SelectiveSyncOptions {
   readonly bucketPath: string;
@@ -16,45 +24,6 @@ export interface SelectiveSyncOptions {
   readonly files: readonly ManifestFileEntry[];
   readonly onProgress?: ProgressCallback | undefined;
   readonly signal?: AbortSignal | undefined;
-}
-
-const ETAG_FILES: Record<string, string> = {
-  'daily': 'sync-etags.json',
-  'hourly': 'sync-etags-hourly.json',
-  'cost-optimization': 'sync-etags-cost-optimization.json',
-};
-
-function extractPeriod(key: string): string {
-  const billingMatch = /BILLING_PERIOD=(\d{4}-\d{2})/.exec(key);
-  if (billingMatch?.[1] !== undefined) return billingMatch[1];
-  const dateMatch = /date=(\d{4}-\d{2})-\d{2}/.exec(key);
-  return dateMatch?.[1] ?? 'unknown';
-}
-
-function extractPeriodPrefix(key: string): string {
-  const billingMatch = /^(.*BILLING_PERIOD=\d{4}-\d{2}\/)/.exec(key);
-  if (billingMatch?.[1] !== undefined) return billingMatch[1];
-  const dateMatch = /^(.*date=\d{4}-\d{2}-\d{2}\/)/.exec(key);
-  return dateMatch?.[1] ?? '';
-}
-
-function extractDate(key: string): string | undefined {
-  const match = /date=(\d{4}-\d{2}-\d{2})/.exec(key);
-  return match?.[1];
-}
-
-function groupByPeriod(files: readonly ManifestFileEntry[]): Map<string, ManifestFileEntry[]> {
-  const groups = new Map<string, ManifestFileEntry[]>();
-  for (const file of files) {
-    const period = extractPeriod(file.key);
-    const existing = groups.get(period);
-    if (existing !== undefined) {
-      existing.push(file);
-    } else {
-      groups.set(period, [file]);
-    }
-  }
-  return groups;
 }
 
 function runAwsS3Sync(options: {
@@ -128,12 +97,11 @@ async function saveEtags(
   period: string,
   periodFiles: readonly ManifestFileEntry[],
 ): Promise<void> {
-  const etagFile = ETAG_FILES[tier] ?? 'sync-etags.json';
-  const etagPath = join(dataDir, etagFile);
+  const etagPath = join(dataDir, getEtagFileName(tier));
   let savedEtags: Record<string, Record<string, string>> = {};
   try {
     const raw = await readFile(etagPath, 'utf-8');
-    savedEtags = JSON.parse(raw) as Record<string, Record<string, string>>;
+    savedEtags = parseEtagsJson(raw);
   } catch {
     // first time
   }

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -1,0 +1,71 @@
+import { isStringRecord } from '../utils/json.js';
+import type { ManifestFileEntry } from './manifest.js';
+
+export type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
+
+const TIER_ETAG_FILES: Record<ExpectedDataType, string> = {
+  'daily': 'sync-etags.json',
+  'hourly': 'sync-etags-hourly.json',
+  'cost-optimization': 'sync-etags-cost-optimization.json',
+};
+
+export function getEtagFileName(tier: string): string {
+  if (tier === 'hourly' || tier === 'cost-optimization' || tier === 'daily') {
+    return TIER_ETAG_FILES[tier];
+  }
+  return TIER_ETAG_FILES['daily'];
+}
+
+export function extractPeriod(key: string): string {
+  const billingMatch = /BILLING_PERIOD=(\d{4}-\d{2})/.exec(key);
+  if (billingMatch?.[1] !== undefined) return billingMatch[1];
+  const dateMatch = /date=(\d{4}-\d{2})-\d{2}/.exec(key);
+  return dateMatch?.[1] ?? 'unknown';
+}
+
+export function extractPeriodPrefix(key: string): string {
+  const billingMatch = /^(.*BILLING_PERIOD=\d{4}-\d{2}\/)/.exec(key);
+  if (billingMatch?.[1] !== undefined) return billingMatch[1];
+  const dateMatch = /^(.*date=\d{4}-\d{2}-\d{2}\/)/.exec(key);
+  return dateMatch?.[1] ?? '';
+}
+
+export function extractDate(key: string): string | undefined {
+  const match = /date=(\d{4}-\d{2}-\d{2})/.exec(key);
+  return match?.[1];
+}
+
+export function groupByPeriod(files: readonly ManifestFileEntry[]): Map<string, ManifestFileEntry[]> {
+  const groups = new Map<string, ManifestFileEntry[]>();
+  for (const file of files) {
+    const period = extractPeriod(file.key);
+    const existing = groups.get(period);
+    if (existing !== undefined) {
+      existing.push(file);
+    } else {
+      groups.set(period, [file]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Parses a sync-etags JSON file. Returns an empty record on any malformed input.
+ * Shape: `{ [period: string]: { [fileKey: string]: contentHash } }`
+ */
+export function parseEtagsJson(raw: string): Record<string, Record<string, string>> {
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return {}; }
+  if (!isStringRecord(parsed)) return {};
+
+  const result: Record<string, Record<string, string>> = {};
+  for (const [period, periodEtags] of Object.entries(parsed)) {
+    if (!isStringRecord(periodEtags)) continue;
+    const stringEtags: Record<string, string> = {};
+    for (const [key, hash] of Object.entries(periodEtags)) {
+      if (typeof hash === 'string') stringEtags[key] = hash;
+    }
+    result[period] = stringEtags;
+  }
+  return result;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { isStringRecord, parseJsonObject } from './json.js';

--- a/packages/core/src/utils/json.ts
+++ b/packages/core/src/utils/json.ts
@@ -1,0 +1,13 @@
+export function isStringRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseJsonObject(raw: string): Readonly<Record<string, unknown>> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return isStringRecord(parsed) ? parsed : null;
+}

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -1,4 +1,4 @@
-import { logger } from '@costgoblin/core';
+import { logger, parseJsonObject } from '@costgoblin/core';
 import type { AutoSyncStatus } from '@costgoblin/core';
 
 export interface AutoSyncDeps {
@@ -20,10 +20,7 @@ export async function readAutoSyncEnabled(prefsPath: string): Promise<boolean> {
   const fs = await import('node:fs/promises');
   try {
     const raw = await fs.readFile(prefsPath, 'utf-8');
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed === 'object' && parsed !== null && 'autoSync' in parsed) {
-      return (parsed as Record<string, unknown>)['autoSync'] === true;
-    }
+    return parseJsonObject(raw)?.['autoSync'] === true;
   } catch {
     // file doesn't exist
   }
@@ -35,9 +32,9 @@ export async function writeAutoSyncEnabled(prefsPath: string, enabled: boolean):
   let existing: Record<string, unknown> = {};
   try {
     const raw = await fs.readFile(prefsPath, 'utf-8');
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed === 'object' && parsed !== null) {
-      existing = parsed as Record<string, unknown>;
+    const parsed = parseJsonObject(raw);
+    if (parsed !== null) {
+      existing = { ...parsed };
     }
   } catch { /* */ }
   existing['autoSync'] = enabled;

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -4,6 +4,7 @@ import {
   loadDimensions,
   loadOrgTree,
   logger,
+  isStringRecord,
 } from '@costgoblin/core';
 import type {
   CostGoblinConfig,
@@ -120,8 +121,21 @@ export function createAppContext(ctx: IpcContext): AppContext {
       // Try to generate from org-accounts.json if it exists
       try {
         const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
-        const data = JSON.parse(raw) as { accounts: { id: string; tags: Record<string, string> }[] };
-        const tagLookup = data.accounts.map(a => ({ id: a.id, tags: a.tags }));
+        let parsed: unknown;
+        try { parsed = JSON.parse(raw); } catch { return undefined; }
+        if (!isStringRecord(parsed) || !Array.isArray(parsed['accounts'])) return undefined;
+        const tagLookup: { id: string; tags: Record<string, string> }[] = [];
+        for (const acct of parsed['accounts']) {
+          if (!isStringRecord(acct)) continue;
+          const id = acct['id'];
+          const tags = acct['tags'];
+          if (typeof id !== 'string' || !isStringRecord(tags)) continue;
+          const stringTags: Record<string, string> = {};
+          for (const [k, v] of Object.entries(tags)) {
+            if (typeof v === 'string') stringTags[k] = v;
+          }
+          tagLookup.push({ id, tags: stringTags });
+        }
         await fs.writeFile(flatPath, JSON.stringify(tagLookup));
         return flatPath;
       } catch {

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -1,7 +1,33 @@
 import { ipcMain } from 'electron';
-import type { OrgSyncResult, OrgSyncProgress } from '@costgoblin/core';
+import { isStringRecord } from '@costgoblin/core';
+import type { OrgSyncResult, OrgSyncProgress, OrgAccount } from '@costgoblin/core';
 import { syncOrgAccounts } from '../aws-org-client.js';
 import type { AppContext } from './context.js';
+
+function isOrgAccount(v: unknown): v is OrgAccount {
+  if (!isStringRecord(v)) return false;
+  return (
+    typeof v['id'] === 'string' &&
+    typeof v['name'] === 'string' &&
+    typeof v['email'] === 'string' &&
+    typeof v['status'] === 'string' &&
+    typeof v['joinedTimestamp'] === 'string' &&
+    typeof v['ouPath'] === 'string' &&
+    isStringRecord(v['tags'])
+  );
+}
+
+function decodeOrgSyncResult(raw: string): OrgSyncResult | null {
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  if (!isStringRecord(parsed)) return null;
+  const accounts = parsed['accounts'];
+  const orgId = parsed['orgId'];
+  const syncedAt = parsed['syncedAt'];
+  if (!Array.isArray(accounts) || typeof orgId !== 'string' || typeof syncedAt !== 'string') return null;
+  if (!accounts.every(isOrgAccount)) return null;
+  return { accounts, orgId, syncedAt };
+}
 
 export function registerOrgHandlers(app: AppContext): void {
   const { ctx } = app;
@@ -33,7 +59,7 @@ export function registerOrgHandlers(app: AppContext): void {
     const fs = await import('node:fs/promises');
     try {
       const raw = await fs.readFile(await orgResultPath(), 'utf-8');
-      return JSON.parse(raw) as OrgSyncResult;
+      return decodeOrgSyncResult(raw);
     } catch {
       return null;
     }

--- a/packages/desktop/src/main/handlers/savings.ts
+++ b/packages/desktop/src/main/handlers/savings.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import { parseJsonObject } from '@costgoblin/core';
 import type { SavingsPreferences } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
@@ -14,9 +15,10 @@ export function registerSavingsHandlers(app: AppContext): void {
     const fs = await import('node:fs/promises');
     try {
       const raw = await fs.readFile(await savingsPrefsPath(), 'utf-8');
-      const parsed: unknown = JSON.parse(raw);
-      if (typeof parsed === 'object' && parsed !== null && 'hiddenActionTypes' in parsed && Array.isArray((parsed as Record<string, unknown>)['hiddenActionTypes'])) {
-        return parsed as SavingsPreferences;
+      const obj = parseJsonObject(raw);
+      const hiddenActionTypes = obj?.['hiddenActionTypes'];
+      if (Array.isArray(hiddenActionTypes) && hiddenActionTypes.every((v): v is string => typeof v === 'string')) {
+        return { hiddenActionTypes };
       }
     } catch {
       // file doesn't exist yet

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -1,5 +1,5 @@
 import { ipcMain, shell } from 'electron';
-import { logger, parseS3Path } from '@costgoblin/core';
+import { logger, parseS3Path, isStringRecord, parseJsonObject } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
 export function registerSetupHandlers(app: AppContext): void {
@@ -134,14 +134,13 @@ export function registerSetupHandlers(app: AppContext): void {
             const manifestResponse = await client.send(new GetObjectCommand({ Bucket: params.bucket, Key: manifestKey }));
             const body = await manifestResponse.Body?.transformToString();
             if (body !== undefined) {
-              const manifest: unknown = JSON.parse(body);
-              let columnNames: string[] = [];
-              if (typeof manifest === 'object' && manifest !== null && 'columns' in manifest && Array.isArray((manifest as Record<string, unknown>)['columns'])) {
-                columnNames = ((manifest as Record<string, unknown>)['columns'] as unknown[])
-                  .filter((c): c is Record<string, unknown> => typeof c === 'object' && c !== null)
+              const columns = parseJsonObject(body)?.['columns'];
+              const columnNames: string[] = Array.isArray(columns)
+                ? columns
+                  .filter(isStringRecord)
                   .map(c => typeof c['name'] === 'string' ? c['name'] : '')
-                  .filter(n => n.length > 0);
-              }
+                  .filter(n => n.length > 0)
+                : [];
 
               if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
                 detectedType = 'cost-optimization';
@@ -178,25 +177,23 @@ export function registerSetupHandlers(app: AppContext): void {
     const configDir = path.dirname(ctx.configPath);
     await fs.mkdir(configDir, { recursive: true });
 
-    let existing: Record<string, unknown> = {};
+    let existing: Readonly<Record<string, unknown>> = {};
     try {
       const raw = await fs.readFile(ctx.configPath, 'utf-8');
       const parsed: unknown = parseYaml(raw);
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        existing = parsed as Record<string, unknown>;
+      if (isStringRecord(parsed)) {
+        existing = parsed;
       }
     } catch {
       // no existing config
     }
 
-    const existingProviders: Record<string, unknown>[] = Array.isArray(existing['providers'])
-      ? existing['providers'].filter((p): p is Record<string, unknown> => typeof p === 'object' && p !== null)
+    const existingProviders: Readonly<Record<string, unknown>>[] = Array.isArray(existing['providers'])
+      ? existing['providers'].filter(isStringRecord)
       : [];
     const existingProvider = existingProviders[0] ?? {};
     const rawSync = existingProvider['sync'];
-    const existingSync: Record<string, unknown> = typeof rawSync === 'object' && rawSync !== null && !Array.isArray(rawSync)
-      ? rawSync as Record<string, unknown>
-      : {};
+    const existingSync: Readonly<Record<string, unknown>> = isStringRecord(rawSync) ? rawSync : {};
 
     const sync: Record<string, unknown> = { ...existingSync, intervalMinutes: 60 };
 

--- a/packages/desktop/src/main/handlers/ui.ts
+++ b/packages/desktop/src/main/handlers/ui.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import { parseJsonObject } from '@costgoblin/core';
 import type { UIPreferences } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
@@ -14,13 +15,9 @@ export function registerUIHandlers(app: AppContext): void {
     const fs = await import('node:fs/promises');
     try {
       const raw = await fs.readFile(await uiPrefsPath(), 'utf-8');
-      const parsed: unknown = JSON.parse(raw);
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        const record: Record<string, unknown> = { ...parsed };
-        const theme = record['theme'];
-        if (theme === 'light' || theme === 'dark') {
-          return { theme };
-        }
+      const theme = parseJsonObject(raw)?.['theme'];
+      if (theme === 'light' || theme === 'dark') {
+        return { theme };
       }
     } catch {
       // file doesn't exist yet


### PR DESCRIPTION
PR 4 of 5 from the strict review. Robustness pass — type safety at IPC/wire boundaries + tests for the previously untested sync helpers.

## Summary

### Type safety at trust boundaries

Added `parseJsonObject` + `isStringRecord` in `@costgoblin/core/utils/json` as the **single isolated point** where `unknown` JSON.parse output gets narrowed to `Record<string, unknown>`. Replaced every `JSON.parse(raw) as T` in the codebase with proper validation through these helpers:

| File | Before | After |
|---|---|---|
| `handlers/savings.ts` | `parsed as SavingsPreferences` | validates `hiddenActionTypes` is `string[]` |
| `handlers/ui.ts` | spread + cast | only returns when `theme` is exactly `'dark'` or `'light'` |
| `handlers/org.ts` | `JSON.parse(raw) as OrgSyncResult` | `decodeOrgSyncResult` with per-account `isOrgAccount` check |
| `handlers/context.ts` | `JSON.parse(raw) as { accounts: ... }` | validates each account shape |
| `handlers/setup.ts` | nested `as Record<string, unknown>` | parses CUR manifest columns through `parseJsonObject` |
| `main/auto-sync.ts` | two `as Record<string, unknown>` | uses codec; existing key access unchanged |
| `core/sync/data-inventory.ts` | `as Record<string, Record<string, string>>` | uses new `parseEtagsJson` |
| `core/sync/selective-sync.ts` | same | uses `parseEtagsJson` |

The only remaining `JSON.parse` calls in the codebase either live inside the codec module or are immediately handed to it.

### Sync coverage

Extracted the previously private pure helpers from `selective-sync.ts` into a new `packages/core/src/sync/sync-utils.ts` module:

- `extractPeriod` — billing period from CUR or date= keys
- `extractPeriodPrefix` — S3 prefix up to and including the period marker
- `extractDate` — date from `date=YYYY-MM-DD/...` keys
- `groupByPeriod` — bucket files into per-period arrays
- `getEtagFileName` — per-tier etag filename
- `parseEtagsJson` — strict parse of the etag-state JSON

Added 18 tests covering edge cases: unknown key shapes, malformed JSON, non-string hash values, mixed CUR vs cost-optimization key formats, empty input. Plus 7 tests for the JSON codec itself.

## Verification

`npm run check` — 174 passed (+25), 5 skipped, tsc + eslint clean.

## What's next

PR 5: worker threads for DuckDB and S3 sync.