### PR TITLE
Run DuckDB on a worker thread

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {
-    "build": "electron-vite build --sourcemap",
+    "build": "electron-vite build --sourcemap && npm run build:worker",
+    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/main/duckdb-worker.js --external:@duckdb/node-api --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",
-    "dev": "electron-vite dev"
+    "dev": "npm run build:worker && electron-vite dev"
   },
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.1029.0",

--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -1,0 +1,97 @@
+import { Worker } from 'node:worker_threads';
+
+export type RawRow = Readonly<Record<string, unknown>>;
+
+export interface DuckDBClient {
+  runQuery(sql: string): Promise<RawRow[]>;
+  terminate(): Promise<void>;
+}
+
+type WorkerResponse =
+  | { kind: 'ready' }
+  | { kind: 'rows'; id: number; rows: RawRow[] }
+  | { kind: 'error'; id: number; message: string };
+
+function isWorkerResponse(msg: unknown): msg is WorkerResponse {
+  if (typeof msg !== 'object' || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  if (m['kind'] === 'ready') return true;
+  if ((m['kind'] === 'rows' || m['kind'] === 'error') && typeof m['id'] === 'number') {
+    if (m['kind'] === 'rows') return Array.isArray(m['rows']);
+    return typeof m['message'] === 'string';
+  }
+  return false;
+}
+
+interface PendingQuery {
+  resolve: (rows: RawRow[]) => void;
+  reject: (err: Error) => void;
+}
+
+export async function createDuckDBClient(workerPath: string): Promise<DuckDBClient> {
+  const worker = new Worker(workerPath);
+  const pending = new Map<number, PendingQuery>();
+  let nextId = 0;
+  let fatalError: Error | null = null;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const onMessage = (msg: unknown): void => {
+      if (!isWorkerResponse(msg)) return;
+      if (msg.kind === 'ready') {
+        worker.off('message', onMessage);
+        resolve();
+        return;
+      }
+      if (msg.kind === 'error' && msg.id === -1) {
+        worker.off('message', onMessage);
+        const err = new Error(msg.message);
+        fatalError = err;
+        reject(err);
+        return;
+      }
+    };
+    worker.on('message', onMessage);
+    worker.once('error', (err) => { fatalError = err; reject(err); });
+  });
+
+  worker.on('message', (msg: unknown) => {
+    if (!isWorkerResponse(msg)) return;
+    if (msg.kind === 'ready') return;
+    const entry = pending.get(msg.id);
+    if (entry === undefined) return;
+    pending.delete(msg.id);
+    if (msg.kind === 'rows') entry.resolve(msg.rows);
+    else entry.reject(new Error(msg.message));
+  });
+
+  worker.on('error', (err) => {
+    fatalError = err;
+    for (const entry of pending.values()) entry.reject(err);
+    pending.clear();
+  });
+
+  worker.on('exit', (code) => {
+    if (code !== 0) {
+      const err = new Error(`DuckDB worker exited unexpectedly with code ${String(code)}`);
+      fatalError ??= err;
+      for (const entry of pending.values()) entry.reject(err);
+      pending.clear();
+    }
+  });
+
+  await ready;
+
+  return {
+    runQuery(sql: string): Promise<RawRow[]> {
+      if (fatalError !== null) return Promise.reject(fatalError);
+      const id = nextId++;
+      return new Promise<RawRow[]>((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        worker.postMessage({ kind: 'query', id, sql });
+      });
+    },
+    async terminate(): Promise<void> {
+      await worker.terminate();
+    },
+  };
+}

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,0 +1,91 @@
+import { parentPort } from 'node:worker_threads';
+import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
+
+interface DuckDBModule {
+  DuckDBInstance: { create: () => Promise<DuckDBInstance> };
+}
+
+async function createDuckDB(): Promise<DuckDBInstance> {
+  const duckdb = (await import('@duckdb/node-api')) as unknown as DuckDBModule;
+  return duckdb.DuckDBInstance.create();
+}
+
+if (parentPort === null) {
+  throw new Error('duckdb-worker.ts must be run as a Node.js Worker thread');
+}
+const port = parentPort;
+
+type WorkerRequest =
+  | { kind: 'query'; id: number; sql: string };
+
+type WorkerResponse =
+  | { kind: 'ready' }
+  | { kind: 'rows'; id: number; rows: Readonly<Record<string, unknown>>[] }
+  | { kind: 'error'; id: number; message: string };
+
+function isQueryRequest(msg: unknown): msg is { kind: 'query'; id: number; sql: string } {
+  if (typeof msg !== 'object' || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  return m['kind'] === 'query' && typeof m['id'] === 'number' && typeof m['sql'] === 'string';
+}
+
+async function fetchAllRows(conn: DuckDBConnection, sql: string): Promise<Readonly<Record<string, unknown>>[]> {
+  const result = await conn.run(sql);
+  const cols = result.columnCount;
+  const names: string[] = [];
+  for (let i = 0; i < cols; i++) names.push(result.columnName(i));
+
+  const rows: Record<string, unknown>[] = [];
+  let chunk = await result.fetchChunk();
+  while (chunk !== null && chunk.rowCount > 0) {
+    for (let r = 0; r < chunk.rowCount; r++) {
+      const row: Record<string, unknown> = {};
+      for (let c = 0; c < cols; c++) {
+        const name = names[c];
+        if (name !== undefined) row[name] = chunk.getColumnVector(c).getItem(r);
+      }
+      rows.push(row);
+    }
+    chunk = await result.fetchChunk();
+  }
+  return rows;
+}
+
+let connectionPromise: Promise<DuckDBConnection> | null = null;
+
+async function getConnection(): Promise<DuckDBConnection> {
+  if (connectionPromise === null) {
+    connectionPromise = createDuckDB().then(db => db.connect());
+  }
+  return connectionPromise;
+}
+
+function send(msg: WorkerResponse): void {
+  port.postMessage(msg);
+}
+
+void getConnection().then(() => {
+  send({ kind: 'ready' });
+}).catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  // Surface init failure as an error response with id -1; the client treats
+  // any error before `ready` as fatal and rejects all in-flight + future queries.
+  send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
+});
+
+async function handleRequest(req: WorkerRequest): Promise<void> {
+  try {
+    const conn = await getConnection();
+    const rows = await fetchAllRows(conn, req.sql);
+    send({ kind: 'rows', id: req.id, rows });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    send({ kind: 'error', id: req.id, message });
+  }
+}
+
+port.on('message', (msg: unknown) => {
+  if (isQueryRequest(msg)) {
+    void handleRequest(msg);
+  }
+});

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -1,4 +1,4 @@
-import type { DuckDBInstance, DuckDBConnection } from '../duckdb-loader.js';
+import type { DuckDBClient, RawRow } from '../duckdb-client.js';
 import {
   loadConfig,
   loadDimensions,
@@ -14,7 +14,7 @@ import type {
 } from '@costgoblin/core';
 
 export interface IpcContext {
-  readonly db: DuckDBInstance;
+  readonly db: DuckDBClient;
   readonly configPath: string;
   readonly dimensionsPath: string;
   readonly orgTreePath: string;
@@ -41,7 +41,7 @@ export interface AppContext {
   readonly getOrgTreeConfig: () => Promise<OrgTreeConfig>;
   readonly getAccountMap: () => Promise<Map<string, string>>;
   readonly getOrgAccountsPath: () => Promise<string | undefined>;
-  readonly withConnection: <T>(fn: (conn: DuckDBConnection) => Promise<T>) => Promise<T>;
+  readonly runQuery: (sql: string) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
   readonly invalidateDimensions: () => void;
 }
@@ -144,15 +144,6 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
   }
 
-  async function withConnection<T>(fn: (conn: DuckDBConnection) => Promise<T>): Promise<T> {
-    const conn = await ctx.db.connect();
-    try {
-      return await fn(conn);
-    } finally {
-      conn.disconnectSync();
-    }
-  }
-
   return {
     ctx,
     state,
@@ -161,7 +152,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getOrgTreeConfig,
     getAccountMap,
     getOrgAccountsPath,
-    withConnection,
+    runQuery: (sql: string) => ctx.db.runQuery(sql),
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => { state.dimensions = null; },
   };

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,87 +1,82 @@
 import { ipcMain } from 'electron';
 import type { DimensionsConfig } from '@costgoblin/core';
 import type { AppContext } from './context.js';
-import { queryAll, toNum, toStr } from './query-utils.js';
+import { toNum, toStr } from './query-utils.js';
 
 export function registerDimensionsHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, invalidateDimensions } = app;
+  const { ctx, getConfig, getDimensions, invalidateDimensions, runQuery } = app;
 
   ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
     const provider = config.providers[0];
     if (provider === undefined) return { tags: [], samplePeriod: '' };
 
-    const conn = await ctx.db.connect();
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const dailyDir = path.join(ctx.dataDir, 'aws', 'raw');
+    let dirs: string[] = [];
     try {
-      const fs = await import('node:fs/promises');
-      const path = await import('node:path');
-      const dailyDir = path.join(ctx.dataDir, 'aws', 'raw');
-      let dirs: string[] = [];
-      try {
-        dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort();
-      } catch { /* no data */ }
-      const recentDirs = dirs.slice(-2);
-      const rawParquet = recentDirs.length > 0
-        ? `read_parquet([${recentDirs.map(d => `'${ctx.dataDir}/aws/raw/${d}/*.parquet'`).join(', ')}])`
-        : `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
-      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort();
+    } catch { /* no data */ }
+    const recentDirs = dirs.slice(-2);
+    const rawParquet = recentDirs.length > 0
+      ? `read_parquet([${recentDirs.map(d => `'${ctx.dataDir}/aws/raw/${d}/*.parquet'`).join(', ')}])`
+      : `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
-      const totalSql = `SELECT COUNT(*) AS total FROM ${rawParquet} WHERE line_item_usage_start_date >= '${thirtyDaysAgo}'`;
-      const totalRows = await queryAll(conn, totalSql);
-      const totalRowCount = totalRows[0] !== undefined ? toNum(totalRows[0]['total']) : 0;
+    const totalSql = `SELECT COUNT(*) AS total FROM ${rawParquet} WHERE line_item_usage_start_date >= '${thirtyDaysAgo}'`;
+    const totalRows = await runQuery(totalSql);
+    const totalRowCount = totalRows[0] !== undefined ? toNum(totalRows[0]['total']) : 0;
 
-      const sql = `
-        WITH tags AS (
-          SELECT unnest(map_keys(resource_tags)) AS tag_key,
-                 unnest(map_values(resource_tags)) AS tag_val
-          FROM ${rawParquet}
-          WHERE resource_tags IS NOT NULL
-            AND line_item_usage_start_date >= '${thirtyDaysAgo}'
-        ),
-        grouped AS (
-          SELECT tag_key, tag_val, COUNT(*) AS val_cnt
-          FROM tags
-          WHERE tag_val IS NOT NULL AND tag_val != ''
-          GROUP BY tag_key, tag_val
-        ),
-        with_stats AS (
-          SELECT *,
-                 SUM(val_cnt) OVER (PARTITION BY tag_key) AS key_cnt,
-                 COUNT(*) OVER (PARTITION BY tag_key) AS distinct_cnt,
-                 ROW_NUMBER() OVER (PARTITION BY tag_key ORDER BY val_cnt DESC) AS rn
-          FROM grouped
-        )
-        SELECT tag_key, key_cnt, distinct_cnt, tag_val, val_cnt
-        FROM with_stats
-        ORDER BY key_cnt DESC, tag_key, rn
-      `;
-      const rows = await queryAll(conn, sql);
+    const sql = `
+      WITH tags AS (
+        SELECT unnest(map_keys(resource_tags)) AS tag_key,
+               unnest(map_values(resource_tags)) AS tag_val
+        FROM ${rawParquet}
+        WHERE resource_tags IS NOT NULL
+          AND line_item_usage_start_date >= '${thirtyDaysAgo}'
+      ),
+      grouped AS (
+        SELECT tag_key, tag_val, COUNT(*) AS val_cnt
+        FROM tags
+        WHERE tag_val IS NOT NULL AND tag_val != ''
+        GROUP BY tag_key, tag_val
+      ),
+      with_stats AS (
+        SELECT *,
+               SUM(val_cnt) OVER (PARTITION BY tag_key) AS key_cnt,
+               COUNT(*) OVER (PARTITION BY tag_key) AS distinct_cnt,
+               ROW_NUMBER() OVER (PARTITION BY tag_key ORDER BY val_cnt DESC) AS rn
+        FROM grouped
+      )
+      SELECT tag_key, key_cnt, distinct_cnt, tag_val, val_cnt
+      FROM with_stats
+      ORDER BY key_cnt DESC, tag_key, rn
+    `;
+    const rows = await runQuery(sql);
 
-      const tagMap = new Map<string, { rowCount: number; distinctCount: number; values: { val: string; cnt: number }[] }>();
-      for (const row of rows) {
-        const key = toStr(row['tag_key']);
-        if (key.length === 0) continue;
-        let entry = tagMap.get(key);
-        if (entry === undefined) {
-          entry = { rowCount: toNum(row['key_cnt']), distinctCount: toNum(row['distinct_cnt']), values: [] };
-          tagMap.set(key, entry);
-        }
-        entry.values.push({ val: toStr(row['tag_val']), cnt: toNum(row['val_cnt']) });
+    const tagMap = new Map<string, { rowCount: number; distinctCount: number; values: { val: string; cnt: number }[] }>();
+    for (const row of rows) {
+      const key = toStr(row['tag_key']);
+      if (key.length === 0) continue;
+      let entry = tagMap.get(key);
+      if (entry === undefined) {
+        entry = { rowCount: toNum(row['key_cnt']), distinctCount: toNum(row['distinct_cnt']), values: [] };
+        tagMap.set(key, entry);
       }
-
-      const tagKeys = [...tagMap.entries()].map(([key, data]) => ({
-        key,
-        sampleValues: data.values.map(v => v.val),
-        rowCount: data.rowCount,
-        distinctCount: data.distinctCount,
-        coveragePct: totalRowCount > 0 ? Math.round((data.rowCount / totalRowCount) * 100) : 0,
-      }));
-
-      const samplePeriod = `last 30 days (since ${thirtyDaysAgo})`;
-      return { tags: tagKeys, samplePeriod };
-    } finally {
-      conn.disconnectSync();
+      entry.values.push({ val: toStr(row['tag_val']), cnt: toNum(row['val_cnt']) });
     }
+
+    const tagKeys = [...tagMap.entries()].map(([key, data]) => ({
+      key,
+      sampleValues: data.values.map(v => v.val),
+      rowCount: data.rowCount,
+      distinctCount: data.distinctCount,
+      coveragePct: totalRowCount > 0 ? Math.round((data.rowCount / totalRowCount) * 100) : 0,
+    }));
+
+    const samplePeriod = `last 30 days (since ${thirtyDaysAgo})`;
+    return { tags: tagKeys, samplePeriod };
   });
 
   ipcMain.handle('dimensions:get-config', async (): Promise<DimensionsConfig> => {

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -1,4 +1,3 @@
-import type { DuckDBConnection } from '../duckdb-loader.js';
 import {
   asEntityRef,
   asDollars,
@@ -19,8 +18,8 @@ import type {
   DistributionSlice,
   OrgNode,
 } from '@costgoblin/core';
+import type { RawRow } from '../duckdb-client.js';
 
-export type RawRow = Readonly<Record<string, unknown>>;
 export type EffortLevel = 'VeryLow' | 'Low' | 'Medium' | 'High';
 
 const EFFORT_LEVELS = new Set<string>(['VeryLow', 'Low', 'Medium', 'High']);
@@ -42,28 +41,6 @@ export function toStr(v: unknown): string {
   if (v instanceof Date) return v.toISOString().slice(0, 10);
   if (typeof v === 'object' && 'toString' in v) return (v as { toString(): string }).toString();
   return '';
-}
-
-export async function queryAll(conn: DuckDBConnection, sql: string): Promise<RawRow[]> {
-  const result = await conn.run(sql);
-  const cols = result.columnCount;
-  const names: string[] = [];
-  for (let i = 0; i < cols; i++) names.push(result.columnName(i));
-
-  const rows: RawRow[] = [];
-  let chunk = await result.fetchChunk();
-  while (chunk !== null && chunk.rowCount > 0) {
-    for (let r = 0; r < chunk.rowCount; r++) {
-      const row: Record<string, unknown> = {};
-      for (let c = 0; c < cols; c++) {
-        const name = names[c];
-        if (name !== undefined) row[name] = chunk.getColumnVector(c).getItem(r);
-      }
-      rows.push(row);
-    }
-    chunk = await result.fetchChunk();
-  }
-  return rows;
 }
 
 export function isOwnerGroupBy(groupBy: string, dimensions: DimensionsConfig): boolean {

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -28,15 +28,14 @@ import type {
   SavingsResult,
 } from '@costgoblin/core';
 import type { AppContext } from './context.js';
+import type { RawRow } from '../duckdb-client.js';
 import {
-  type RawRow,
   applyOrgTreeRollup,
   buildCostResult,
   buildEntityDetailResult,
   buildMissingTagsResult,
   buildTrendResult,
   isOwnerGroupBy,
-  queryAll,
   resolveEntityName,
   toEffort,
   toNum,
@@ -44,7 +43,7 @@ import {
 } from './query-utils.js';
 
 export function registerQueryHandlers(app: AppContext): void {
-  const { ctx, getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, withConnection } = app;
+  const { ctx, getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, runQuery } = app;
 
   ipcMain.handle('query:costs', async (_event, params: CostQueryParams): Promise<CostResult> => {
     const dimensions = await getDimensions();
@@ -53,26 +52,24 @@ export function registerQueryHandlers(app: AppContext): void {
     const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath);
     logger.info('query:costs', { groupBy: params.groupBy });
 
-    return withConnection(async (conn) => {
-      const rows = await queryAll(conn, sql);
-      let result = buildCostResult(rows, params.dateRange);
+    const rows = await runQuery(sql);
+    let result = buildCostResult(rows, params.dateRange);
 
-      if (params.groupBy === 'account' || params.groupBy === 'account_id') {
-        result = {
-          ...result,
-          rows: result.rows.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
-        };
+    if (params.groupBy === 'account' || params.groupBy === 'account_id') {
+      result = {
+        ...result,
+        rows: result.rows.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
+      };
+    }
+
+    if (isOwnerGroupBy(params.groupBy, dimensions) && params.orgNodeValues === undefined) {
+      const orgTreeConfig = await getOrgTreeConfig();
+      if (orgTreeConfig.tree.length > 0) {
+        result = applyOrgTreeRollup(result, orgTreeConfig.tree);
       }
+    }
 
-      if (isOwnerGroupBy(params.groupBy, dimensions) && params.orgNodeValues === undefined) {
-        const orgTreeConfig = await getOrgTreeConfig();
-        if (orgTreeConfig.tree.length > 0) {
-          result = applyOrgTreeRollup(result, orgTreeConfig.tree);
-        }
-      }
-
-      return result;
-    });
+    return result;
   });
 
   ipcMain.handle('query:daily-costs', async (_event, params: DailyCostsParams): Promise<DailyCostsResult> => {
@@ -81,51 +78,49 @@ export function registerQueryHandlers(app: AppContext): void {
     const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
-    return withConnection(async (conn) => {
-      const rows = await queryAll(conn, sql);
+    const rows = await runQuery(sql);
 
-      const dayMap = new Map<string, Record<string, number>>();
-      const groupSet = new Set<string>();
-      let totalCost = 0;
+    const dayMap = new Map<string, Record<string, number>>();
+    const groupSet = new Set<string>();
+    let totalCost = 0;
 
-      for (const row of rows) {
-        const rawDate = row['date'];
-        const rawGroup = row['group_name'];
-        let date: string;
-        if (rawDate instanceof Date) {
-          date = rawDate.toISOString().slice(0, 10);
-        } else if (typeof rawDate === 'string') {
-          date = rawDate;
-        } else {
-          date = '';
-        }
-        const group = typeof rawGroup === 'string' ? rawGroup : '';
-        const cost = Number(row['cost'] ?? 0);
-
-        groupSet.add(group);
-        totalCost += cost;
-
-        const existing = dayMap.get(date);
-        if (existing !== undefined) {
-          existing[group] = (existing[group] ?? 0) + cost;
-        } else {
-          dayMap.set(date, { [group]: cost });
-        }
+    for (const row of rows) {
+      const rawDate = row['date'];
+      const rawGroup = row['group_name'];
+      let date: string;
+      if (rawDate instanceof Date) {
+        date = rawDate.toISOString().slice(0, 10);
+      } else if (typeof rawDate === 'string') {
+        date = rawDate;
+      } else {
+        date = '';
       }
+      const group = typeof rawGroup === 'string' ? rawGroup : '';
+      const cost = Number(row['cost'] ?? 0);
 
-      const days: DailyCostDay[] = [...dayMap.entries()]
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([date, breakdown]) => {
-          const total = Object.values(breakdown).reduce((s, v) => s + v, 0);
-          const typedBreakdown: Record<string, Dollars> = {};
-          for (const [k, v] of Object.entries(breakdown)) {
-            typedBreakdown[k] = asDollars(v);
-          }
-          return { date: asDateString(date), total: asDollars(total), breakdown: typedBreakdown };
-        });
+      groupSet.add(group);
+      totalCost += cost;
 
-      return { days, groups: [...groupSet], totalCost: asDollars(totalCost) };
-    });
+      const existing = dayMap.get(date);
+      if (existing !== undefined) {
+        existing[group] = (existing[group] ?? 0) + cost;
+      } else {
+        dayMap.set(date, { [group]: cost });
+      }
+    }
+
+    const days: DailyCostDay[] = [...dayMap.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([date, breakdown]) => {
+        const total = Object.values(breakdown).reduce((s, v) => s + v, 0);
+        const typedBreakdown: Record<string, Dollars> = {};
+        for (const [k, v] of Object.entries(breakdown)) {
+          typedBreakdown[k] = asDollars(v);
+        }
+        return { date: asDateString(date), total: asDollars(total), breakdown: typedBreakdown };
+      });
+
+    return { days, groups: [...groupSet], totalCost: asDollars(totalCost) };
   });
 
   ipcMain.handle('query:trends', async (_event, params: TrendQueryParams): Promise<TrendResult> => {
@@ -135,18 +130,16 @@ export function registerQueryHandlers(app: AppContext): void {
     const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:trends', { groupBy: params.groupBy });
 
-    return withConnection(async (conn) => {
-      const rows = await queryAll(conn, sql);
-      const result = buildTrendResult(rows, params.deltaThreshold, params.percentThreshold);
-      if (params.groupBy === 'account' || params.groupBy === 'account_id') {
-        return {
-          ...result,
-          increases: result.increases.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
-          savings: result.savings.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
-        };
-      }
-      return result;
-    });
+    const rows = await runQuery(sql);
+    const result = buildTrendResult(rows, params.deltaThreshold, params.percentThreshold);
+    if (params.groupBy === 'account' || params.groupBy === 'account_id') {
+      return {
+        ...result,
+        increases: result.increases.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
+        savings: result.savings.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
+      };
+    }
+    return result;
   });
 
   ipcMain.handle('query:missing-tags', async (_event, params: MissingTagsParams): Promise<MissingTagsResult> => {
@@ -156,17 +149,15 @@ export function registerQueryHandlers(app: AppContext): void {
     const sql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
-    return withConnection(async (conn) => {
-      const rows = await queryAll(conn, sql);
-      const result = buildMissingTagsResult(rows);
-      return {
-        ...result,
-        rows: result.rows.map(r => ({
-          ...r,
-          accountName: resolveEntityName(r.accountId, accountMap) || r.accountName,
-        })),
-      };
-    });
+    const rows = await runQuery(sql);
+    const result = buildMissingTagsResult(rows);
+    return {
+      ...result,
+      rows: result.rows.map(r => ({
+        ...r,
+        accountName: resolveEntityName(r.accountId, accountMap) || r.accountName,
+      })),
+    };
   });
 
   ipcMain.handle('query:savings', async (): Promise<SavingsResult> => {
@@ -176,63 +167,61 @@ export function registerQueryHandlers(app: AppContext): void {
       return { recommendations: [], totalMonthlySavings: asDollars(0) };
     }
 
-    return withConnection(async (conn) => {
-      let rows: RawRow[];
-      try {
-        rows = await queryAll(conn, `
-          SELECT
-            account_id,
-            account_name,
-            action_type,
-            current_resource_type,
-            COALESCE(recommended_resource_summary, '') AS summary,
-            COALESCE(region, '') AS region,
-            COALESCE(estimated_monthly_savings_after_discount, 0) AS monthly_savings,
-            COALESCE(estimated_monthly_cost_after_discount, 0) AS monthly_cost,
-            COALESCE(estimated_savings_percentage_after_discount, 0) AS savings_pct,
-            COALESCE(implementation_effort, '') AS effort,
-            COALESCE(resource_arn, '') AS resource_arn,
-            COALESCE(current_resource_details, '') AS current_details,
-            COALESCE(recommended_resource_details, '') AS recommended_details,
-            COALESCE(current_resource_summary, '') AS current_summary,
-            COALESCE(restart_needed, false) AS restart_needed,
-            COALESCE(rollback_possible, false) AS rollback_possible,
-            COALESCE(recommendation_source, '') AS recommendation_source
-          FROM read_parquet('${ctx.dataDir}/aws/raw/cost-opt-*/*.parquet', filename=true)
-          QUALIFY ROW_NUMBER() OVER (PARTITION BY recommendation_id ORDER BY filename DESC) = 1
-          ORDER BY monthly_savings DESC
-        `);
-      } catch {
-        return { recommendations: [], totalMonthlySavings: asDollars(0) };
-      }
+    let rows: RawRow[];
+    try {
+      rows = await runQuery(`
+        SELECT
+          account_id,
+          account_name,
+          action_type,
+          current_resource_type,
+          COALESCE(recommended_resource_summary, '') AS summary,
+          COALESCE(region, '') AS region,
+          COALESCE(estimated_monthly_savings_after_discount, 0) AS monthly_savings,
+          COALESCE(estimated_monthly_cost_after_discount, 0) AS monthly_cost,
+          COALESCE(estimated_savings_percentage_after_discount, 0) AS savings_pct,
+          COALESCE(implementation_effort, '') AS effort,
+          COALESCE(resource_arn, '') AS resource_arn,
+          COALESCE(current_resource_details, '') AS current_details,
+          COALESCE(recommended_resource_details, '') AS recommended_details,
+          COALESCE(current_resource_summary, '') AS current_summary,
+          COALESCE(restart_needed, false) AS restart_needed,
+          COALESCE(rollback_possible, false) AS rollback_possible,
+          COALESCE(recommendation_source, '') AS recommendation_source
+        FROM read_parquet('${ctx.dataDir}/aws/raw/cost-opt-*/*.parquet', filename=true)
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY recommendation_id ORDER BY filename DESC) = 1
+        ORDER BY monthly_savings DESC
+      `);
+    } catch {
+      return { recommendations: [], totalMonthlySavings: asDollars(0) };
+    }
 
-      let totalSavings = 0;
-      const recommendations = rows.map(r => {
-        const savings = toNum(r['monthly_savings']);
-        totalSavings += savings;
-        return {
-          accountId: toStr(r['account_id']),
-          accountName: toStr(r['account_name']),
-          actionType: toStr(r['action_type']),
-          resourceType: toStr(r['current_resource_type']),
-          summary: toStr(r['summary']),
-          region: toStr(r['region']),
-          monthlySavings: asDollars(savings),
-          monthlyCost: asDollars(toNum(r['monthly_cost'])),
-          savingsPercentage: toNum(r['savings_pct']),
-          effort: toEffort(toStr(r['effort'])),
-          resourceArn: toStr(r['resource_arn']),
-          currentDetails: toStr(r['current_details']),
-          recommendedDetails: toStr(r['recommended_details']),
-          currentSummary: toStr(r['current_summary']),
-          restartNeeded: Boolean(r['restart_needed']),
-          rollbackPossible: Boolean(r['rollback_possible']),
-          recommendationSource: toStr(r['recommendation_source']),
-        };
-      });
-
-      return { recommendations, totalMonthlySavings: asDollars(totalSavings) };
+    let totalSavings = 0;
+    const recommendations = rows.map(r => {
+      const savings = toNum(r['monthly_savings']);
+      totalSavings += savings;
+      return {
+        accountId: toStr(r['account_id']),
+        accountName: toStr(r['account_name']),
+        actionType: toStr(r['action_type']),
+        resourceType: toStr(r['current_resource_type']),
+        summary: toStr(r['summary']),
+        region: toStr(r['region']),
+        monthlySavings: asDollars(savings),
+        monthlyCost: asDollars(toNum(r['monthly_cost'])),
+        savingsPercentage: toNum(r['savings_pct']),
+        effort: toEffort(toStr(r['effort'])),
+        resourceArn: toStr(r['resource_arn']),
+        currentDetails: toStr(r['current_details']),
+        recommendedDetails: toStr(r['recommended_details']),
+        currentSummary: toStr(r['current_summary']),
+        restartNeeded: Boolean(r['restart_needed']),
+        rollbackPossible: Boolean(r['rollback_possible']),
+        recommendationSource: toStr(r['recommendation_source']),
+      };
     });
+
+    return { recommendations, totalMonthlySavings: asDollars(totalSavings) };
   });
 
   ipcMain.handle('query:entity-detail', async (_event, params: EntityDetailParams): Promise<EntityDetailResult> => {
@@ -242,17 +231,15 @@ export function registerQueryHandlers(app: AppContext): void {
     const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:entity-detail', { entity: params.entity });
 
-    return withConnection(async (conn) => {
-      const rows = await queryAll(conn, sql);
-      const result = buildEntityDetailResult(rows, params.entity);
-      return {
-        ...result,
-        byAccount: result.byAccount.map(s => ({
-          ...s,
-          name: resolveEntityName(s.name, accountMap),
-        })),
-      };
-    });
+    const rows = await runQuery(sql);
+    const result = buildEntityDetailResult(rows, params.entity);
+    return {
+      ...result,
+      byAccount: result.byAccount.map(s => ({
+        ...s,
+        name: resolveEntityName(s.name, accountMap),
+      })),
+    };
   });
 
   ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, string>, dateRange?: { start: string; end: string }): Promise<{ value: string; label: string; count: number }[]> => {
@@ -298,14 +285,12 @@ export function registerQueryHandlers(app: AppContext): void {
       LIMIT 100
     `;
 
-    return withConnection(async (conn) => {
-      const rows = await queryAll(conn, sql);
-      return rows.map(r => {
-        const rawVal = toStr(r['val']);
-        const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
-        const label = isAccountDim ? (accountMap.get(rawVal) ?? rawVal) : rawVal;
-        return { value: rawVal, label, count: toNum(r['total_cost']) };
-      });
+    const rows = await runQuery(sql);
+    return rows.map(r => {
+      const rawVal = toStr(r['val']);
+      const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
+      const label = isAccountDim ? (accountMap.get(rawVal) ?? rawVal) : rawVal;
+      return { value: rawVal, label, count: toNum(r['total_cost']) };
     });
   });
 }

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -2,8 +2,8 @@ import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'node:path';
 import { logger } from '@costgoblin/core';
 import type { LogEntry } from '@costgoblin/core';
-import { createDuckDB } from './duckdb-loader.js';
-import type { DuckDBInstance } from './duckdb-loader.js';
+import { createDuckDBClient } from './duckdb-client.js';
+import type { DuckDBClient } from './duckdb-client.js';
 import { registerIpcHandlers } from './ipc.js';
 
 logger.addHandler((entry: LogEntry) => {
@@ -17,7 +17,7 @@ function resolveConfigPath(base: string, name: string): string {
   return typeof env === 'string' && env.length > 0 ? env : join(base, `${name}.yaml`);
 }
 
-async function createWindow(db: DuckDBInstance): Promise<void> {
+async function createWindow(db: DuckDBClient): Promise<void> {
   const userDataPath = app.getPath('userData');
   const dataDir = process.env['COSTGOBLIN_DATA_DIR'] ?? join(userDataPath, 'data');
   const configBase = process.env['COSTGOBLIN_CONFIG_DIR'] ?? join(userDataPath, 'config');
@@ -69,8 +69,9 @@ async function createWindow(db: DuckDBInstance): Promise<void> {
 async function main(): Promise<void> {
   await app.whenReady();
 
-  const db = await createDuckDB();
-  logger.info('DuckDB initialized');
+  const workerPath = join(__dirname, 'duckdb-worker.js');
+  const db = await createDuckDBClient(workerPath);
+  logger.info('DuckDB worker ready');
 
   await createWindow(db);
 


### PR DESCRIPTION
PR 5 of 5 from the strict review. The architectural change the spec committed to: DuckDB no longer runs on Electron's main process.

## Summary

- `duckdb-worker.ts` runs in a Node.js Worker. It owns the `DuckDBInstance` + `DuckDBConnection`, marshals row chunks into structured-clone-safe arrays, and responds to `query` messages by id.
- `duckdb-client.ts` wraps the worker on the main side: spawns it, waits for the `ready` handshake, correlates outstanding queries by id, and exposes `runQuery(sql): Promise<RawRow[]>`. Also handles fatal worker errors and unexpected exits — all in-flight queries reject.
- `IpcContext.db` is now `DuckDBClient`. `AppContext.withConnection` is gone, replaced by `AppContext.runQuery` which forwards to the worker.
- `handlers/query.ts` and `handlers/dimensions.ts` switch each `withConnection + queryAll` pair to a single `runQuery` call. Net code shrinks since the IIFE wrapping is no longer needed.
- `queryAll` and the local `RawRow` type drop out of `query-utils.ts`; the worker does row marshalling and `RawRow` now lives with the client.
- `main.ts` spawns the worker on startup and passes the client into IPC.

## Build wiring

Kept `electron-vite` for the main bundle (single entry, simpler) and added a 1ms `esbuild` step for the worker. The worker bundles to `out/main/duckdb-worker.js` with `@duckdb/node-api` and `electron` externalized. Wired into the `dev` script too so the dev workflow stays one command.

```json
"build": "electron-vite build --sourcemap && npm run build:worker",
"build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/main/duckdb-worker.js --external:@duckdb/node-api --external:electron",
"dev": "npm run build:worker && electron-vite dev"
```

## Why not have the sync worker too?

The spec originally called for both a DuckDB worker and an S3 sync worker. After PR 1 deleted the legacy `runSync` (which did DuckDB-side repartitioning), the active sync flow is `aws s3 sync` (subprocess) + tiny Node bookkeeping. CPU work happens in the subprocess, not in the Node event loop — there's nothing to offload. Adding a sync worker would be ceremony without benefit. Spec already reflects this (PR 1).

## Verification

- `npm run check` — 174 passed, 5 skipped, tsc + eslint clean.
- `npm run build` — produces both `out/main/main.js` (350KB) and `out/main/duckdb-worker.js` (3.5KB).

## What's left

The 5-PR plan is done. Open follow-ups from the original review (lower priority):

- SQL builder hardening (parameterize date ranges and validate identifiers against allow-lists)
- Replace hand-rolled `validator.ts` with zod
- Memoization on chart components
- Consolidate `app-preferences.json`, `savings-preferences.json`, and `ui-preferences.json` into a single per-user prefs file