### PR TITLE
Fix worker bundle path so make dev launches

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {
-    "build": "electron-vite build --sourcemap && npm run build:worker",
-    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/main/duckdb-worker.js --external:@duckdb/node-api --external:electron",
+    "build": "npm run build:worker && electron-vite build --sourcemap",
+    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",
     "dev": "npm run build:worker && electron-vite dev"

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -69,7 +69,10 @@ async function createWindow(db: DuckDBClient): Promise<void> {
 async function main(): Promise<void> {
   await app.whenReady();
 
-  const workerPath = join(__dirname, 'duckdb-worker.js');
+  // Worker bundle is built by `npm run build:worker` (esbuild) into out/worker/
+  // — sibling to out/main/ where this file lives. We resolve up one level then
+  // into out/worker/ to find it.
+  const workerPath = join(__dirname, '..', 'worker', 'duckdb-worker.cjs');
   const db = await createDuckDBClient(workerPath);
   logger.info('DuckDB worker ready');
 


### PR DESCRIPTION
Follow-up to #37. The worker thread landed but `make dev` couldn't actually start the app — two bugs in the bundle layout.

## What broke

1. **Worker output dir collided with electron-vite.** `npm run build:worker` wrote `out/main/duckdb-worker.js`, but `electron-vite dev` clears `out/main/` on every rebuild, so the worker was deleted before Electron launched.
2. **`.js` + `"type": "module"`** in `packages/desktop/package.json` made Node treat the CJS bundle as ESM and reject the `require()` calls esbuild emits.

## Fix

- esbuild now writes to `out/worker/duckdb-worker.cjs` (sibling of `out/main/`, untouched by electron-vite). `.cjs` forces CJS regardless of package type.
- `main.ts` resolves the worker via `../worker/duckdb-worker.cjs` from `__dirname`.
- `build` reorders to `build:worker && electron-vite build`, mirroring `dev`.

## Verification

`make dev` now boots cleanly:

```
[2026-04-18T13:03:47.115Z] INFO DuckDB worker ready
[2026-04-18T13:03:47.507Z] INFO Window created
```