### PR TITLE
Fix black screen: revert sandbox: true (preload incompatibility)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev reset test lint help
+.PHONY: dev reset test e2e lint help
 .DEFAULT_GOAL := help
 
 dev: ## Launch Electron in dev mode
@@ -10,6 +10,10 @@ reset: ## Wipe app data and config — next launch shows wizard
 
 test: ## Run vitest
 	npx vitest run
+
+e2e: ## Build the app and run the Playwright E2E suite
+	npm run build --workspace=packages/desktop
+	npx playwright test
 
 lint: ## Run tsc + eslint
 	npx tsc --noEmit -p packages/core/tsconfig.json

--- a/SPEC.md
+++ b/SPEC.md
@@ -168,7 +168,7 @@ Constraints:
 
 - `contextIsolation: true`
 - `nodeIntegration: false`
-- `sandbox: true` (v1 — currently `false`)
+- `sandbox: false` — target is `true` (v1) but blocked on tooling: `electron-vite` emits an ESM (`.mjs`) preload, and Electron's sandboxed loader is CJS-only. Switching requires either replacing the preload build with esbuild (which gets clobbered every time `electron-vite dev` rebuilds) or upstream electron-vite support for CJS preload output. The two flags above already prevent the main attack vectors; sandboxing is defense-in-depth on top.
 - Preload uses `contextBridge.exposeInMainWorld` to expose only the typed `CostApi`.
 - Renderer has zero Node imports. No `localStorage`/`sessionStorage` for app data — see Configuration System.
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {
-    "build": "npm run build:worker && electron-vite build --sourcemap",
+    "build": "electron-vite build --sourcemap && npm run build:worker",
     "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -42,7 +42,11 @@ async function createWindow(db: DuckDBClient): Promise<void> {
       preload: join(__dirname, '..', 'preload', 'preload.mjs'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: true,
+      // sandbox: true is the v1 target but breaks ESM preloads (electron-vite
+      // emits .mjs and the sandboxed loader is CJS-only). contextIsolation +
+      // nodeIntegration: false already prevent the main attack vectors;
+      // sandboxing remains a future hardening task.
+      sandbox: false,
     },
   });
 


### PR DESCRIPTION
## What was wrong

The user reported a black screen after running \`make dev\`. The existing Playwright suite was failing — confirming the renderer never mounted — but no one had run it after PR 1.

Root cause: PR 1 enabled \`sandbox: true\`. Electron's sandboxed preload loader is CJS-only, but \`electron-vite\` emits an ESM (\`.mjs\`) preload because the desktop's \`package.json\` has \`"type": "module"\`. So the preload threw \`SyntaxError: Cannot use import statement outside a module\`, \`globalThis.costgoblin\` was never defined, and \`App.tsx\` got stuck in the \`'checking'\` setup state — which renders an empty \`<div>\` with the dark background.

Confirmed via a one-off diagnostic Playwright test:

\`\`\`
CONSOLE error Unable to load preload script: .../preload.mjs
              SyntaxError: Cannot use import statement outside a module
PAGEERROR Cannot read properties of undefined (reading 'getSetupStatus')
HAS_API undefined
BODY_LEN 410   # empty render
\`\`\`

The main process logged \`Window created\` normally — that's why the launch verification in [#38](https://github.com/etiennechabert/cost-goblin/pull/38) looked green.

## Fixes I tried that didn't stick

1. Force \`.cjs\` output via \`electron-vite\` lib options — silently overridden to \`.mjs\` because of \`"type": "module"\`.
2. Build preload with \`esbuild\` (matching what we did for the worker) — works for prod build, but \`electron-vite dev\` rebuilds preload on every cycle and clobbers the \`.cjs\`.

## Fix that worked

Revert \`sandbox: true\` → \`false\`. \`contextIsolation: true\` + \`nodeIntegration: false\` already block the main attack vectors (renderer can't \`require\` Node modules, can't access the main world). Sandboxing is defense-in-depth on top, not load-bearing for an app that only loads bundled local code.

The spec section is updated to record the tooling blocker so this isn't reattempted without addressing it upstream.

## Also: \`make e2e\`

Added a Make target so the existing Playwright suite is one command away. Running \`make e2e\` after PR 1 would have caught this immediately.

## Verification

- All 5 \`App shell\` Playwright tests pass.
- Full suite: 58 passed, 1 failed (pre-existing assertion on a hidden \`<option>\` element — unrelated), 9 skipped (conditional on data being present).
- \`make dev\` boots, renderer renders, IPC works (visible in the renderer making real \`data:inventory\` calls that fail with the user's expired SSO — meaning the React app and IPC bridge are fully functional).