### PR TITLE
Fix hourly cost queries dropping ~23h of the end day

### DIFF
--- a/packages/core/src/__tests__/query-integration.test.ts
+++ b/packages/core/src/__tests__/query-integration.test.ts
@@ -161,6 +161,56 @@ describe('DuckDB query integration', () => {
     expect(Number(rows[0]?.['cnt'])).toBeGreaterThan(0);
   });
 
+  it('hourly tier exposes both usage_date (DATE) and usage_hour (TIMESTAMP)', async () => {
+    const source = buildSource(SYNTHETIC_DIR, 'hourly', dimensions);
+    const rows = await queryAll(conn, `
+      SELECT typeof(usage_date) AS d_type, typeof(usage_hour) AS h_type
+      FROM ${source} LIMIT 1
+    `);
+    expect(rows[0]?.['d_type']).toBe('DATE');
+    expect(rows[0]?.['h_type']).toBe('TIMESTAMP');
+  });
+
+  it('cost query with hourly granularity returns rows for an end-day-inclusive range', async () => {
+    // Regression: BETWEEN against a TIMESTAMP would truncate the end string to
+    // midnight and silently drop most of the end day. With usage_date as DATE,
+    // the same 'YYYY-MM-DD' end value covers the full day.
+    const sql = buildCostQuery(
+      {
+        groupBy: asDimensionId('service'),
+        dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
+        filters: {},
+        granularity: 'hourly',
+      },
+      SYNTHETIC_DIR,
+      dimensions,
+    );
+    const rows = await queryAll(conn, sql);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(Number(rows[0]?.['total_cost'])).toBeGreaterThan(0);
+  });
+
+  it('hourly cost query returns the same total as a SUM over the raw hourly source', async () => {
+    const range = { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') } as const;
+    const sql = buildCostQuery(
+      { groupBy: asDimensionId('service'), dateRange: range, filters: {}, granularity: 'hourly' },
+      SYNTHETIC_DIR,
+      dimensions,
+    );
+    const queryTotalRows = await queryAll(conn, `SELECT SUM(total_cost) AS t FROM (${sql})`);
+    const queryTotal = Number(queryTotalRows[0]?.['t'] ?? 0);
+
+    const source = buildSource(SYNTHETIC_DIR, 'hourly', dimensions);
+    const rawRows = await queryAll(conn, `
+      SELECT SUM(cost) AS t FROM ${source}
+      WHERE usage_date BETWEEN '${range.start}' AND '${range.end}'
+    `);
+    const rawTotal = Number(rawRows[0]?.['t'] ?? 0);
+
+    expect(queryTotal).toBeGreaterThan(0);
+    expect(queryTotal).toBeCloseTo(rawTotal, 2);
+  });
+
   it('daily costs query with hourly granularity includes hour in date field', async () => {
     const sql = buildDailyCostsQuery(
       {

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -61,8 +61,12 @@ export function buildSource(dataDir: string, tier: string, dimensions: Dimension
 
   const tagClause = tagSelects.length > 0 ? `,\n      ${tagSelects.join(',\n      ')}` : '';
 
+  // usage_date is always DATE so date-range filters work consistently across
+  // tiers (BETWEEN against a TIMESTAMP truncates 'YYYY-MM-DD' to midnight and
+  // would silently drop ~23h of rows on the end day). For hourly we additionally
+  // expose usage_hour as the original TIMESTAMP for hour-resolution grouping.
   const dateExpr = tier === 'hourly'
-    ? 'line_item_usage_start_date AS usage_date'
+    ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date AS usage_hour'
     : 'line_item_usage_start_date::DATE AS usage_date';
 
   const parquetSource = `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
@@ -274,7 +278,7 @@ export function buildDailyCostsQuery(
   ];
 
   const dateExpr = dailyTier === 'hourly'
-    ? "strftime(usage_date, '%Y-%m-%d %H:00')"
+    ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 
   return `
@@ -307,16 +311,22 @@ export function buildEntityDetailQuery(
     ...filterClauses,
   ];
 
+  // Group by hour for hourly tier so the entity detail histogram doesn't
+  // collapse 24 hourly rows into one date row.
+  const groupKey = tier === 'hourly'
+    ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
+    : 'usage_date::VARCHAR';
+
   return `
     SELECT
-      usage_date,
+      ${groupKey} AS usage_date,
       service,
       account_id,
       account_name,
       SUM(cost) AS cost
     FROM ${source}
     WHERE ${whereConditions.join(' AND ')}
-    GROUP BY usage_date, service, account_id, account_name
+    GROUP BY ${groupKey}, service, account_id, account_name
     ORDER BY usage_date, cost DESC
   `.trim();
 }


### PR DESCRIPTION
## Bug

User reported: "the primary view is not able to display hourly data anymore, on daily everything seems fine."

Root cause in `buildSource`:

\`\`\`ts
const dateExpr = tier === 'hourly'
  ? 'line_item_usage_start_date AS usage_date'              // ← TIMESTAMP
  : 'line_item_usage_start_date::DATE AS usage_date';       // ← DATE
\`\`\`

Every query then filters with:

\`\`\`sql
WHERE usage_date BETWEEN '2026-04-12' AND '2026-04-18'
\`\`\`

DuckDB casts the right-hand strings to TIMESTAMP at midnight, so for hourly the comparison silently drops rows from `01:00` through `23:00` on the end day. Cost Overview, the hourly histogram, and entity detail all under-reported when `granularity = hourly`. The exact symptom depends on the date range and the data — sometimes empty, sometimes wrong.

## Fix

- `buildSource` now always exposes `usage_date` as `DATE`. For hourly it additionally exposes `usage_hour` as the original `TIMESTAMP` for hour-resolution grouping.
- `buildDailyCostsQuery` uses `usage_hour` for the histogram's `strftime` grouping when hourly.
- `buildEntityDetailQuery` groups by hour when hourly so the entity detail histogram doesn't collapse 24 hourly rows into one date row.

## Tests

Added 3 integration tests that would have caught this:

1. usage_date is `DATE` and usage_hour is `TIMESTAMP` for hourly tier (schema-level guard)
2. Cost query at hourly granularity returns rows over an end-day-inclusive range (the original symptom)
3. Total cost from the cost query matches a direct `SUM` over the raw hourly source for the same range (correctness)

`npm run check` — 177 passed (+3), 5 skipped, tsc + eslint clean.