### PR TITLE
Cast usage_hour to TIMESTAMP + surface query errors on Cost Overview

### DIFF
--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -64,9 +64,17 @@ export function buildSource(dataDir: string, tier: string, dimensions: Dimension
   // usage_date is always DATE so date-range filters work consistently across
   // tiers (BETWEEN against a TIMESTAMP truncates 'YYYY-MM-DD' to midnight and
   // would silently drop ~23h of rows on the end day). For hourly we additionally
-  // expose usage_hour as the original TIMESTAMP for hour-resolution grouping.
+  // expose usage_hour as a standard TIMESTAMP — the source column is TIMESTAMP_NS
+  // (nanoseconds) in CUR and the @duckdb/node-api row converter doesn't know
+  // how to serialize that variant; casting to plain TIMESTAMP fixes it.
+  // usage_date is always DATE so date-range filters work consistently across
+  // tiers (BETWEEN against a TIMESTAMP truncates 'YYYY-MM-DD' to midnight and
+  // would silently drop ~23h of rows on the end day). For hourly we additionally
+  // expose usage_hour as a standard TIMESTAMP — the source column is TIMESTAMP_NS
+  // (nanoseconds) in CUR and the @duckdb/node-api row converter doesn't know
+  // how to serialize that variant; casting to plain TIMESTAMP fixes it.
   const dateExpr = tier === 'hourly'
-    ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date AS usage_hour'
+    ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date::TIMESTAMP AS usage_hour'
     : 'line_item_usage_start_date::DATE AS usage_date';
 
   const parquetSource = `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;

--- a/packages/ui/src/views/cost-overview.tsx
+++ b/packages/ui/src/views/cost-overview.tsx
@@ -262,6 +262,14 @@ function OverviewInner() {
     || pie1Query.status === 'loading'
     || pie3Query.status === 'loading';
 
+  // Surface query errors so corruption / credential issues / etc. don't silently
+  // fall through as $0.00. Picks the first error from the cost queries.
+  const queryError = pie1Query.status === 'error' ? pie1Query.error
+    : pie2Query.status === 'error' ? pie2Query.error
+    : pie3Query.status === 'error' ? pie3Query.error
+    : dailyQuery.status === 'error' ? dailyQuery.error
+    : null;
+
   // Breakdown table data — use the first pie query's rows with service breakdown
   const breakdownRows = pie1Query.status === 'success'
     ? pie1Query.data.rows
@@ -304,6 +312,20 @@ function OverviewInner() {
 
       {/* Filter active banner */}
       <FilterActiveBanner />
+
+      {queryError !== null && (
+        <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3">
+          <p className="text-sm font-medium text-negative">Query failed: {queryError.message}</p>
+          {(queryError.message.includes("don't know what type") || queryError.message.includes('TProtocolException')) && (
+            <p className="text-xs text-text-secondary mt-1">
+              The Parquet files for this period look corrupt. Open the Sync view, delete the affected period, and re-download.
+            </p>
+          )}
+          {queryError.message.includes('aws sso login') && (
+            <p className="text-xs text-text-secondary mt-1">Refresh after logging in.</p>
+          )}
+        </div>
+      )}
 
       {isLoading && (
         <div className="text-sm text-text-secondary">Loading...</div>


### PR DESCRIPTION
After ${'#40'} I E2E-tested the hourly path against the user's real CUR data. The query was failing for a different reason and the failure was being silently swallowed.

## What I found

\`make e2e\`-style Playwright run captured this from the DuckDB worker:

\`\`\`
Error occurred in handler for 'query:costs': Error: Invalid Error: don't know what type:
\`\`\`

The cost overview's \`pie1Query\` (which feeds \`totalCost\`) was throwing on every hourly request and the view was falling back to \`0\`. From outside, identical to "no hourly data."

## Two issues, two fixes

### 1. \`usage_hour\` was \`TIMESTAMP_NS\`

The user's CUR exports \`line_item_usage_start_date\` as \`TIMESTAMP_NS\` (nanosecond). The @duckdb/node-api row converter doesn't serialize that variant — hence the cryptic "don't know what type:" with empty payload after the colon. Explicit \`::TIMESTAMP\` cast resolves it.

### 2. Cost Overview swallowed query errors

Every \`status === 'error'\` branch silently degraded to \`0\`. Added a red error banner that shows the actual message, plus a one-line hint for the two patterns we can act on:

- \`don't know what type\` / \`TProtocolException\` → "Parquet files look corrupt — re-download via Sync view"
- \`aws sso login\` → "Refresh after logging in"

## A separate finding (data, not code)

While bisecting the error I confirmed that several columns in the user's local hourly Parquet files are themselves corrupt — not just \`TIMESTAMP_NS\`. \`line_item_operation\`, \`line_item_resource_id\`, \`line_item_line_item_type\`, \`line_item_net_unblended_cost\`, \`line_item_line_item_description\` all fail with either \`don't know what type:\` or \`TProtocolException: Invalid data\` (Parquet page-level corruption). The same columns work fine for the daily files in the same period. Most likely cause: the \`aws s3 sync\` download produced bad files for hourly. The fix from the user side is to delete \`hourly-2026-04\` from the Sync view and re-download. The new error banner from this PR will tell them exactly that the next time it happens.

## Verification

- \`npm run check\` — 177 passed, 5 skipped, tsc + eslint clean.
- The 3 hourly integration tests added in #40 still pass against the synthetic fixtures.