### PR TITLE
Fix delete-period: target the actual data layout, clean etags too

### DIFF
--- a/packages/core/src/__tests__/sync-utils.test.ts
+++ b/packages/core/src/__tests__/sync-utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractPeriod,
   extractPeriodPrefix,
   getEtagFileName,
+  getRawDirPrefix,
   groupByPeriod,
   parseEtagsJson,
 } from '../sync/sync-utils.js';
@@ -83,6 +84,21 @@ describe('getEtagFileName', () => {
 
   it('falls back to the daily filename for unknown tiers', () => {
     expect(getEtagFileName('bogus')).toBe('sync-etags.json');
+  });
+});
+
+describe('getRawDirPrefix', () => {
+  it('returns the per-tier raw directory prefix', () => {
+    // Files for a period are stored at aws/raw/{prefix}-{period}/.
+    // cost-optimization uses 'cost-opt' (not 'cost-optimization') because that's
+    // the directory name selective-sync.ts writes.
+    expect(getRawDirPrefix('daily')).toBe('daily');
+    expect(getRawDirPrefix('hourly')).toBe('hourly');
+    expect(getRawDirPrefix('cost-optimization')).toBe('cost-opt');
+  });
+
+  it('falls back to the daily prefix for unknown tiers', () => {
+    expect(getRawDirPrefix('bogus')).toBe('daily');
   });
 });
 

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -4,7 +4,7 @@ import { createS3Handle, parseS3Path } from './s3-client.js';
 import type { S3Handle } from './s3-client.js';
 import type { ManifestFileEntry } from './manifest.js';
 import type { DataTier } from '../types/api.js';
-import { parseEtagsJson } from './sync-utils.js';
+import { getRawDirPrefix, parseEtagsJson } from './sync-utils.js';
 
 export type PeriodStatus = 'missing' | 'repartitioned' | 'stale';
 
@@ -90,12 +90,6 @@ const ETAG_FILES: Record<DataTier, string> = {
   'cost-optimization': 'sync-etags-cost-optimization.json',
 };
 
-const TIER_PREFIXES: Record<DataTier, string> = {
-  'daily': 'daily',
-  'hourly': 'hourly',
-  'cost-optimization': 'cost-opt',
-};
-
 export async function getDataInventory(
   bucketPath: string,
   profile: string,
@@ -120,7 +114,7 @@ export async function getDataInventory(
   }
 
   const rawDir = join(dataDir, 'aws', 'raw');
-  const tierPrefix = TIER_PREFIXES[tier];
+  const tierPrefix = getRawDirPrefix(tier);
   const localPeriodList = await listRawPeriods(rawDir, tierPrefix);
   const diskBytes = await getRawTierSize(rawDir, tierPrefix);
   const localPeriods = new Set(localPeriodList);

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -33,6 +33,7 @@ export {
   extractPeriod,
   extractPeriodPrefix,
   getEtagFileName,
+  getRawDirPrefix,
   groupByPeriod,
   parseEtagsJson,
 } from './sync-utils.js';

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -9,11 +9,29 @@ const TIER_ETAG_FILES: Record<ExpectedDataType, string> = {
   'cost-optimization': 'sync-etags-cost-optimization.json',
 };
 
+const TIER_RAW_PREFIXES: Record<ExpectedDataType, string> = {
+  'daily': 'daily',
+  'hourly': 'hourly',
+  'cost-optimization': 'cost-opt',
+};
+
 export function getEtagFileName(tier: string): string {
   if (tier === 'hourly' || tier === 'cost-optimization' || tier === 'daily') {
     return TIER_ETAG_FILES[tier];
   }
   return TIER_ETAG_FILES['daily'];
+}
+
+/**
+ * Returns the directory-name prefix used under aws/raw/ for a given tier.
+ * Files for a period live under aws/raw/{prefix}-{period}/ — e.g.
+ * aws/raw/daily-2026-04/, aws/raw/cost-opt-2026-04-08/.
+ */
+export function getRawDirPrefix(tier: string): string {
+  if (tier === 'hourly' || tier === 'cost-optimization' || tier === 'daily') {
+    return TIER_RAW_PREFIXES[tier];
+  }
+  return TIER_RAW_PREFIXES['daily'];
 }
 
 export function extractPeriod(key: string): string {

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -1,6 +1,9 @@
 import { ipcMain, shell } from 'electron';
 import {
   getDataInventory,
+  getEtagFileName,
+  getRawDirPrefix,
+  parseEtagsJson,
   syncSelectedFiles,
   logger,
 } from '@costgoblin/core';
@@ -58,17 +61,53 @@ export function registerSyncHandlers(app: AppContext): void {
   ipcMain.handle('data:delete-period', async (_event, period: string, tier: ExpectedDataType = 'daily'): Promise<void> => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
-    const tierDir = path.join(ctx.dataDir, 'aws', tier);
+
+    // Data files for a period live under aws/raw/{prefix}-{period}/.
+    // For cost-optimization the period field is a YYYY-MM-DD (per-day download)
+    // — the directory name is e.g. cost-opt-2026-04-08 — so match on
+    // ${prefix}-${period} OR ${prefix}-${period}-* to cover both cases.
+    const prefix = getRawDirPrefix(tier);
+    const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
+    let removedAny = false;
     try {
-      const entries = await fs.readdir(tierDir);
+      const entries = await fs.readdir(rawDir);
       for (const entry of entries) {
-        if (entry.startsWith(`usage_date=${period}`)) {
-          await fs.rm(path.join(tierDir, entry), { recursive: true });
-          logger.info(`Deleted local partition (${tier}): ${entry}`);
+        if (entry === `${prefix}-${period}` || entry.startsWith(`${prefix}-${period}-`)) {
+          await fs.rm(path.join(rawDir, entry), { recursive: true });
+          logger.info(`Deleted local data (${tier}): ${entry}`);
+          removedAny = true;
         }
       }
     } catch {
-      // dir may not exist
+      // raw dir may not exist
+    }
+
+    // Drop the period from the etag manifest so the inventory marks it
+    // 'missing' on the next refresh — otherwise stale etags can cause the
+    // re-download path to skip files. Keys in the etag map can be the period
+    // itself ('2026-04') or a date within it ('2026-04-08').
+    const etagPath = path.join(ctx.dataDir, getEtagFileName(tier));
+    try {
+      const raw = await fs.readFile(etagPath, 'utf-8');
+      const etags = parseEtagsJson(raw);
+      const kept: Record<string, Record<string, string>> = {};
+      let changed = false;
+      for (const [key, value] of Object.entries(etags)) {
+        if (key === period || key.startsWith(`${period}-`)) {
+          changed = true;
+          continue;
+        }
+        kept[key] = value;
+      }
+      if (changed) {
+        await fs.writeFile(etagPath, JSON.stringify(kept, null, 2));
+      }
+    } catch {
+      // etag file may not exist
+    }
+
+    if (!removedAny) {
+      logger.info(`Delete (${tier}) for ${period}: nothing matched ${prefix}-${period}*`);
     }
   });
 

--- a/packages/ui/src/views/data-management-tier.tsx
+++ b/packages/ui/src/views/data-management-tier.tsx
@@ -239,7 +239,7 @@ export function TierPanel({
       {pendingDelete !== null && (
         <ConfirmModal
           title="Delete local data"
-          message={`Remove all local daily partitions for ${formatPeriod(pendingDelete)}? The data can be re-downloaded from S3.`}
+          message={`Remove local ${title.toLowerCase()} data for ${formatPeriod(pendingDelete)}? The data can be re-downloaded from S3.`}
           confirmLabel="Delete"
           destructive
           onConfirm={() => { onDeletePeriod(pendingDelete); setPendingDelete(null); }}


### PR DESCRIPTION
## Bug

User reported (with screenshots): clicking the X on Hourly → Apr 2026, confirming the modal, the UI reloads and the data is still listed as downloaded.

## Cause

\`data:delete-period\` was leftover from the legacy repartition flow removed in #1. It looked at \`aws/{tier}/usage_date=*\` — a path that hasn't existed since selective-sync took over. Since the post-repartition layout was deleted in PR 1, data has lived under \`aws/raw/{tier-prefix}-{period}/\`. \`readdir\` on the non-existent \`aws/hourly/\` threw \`ENOENT\`, the handler caught and ignored it, returned cleanly, and the UI refreshed — to find the data still on disk.

## Fix

- \`handlers/sync.ts\`: rewrite to:
  - delete \`aws/raw/{prefix}-{period}/\` (and \`-{period}-*\` for cost-opt's per-day directories)
  - remove the period from \`sync-etags-{tier}.json\` so the inventory marks it \`missing\` on next refresh — otherwise re-downloading could skip files because the etags still match
  - log when nothing matched, so future regressions of this shape are visible in stdout instead of silent
- \`core/sync/sync-utils.ts\`: extract \`getRawDirPrefix(tier)\` so the prefix (\`daily\` / \`hourly\` / \`cost-opt\`) has one source of truth shared with \`data-inventory.ts\`. Sync-utils test covers the mapping including the \`cost-optimization → cost-opt\` rename.
- \`data-management-tier.tsx\`: the confirm modal said "Remove all local **daily** partitions for Apr 2026?" no matter which tier you were deleting from (visible in the user's screenshot). Now uses the panel's title ("Daily" / "Hourly" / "Cost Optimization").

## Verification

- Manual E2E against the user's real data: clicked X on Hourly → Apr 2026 → Delete. Main process logs \`INFO Deleted local data (hourly): hourly-2026-04\`. Disk: \`aws/raw/hourly-2026-04/\` is gone, \`sync-etags-hourly.json\` reduced to \`{}\`.
- \`npm run check\` — 179 passed (+2 sync-utils tests for the new prefix mapping), 5 skipped, tsc + eslint clean.

## Bonus

This unblocks the user's other open issue (corrupt hourly Parquet from #41): they can now actually delete and re-download.