### PR TITLE
Missing Tags: classifier + actionable / untaggable / non-resource buckets

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -570,7 +570,8 @@ test.describe('Missing Tags', () => {
   test.afterAll(async () => { await app.close(); });
 
   test('shows heading and subtitle', async () => {
-    await expect(page.getByText('Resources without cost allocation tags')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+    await expect(page.getByText(/without the selected allocation tag/i)).toBeVisible();
   });
 
   test('tag dimension tabs are visible and switchable', async () => {
@@ -619,9 +620,10 @@ test.describe('Missing Tags', () => {
     const hasError = await errorMsg.isVisible().catch(() => false);
 
     if (hasData) {
-      // summary should show cost amount and resource count
-      await expect(page.getByText(/untagged/)).toBeVisible();
-      await expect(page.getByText(/resources/)).toBeVisible();
+      // summary shows the three buckets: actionable / likely not taggable / non-resource
+      await expect(page.getByText('Actionable missing tags')).toBeVisible();
+      await expect(page.getByText('Likely not taggable')).toBeVisible();
+      await expect(page.getByText('Non-resource cost')).toBeVisible();
     } else if (hasError) {
       // error is displayed, that's fine
       await screenshot(page, 'missing-tags-error');

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCostQuery, buildTrendQuery, buildMissingTagsQuery, buildEntityDetailQuery, buildSource } from '../query/builder.js';
+import { buildCostQuery, buildTrendQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId, asDateString, asDollars, asEntityRef, asTagValue } from '../types/branded.js';
 
@@ -86,20 +86,57 @@ describe('buildTrendQuery', () => {
 });
 
 describe('buildMissingTagsQuery', () => {
-  it('filters on NULL or empty tag', () => {
-    const sql = buildMissingTagsQuery(
+  const baseParams = {
+    dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+    filters: {},
+    minCost: asDollars(50),
+    tagDimension: asDimensionId('tag_org_team'),
+  };
+
+  it('filters to resource-bound Usage lines (excludes Tax / Support / empty resource_id)', () => {
+    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    expect(sql).toContain("line_item_type IN ('Usage', 'DiscountedUsage')");
+    expect(sql).toContain("resource_id IS NOT NULL AND resource_id != ''");
+  });
+
+  it('computes has_tag per resource and category tagged_ratio', () => {
+    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    // Resource is tagged if ANY line for it has the tag populated — MAX over a
+    // CASE expression does exactly that.
+    expect(sql).toContain('MAX(CASE WHEN');
+    expect(sql).toContain('AS has_tag');
+    // Category coverage divides tagged cost by total cost.
+    expect(sql).toContain('tagged_ratio');
+    expect(sql).toContain('SUM(CASE WHEN has_tag = 1 THEN cost ELSE 0 END)');
+  });
+
+  it('buckets into actionable (ratio > 0) vs likely-untaggable (ratio = 0)', () => {
+    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    expect(sql).toContain("WHEN c.tagged_ratio > 0 THEN 'actionable'");
+    expect(sql).toContain("ELSE 'likely-untaggable'");
+  });
+
+  it('applies minCost to the per-resource cost after classification', () => {
+    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    expect(sql).toContain('r.cost >= 50');
+  });
+});
+
+describe('buildNonResourceCostQuery', () => {
+  it('captures non-Usage lines and Usage lines with no resource_id', () => {
+    const sql = buildNonResourceCostQuery(
       {
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
         filters: {},
-        minCost: asDollars(50),
+        minCost: asDollars(0),
         tagDimension: asDimensionId('tag_org_team'),
       },
       '/data',
       dimensions,
     );
-    expect(sql).toContain('IS NULL');
-    expect(sql).toContain("= ''");
-    expect(sql).toContain('50');
+    expect(sql).toContain("line_item_type NOT IN ('Usage', 'DiscountedUsage')");
+    expect(sql).toContain("OR resource_id IS NULL OR resource_id = ''");
+    expect(sql).toContain('GROUP BY service, service_family, line_item_type');
   });
 });
 

--- a/packages/core/src/__tests__/query-integration.test.ts
+++ b/packages/core/src/__tests__/query-integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { DuckDBInstance } from '@duckdb/node-api';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildCostQuery, buildDailyCostsQuery, buildMissingTagsQuery, buildEntityDetailQuery, buildSource } from '../query/builder.js';
+import { buildCostQuery, buildDailyCostsQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId, asDateString, asDollars, asEntityRef, asTagValue } from '../types/branded.js';
 
@@ -138,6 +138,57 @@ describe('DuckDB query integration', () => {
     const firstRow = rows[0];
     expect(firstRow?.['service']).toBeDefined();
     expect(Number(firstRow?.['cost'])).toBeGreaterThanOrEqual(0);
+  });
+
+  it('classifies missing tags into actionable vs likely-untaggable buckets', async () => {
+    const sql = buildMissingTagsQuery(
+      {
+        dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+        filters: {},
+        minCost: asDollars(0),
+        tagDimension: asDimensionId('tag_team'),
+      },
+      SYNTHETIC_DIR,
+      dimensions,
+    );
+    const rows = await queryAll(conn, sql);
+    expect(rows.length).toBeGreaterThan(0);
+
+    // Every row carries a bucket and a tagged_ratio.
+    for (const row of rows) {
+      const bucket = String(row['bucket']);
+      expect(['actionable', 'likely-untaggable']).toContain(bucket);
+      const ratio = Number(row['tagged_ratio']);
+      expect(ratio).toBeGreaterThanOrEqual(0);
+      expect(ratio).toBeLessThanOrEqual(1);
+      // Invariant: actionable iff ratio > 0.
+      if (bucket === 'actionable') {
+        expect(ratio).toBeGreaterThan(0);
+      } else {
+        expect(ratio).toBe(0);
+      }
+    }
+  });
+
+  it('non-resource cost query returns rows for non-Usage line items', async () => {
+    const sql = buildNonResourceCostQuery(
+      {
+        dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+        filters: {},
+        minCost: asDollars(0),
+        tagDimension: asDimensionId('tag_team'),
+      },
+      SYNTHETIC_DIR,
+      dimensions,
+    );
+    const rows = await queryAll(conn, sql);
+    // Fixture may have zero non-Usage lines; just verify the query is valid
+    // and every returned row has the expected shape.
+    for (const row of rows) {
+      expect(typeof row['service']).toBe('string');
+      expect(typeof row['line_item_type']).toBe('string');
+      expect(Number(row['cost'])).toBeGreaterThan(0);
+    }
   });
 
   it('queries entity detail by service', async () => {

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -237,6 +237,24 @@ export function buildTrendQuery(
   `.trim();
 }
 
+/**
+ * Missing-tags classifier.
+ *
+ * Pass 1 (resources CTE): aggregate Usage/DiscountedUsage line items by
+ * resource_id. A resource is "tagged" if ANY of its line items in the window
+ * has the target tag populated — tags can be added mid-month.
+ *
+ * Pass 2 (category_coverage CTE): per (service, service_family), compute the
+ * cost-weighted ratio of cost that is tagged. A category with ratio = 0 is
+ * "likely-untaggable": no resource in it has ever been tagged, so either AWS
+ * doesn't allow it or the org never has. A category with ratio > 0 has proof
+ * that it IS taggable, so untagged resources in it are "actionable".
+ *
+ * Returns one row per untagged resource with its category's tagged ratio and
+ * bucket. The minCost threshold filters per-resource, after classification —
+ * so a small untaggable resource is hidden the same way a small actionable
+ * one is.
+ */
 export function buildMissingTagsQuery(
   params: MissingTagsParams,
   dataDir: string,
@@ -247,24 +265,92 @@ export function buildMissingTagsQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
 
+  // Date + user filters apply to the resource aggregation.
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
-    `(${tagResolved.rawField} IS NULL OR ${tagResolved.rawField} = '')`,
+    `line_item_type IN ('Usage', 'DiscountedUsage')`,
+    `resource_id IS NOT NULL AND resource_id != ''`,
+    ...filterClauses,
+  ];
+
+  return `
+    WITH resources AS (
+      SELECT
+        account_id,
+        account_name,
+        service,
+        service_family,
+        resource_id,
+        SUM(cost) AS cost,
+        MAX(CASE WHEN ${tagResolved.rawField} IS NOT NULL AND ${tagResolved.rawField} != '' THEN 1 ELSE 0 END) AS has_tag
+      FROM ${source}
+      WHERE ${whereConditions.join(' AND ')}
+      GROUP BY account_id, account_name, service, service_family, resource_id
+    ),
+    category_coverage AS (
+      SELECT
+        service,
+        service_family,
+        CASE
+          WHEN SUM(cost) > 0 THEN SUM(CASE WHEN has_tag = 1 THEN cost ELSE 0 END) / SUM(cost)
+          ELSE 0
+        END AS tagged_ratio
+      FROM resources
+      GROUP BY service, service_family
+    )
+    SELECT
+      r.account_id,
+      r.account_name,
+      r.resource_id,
+      r.service,
+      r.service_family,
+      r.cost,
+      c.tagged_ratio,
+      CASE WHEN c.tagged_ratio > 0 THEN 'actionable' ELSE 'likely-untaggable' END AS bucket
+    FROM resources r
+    JOIN category_coverage c USING (service, service_family)
+    WHERE r.has_tag = 0
+      AND r.cost >= ${String(params.minCost)}
+    ORDER BY r.cost DESC
+  `.trim();
+}
+
+/**
+ * Non-resource cost: everything that's NOT a resource-bound Usage line.
+ *   - line_item_type not in (Usage, DiscountedUsage): tax, support, fees,
+ *     credits, savings-plan recurring fees, bundled discounts, etc.
+ *   - resource_id empty on a Usage line: some data-transfer and misc charges
+ *     are Usage but have no resource to attach tags to.
+ *
+ * Returns cost by (service, service_family, line_item_type) for a sidebar
+ * breakdown. These totals reconcile against the cost overview but are
+ * inherently un-taggable at the resource level.
+ */
+export function buildNonResourceCostQuery(
+  params: MissingTagsParams,
+  dataDir: string,
+  dimensions: DimensionsConfig,
+  orgAccountsPath?: string,
+): string {
+  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
+
+  const whereConditions = [
+    `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
+    `(line_item_type NOT IN ('Usage', 'DiscountedUsage') OR resource_id IS NULL OR resource_id = '')`,
     ...filterClauses,
   ];
 
   return `
     SELECT
-      account_id,
-      account_name,
-      resource_id,
       service,
       service_family,
+      line_item_type,
       SUM(cost) AS cost
     FROM ${source}
     WHERE ${whereConditions.join(' AND ')}
-    GROUP BY account_id, account_name, resource_id, service, service_family
-    HAVING SUM(cost) >= ${String(params.minCost)}
+    GROUP BY service, service_family, line_item_type
+    HAVING SUM(cost) > 0
     ORDER BY cost DESC
   `.trim();
 }

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -3,6 +3,7 @@ export {
   buildDailyCostsQuery,
   buildTrendQuery,
   buildMissingTagsQuery,
+  buildNonResourceCostQuery,
   buildEntityDetailQuery,
   buildSource,
 } from './builder.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -44,6 +44,8 @@ export type {
   TrendResult,
   MissingTagsParams,
   MissingTagRow,
+  MissingTagBucket,
+  NonResourceCostRow,
   MissingTagsResult,
   DailyCostsParams,
   DailyCostDay,

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -61,6 +61,17 @@ export interface MissingTagsParams {
   readonly tagDimension: DimensionId;
 }
 
+/**
+ * Classification of an untagged resource line:
+ *   - 'actionable'          → other resources in the same (service, service_family)
+ *                             category ARE tagged, so this one is taggable and
+ *                             missing. The work queue.
+ *   - 'likely-untaggable'   → no resource in the same category has ever been
+ *                             tagged in the dataset. Either AWS doesn't allow
+ *                             it or the org never has. Hidden by default.
+ */
+export type MissingTagBucket = 'actionable' | 'likely-untaggable';
+
 export interface MissingTagRow {
   readonly accountId: string;
   readonly accountName: string;
@@ -69,12 +80,34 @@ export interface MissingTagRow {
   readonly serviceFamily: string;
   readonly cost: Dollars;
   readonly closestOwner: EntityRef | null;
+  readonly bucket: MissingTagBucket;
+  /** Fraction of this resource's category (service, service_family) that IS
+   *  tagged, by cost. 0 for likely-untaggable, >0 for actionable. */
+  readonly categoryTaggedRatio: number;
+}
+
+/** A single service/family slice of cost that is not attributable to a
+ *  resource — tax, support, credits, savings-plan fees, and usage lines with
+ *  no resource_id (e.g. inter-AZ data transfer). Reconciles the missing-tag
+ *  totals against the overall cost. */
+export interface NonResourceCostRow {
+  readonly service: string;
+  readonly serviceFamily: string;
+  readonly lineItemType: string;
+  readonly cost: Dollars;
 }
 
 export interface MissingTagsResult {
   readonly rows: readonly MissingTagRow[];
-  readonly totalUntaggedCost: Dollars;
-  readonly resourceCount: number;
+  /** Cost of actionable untagged resources — the total to chase. */
+  readonly totalActionableCost: Dollars;
+  /** Cost of resources in categories where nothing is ever tagged. */
+  readonly totalLikelyUntaggableCost: Dollars;
+  /** Cost of line items that are not resource-bound (tax, support, etc.). */
+  readonly totalNonResourceCost: Dollars;
+  readonly actionableCount: number;
+  readonly likelyUntaggableCount: number;
+  readonly nonResourceRows: readonly NonResourceCostRow[];
 }
 
 export interface EntityDetailParams {

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -13,6 +13,8 @@ import type {
   TrendRow,
   MissingTagsResult,
   MissingTagRow,
+  MissingTagBucket,
+  NonResourceCostRow,
   EntityDetailResult,
   DailyCost,
   DistributionSlice,
@@ -145,14 +147,23 @@ export function buildTrendResult(rows: RawRow[], deltaThreshold: number, percent
   };
 }
 
-export function buildMissingTagsResult(rows: RawRow[]): MissingTagsResult {
-  let totalUntaggedCost = 0;
+function toMissingTagBucket(v: unknown): MissingTagBucket {
+  return v === 'likely-untaggable' ? 'likely-untaggable' : 'actionable';
+}
+
+export function buildMissingTagsResult(
+  resourceRows: RawRow[],
+  nonResourceRawRows: RawRow[],
+): MissingTagsResult {
   const missingRows: MissingTagRow[] = [];
+  let totalActionableCost = 0;
+  let totalLikelyUntaggableCost = 0;
+  let actionableCount = 0;
+  let likelyUntaggableCount = 0;
 
-  for (const row of rows) {
+  for (const row of resourceRows) {
     const cost = toNum(row['cost']);
-    totalUntaggedCost += cost;
-
+    const bucket = toMissingTagBucket(row['bucket']);
     const closestOwner = typeof row['closest_owner'] === 'string' && row['closest_owner'].length > 0
       ? asEntityRef(row['closest_owner'])
       : null;
@@ -165,13 +176,40 @@ export function buildMissingTagsResult(rows: RawRow[]): MissingTagsResult {
       serviceFamily: toStr(row['service_family']),
       cost: asDollars(cost),
       closestOwner,
+      bucket,
+      categoryTaggedRatio: toNum(row['tagged_ratio']),
+    });
+
+    if (bucket === 'actionable') {
+      totalActionableCost += cost;
+      actionableCount += 1;
+    } else {
+      totalLikelyUntaggableCost += cost;
+      likelyUntaggableCount += 1;
+    }
+  }
+
+  const nonResourceRows: NonResourceCostRow[] = [];
+  let totalNonResourceCost = 0;
+  for (const row of nonResourceRawRows) {
+    const cost = toNum(row['cost']);
+    totalNonResourceCost += cost;
+    nonResourceRows.push({
+      service: toStr(row['service']),
+      serviceFamily: toStr(row['service_family']),
+      lineItemType: toStr(row['line_item_type']),
+      cost: asDollars(cost),
     });
   }
 
   return {
     rows: missingRows,
-    totalUntaggedCost: asDollars(totalUntaggedCost),
-    resourceCount: missingRows.length,
+    totalActionableCost: asDollars(totalActionableCost),
+    totalLikelyUntaggableCost: asDollars(totalLikelyUntaggableCost),
+    totalNonResourceCost: asDollars(totalNonResourceCost),
+    actionableCount,
+    likelyUntaggableCount,
+    nonResourceRows,
   };
 }
 

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -4,6 +4,7 @@ import {
   buildDailyCostsQuery,
   buildTrendQuery,
   buildMissingTagsQuery,
+  buildNonResourceCostQuery,
   buildEntityDetailQuery,
   buildSource,
   buildAliasSqlCase,
@@ -146,11 +147,15 @@ export function registerQueryHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
-    const sql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath);
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
-    const rows = await runQuery(sql);
-    const result = buildMissingTagsResult(rows);
+    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath);
+    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath);
+    const [resourceRows, nonResourceRows] = await Promise.all([
+      runQuery(resourceSql),
+      runQuery(nonResourceSql),
+    ]);
+    const result = buildMissingTagsResult(resourceRows, nonResourceRows);
     return {
       ...result,
       rows: result.rows.map(r => ({

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -101,12 +101,19 @@ const trendResult: TrendResult = {
 
 const missingTagsResult: MissingTagsResult = {
   rows: [
-    { accountId: '123456789012', accountName: 'prod-main', resourceId: 'i-0abc123def456gh78', service: 'Amazon EC2', serviceFamily: 'Compute', cost: asDollars(1_200), closestOwner: asEntityRef('platform') },
-    { accountId: '234567890123', accountName: 'prod-data', resourceId: 'arn:aws:rds:us-east-1:234567890123:db:analytics-prod', service: 'Amazon RDS', serviceFamily: 'Database', cost: asDollars(870), closestOwner: asEntityRef('data') },
-    { accountId: '345678901234', accountName: 'staging', resourceId: 'arn:aws:s3:::untagged-bucket-staging', service: 'Amazon S3', serviceFamily: 'Storage', cost: asDollars(340), closestOwner: null },
+    { accountId: '123456789012', accountName: 'prod-main', resourceId: 'i-0abc123def456gh78', service: 'Amazon EC2', serviceFamily: 'Compute', cost: asDollars(1_200), closestOwner: asEntityRef('platform'), bucket: 'actionable', categoryTaggedRatio: 0.82 },
+    { accountId: '234567890123', accountName: 'prod-data', resourceId: 'arn:aws:rds:us-east-1:234567890123:db:analytics-prod', service: 'Amazon RDS', serviceFamily: 'Database', cost: asDollars(870), closestOwner: asEntityRef('data'), bucket: 'actionable', categoryTaggedRatio: 0.65 },
+    { accountId: '345678901234', accountName: 'staging', resourceId: 'arn:aws:s3:::untagged-bucket-staging', service: 'Amazon S3', serviceFamily: 'Storage', cost: asDollars(340), closestOwner: null, bucket: 'likely-untaggable', categoryTaggedRatio: 0 },
   ],
-  totalUntaggedCost: asDollars(2_410),
-  resourceCount: 3,
+  totalActionableCost: asDollars(2_070),
+  totalLikelyUntaggableCost: asDollars(340),
+  totalNonResourceCost: asDollars(150),
+  actionableCount: 2,
+  likelyUntaggableCount: 1,
+  nonResourceRows: [
+    { service: 'Tax', serviceFamily: '', lineItemType: 'Tax', cost: asDollars(95) },
+    { service: 'AWS Support', serviceFamily: '', lineItemType: 'Fee', cost: asDollars(55) },
+  ],
 };
 
 const entityDetailResult: EntityDetailResult = {

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -4,6 +4,7 @@ import type {
   DimensionId,
   DateString,
   MissingTagsResult,
+  MissingTagRow,
 } from '@costgoblin/core/browser';
 import { asDimensionId, asDateString, asDollars } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
@@ -19,12 +20,57 @@ function getDateRange(): { start: DateString; end: DateString } {
   return { start, end };
 }
 
+function ResourceTable({ rows, showRatio }: Readonly<{ rows: readonly MissingTagRow[]; showRatio: boolean }>) {
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-text-secondary">
+            <th className="px-4 pb-3 pt-4 font-medium">Account</th>
+            <th className="px-4 pb-3 pt-4 font-medium">Resource</th>
+            <th className="px-4 pb-3 pt-4 font-medium">Service</th>
+            <th className="px-4 pb-3 pt-4 font-medium">Family</th>
+            <th className="px-4 pb-3 pt-4 text-right font-medium">Cost</th>
+            <th className="px-4 pb-3 pt-4 font-medium">Closest Owner</th>
+            {showRatio && <th className="px-4 pb-3 pt-4 text-right font-medium">Tagged in category</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={`${row.resourceId}-${String(i)}`} className="border-b border-border-subtle hover:bg-bg-tertiary/30 transition-colors">
+              <td className="px-4 py-3 text-text-primary">{row.accountName}</td>
+              <td className="px-4 py-3 text-text-secondary font-mono text-xs max-w-64 truncate" title={row.resourceId}>
+                {row.resourceId}
+              </td>
+              <td className="px-4 py-3 text-text-secondary">{row.service}</td>
+              <td className="px-4 py-3 text-text-secondary">{row.serviceFamily}</td>
+              <td className="px-4 py-3 text-right tabular-nums font-medium text-text-primary">
+                {formatDollars(row.cost)}
+              </td>
+              <td className="px-4 py-3 text-text-secondary">
+                {row.closestOwner ?? '—'}
+              </td>
+              {showRatio && (
+                <td className="px-4 py-3 text-right tabular-nums text-text-muted">
+                  {`${String(Math.round(row.categoryTaggedRatio * 100))}%`}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function MissingTags() {
   const api = useCostApi();
   const dimensionsQuery = useQuery(() => api.getDimensions(), []);
 
   const [minCost, setMinCost] = useState(50);
   const [selectedTag, setSelectedTag] = useState<DimensionId | null>(null);
+  const [showLikelyUntaggable, setShowLikelyUntaggable] = useState(false);
+  const [nonResourceExpanded, setNonResourceExpanded] = useState(false);
 
   const dimensions: Dimension[] =
     dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
@@ -51,11 +97,16 @@ export function MissingTags() {
   const data: MissingTagsResult | null =
     missingQuery.status === 'success' ? missingQuery.data : null;
 
+  const actionableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'actionable');
+  const likelyUntaggableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'likely-untaggable');
+
   return (
     <div className="flex flex-col gap-6 p-6">
       <div>
         <h2 className="text-xl font-semibold text-text-primary">Missing Tags</h2>
-        <p className="text-sm text-text-secondary mt-1">Resources without cost allocation tags</p>
+        <p className="text-sm text-text-secondary mt-1">
+          Resources without the selected allocation tag, classified by whether other resources in the same service category are tagged.
+        </p>
       </div>
 
       <div className="flex flex-wrap items-center gap-4">
@@ -92,16 +143,47 @@ export function MissingTags() {
             className="w-20 rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary"
           />
         </label>
+
+        <label className="flex items-center gap-1.5 text-xs text-text-secondary">
+          <input
+            type="checkbox"
+            checked={showLikelyUntaggable}
+            onChange={(e) => { setShowLikelyUntaggable(e.target.checked); }}
+            className="h-3.5 w-3.5 rounded accent-emerald-500"
+          />
+          <span>Show likely-untaggable categories</span>
+        </label>
       </div>
 
       {data !== null && (
-        <div className="flex items-center gap-4 text-sm">
-          <span className="font-medium text-text-primary">
-            {formatDollars(data.totalUntaggedCost)} untagged
-          </span>
-          <span className="text-text-secondary">
-            {String(data.resourceCount)} resources
-          </span>
+        <div className="flex flex-wrap items-center gap-5 rounded-xl border border-border bg-bg-secondary/30 px-5 py-4">
+          <div>
+            <p className="text-xs text-text-muted">Actionable missing tags</p>
+            <p className="text-lg font-bold tabular-nums text-accent">
+              {formatDollars(data.totalActionableCost)}
+            </p>
+            <p className="text-[11px] text-text-muted">
+              {String(data.actionableCount)} resources in taggable categories
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-text-muted">Likely not taggable</p>
+            <p className="text-lg font-bold tabular-nums text-text-secondary">
+              {formatDollars(data.totalLikelyUntaggableCost)}
+            </p>
+            <p className="text-[11px] text-text-muted">
+              {String(data.likelyUntaggableCount)} resources in categories where nothing is tagged
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-text-muted">Non-resource cost</p>
+            <p className="text-lg font-bold tabular-nums text-text-secondary">
+              {formatDollars(data.totalNonResourceCost)}
+            </p>
+            <p className="text-[11px] text-text-muted">
+              tax, support, credits, and usage without a resource
+            </p>
+          </div>
         </div>
       )}
 
@@ -114,44 +196,80 @@ export function MissingTags() {
         </div>
       )}
 
-      {data !== null && data.rows.length > 0 && (
-        <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-text-secondary">
-                <th className="px-4 pb-3 pt-4 font-medium">Account</th>
-                <th className="px-4 pb-3 pt-4 font-medium">Resource</th>
-                <th className="px-4 pb-3 pt-4 font-medium">Service</th>
-                <th className="px-4 pb-3 pt-4 font-medium">Family</th>
-                <th className="px-4 pb-3 pt-4 text-right font-medium">Cost</th>
-                <th className="px-4 pb-3 pt-4 font-medium">Closest Owner</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.rows.map((row, i) => (
-                <tr key={`${row.resourceId}-${String(i)}`} className="border-b border-border-subtle hover:bg-bg-tertiary/30 transition-colors">
-                  <td className="px-4 py-3 text-text-primary">{row.accountName}</td>
-                  <td className="px-4 py-3 text-text-secondary font-mono text-xs max-w-64 truncate" title={row.resourceId}>
-                    {row.resourceId}
-                  </td>
-                  <td className="px-4 py-3 text-text-secondary">{row.service}</td>
-                  <td className="px-4 py-3 text-text-secondary">{row.serviceFamily}</td>
-                  <td className="px-4 py-3 text-right tabular-nums font-medium text-text-primary">
-                    {formatDollars(row.cost)}
-                  </td>
-                  <td className="px-4 py-3 text-text-secondary">
-                    {row.closestOwner ?? '—'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      {data !== null && actionableRows.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold text-text-primary">
+            Actionable
+            <span className="ml-2 text-xs font-normal text-text-muted">
+              {String(actionableRows.length)} resources · {formatDollars(data.totalActionableCost)}
+            </span>
+          </h3>
+          <ResourceTable rows={actionableRows} showRatio />
         </div>
       )}
 
-      {data !== null && data.rows.length === 0 && (
+      {data !== null && actionableRows.length === 0 && likelyUntaggableRows.length === 0 && (
         <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center text-text-secondary">
           No untagged resources above ${String(minCost)}
+        </div>
+      )}
+
+      {data !== null && showLikelyUntaggable && likelyUntaggableRows.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold text-text-secondary">
+            Likely not taggable
+            <span className="ml-2 text-xs font-normal text-text-muted">
+              {String(likelyUntaggableRows.length)} resources · {formatDollars(data.totalLikelyUntaggableCost)}
+            </span>
+          </h3>
+          <p className="text-xs text-text-muted -mt-2">
+            No resource in these categories has been tagged in the selected period — either AWS doesn't allow tagging them, or your org never has.
+          </p>
+          <ResourceTable rows={likelyUntaggableRows} showRatio={false} />
+        </div>
+      )}
+
+      {data !== null && data.nonResourceRows.length > 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/30 overflow-hidden">
+          <button
+            type="button"
+            onClick={() => { setNonResourceExpanded(v => !v); }}
+            className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-bg-tertiary/20 transition-colors"
+          >
+            <div>
+              <p className="text-sm font-medium text-text-primary">
+                Non-resource cost
+              </p>
+              <p className="text-xs text-text-muted">
+                {formatDollars(data.totalNonResourceCost)} across {String(data.nonResourceRows.length)} categories — not attributable to a tagged resource
+              </p>
+            </div>
+            <span className="text-text-muted text-xs">{nonResourceExpanded ? '▾' : '▸'}</span>
+          </button>
+          {nonResourceExpanded && (
+            <div className="border-t border-border">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="text-left text-text-muted bg-bg-tertiary/20">
+                    <th className="px-4 py-2 font-medium">Service</th>
+                    <th className="px-4 py-2 font-medium">Family</th>
+                    <th className="px-4 py-2 font-medium">Line item type</th>
+                    <th className="px-4 py-2 text-right font-medium">Cost</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border-subtle">
+                  {data.nonResourceRows.map((row, i) => (
+                    <tr key={`${row.service}-${row.lineItemType}-${String(i)}`}>
+                      <td className="px-4 py-1.5 text-text-primary">{row.service}</td>
+                      <td className="px-4 py-1.5 text-text-secondary">{row.serviceFamily}</td>
+                      <td className="px-4 py-1.5 text-text-secondary">{row.lineItemType}</td>
+                      <td className="px-4 py-1.5 text-right tabular-nums text-text-primary">{formatDollars(row.cost)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Per discussion — reshape the Missing Tags view from "every line-item with an empty tag" into three actionable buckets backed by evidence from the dataset.

## Design

Two-CTE classifier over \`line_item_type IN ('Usage', 'DiscountedUsage')\` + non-empty \`resource_id\`:

1. **\`resources\`** — aggregate by \`resource_id\`. A resource is "tagged" if ANY of its lines in the window has the target tag populated (tags can be added mid-period).
2. **\`category_coverage\`** — per \`(service, service_family)\`, cost-weighted ratio of cost that is tagged.

Each untagged resource joins its category's ratio and gets bucketed:
- **\`actionable\`** (ratio > 0) — proof that the category is taggable, so this resource is missing a tag someone else remembered to set.
- **\`likely-untaggable\`** (ratio == 0) — nobody's ever tagged anything in this category. Either AWS doesn't allow it or your org never has.

A separate \`buildNonResourceCostQuery\` returns everything that's NOT a resource-bound Usage line: tax, support, fees, credits, bundled discounts, SP recurring fees, and Usage lines with empty \`resource_id\` (some data-transfer charges). These are inherently untaggable at the resource level, but surfacing them means the totals reconcile against the Cost Overview.

## Why zero as the threshold

Tempting to say \`< 5%\` but it misclassifies new services (first-week usage, nothing tagged yet) and flips based on tiny changes. Zero is a principled line — "we have evidence it's taggable" or "we don't."

## UI

- Three summary cards: **Actionable** / **Likely not taggable** / **Non-resource**. Each shows \$ and resource count.
- Default: only Actionable table is shown.
- Toggle: "Show likely-untaggable categories" — default off, reveals a second table with a note about why these showed up.
- Collapsible footer: "Non-resource cost in period" with a service × line_item_type breakdown.
- Per-row "tagged in category" badge on the Actionable table — quick outlier signal.

## Tests

- **query-builder** (4 new) — line-item-type filter, \`has_tag\` aggregation, \`tagged_ratio\` computation, \`actionable\` vs \`likely-untaggable\` case, minCost applied to per-resource cost.
- **query-builder** (1 new for \`buildNonResourceCostQuery\`) — non-Usage filter + empty-resource_id branch + group-by shape.
- **query-integration** (2 new) — full classifier over the DuckDB synthetic fixtures, checking every row has a valid bucket + ratio in [0,1] and the invariant \`actionable iff ratio > 0\`; non-resource query returns rows in the expected shape.
- **e2e/app.test.ts** (2 updated) — subtitle copy changed, summary bucket labels assert the new three-card layout.

\`npm run check\`: **188 passed**, 5 skipped. All 6 Missing Tags Playwright tests green.

## Out of scope

Line-item-type is normalized at the source (CUR) so I used the raw column from the inner \`cur.\` alias via buildSource. The query builder's buildSource doesn't currently project \`line_item_type\` into the outer source subquery — it already does (verified at [builder.ts:102](packages/core/src/query/builder.ts#L102)), so no schema change needed.