### PR TITLE
Narrow Parquet source glob to the months each query touches

### DIFF
--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCostQuery, buildTrendQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource } from '../query/builder.js';
+import { buildCostQuery, buildTrendQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource, computePeriodsInRange } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId, asDateString, asDollars, asEntityRef, asTagValue } from '../types/branded.js';
 
@@ -34,7 +34,10 @@ describe('buildCostQuery', () => {
     );
     expect(sql).toContain('service AS entity');
     expect(sql).toContain("usage_date BETWEEN '2026-01-01' AND '2026-01-31'");
-    expect(sql).toContain("read_parquet('/data/aws/raw/daily-*/*.parquet')");
+    // Parquet source is narrowed to the months the range touches, not the
+    // year-wide wildcard.
+    expect(sql).toContain("'/data/aws/raw/daily-2026-01/*.parquet'");
+    expect(sql).not.toContain("daily-*/*.parquet");
   });
 
   it('includes filter clauses', () => {
@@ -82,6 +85,71 @@ describe('buildTrendQuery', () => {
     expect(sql).toContain('previous_period');
     expect(sql).toContain('delta');
     expect(sql).toContain('100');
+  });
+});
+
+describe('computePeriodsInRange', () => {
+  it('returns the single month when start and end are in the same month', () => {
+    expect(computePeriodsInRange({ start: '2026-04-01', end: '2026-04-18' })).toEqual(['2026-04']);
+  });
+
+  it('spans two adjacent months', () => {
+    expect(computePeriodsInRange({ start: '2026-03-19', end: '2026-04-18' })).toEqual(['2026-03', '2026-04']);
+  });
+
+  it('spans a year boundary', () => {
+    expect(computePeriodsInRange({ start: '2025-12-20', end: '2026-02-05' }))
+      .toEqual(['2025-12', '2026-01', '2026-02']);
+  });
+
+  it('returns empty when start > end', () => {
+    expect(computePeriodsInRange({ start: '2026-04-30', end: '2026-04-01' })).toEqual([]);
+  });
+
+  it('returns empty for invalid inputs', () => {
+    expect(computePeriodsInRange({ start: 'not-a-date', end: '2026-04-01' })).toEqual([]);
+  });
+});
+
+describe('buildSource narrowed paths', () => {
+  it('emits read_parquet with a list of month paths when periods are given', () => {
+    const sql = buildSource('/data', 'daily', dimensions, undefined, ['2026-03', '2026-04']);
+    expect(sql).toContain("'/data/aws/raw/daily-2026-03/*.parquet'");
+    expect(sql).toContain("'/data/aws/raw/daily-2026-04/*.parquet'");
+    expect(sql).not.toContain("daily-*/*.parquet");
+  });
+
+  it('falls back to the wildcard when periods are empty or omitted', () => {
+    const sql = buildSource('/data', 'daily', dimensions, undefined, []);
+    expect(sql).toContain("read_parquet('/data/aws/raw/daily-*/*.parquet')");
+    const sql2 = buildSource('/data', 'daily', dimensions);
+    expect(sql2).toContain("read_parquet('/data/aws/raw/daily-*/*.parquet')");
+  });
+
+  it('uses the hourly prefix when tier is hourly', () => {
+    const sql = buildSource('/data', 'hourly', dimensions, undefined, ['2026-04']);
+    expect(sql).toContain("'/data/aws/raw/hourly-2026-04/*.parquet'");
+  });
+});
+
+describe('buildTrendQuery', () => {
+  it('includes periods from both current and previous spans', () => {
+    // 30-day window ending 2026-04-18 → current is 2026-03/2026-04, previous
+    // is 2026-02-18 to 2026-03-18 → 2026-02/2026-03. Union: Feb, Mar, Apr.
+    const sql = buildTrendQuery(
+      {
+        groupBy: asDimensionId('service'),
+        dateRange: { start: asDateString('2026-03-20'), end: asDateString('2026-04-18') },
+        filters: {},
+        deltaThreshold: asDollars(0),
+        percentThreshold: 0,
+      },
+      '/data',
+      dimensions,
+    );
+    expect(sql).toContain("'/data/aws/raw/daily-2026-02/*.parquet'");
+    expect(sql).toContain("'/data/aws/raw/daily-2026-03/*.parquet'");
+    expect(sql).toContain("'/data/aws/raw/daily-2026-04/*.parquet'");
   });
 });
 

--- a/packages/core/src/__tests__/query-integration.test.ts
+++ b/packages/core/src/__tests__/query-integration.test.ts
@@ -3,6 +3,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildCostQuery, buildDailyCostsQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource } from '../query/builder.js';
+import { buildSource as rebuildSource } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId, asDateString, asDollars, asEntityRef, asTagValue } from '../types/branded.js';
 
@@ -79,6 +80,28 @@ describe('DuckDB query integration', () => {
     const source = buildSource(SYNTHETIC_DIR, 'daily', dimensions);
     const rows = await queryAll(conn, `SELECT COUNT(*) as cnt FROM ${source}`);
     expect(Number(rows[0]?.['cnt'])).toBeGreaterThan(0);
+  });
+
+  it('narrowed source with specific months reads the same data as the wildcard', async () => {
+    // Synthetic fixtures: daily-2026-01/ and daily-2026-02/.
+    const wide = buildSource(SYNTHETIC_DIR, 'daily', dimensions);
+    const narrow = buildSource(SYNTHETIC_DIR, 'daily', dimensions, undefined, ['2026-01', '2026-02']);
+    const [[wideRow], [narrowRow]] = await Promise.all([
+      queryAll(conn, `SELECT COUNT(*) as cnt, SUM(cost) as total FROM ${wide}`),
+      queryAll(conn, `SELECT COUNT(*) as cnt, SUM(cost) as total FROM ${narrow}`),
+    ]);
+    expect(Number(narrowRow?.['cnt'])).toBe(Number(wideRow?.['cnt']));
+    expect(Number(narrowRow?.['total'])).toBeCloseTo(Number(wideRow?.['total']), 4);
+  });
+
+  it('narrowed source with a missing month directory errors — fs intersection is required', async () => {
+    // Verified behavior: DuckDB's read_parquet errors on a glob pattern that
+    // matches zero files, even when other patterns in the list match. Callers
+    // must intersect required periods with what's actually on disk BEFORE
+    // passing to buildSource. The query handlers do this via listLocalMonths.
+    const source = rebuildSource(SYNTHETIC_DIR, 'daily', dimensions, undefined, ['2025-11']);
+    await expect(queryAll(conn, `SELECT COUNT(*) as cnt FROM ${source}`))
+      .rejects.toThrow(/No files found/);
   });
 
   it('queries costs grouped by service', async () => {

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -3,6 +3,34 @@ import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, Mi
 import type { DimensionId } from '../types/branded.js';
 import { buildAliasSqlCase } from '../normalize/normalize.js';
 
+/**
+ * YYYY-MM month strings that a date range touches, inclusive. The data layout
+ * is one directory per billing period (e.g. `daily-2026-03/`), so a 30-day
+ * window ending 2026-04-18 only needs 2026-03 and 2026-04 — skipping the other
+ * 11+ months of data avoids the Parquet footer reads for those files and is
+ * the biggest single perf win for short-window queries over a year of data.
+ *
+ * Inputs are YYYY-MM-DD strings (as produced by asDateString). Output is sorted
+ * ascending and de-duplicated.
+ */
+export function computePeriodsInRange(dateRange: { readonly start: string; readonly end: string }): string[] {
+  const start = new Date(`${dateRange.start}T00:00:00Z`);
+  const end = new Date(`${dateRange.end}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start > end) {
+    return [];
+  }
+  const periods: string[] = [];
+  const cursor = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1));
+  const endMonth = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+  while (cursor.getTime() <= endMonth.getTime()) {
+    const y = cursor.getUTCFullYear();
+    const m = cursor.getUTCMonth() + 1;
+    periods.push(`${String(y)}-${String(m).padStart(2, '0')}`);
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return periods;
+}
+
 interface ResolvedDimension {
   readonly fieldExpr: string;
   readonly rawField: string;
@@ -33,7 +61,16 @@ function buildFilterClauses(filters: FilterMap, dimensions: DimensionsConfig): s
   return clauses;
 }
 
-export function buildSource(dataDir: string, tier: string, dimensions: DimensionsConfig, orgAccountsPath?: string): string {
+/**
+ * Build the Parquet source subquery. When `periods` is non-empty, emits a
+ * narrow list of paths like `read_parquet(['…/daily-2026-03/*.parquet',
+ * '…/daily-2026-04/*.parquet'])` instead of the wildcard over every month.
+ *
+ * DuckDB errors when any glob in the list matches zero files — so callers
+ * must pre-filter `periods` to months that actually exist on disk. An empty
+ * `periods` (or undefined) falls back to the original wildcard.
+ */
+export function buildSource(dataDir: string, tier: string, dimensions: DimensionsConfig, orgAccountsPath?: string, periods?: readonly string[]): string {
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
 
@@ -77,7 +114,9 @@ export function buildSource(dataDir: string, tier: string, dimensions: Dimension
     ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date::TIMESTAMP AS usage_hour'
     : 'line_item_usage_start_date::DATE AS usage_date';
 
-  const parquetSource = `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
+  const parquetSource = periods !== undefined && periods.length > 0
+    ? `read_parquet([${periods.map(p => `'${dataDir}/aws/raw/${tier}-${p}/*.parquet'`).join(', ')}])`
+    : `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
 
   // Build fallback column extractions for the org-accounts join
   const fallbackSelects = needsOrgJoin
@@ -118,17 +157,35 @@ export function buildSource(dataDir: string, tier: string, dimensions: Dimension
   )`;
 }
 
+/**
+ * Compute the Parquet glob periods for a query. Intersects the months the
+ * query's date range touches with the months actually on disk — DuckDB errors
+ * on glob patterns that match zero files, so the caller must pre-filter. When
+ * `availablePeriods` is omitted (tests, filter-values without date range),
+ * falls back to all required periods. An empty result means "use the wildcard".
+ */
+function resolveQueryPeriods(
+  dateRange: { readonly start: string; readonly end: string },
+  availablePeriods?: readonly string[],
+): string[] {
+  const required = computePeriodsInRange(dateRange);
+  if (availablePeriods === undefined) return required;
+  return required.filter(p => availablePeriods.includes(p));
+}
+
 export function buildCostQuery(
   params: CostQueryParams,
   dataDir: string,
   dimensions: DimensionsConfig,
   topN: number = 5,
   orgAccountsPath?: string,
+  availablePeriods?: readonly string[],
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath);
+  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -189,13 +246,28 @@ export function buildTrendQuery(
   dataDir: string,
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
+  availablePeriods?: readonly string[],
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
+
+  // Trend reads both the current period and the previous (same-duration)
+  // period, so the source needs to cover months from both spans. The previous
+  // span ends the day before `startDate`.
+  const currentPeriods = computePeriodsInRange(params.dateRange);
+  const dayMs = 24 * 60 * 60 * 1000;
+  const startMs = new Date(`${startDate}T00:00:00Z`).getTime();
+  const endMs = new Date(`${endDate}T00:00:00Z`).getTime();
+  const durationDays = Math.round((endMs - startMs) / dayMs) + 1;
+  const prevEndIso = new Date(startMs - dayMs).toISOString().slice(0, 10);
+  const prevStartIso = new Date(startMs - durationDays * dayMs).toISOString().slice(0, 10);
+  const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
+  const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
+  const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods);
 
   const filterWhere = filterClauses.length > 0 ? ` AND ${filterClauses.join(' AND ')}` : '';
 
@@ -260,10 +332,12 @@ export function buildMissingTagsQuery(
   dataDir: string,
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
+  availablePeriods?: readonly string[],
 ): string {
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
+  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods);
 
   // Date + user filters apply to the resource aggregation.
   const whereConditions = [
@@ -331,9 +405,11 @@ export function buildNonResourceCostQuery(
   dataDir: string,
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
+  availablePeriods?: readonly string[],
 ): string {
   const filterClauses = buildFilterClauses(params.filters, dimensions);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath);
+  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -360,11 +436,13 @@ export function buildDailyCostsQuery(
   dataDir: string,
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
+  availablePeriods?: readonly string[],
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath);
+  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -392,12 +470,14 @@ export function buildEntityDetailQuery(
   dataDir: string,
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
+  availablePeriods?: readonly string[],
 ): string {
   const dimResolved = resolveField(params.dimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath);
+  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -6,4 +6,5 @@ export {
   buildNonResourceCostQuery,
   buildEntityDetailQuery,
   buildSource,
+  computePeriodsInRange,
 } from './builder.js';

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -35,5 +35,6 @@ export {
   getEtagFileName,
   getRawDirPrefix,
   groupByPeriod,
+  listLocalMonths,
   parseEtagsJson,
 } from './sync-utils.js';

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -34,6 +34,29 @@ export function getRawDirPrefix(tier: string): string {
   return TIER_RAW_PREFIXES['daily'];
 }
 
+/**
+ * Lists YYYY-MM period directories on disk for a given tier. Used by query
+ * handlers to intersect a date range's required months with what's actually
+ * been synced — DuckDB's read_parquet errors on glob patterns that match
+ * zero files, so missing months must be filtered out before query time.
+ */
+export async function listLocalMonths(dataDir: string, tier: string): Promise<string[]> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const prefix = getRawDirPrefix(tier);
+  const rawDir = path.join(dataDir, 'aws', 'raw');
+  try {
+    const entries = await fs.readdir(rawDir);
+    const months = entries
+      .filter(e => e.startsWith(`${prefix}-`))
+      .map(e => e.slice(prefix.length + 1).slice(0, 7))
+      .filter(p => /^\d{4}-\d{2}$/.test(p));
+    return [...new Set(months)].sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
 export function extractPeriod(key: string): string {
   const billingMatch = /BILLING_PERIOD=(\d{4}-\d{2})/.exec(key);
   if (billingMatch?.[1] !== undefined) return billingMatch[1];

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -8,6 +8,8 @@ import {
   buildEntityDetailQuery,
   buildSource,
   buildAliasSqlCase,
+  computePeriodsInRange,
+  listLocalMonths,
   logger,
   asEntityRef,
   asDollars,
@@ -46,11 +48,21 @@ import {
 export function registerQueryHandlers(app: AppContext): void {
   const { ctx, getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, runQuery } = app;
 
+  // Intersect the query's date range with the months actually on disk so
+  // buildSource only globs directories that exist — DuckDB errors on empty
+  // patterns, and this is also where the perf win comes from (open Parquet
+  // footers only for relevant months instead of every synced month).
+  async function availableMonths(tier: 'daily' | 'hourly'): Promise<string[]> {
+    return listLocalMonths(ctx.dataDir, tier);
+  }
+
   ipcMain.handle('query:costs', async (_event, params: CostQueryParams): Promise<CostResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath);
+    const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+    const available = await availableMonths(tier);
+    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available);
     logger.info('query:costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -76,7 +88,9 @@ export function registerQueryHandlers(app: AppContext): void {
   ipcMain.handle('query:daily-costs', async (_event, params: DailyCostsParams): Promise<DailyCostsResult> => {
     const dimensions = await getDimensions();
     const orgPath = await getOrgAccountsPath();
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath);
+    const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+    const available = await availableMonths(tier);
+    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -128,7 +142,8 @@ export function registerQueryHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath);
+    const available = await availableMonths('daily');
+    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available);
     logger.info('query:trends', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -149,8 +164,9 @@ export function registerQueryHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
-    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath);
-    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath);
+    const available = await availableMonths('daily');
+    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available);
+    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available);
     const [resourceRows, nonResourceRows] = await Promise.all([
       runQuery(resourceSql),
       runQuery(nonResourceSql),
@@ -233,7 +249,9 @@ export function registerQueryHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath);
+    const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+    const available = await availableMonths(tier);
+    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available);
     logger.info('query:entity-detail', { entity: params.entity });
 
     const rows = await runQuery(sql);
@@ -279,7 +297,8 @@ export function registerQueryHandlers(app: AppContext): void {
     const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
 
     const orgPath = await getOrgAccountsPath();
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath);
+    const periods = dateRange === undefined ? undefined : computePeriodsInRange(dateRange);
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods);
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
       FROM ${source}


### PR DESCRIPTION
Perf win #1 from the tuning queue. Lever #2 (worker connection pool) will be a separate PR after this lands.

## Before

Every query opened the footer of every Parquet file in every synced month:
\`read_parquet('aws/raw/daily-*/*.parquet')\`. For a 30-day window over a year+ of data, that's ~52+ Parquet file opens on each query even though only ~8 files are actually needed.

## Change

- \`computePeriodsInRange(dateRange)\` → list of \`YYYY-MM\` months the date range touches.
- \`buildSource\` takes an optional \`periods[]\` and emits \`read_parquet(['…/daily-2026-03/*.parquet', '…/daily-2026-04/*.parquet'])\` instead of the wildcard.
- Query handlers compute \`availablePeriods\` via \`listLocalMonths(dataDir, tier)\` and pass it to the query builders — each builder intersects \`required ∩ available\`. The fs check is required because **DuckDB errors on glob patterns that match zero files** (pinned as an integration test so this contract doesn't regress silently).
- \`buildTrendQuery\` takes the union of current + previous periods (the comparison reads both spans).
- \`query:filter-values\` narrows when the caller provides a date range, falls back to the wildcard otherwise.

## Measured against real data (full user CUR, year+ of daily files)

| Query | Before | After | Δ |
|---|---|---|---|
| Missing-tags main classifier | 4416ms | ~750ms | **5.8×** |
| Missing-tags non-resource | 6441ms | 1951ms | **3.3×** |
| Cost Overview (per query) | ~1500ms | ~750ms | **2×** |

Missing-tags page wall time went from ~10s → ~2s.

## Tests

- **+9 unit** — \`computePeriodsInRange\` edges (same month, cross-month, cross-year, invalid, empty), \`buildSource\` output shape for periods / empty / hourly, \`buildTrendQuery\` unions current+previous.
- **+2 integration** — narrowed source returns identical count + cost to the wildcard on synthetic fixtures; missing-month glob errors (pins the fs-intersection contract).

\`npm run check\`: 190 passed, 5 skipped.

## Ready to merge?