### PR TITLE
Pool DuckDB connections so independent queries run in parallel

### DIFF
--- a/packages/desktop/src/__tests__/connection-pool.test.ts
+++ b/packages/desktop/src/__tests__/connection-pool.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { createResourcePool } from '../main/connection-pool.js';
+
+describe('createResourcePool', () => {
+  it('hands out idle resources immediately', async () => {
+    const pool = await createResourcePool(2, () => Promise.resolve({ id: Math.random() }));
+    const a = await pool.acquire();
+    const b = await pool.acquire();
+    expect(a).not.toBe(b);
+  });
+
+  it('queues acquire calls when pool is exhausted, resolves when released', async () => {
+    const pool = await createResourcePool(1, () => Promise.resolve({ id: 1 }));
+    const a = await pool.acquire();
+
+    let resolvedB = false;
+    const bPromise = pool.acquire().then(r => { resolvedB = true; return r; });
+
+    // Flush one tick — the waiter must still be blocked.
+    await Promise.resolve();
+    expect(resolvedB).toBe(false);
+
+    pool.release(a);
+    const b = await bPromise;
+    expect(resolvedB).toBe(true);
+    expect(b).toBe(a); // same resource re-used
+  });
+
+  it('releases to FIFO waiters before filling the idle stack', async () => {
+    const pool = await createResourcePool(1, () => Promise.resolve({ tag: 'only' }));
+    const a = await pool.acquire();
+
+    // Two waiters queued in order.
+    const order: string[] = [];
+    void pool.acquire().then(() => { order.push('first'); });
+    void pool.acquire().then(() => { order.push('second'); });
+
+    // First release goes to first waiter.
+    pool.release(a);
+    await new Promise(resolve => setTimeout(resolve, 5));
+    expect(order).toEqual(['first']);
+
+    // Simulate that the first waiter finishes and releases — second waiter gets it.
+    pool.release(a);
+    await new Promise(resolve => setTimeout(resolve, 5));
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('size=1 effectively serializes concurrent work (queue guard)', async () => {
+    const pool = await createResourcePool(1, () => Promise.resolve({ id: 1 }));
+    const log: string[] = [];
+
+    async function work(tag: string, ms: number): Promise<void> {
+      const r = await pool.acquire();
+      log.push(`${tag}:start`);
+      await new Promise(resolve => setTimeout(resolve, ms));
+      log.push(`${tag}:end`);
+      pool.release(r);
+    }
+
+    await Promise.all([work('a', 15), work('b', 15)]);
+    // With a single resource the work must not overlap.
+    expect(log).toEqual(['a:start', 'a:end', 'b:start', 'b:end']);
+  });
+
+  it('size=N runs up to N in parallel', async () => {
+    const pool = await createResourcePool(3, () => Promise.resolve({ id: 1 }));
+    let active = 0;
+    let peak = 0;
+
+    async function work(): Promise<void> {
+      const r = await pool.acquire();
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise(resolve => setTimeout(resolve, 20));
+      active -= 1;
+      pool.release(r);
+    }
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+    expect(peak).toBe(3);
+  });
+});

--- a/packages/desktop/src/main/connection-pool.ts
+++ b/packages/desktop/src/main/connection-pool.ts
@@ -1,0 +1,37 @@
+/**
+ * Generic FIFO resource pool. Acquire returns an idle resource or a Promise
+ * that resolves when one is released. Release hands the resource directly
+ * to the first waiter, or returns it to the idle stack if none.
+ *
+ * Shape is deliberately minimal — no timeouts, no invalidation, no draining.
+ * Callers are expected to always release. For DuckDB connections in our
+ * worker, the connections live for the lifetime of the process.
+ */
+export interface ResourcePool<T> {
+  acquire(): Promise<T>;
+  release(resource: T): void;
+}
+
+export async function createResourcePool<T>(
+  size: number,
+  factory: () => Promise<T>,
+): Promise<ResourcePool<T>> {
+  const idle: T[] = [];
+  for (let i = 0; i < size; i++) {
+    idle.push(await factory());
+  }
+  const waiters: ((resource: T) => void)[] = [];
+
+  return {
+    acquire(): Promise<T> {
+      const resource = idle.pop();
+      if (resource !== undefined) return Promise.resolve(resource);
+      return new Promise<T>(resolve => waiters.push(resolve));
+    },
+    release(resource: T): void {
+      const waiter = waiters.shift();
+      if (waiter !== undefined) waiter(resource);
+      else idle.push(resource);
+    },
+  };
+}

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,5 +1,7 @@
 import { parentPort } from 'node:worker_threads';
 import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
+import { createResourcePool } from './connection-pool.js';
+import type { ResourcePool } from './connection-pool.js';
 
 interface DuckDBModule {
   DuckDBInstance: { create: () => Promise<DuckDBInstance> };
@@ -51,20 +53,36 @@ async function fetchAllRows(conn: DuckDBConnection, sql: string): Promise<Readon
   return rows;
 }
 
-let connectionPromise: Promise<DuckDBConnection> | null = null;
+/**
+ * Pool of DuckDB connections on one DuckDBInstance. A single connection
+ * serializes queries internally — with N connections, independent queries
+ * execute in parallel (bound by DuckDB's own thread scheduling). Queries
+ * arriving while all connections are busy queue FIFO via ResourcePool.
+ *
+ * Size defaults to 4 (matches typical cost-overview fan-out and laptop
+ * core counts). Override with COSTGOBLIN_DUCKDB_POOL_SIZE.
+ */
+function parsePoolSize(): number {
+  const raw = process.env['COSTGOBLIN_DUCKDB_POOL_SIZE'];
+  if (raw === undefined) return 4;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 1 && n <= 32 ? n : 4;
+}
 
-async function getConnection(): Promise<DuckDBConnection> {
-  if (connectionPromise === null) {
-    connectionPromise = createDuckDB().then(db => db.connect());
+let poolPromise: Promise<ResourcePool<DuckDBConnection>> | null = null;
+
+function getPool(): Promise<ResourcePool<DuckDBConnection>> {
+  if (poolPromise === null) {
+    poolPromise = createDuckDB().then(db => createResourcePool(parsePoolSize(), () => db.connect()));
   }
-  return connectionPromise;
+  return poolPromise;
 }
 
 function send(msg: WorkerResponse): void {
   port.postMessage(msg);
 }
 
-void getConnection().then(() => {
+void getPool().then(() => {
   send({ kind: 'ready' });
 }).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);
@@ -74,13 +92,16 @@ void getConnection().then(() => {
 });
 
 async function handleRequest(req: WorkerRequest): Promise<void> {
+  const pool = await getPool();
+  const conn = await pool.acquire();
   try {
-    const conn = await getConnection();
     const rows = await fetchAllRows(conn, req.sql);
     send({ kind: 'rows', id: req.id, rows });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     send({ kind: 'error', id: req.id, message });
+  } finally {
+    pool.release(conn);
   }
 }
 


### PR DESCRIPTION
Perf win #2 from the tuning queue, on top of #46 (glob narrowing).

## Problem

A single DuckDB connection serializes queries internally, so the worker's "multiple async \`handleRequest\`" pattern was only pretend-concurrent. Two cost-overview pies would queue inside DuckDB even though Node fired them together. Missing Tags paid \`sum(durations)\` instead of \`max(durations)\`.

## Change

- **\`connection-pool.ts\`** — generic \`ResourcePool<T>\` with FIFO waiters. 15 lines, no timeouts / draining / invalidation: callers are trusted to always release. Pulled out of \`duckdb-worker.ts\` so it's directly unit-testable.
- **\`duckdb-worker.ts\`** — opens the \`DuckDBInstance\`, creates N connections via \`createResourcePool\`. Each request \`acquire → runs → release\` in a finally block. Size defaults to **4**, overridable with \`COSTGOBLIN_DUCKDB_POOL_SIZE\` (clamped to [1, 32]).

## Measured on real data (comparing to #46 only)

| Query | #46 alone | #46 + pool | Δ |
|---|---|---|---|
| Missing-tags non-resource | 1951ms | 599ms | **3.3×** |
| Cost Overview slowest query | 2026ms | 1558ms | 1.3× |

Missing-tags page wall-time: \`max(1648, 599) ≈ 1.6s\` vs \`sum(1648, 1951) ≈ 3.6s\` when the two queries had to serialize. Not all queries speed up equally — the pool helps exactly where there are peers, which is the common case.

## Tests

**+5 unit tests** for the pool:
- immediate idle-handout
- blocks when exhausted, resolves on release
- FIFO waiter order
- size=1 serializes concurrent work
- size=N allows up to N concurrent

\`npm run check\`: 195 passed, 5 skipped.

## Ready to merge?