### PR TITLE
Sort raw Parquet + combined sidecar optimizer

### DIFF
--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,7 +1,26 @@
-import type { DimensionsConfig } from '../types/config.js';
+import type { DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
 import { buildAliasSqlCase } from '../normalize/normalize.js';
+
+/**
+ * When all raw files for a query's periods have fresh combined sidecars, the
+ * handler builds this plan and passes it through to buildSource, which then
+ * emits a single POSITIONAL JOIN instead of per-row element_at() lookups.
+ *
+ * `rawFiles` and `sidecarFiles` must be the same length and in matching order
+ * — POSITIONAL JOIN pairs rows by position, and concatenates file reads in
+ * list order, so a single misalignment breaks every subsequent row. Each
+ * sidecar file is a wide Parquet with one column per configured tag dim.
+ */
+export interface SidecarPlan {
+  readonly rawFiles: readonly string[];
+  readonly sidecarFiles: readonly string[];
+}
+
+function tagColumnNameFromTag(t: TagDimension): string {
+  return `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+}
 
 /**
  * YYYY-MM month strings that a date range touches, inclusive. The data layout
@@ -61,16 +80,79 @@ function buildFilterClauses(filters: FilterMap, dimensions: DimensionsConfig): s
   return clauses;
 }
 
+function quoteList(paths: readonly string[]): string {
+  return `[${paths.map(p => `'${p}'`).join(', ')}]`;
+}
+
 /**
- * Build the Parquet source subquery. When `periods` is non-empty, emits a
- * narrow list of paths like `read_parquet(['…/daily-2026-03/*.parquet',
- * '…/daily-2026-04/*.parquet'])` instead of the wildcard over every month.
+ * Sidecar-mode source: a single POSITIONAL JOIN against the wide combined
+ * sidecar. Pairs each raw file with its sidecar by list position; the sidecar
+ * holds one column per configured tag dim. Replaces per-row element_at(map, key)
+ * lookups with a flat column read.
+ *
+ * Drops the org-accounts JOIN entirely — fallback logic was baked into each
+ * sidecar column at generation time.
+ */
+function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan): string {
+  const rawList = quoteList(plan.rawFiles);
+  const sidecarList = quoteList(plan.sidecarFiles);
+
+  const tagSelects = dimensions.tags.map(t => {
+    const colName = tagColumnNameFromTag(t);
+    return `side.${colName} AS ${colName}`;
+  });
+  const tagClause = tagSelects.length > 0 ? `,\n      ${tagSelects.join(',\n      ')}` : '';
+  const joinClause = dimensions.tags.length > 0
+    ? `\n      POSITIONAL JOIN read_parquet(${sidecarList}) AS side`
+    : '';
+
+  const dateExpr = tier === 'hourly'
+    ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date::TIMESTAMP AS usage_hour'
+    : 'line_item_usage_start_date::DATE AS usage_date';
+
+  return `(
+    SELECT
+      ${dateExpr},
+      cur.line_item_usage_account_id AS account_id,
+      COALESCE(cur.line_item_usage_account_name, '') AS account_name,
+      COALESCE(cur.product_region_code, '') AS region,
+      COALESCE(cur.product_servicecode, '') AS service,
+      COALESCE(cur.product_product_family, '') AS service_family,
+      COALESCE(cur.line_item_line_item_description, '') AS description,
+      COALESCE(cur.line_item_resource_id, '') AS resource_id,
+      COALESCE(cur.line_item_usage_amount, 0) AS usage_amount,
+      COALESCE(cur.line_item_unblended_cost, 0) AS cost,
+      COALESCE(cur.pricing_public_on_demand_cost, 0) AS list_cost,
+      COALESCE(cur.line_item_line_item_type, '') AS line_item_type,
+      COALESCE(cur.line_item_operation, '') AS operation,
+      COALESCE(cur.line_item_usage_type, '') AS usage_type${tagClause}
+    FROM read_parquet(${rawList}) AS cur${joinClause}
+  )`;
+}
+
+/**
+ * Build the Parquet source subquery. Three modes:
+ *   1. sidecar mode (plan provided): POSITIONAL JOIN with pre-computed tag
+ *      columns. Dramatically faster on tag-heavy queries — column scan vs
+ *      per-row map lookup.
+ *   2. narrowed wildcard (periods provided): read_parquet on explicit month
+ *      directories. Element_at at query time, but cuts Parquet footer reads.
+ *   3. full wildcard (neither): daily-*\/*.parquet. Original path.
  *
  * DuckDB errors when any glob in the list matches zero files — so callers
- * must pre-filter `periods` to months that actually exist on disk. An empty
- * `periods` (or undefined) falls back to the original wildcard.
+ * must pre-filter `periods` to months that actually exist on disk.
  */
-export function buildSource(dataDir: string, tier: string, dimensions: DimensionsConfig, orgAccountsPath?: string, periods?: readonly string[]): string {
+export function buildSource(
+  dataDir: string,
+  tier: string,
+  dimensions: DimensionsConfig,
+  orgAccountsPath?: string,
+  periods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
+): string {
+  if (sidecarPlan !== undefined) {
+    return buildSourceFromSidecars(tier, dimensions, sidecarPlan);
+  }
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
 
@@ -180,12 +262,13 @@ export function buildCostQuery(
   topN: number = 5,
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -247,6 +330,7 @@ export function buildTrendQuery(
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
@@ -267,7 +351,7 @@ export function buildTrendQuery(
   const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
   const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
   const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
 
   const filterWhere = filterClauses.length > 0 ? ` AND ${filterClauses.join(' AND ')}` : '';
 
@@ -333,11 +417,12 @@ export function buildMissingTagsQuery(
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
 ): string {
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
 
   // Date + user filters apply to the resource aggregation.
   const whereConditions = [
@@ -406,10 +491,11 @@ export function buildNonResourceCostQuery(
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
 ): string {
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -437,12 +523,13 @@ export function buildDailyCostsQuery(
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -471,13 +558,14 @@ export function buildEntityDetailQuery(
   dimensions: DimensionsConfig,
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
+  sidecarPlan?: SidecarPlan,
 ): string {
   const dimResolved = resolveField(params.dimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions);
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -8,3 +8,5 @@ export {
   buildSource,
   computePeriodsInRange,
 } from './builder.js';
+
+export type { SidecarPlan } from './builder.js';

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -24,6 +24,12 @@ export interface SelectiveSyncOptions {
   readonly files: readonly ManifestFileEntry[];
   readonly onProgress?: ProgressCallback | undefined;
   readonly signal?: AbortSignal | undefined;
+  /**
+   * Called as each file finishes downloading, with the local path. Used by
+   * the desktop handler to enqueue post-download optimization (sort + sidecar
+   * generation) in parallel with ongoing downloads of other files.
+   */
+  readonly onFileDownloaded?: ((localPath: string) => void) | undefined;
 }
 
 function runAwsS3Sync(options: {
@@ -246,6 +252,14 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
         logger.info(`[aws] ${line}`);
         if (line.startsWith('download:')) {
           globalFilesDone++;
+          // Extract the local path from `download: s3://bucket/key to /local/path`.
+          // Kicks off optimize in parallel with the next download.
+          if (options.onFileDownloaded !== undefined) {
+            const match = / to (.+)$/.exec(line);
+            if (match?.[1] !== undefined) {
+              options.onFileDownloaded(match[1]);
+            }
+          }
         }
         if (onProgress !== undefined) {
           onProgress({

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -47,11 +47,20 @@ export async function listLocalMonths(dataDir: string, tier: string): Promise<st
   const rawDir = path.join(dataDir, 'aws', 'raw');
   try {
     const entries = await fs.readdir(rawDir);
-    const months = entries
-      .filter(e => e.startsWith(`${prefix}-`))
-      .map(e => e.slice(prefix.length + 1).slice(0, 7))
-      .filter(p => /^\d{4}-\d{2}$/.test(p));
-    return [...new Set(months)].sort((a, b) => a.localeCompare(b));
+    const months = new Set<string>();
+    for (const entry of entries) {
+      if (!entry.startsWith(`${prefix}-`)) continue;
+      const period = entry.slice(prefix.length + 1).slice(0, 7);
+      if (!/^\d{4}-\d{2}$/.test(period)) continue;
+      // Must contain at least one .parquet — otherwise DuckDB errors on the
+      // glob. Empty dirs can linger after interrupted downloads or partial
+      // deletes; silently skip them.
+      try {
+        const files = await fs.readdir(path.join(rawDir, entry));
+        if (files.some(f => f.endsWith('.parquet'))) months.add(period);
+      } catch { /* dir vanished mid-scan */ }
+    }
+    return [...months].sort((a, b) => a.localeCompare(b));
   } catch {
     return [];
   }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -130,6 +130,7 @@ export interface CostApi {
   getOptimizeStatus(): Promise<OptimizeStatus>;
   getOptimizeEnabled(): Promise<boolean>;
   setOptimizeEnabled(enabled: boolean): Promise<void>;
+  clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -18,6 +18,31 @@ export interface SavingsPreferences {
   readonly hiddenActionTypes: readonly string[];
 }
 
+/** Stages a file moves through as it's optimized (sort → sidecars). */
+export type FileActivityStage =
+  | 'downloaded'
+  | 'sorting'
+  | 'sorted'
+  | 'building-sidecar'
+  | 'complete'
+  | 'failed';
+
+/** Single entry in the rolling file-activity feed shown under the Sync view. */
+export interface FileActivityEvent {
+  readonly timestamp: string;
+  readonly rawPath: string;
+  readonly relName: string;
+  readonly stage: FileActivityStage;
+  readonly tagKey?: string | undefined;
+  readonly durationMs?: number | undefined;
+  readonly error?: string | undefined;
+}
+
+export interface OptimizeStatus {
+  readonly queued: number;
+  readonly running: boolean;
+}
+
 export interface UIPreferences {
   readonly theme: 'dark' | 'light';
 }
@@ -101,6 +126,10 @@ export interface CostApi {
   saveSavingsPreferences(prefs: SavingsPreferences): Promise<void>;
   getUIPreferences(): Promise<UIPreferences>;
   saveUIPreferences(prefs: UIPreferences): Promise<void>;
+  getFileActivity(sinceIso?: string): Promise<FileActivityEvent[]>;
+  getOptimizeStatus(): Promise<OptimizeStatus>;
+  getOptimizeEnabled(): Promise<boolean>;
+  setOptimizeEnabled(enabled: boolean): Promise<void>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -59,4 +59,4 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, FileActivityEvent, FileActivityStage, OptimizeStatus } from './api.js';

--- a/packages/desktop/src/main/file-activity.ts
+++ b/packages/desktop/src/main/file-activity.ts
@@ -1,0 +1,70 @@
+/**
+ * Rolling log of file-level sync/optimize transitions. Lives in memory; the
+ * UI's "Recent file activity" panel pulls from it via IPC. Lost across app
+ * restarts — the current on-disk stage is always re-derivable from file
+ * presence + mtimes, so we don't need durable state.
+ */
+
+export type FileStage =
+  | 'downloaded'
+  | 'sorting'
+  | 'sorted'
+  | 'building-sidecar'
+  | 'complete'
+  | 'failed';
+
+export interface FileActivityEvent {
+  readonly timestamp: string;        // ISO
+  readonly rawPath: string;          // full path on disk
+  readonly relName: string;          // 'daily-2026-04/cur-00001.parquet' for display
+  readonly stage: FileStage;
+  readonly tagKey?: string | undefined;      // when stage is 'building-sidecar'
+  readonly durationMs?: number | undefined;  // on stage completion
+  readonly error?: string | undefined;       // when stage is 'failed'
+}
+
+/**
+ * Ring buffer. Size bounds memory footprint and ensures the activity feed
+ * stays snappy to read.
+ */
+export class FileActivityLog {
+  private readonly events: FileActivityEvent[] = [];
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = 500) {
+    this.maxEntries = maxEntries;
+  }
+
+  record(event: Omit<FileActivityEvent, 'timestamp'>): void {
+    const full: FileActivityEvent = {
+      ...event,
+      timestamp: new Date().toISOString(),
+    };
+    this.events.push(full);
+    if (this.events.length > this.maxEntries) {
+      this.events.splice(0, this.events.length - this.maxEntries);
+    }
+  }
+
+  /** Returns events since (exclusive) a given ISO timestamp. Used for polling. */
+  since(isoTimestamp?: string): FileActivityEvent[] {
+    if (isoTimestamp === undefined) return [...this.events];
+    return this.events.filter(e => e.timestamp > isoTimestamp);
+  }
+
+  all(): readonly FileActivityEvent[] {
+    return this.events;
+  }
+
+  clear(): void {
+    this.events.length = 0;
+  }
+
+  /** Drop events whose rawPath matches the predicate (e.g. after deleting a period). */
+  removeWhere(predicate: (rawPath: string) => boolean): void {
+    for (let i = this.events.length - 1; i >= 0; i--) {
+      const ev = this.events[i];
+      if (ev !== undefined && predicate(ev.rawPath)) this.events.splice(i, 1);
+    }
+  }
+}

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -12,6 +12,10 @@ import type {
   OrgNode,
   SyncStatus,
 } from '@costgoblin/core';
+import { FileActivityLog } from '../file-activity.js';
+import { createOptimizeQueue } from '../optimize-queue.js';
+import type { OptimizeQueue } from '../optimize-queue.js';
+import { readOptimizeEnabled } from '../optimize-enabled.js';
 
 export interface IpcContext {
   readonly db: DuckDBClient;
@@ -36,6 +40,8 @@ export interface AppState {
 export interface AppContext {
   readonly ctx: IpcContext;
   readonly state: AppState;
+  readonly activity: FileActivityLog;
+  readonly optimizeQueue: OptimizeQueue;
   readonly getConfig: () => Promise<CostGoblinConfig>;
   readonly getDimensions: () => Promise<DimensionsConfig>;
   readonly getOrgTreeConfig: () => Promise<OrgTreeConfig>;
@@ -144,9 +150,24 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
   }
 
+  const activity = new FileActivityLog();
+  async function prefsPath(): Promise<string> {
+    const path = await import('node:path');
+    return path.join(path.dirname(ctx.dataDir), 'app-preferences.json');
+  }
+  const optimizeQueue = createOptimizeQueue({
+    client: ctx.db,
+    activity,
+    getTags: async () => (await getDimensions()).tags,
+    getOrgAccountsPath,
+    isEnabled: async () => readOptimizeEnabled(await prefsPath()),
+  });
+
   return {
     ctx,
     state,
+    activity,
+    optimizeQueue,
     getConfig,
     getDimensions,
     getOrgTreeConfig,

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,10 +1,46 @@
 import { ipcMain } from 'electron';
-import type { DimensionsConfig } from '@costgoblin/core';
+import { join } from 'node:path';
+import { readdir } from 'node:fs/promises';
+import { getRawDirPrefix, logger } from '@costgoblin/core';
+import type { DimensionsConfig, TagDimension } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import { toNum, toStr } from './query-utils.js';
+import { removeAllSidecars } from '../optimize.js';
+
+/** Returns a hash-like fingerprint of the fields that affect sidecar output
+ *  for a tag. Aliases are excluded (they apply at query time, not at sidecar
+ *  generation). When this fingerprint changes for a tag, its sidecars are
+ *  stale and must be regenerated. */
+function tagFingerprint(tag: TagDimension): string {
+  return JSON.stringify({
+    tagName: tag.tagName,
+    fallback: tag.accountTagFallback ?? null,
+    template: tag.missingValueTemplate ?? null,
+  });
+}
+
+/** Snapshot of existing raw files for a tier, used to enqueue regen jobs. */
+async function listRawFilesForTier(dataDir: string, tier: 'daily' | 'hourly'): Promise<string[]> {
+  const prefix = getRawDirPrefix(tier);
+  const rawDir = join(dataDir, 'aws', 'raw');
+  const paths: string[] = [];
+  try {
+    const periods = await readdir(rawDir);
+    for (const periodDir of periods) {
+      if (!periodDir.startsWith(`${prefix}-`)) continue;
+      try {
+        const files = await readdir(join(rawDir, periodDir));
+        for (const f of files) {
+          if (f.endsWith('.parquet')) paths.push(join(rawDir, periodDir, f));
+        }
+      } catch { /* vanished */ }
+    }
+  } catch { /* raw dir doesn't exist yet */ }
+  return paths;
+}
 
 export function registerDimensionsHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, invalidateDimensions, runQuery } = app;
+  const { ctx, getConfig, getDimensions, invalidateDimensions, runQuery, optimizeQueue } = app;
 
   ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
@@ -86,6 +122,17 @@ export function registerDimensionsHandlers(app: AppContext): void {
   ipcMain.handle('dimensions:save-config', async (_event, config: DimensionsConfig): Promise<void> => {
     const yaml = await import('yaml');
     const fs = await import('node:fs/promises');
+
+    // Diff the old config against the incoming one to decide which sidecars
+    // need to be removed (tags dropped or meaningfully changed) and which raw
+    // files need re-optimization (added tags, or changed-fingerprint tags).
+    let previousTags: readonly TagDimension[] = [];
+    try {
+      previousTags = (await getDimensions()).tags;
+    } catch {
+      // First-time save or config file missing — treat as no previous tags.
+    }
+
     const output = yaml.stringify({
       builtIn: config.builtIn.map(d => ({
         name: d.name,
@@ -106,5 +153,32 @@ export function registerDimensionsHandlers(app: AppContext): void {
     });
     await fs.writeFile(ctx.dimensionsPath, output);
     invalidateDimensions();
+
+    // Sidecar housekeeping: wide combined-sidecar design means ANY storage-
+    // affecting tag change invalidates the whole sidecar file. Alias-only edits
+    // apply at query time and don't touch disk.
+    const prevByName = new Map(previousTags.map(t => [t.tagName, t]));
+    const nextByName = new Map(config.tags.map(t => [t.tagName, t]));
+    const columnsRoot = join(ctx.dataDir, 'aws', 'columns');
+
+    let needsRegen = false;
+    for (const [name, prev] of prevByName) {
+      const next = nextByName.get(name);
+      if (next === undefined || tagFingerprint(prev) !== tagFingerprint(next)) { needsRegen = true; break; }
+    }
+    if (!needsRegen) {
+      for (const name of nextByName.keys()) {
+        if (!prevByName.has(name)) { needsRegen = true; break; }
+      }
+    }
+
+    if (needsRegen) {
+      const removed = await removeAllSidecars(columnsRoot);
+      if (removed > 0) logger.info(`dimensions: removed ${String(removed)} stale sidecar(s)`);
+      const daily = await listRawFilesForTier(ctx.dataDir, 'daily');
+      const hourly = await listRawFilesForTier(ctx.dataDir, 'hourly');
+      for (const p of [...daily, ...hourly]) optimizeQueue.enqueue(p);
+      logger.info(`dimensions: enqueued ${String(daily.length + hourly.length)} files for sidecar regen`);
+    }
   });
 }

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -15,6 +15,8 @@ import {
   asDollars,
   asDateString,
 } from '@costgoblin/core';
+import type { SidecarPlan } from '@costgoblin/core';
+import { resolveSidecarPlan } from '../optimize.js';
 import type {
   CostQueryParams,
   CostResult,
@@ -56,13 +58,45 @@ export function registerQueryHandlers(app: AppContext): void {
     return listLocalMonths(ctx.dataDir, tier);
   }
 
+  /**
+   * Given a date range + tier, resolve the optimized-query plan:
+   *   - availablePeriods: months actually on disk (required for glob safety)
+   *   - sidecarPlan: the POSITIONAL JOIN plan iff every file in the requested
+   *     periods is fully optimized (sorted + sidecars fresh for every
+   *     configured tag). Null means fall back to element_at.
+   *
+   * Logs the chosen mode for visibility. Also emits a timing note on the
+   * debug logger so the query-log lines tell you which path was used.
+   */
+  async function planQuery(
+    tier: 'daily' | 'hourly',
+    dateRange: { readonly start: string; readonly end: string },
+  ): Promise<{ available: string[]; plan: SidecarPlan | undefined; empty: boolean }> {
+    const available = await availableMonths(tier);
+    const required = computePeriodsInRange(dateRange);
+    const usePeriods = required.filter(p => available.includes(p));
+    // No overlap between requested range and on-disk data — caller must
+    // short-circuit, otherwise the builder falls back to a full wildcard
+    // and DuckDB errors on an empty aws/raw/ or zero-match glob.
+    if (usePeriods.length === 0) {
+      logger.debug('query:plan', { tier, mode: 'empty', requestedMonths: required.length, availableMonths: available.length });
+      return { available, plan: undefined, empty: true };
+    }
+    const dimensions = await getDimensions();
+    const resolved = await resolveSidecarPlan(ctx.dataDir, tier, usePeriods, dimensions.tags);
+    const plan = resolved === null ? undefined : resolved;
+    logger.debug('query:plan', { tier, mode: plan === undefined ? 'element_at' : 'sidecar', periods: usePeriods.length });
+    return { available, plan, empty: false };
+  }
+
   ipcMain.handle('query:costs', async (_event, params: CostQueryParams): Promise<CostResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-    const available = await availableMonths(tier);
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available);
+    const { available, plan, empty } = await planQuery(tier, params.dateRange);
+    if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
+    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan);
     logger.info('query:costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -89,8 +123,9 @@ export function registerQueryHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const orgPath = await getOrgAccountsPath();
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-    const available = await availableMonths(tier);
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available);
+    const { available, plan, empty } = await planQuery(tier, params.dateRange);
+    if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
+    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -142,8 +177,9 @@ export function registerQueryHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
-    const available = await availableMonths('daily');
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available);
+    const { available, plan, empty } = await planQuery('daily', params.dateRange);
+    if (empty) return { increases: [], savings: [], totalIncrease: asDollars(0), totalSavings: asDollars(0) };
+    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
     logger.info('query:trends', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -164,9 +200,20 @@ export function registerQueryHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
-    const available = await availableMonths('daily');
-    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available);
-    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available);
+    const { available, plan, empty } = await planQuery('daily', params.dateRange);
+    if (empty) {
+      return {
+        rows: [],
+        totalActionableCost: asDollars(0),
+        totalLikelyUntaggableCost: asDollars(0),
+        totalNonResourceCost: asDollars(0),
+        actionableCount: 0,
+        likelyUntaggableCount: 0,
+        nonResourceRows: [],
+      };
+    }
+    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
+    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
     const [resourceRows, nonResourceRows] = await Promise.all([
       runQuery(resourceSql),
       runQuery(nonResourceSql),
@@ -250,8 +297,20 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const orgPath = await getOrgAccountsPath();
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-    const available = await availableMonths(tier);
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available);
+    const { available, plan, empty } = await planQuery(tier, params.dateRange);
+    if (empty) {
+      return {
+        entity: params.entity,
+        totalCost: asDollars(0),
+        previousCost: asDollars(0),
+        percentChange: 0,
+        dailyCosts: [],
+        byAccount: [],
+        byService: [],
+        bySubEntity: [],
+      };
+    }
+    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
     logger.info('query:entity-detail', { entity: params.entity });
 
     const rows = await runQuery(sql);

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -204,7 +204,7 @@ export function registerSetupHandlers(app: AppContext): void {
       sync['hourly'] = { bucket: wizardConfig.hourlyBucket, retentionDays: 30 };
     }
     if (wizardConfig.costOptBucket !== undefined && wizardConfig.costOptBucket.length > 0) {
-      sync['costOptimization'] = { bucket: wizardConfig.costOptBucket, retentionDays: 90 };
+      sync['costOptimization'] = { bucket: wizardConfig.costOptBucket, retentionDays: 30 };
     }
 
     const costgoblinYaml = {

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -56,6 +56,41 @@ export function registerSyncHandlers(app: AppContext): void {
     if (enabled) optimizeQueue.kick();
   });
 
+  ipcMain.handle('optimize:clear-sidecars', async (): Promise<{ removed: number; requeued: number }> => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const columnsRoot = path.join(ctx.dataDir, 'aws', 'columns');
+    let removed = 0;
+    try {
+      const periods = await fs.readdir(columnsRoot);
+      for (const periodDir of periods) {
+        await fs.rm(path.join(columnsRoot, periodDir), { recursive: true, force: true });
+        removed += 1;
+      }
+    } catch { /* columns dir doesn't exist yet */ }
+
+    // Re-enqueue every raw daily + hourly file so the optimizer rebuilds
+    // sidecars. Sort markers stay — we only nuked derived tag data.
+    const rawRoot = path.join(ctx.dataDir, 'aws', 'raw');
+    let requeued = 0;
+    try {
+      const entries = await fs.readdir(rawRoot);
+      for (const entry of entries) {
+        if (!entry.startsWith('daily-') && !entry.startsWith('hourly-')) continue;
+        const full = path.join(rawRoot, entry);
+        const files = await fs.readdir(full);
+        for (const f of files) {
+          if (f.endsWith('.parquet')) {
+            optimizeQueue.enqueue(path.join(full, f));
+            requeued += 1;
+          }
+        }
+      }
+    } catch { /* raw dir doesn't exist yet */ }
+    logger.info(`optimize:clear-sidecars — removed ${String(removed)} period dirs, re-enqueued ${String(requeued)} files`);
+    return { removed, requeued };
+  });
+
   ipcMain.handle('sync:status', (_event, syncId: string = 'default'): SyncStatus => {
     return state.syncStatuses[syncId] ?? { status: 'idle', lastSync: null };
   });

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -1,4 +1,5 @@
 import { ipcMain, shell } from 'electron';
+import { dirname, basename } from 'node:path';
 import {
   getDataInventory,
   getEtagFileName,
@@ -19,6 +20,7 @@ import {
   isCredentialError,
   toUserFriendlyError,
 } from './context.js';
+import { readOptimizeEnabled, writeOptimizeEnabled } from '../optimize-enabled.js';
 
 type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
 
@@ -29,8 +31,30 @@ function resolveDataType(syncId: string): ExpectedDataType {
 }
 
 export function registerSyncHandlers(app: AppContext): void {
-  const { ctx, state, getConfig } = app;
+  const { ctx, state, getConfig, activity, optimizeQueue } = app;
   const syncAbortControllers = new Map<string, AbortController>();
+
+  ipcMain.handle('sync:get-file-activity', (_event, sinceIso?: string): ReturnType<typeof activity.since> => {
+    return activity.since(sinceIso);
+  });
+
+  ipcMain.handle('sync:get-optimize-status', (): { queued: number; running: boolean } => {
+    return { queued: optimizeQueue.size(), running: optimizeQueue.running() };
+  });
+
+  async function optimizePrefsPath(): Promise<string> {
+    const path = await import('node:path');
+    return path.join(path.dirname(ctx.dataDir), 'app-preferences.json');
+  }
+
+  ipcMain.handle('optimize:get-enabled', async (): Promise<boolean> => {
+    return readOptimizeEnabled(await optimizePrefsPath());
+  });
+
+  ipcMain.handle('optimize:set-enabled', async (_event, enabled: boolean): Promise<void> => {
+    await writeOptimizeEnabled(await optimizePrefsPath(), enabled);
+    if (enabled) optimizeQueue.kick();
+  });
 
   ipcMain.handle('sync:status', (_event, syncId: string = 'default'): SyncStatus => {
     return state.syncStatuses[syncId] ?? { status: 'idle', lastSync: null };
@@ -68,18 +92,32 @@ export function registerSyncHandlers(app: AppContext): void {
     // ${prefix}-${period} OR ${prefix}-${period}-* to cover both cases.
     const prefix = getRawDirPrefix(tier);
     const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
+    const columnsDir = path.join(ctx.dataDir, 'aws', 'columns');
     let removedAny = false;
+    const removedDirs: string[] = [];
     try {
       const entries = await fs.readdir(rawDir);
       for (const entry of entries) {
         if (entry === `${prefix}-${period}` || entry.startsWith(`${prefix}-${period}-`)) {
           await fs.rm(path.join(rawDir, entry), { recursive: true });
+          // Also drop matching sidecars (otherwise they linger until regen).
+          await fs.rm(path.join(columnsDir, entry), { recursive: true, force: true });
           logger.info(`Deleted local data (${tier}): ${entry}`);
           removedAny = true;
+          removedDirs.push(entry);
         }
       }
     } catch {
       // raw dir may not exist
+    }
+
+    // Purge in-memory queue + activity for anything under the removed dirs,
+    // otherwise the "Local optimizer" panel keeps listing files that no
+    // longer exist on disk.
+    if (removedDirs.length > 0) {
+      const matches = (p: string): boolean => removedDirs.some(d => p.includes(`/${d}/`));
+      optimizeQueue.removeWhere(matches);
+      activity.removeWhere(matches);
     }
 
     // Drop the period from the etag manifest so the inventory marks it
@@ -131,14 +169,27 @@ export function registerSyncHandlers(app: AppContext): void {
     syncAbortControllers.set(syncId, controller);
     state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: fileEntries.length, filesDone: 0, message: '' };
 
+    const tier = resolveDataType(syncId);
+    // Only daily/hourly tiers benefit from sidecar optimization. cost-opt
+    // stays raw — the Savings view is already fast and its data shape differs.
+    const optimizable = tier === 'daily' || tier === 'hourly';
+
     try {
       const result = await syncSelectedFiles({
         bucketPath,
         profile: provider.credentials.profile,
         dataDir: ctx.dataDir,
-        expectedDataType: resolveDataType(syncId),
+        expectedDataType: tier,
         files: fileEntries,
         signal: controller.signal,
+        onFileDownloaded: optimizable ? (localPath) => {
+          // Record the download event, then enqueue optimize. The queue drains
+          // in parallel with subsequent downloads — the whole point of the
+          // pipeline.
+          const relName = `${basename(dirname(localPath))}/${basename(localPath)}`;
+          activity.record({ rawPath: localPath, relName, stage: 'downloaded' });
+          optimizeQueue.enqueue(localPath);
+        } : undefined,
         onProgress: (progress) => {
           state.syncStatuses[syncId] = {
             status: 'syncing',

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1,3 +1,4 @@
+import { logger } from '@costgoblin/core';
 import { createAppContext, type IpcContext } from './handlers/context.js';
 import { registerQueryHandlers } from './handlers/query.js';
 import { registerSyncHandlers } from './handlers/sync.js';
@@ -8,6 +9,7 @@ import { registerSavingsHandlers } from './handlers/savings.js';
 import { registerUIHandlers } from './handlers/ui.js';
 import { registerOrgHandlers } from './handlers/org.js';
 import { registerAutoSyncHandlers } from './handlers/auto-sync.js';
+import { enqueueStartupMigration } from './startup-migrate.js';
 
 export type { IpcContext };
 
@@ -22,4 +24,14 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   registerUIHandlers(app);
   registerOrgHandlers(app);
   registerAutoSyncHandlers(app);
+
+  // Kick off background optimization for any raw files that aren't yet
+  // sorted + sidecar'd. Idempotent — skips already-optimized files. Runs in
+  // parallel with queries (queries fall back to element_at meanwhile).
+  void app.getDimensions()
+    .then(dims => enqueueStartupMigration(ctx.dataDir, dims.tags, app.optimizeQueue))
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`startup migration skipped: ${message}`);
+    });
 }

--- a/packages/desktop/src/main/optimize-enabled.ts
+++ b/packages/desktop/src/main/optimize-enabled.ts
@@ -1,0 +1,30 @@
+import { parseJsonObject } from '@costgoblin/core';
+
+const KEY = 'optimizeEnabled';
+
+/** Default to enabled — the optimizer is the whole point of the local layer. */
+export async function readOptimizeEnabled(prefsPath: string): Promise<boolean> {
+  const fs = await import('node:fs/promises');
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const parsed = parseJsonObject(raw);
+    if (parsed === null) return true;
+    const value = parsed[KEY];
+    if (value === false) return false;
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+export async function writeOptimizeEnabled(prefsPath: string, enabled: boolean): Promise<void> {
+  const fs = await import('node:fs/promises');
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const parsed = parseJsonObject(raw);
+    if (parsed !== null) existing = { ...parsed };
+  } catch { /* missing file */ }
+  existing[KEY] = enabled;
+  await fs.writeFile(prefsPath, JSON.stringify(existing, null, 2));
+}

--- a/packages/desktop/src/main/optimize-queue.ts
+++ b/packages/desktop/src/main/optimize-queue.ts
@@ -1,0 +1,103 @@
+import type { TagDimension } from '@costgoblin/core';
+import { logger } from '@costgoblin/core';
+import type { DuckDBClient } from './duckdb-client.js';
+import type { FileActivityLog } from './file-activity.js';
+import { optimizeFile } from './optimize.js';
+
+/**
+ * Per-file optimize queue (sort + sidecar generation). Each COPY ORDER BY
+ * already fans out across cores inside DuckDB, so running too many files
+ * in parallel just oversubscribes CPU and starves query traffic. We run a
+ * small, fixed number of workers (default 2) — enough to overlap parquet
+ * I/O between files, few enough to leave connections free in the 4-slot
+ * pool for user queries.
+ */
+const MAX_PARALLEL = 2;
+
+export interface OptimizeQueueDeps {
+  readonly client: DuckDBClient;
+  readonly activity: FileActivityLog;
+  readonly getTags: () => Promise<readonly TagDimension[]>;
+  readonly getOrgAccountsPath: () => Promise<string | undefined>;
+  /** Gate read on every worker pickup; flipping false drains cleanly. */
+  readonly isEnabled: () => Promise<boolean>;
+}
+
+export interface OptimizeQueue {
+  enqueue(rawPath: string): void;
+  /** Call when the enabled flag flips to true — spawns workers if needed. */
+  kick(): void;
+  /** Drop queued entries whose path matches the predicate. */
+  removeWhere(predicate: (rawPath: string) => boolean): void;
+  size(): number;
+  running(): boolean;
+}
+
+export function createOptimizeQueue(deps: OptimizeQueueDeps): OptimizeQueue {
+  const pending: string[] = [];
+  const pendingSet = new Set<string>();
+  let activeWorkers = 0;
+
+  async function runOne(path: string): Promise<void> {
+    try {
+      const tags = await deps.getTags();
+      const orgAccountsPath = await deps.getOrgAccountsPath();
+      await optimizeFile({
+        rawPath: path,
+        tags,
+        orgAccountsPath,
+        client: deps.client,
+        activity: deps.activity,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`optimize failed for ${path}: ${message}`);
+    }
+  }
+
+  async function worker(): Promise<void> {
+    while (pending.length > 0) {
+      // Re-check gate each pickup. In-flight file completes; next file waits.
+      if (!(await deps.isEnabled())) return;
+      const path = pending.shift();
+      if (path === undefined) return;
+      pendingSet.delete(path);
+      await runOne(path);
+    }
+  }
+
+  function spawnWorkers(): void {
+    while (activeWorkers < MAX_PARALLEL && pending.length > 0) {
+      activeWorkers++;
+      void worker().finally(() => { activeWorkers--; });
+    }
+  }
+
+  return {
+    enqueue(rawPath: string): void {
+      if (pendingSet.has(rawPath)) return;
+      pendingSet.add(rawPath);
+      pending.push(rawPath);
+      // Fire-and-forget gate probe — if disabled, no workers spin up.
+      void deps.isEnabled().then(on => { if (on) spawnWorkers(); });
+    },
+    kick(): void {
+      void deps.isEnabled().then(on => { if (on) spawnWorkers(); });
+    },
+    removeWhere(predicate: (rawPath: string) => boolean): void {
+      for (let i = pending.length - 1; i >= 0; i--) {
+        const p = pending[i];
+        if (p !== undefined && predicate(p)) {
+          pending.splice(i, 1);
+          pendingSet.delete(p);
+        }
+      }
+    },
+    size(): number {
+      return pending.length;
+    },
+    running(): boolean {
+      return activeWorkers > 0;
+    },
+  };
+}

--- a/packages/desktop/src/main/optimize.ts
+++ b/packages/desktop/src/main/optimize.ts
@@ -1,0 +1,334 @@
+/**
+ * Per-file optimize pipeline: sort raw Parquet by date, then generate one
+ * wide "combined sidecar" Parquet containing one column per configured tag
+ * dimension. The sidecar is row-aligned with the sorted raw (same row count,
+ * same scan order), so queries can POSITIONAL-JOIN against it — cheaper than
+ * per-row element_at(map, key) lookups on the raw path.
+ *
+ * Everything is idempotent and mtime-driven:
+ *   - Sort is fresh iff `<raw>.sorted` marker mtime >= raw mtime
+ *   - Sidecar is fresh iff sidecar file mtime >= raw mtime AND it contains
+ *     exactly the currently-configured tag columns (fingerprinted into the
+ *     sidecar filename so a tag change invalidates via name-miss).
+ *
+ * A re-download (which bumps raw mtime) automatically invalidates both.
+ * No separate state database; the filesystem is the source of truth.
+ */
+
+import { stat, rename, rm, mkdir, writeFile, readdir } from 'node:fs/promises';
+import { dirname, join, basename } from 'node:path';
+import { getRawDirPrefix } from '@costgoblin/core';
+import type { TagDimension, SidecarPlan } from '@costgoblin/core';
+import type { DuckDBClient } from './duckdb-client.js';
+import type { FileActivityLog } from './file-activity.js';
+
+/** Derive the sidecar directory for a given raw file. Mirrors the raw layout:
+ *  aws/raw/daily-2026-04/cur-00001.parquet
+ *    → aws/columns/daily-2026-04/                                           */
+export function columnsDirFor(rawPath: string): string {
+  const rawDir = dirname(rawPath);              // aws/raw/daily-2026-04
+  const awsDir = dirname(dirname(rawDir));      // aws
+  const periodDir = basename(rawDir);           // daily-2026-04
+  return join(awsDir, 'columns', periodDir);
+}
+
+/** `aws/raw/daily-2026-04/cur-00001.parquet.sorted` */
+export function sortMarkerPath(rawPath: string): string {
+  return `${rawPath}.sorted`;
+}
+
+/** Sanitized column name matching what buildSource uses: tag_<sanitized>. */
+export function tagColName(tag: TagDimension): string {
+  return `tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+}
+
+/**
+ * Combined sidecar filename — one file per raw, containing every configured
+ * tag dimension as a column. Mirrors the raw basename so the columns/ dir
+ * stays parallel to raw/.
+ */
+export function sidecarPath(rawPath: string): string {
+  return join(columnsDirFor(rawPath), `${basename(rawPath)}.sidecar.parquet`);
+}
+
+async function mtimeOrNull(path: string): Promise<number | null> {
+  try {
+    const s = await stat(path);
+    return s.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export async function isSortFresh(rawPath: string): Promise<boolean> {
+  const rawMtime = await mtimeOrNull(rawPath);
+  if (rawMtime === null) return false;
+  const markerMtime = await mtimeOrNull(sortMarkerPath(rawPath));
+  // Marker newer than raw means sort is current. Small tolerance to avoid
+  // fs-timestamp-granularity flakes on fast renames.
+  return markerMtime !== null && markerMtime + 500 >= rawMtime;
+}
+
+export async function isSidecarFresh(rawPath: string): Promise<boolean> {
+  const rawMtime = await mtimeOrNull(rawPath);
+  if (rawMtime === null) return false;
+  const side = await mtimeOrNull(sidecarPath(rawPath));
+  return side !== null && side + 500 >= rawMtime;
+}
+
+/**
+ * Builds the SQL expression for resolving a tag's value at the row level.
+ * Mirrors the expression inside buildSource — kept in sync so sidecar and
+ * fallback paths produce the same output.
+ *
+ * Uses the plain `resource_tags` column name, no `cur.` prefix, so it works
+ * whether or not the source does a JOIN.
+ */
+function buildTagValueExpr(tag: TagDimension, hasOrgJoin: boolean): string {
+  const curKey = `user_${tag.tagName}`;
+  const resource = `element_at(resource_tags, '${curKey}')[1]`;
+  if (tag.accountTagFallback === undefined || !hasOrgJoin) {
+    return resource;
+  }
+  const col = tagColName(tag);
+  const fallback = `acct_tags.fallback_${col}`;
+  const tpl = tag.missingValueTemplate;
+  if (tpl !== undefined && tpl.length > 0 && tpl !== '{fallback}') {
+    const [pre = '', post = ''] = tpl.split('{fallback}');
+    const p = pre.replaceAll("'", "''");
+    const q = post.replaceAll("'", "''");
+    return `COALESCE(NULLIF(${resource}, ''), '${p}' || ${fallback} || '${q}')`;
+  }
+  return `COALESCE(NULLIF(${resource}, ''), ${fallback})`;
+}
+
+/** Atomic write: write to .tmp, fsync via DuckDB, rename over target. */
+async function atomicRename(from: string, to: string): Promise<void> {
+  await rename(from, to);
+}
+
+/**
+ * Sort a raw Parquet file in place (replaces the file with a date-sorted
+ * version). Row-group size 100k gives tight min/max statistics per group for
+ * date range pruning.
+ */
+export async function sortRaw(client: DuckDBClient, rawPath: string): Promise<void> {
+  const tmp = `${rawPath}.sort.tmp`;
+  const sortCol = 'line_item_usage_start_date';
+  const sql = `COPY (SELECT * FROM read_parquet('${rawPath}') ORDER BY ${sortCol})
+    TO '${tmp}' (FORMAT PARQUET, ROW_GROUP_SIZE 100000)`;
+  await client.runQuery(sql);
+  // Swap in place.
+  await atomicRename(tmp, rawPath);
+  // Touch the marker so its mtime is after raw's.
+  const marker = sortMarkerPath(rawPath);
+  await writeFile(marker, '');
+  const rawMtime = (await stat(rawPath)).mtimeMs;
+  // Try to align marker mtime at/after raw mtime. Node's utimes uses seconds;
+  // the +500ms tolerance in isSortFresh covers sub-second drift.
+  const when = new Date(rawMtime);
+  try {
+    const fs = await import('node:fs/promises');
+    await fs.utimes(marker, when, when);
+  } catch {
+    // Best-effort. mtime tolerance in isSortFresh handles small drift.
+  }
+}
+
+/**
+ * Generate the combined sidecar Parquet for a raw file — one wide file with
+ * one column per configured tag dimension. Row-aligned with the raw file (no
+ * ORDER BY inside the SELECT — POSITIONAL JOIN at query time pairs rows by
+ * position, so any reorder breaks correctness).
+ *
+ * Account-tag fallback is resolved here once (vs per-query) via a single
+ * LEFT JOIN against the org-accounts JSON if any tag needs it.
+ */
+export async function generateSidecar(
+  client: DuckDBClient,
+  rawPath: string,
+  tags: readonly TagDimension[],
+  orgAccountsPath: string | undefined,
+): Promise<void> {
+  const dir = columnsDirFor(rawPath);
+  await mkdir(dir, { recursive: true });
+  const target = sidecarPath(rawPath);
+  const tmp = `${target}.tmp`;
+
+  if (tags.length === 0) {
+    // No configured dims — emit a single-row-count column so the file is still
+    // row-aligned but carries no data. Keeps POSITIONAL JOIN valid.
+    const sql = `COPY (
+      SELECT TRUE AS _ FROM read_parquet('${rawPath}')
+    ) TO '${tmp}' (FORMAT PARQUET)`;
+    await client.runQuery(sql);
+    await atomicRename(tmp, target);
+    return;
+  }
+
+  const needsOrgJoin = tags.some(t => t.accountTagFallback !== undefined) && orgAccountsPath !== undefined;
+  const colExprs = tags.map(t => `${buildTagValueExpr(t, needsOrgJoin)} AS ${tagColName(t)}`);
+
+  let sql: string;
+  if (needsOrgJoin) {
+    const fallbackSelects = tags
+      .filter(t => t.accountTagFallback !== undefined)
+      .map(t => {
+        const col = tagColName(t);
+        const key = (t.accountTagFallback ?? '').replaceAll("'", "''");
+        return `tags->>'${key}' AS fallback_${col}`;
+      });
+    sql = `COPY (
+      SELECT ${colExprs.join(',\n             ')}
+      FROM read_parquet('${rawPath}') AS cur
+      LEFT JOIN (
+        SELECT id, ${fallbackSelects.join(', ')}
+        FROM read_json_auto('${orgAccountsPath}')
+      ) AS acct_tags ON cur.line_item_usage_account_id = acct_tags.id
+    ) TO '${tmp}' (FORMAT PARQUET)`;
+  } else {
+    sql = `COPY (
+      SELECT ${colExprs.join(',\n             ')}
+      FROM read_parquet('${rawPath}')
+    ) TO '${tmp}' (FORMAT PARQUET)`;
+  }
+
+  await client.runQuery(sql);
+  await atomicRename(tmp, target);
+}
+
+export interface OptimizeFileOptions {
+  readonly rawPath: string;
+  readonly tags: readonly TagDimension[];
+  readonly orgAccountsPath: string | undefined;
+  readonly client: DuckDBClient;
+  readonly activity?: FileActivityLog | undefined;
+}
+
+function rel(rawPath: string): string {
+  const rawDir = dirname(rawPath);
+  return `${basename(rawDir)}/${basename(rawPath)}`;
+}
+
+/**
+ * Full per-file optimize pass: sort (if stale) then generate every missing/
+ * stale sidecar for the configured tag dims. Emits activity events as it
+ * progresses. Idempotent — calling twice does only the work that's needed.
+ *
+ * Any step's failure is recorded and thrown; the caller decides what to do
+ * (typically log + move on to the next file).
+ */
+export async function optimizeFile(opts: OptimizeFileOptions): Promise<void> {
+  const { rawPath, tags, orgAccountsPath, client, activity } = opts;
+  const relName = rel(rawPath);
+
+  try {
+    if (!(await isSortFresh(rawPath))) {
+      activity?.record({ rawPath, relName, stage: 'sorting' });
+      const t = Date.now();
+      await sortRaw(client, rawPath);
+      activity?.record({ rawPath, relName, stage: 'sorted', durationMs: Date.now() - t });
+    }
+
+    if (!(await isSidecarFresh(rawPath))) {
+      activity?.record({ rawPath, relName, stage: 'building-sidecar' });
+      const t = Date.now();
+      await generateSidecar(client, rawPath, tags, orgAccountsPath);
+      activity?.record({ rawPath, relName, stage: 'building-sidecar', durationMs: Date.now() - t });
+    }
+
+    activity?.record({ rawPath, relName, stage: 'complete' });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    activity?.record({ rawPath, relName, stage: 'failed', error: message });
+    throw err;
+  }
+}
+
+/**
+ * For each requested period, list all raw Parquet files on disk in stable
+ * (sorted-by-name) order. Used by the query layer to pair raw files with
+ * their sidecars at query time.
+ */
+async function listRawFilesForPeriods(
+  dataDir: string,
+  tier: string,
+  periods: readonly string[],
+): Promise<string[]> {
+  const prefix = getRawDirPrefix(tier);
+  const rawDir = join(dataDir, 'aws', 'raw');
+  const out: string[] = [];
+  for (const period of periods) {
+    const periodDir = join(rawDir, `${prefix}-${period}`);
+    try {
+      const entries = await readdir(periodDir);
+      const files = entries
+        .filter(f => f.endsWith('.parquet'))
+        .sort((a, b) => a.localeCompare(b));
+      for (const f of files) out.push(join(periodDir, f));
+    } catch {
+      // directory doesn't exist — caller already filtered by availablePeriods,
+      // so this shouldn't happen, but we fail soft.
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a SidecarPlan if every raw file in the requested periods has fresh
+ * sidecars for every configured tag, AND is itself sorted. Returns null if
+ * ANY file is stale/missing — the query layer then falls back to element_at.
+ *
+ * This is the "are we fully optimized for this query?" gate. All-or-nothing
+ * by design: mixing sidecar and element_at paths within a single query would
+ * require per-file UNIONs which are much harder to reason about.
+ */
+export async function resolveSidecarPlan(
+  dataDir: string,
+  tier: string,
+  periods: readonly string[],
+  tags: readonly TagDimension[],
+): Promise<SidecarPlan | null> {
+  if (tags.length === 0) return null;       // nothing to sidecar
+  if (periods.length === 0) return null;    // query spans no on-disk months
+
+  const rawFiles = await listRawFilesForPeriods(dataDir, tier, periods);
+  if (rawFiles.length === 0) return null;
+
+  const sidecarFiles: string[] = [];
+  for (const rawPath of rawFiles) {
+    if (!(await isSortFresh(rawPath))) return null;
+    if (!(await isSidecarFresh(rawPath))) return null;
+    sidecarFiles.push(sidecarPath(rawPath));
+  }
+
+  return { rawFiles, sidecarFiles };
+}
+
+/**
+ * Delete every combined sidecar under `columnsRoot`. Called after any tag
+ * dimension change — since sidecars are wide files holding all configured
+ * columns, a single dim change invalidates the whole lot; the optimizer queue
+ * then regenerates them with the new schema.
+ */
+export async function removeAllSidecars(columnsRoot: string): Promise<number> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  let removed = 0;
+  try {
+    const periods = await fs.readdir(columnsRoot);
+    for (const periodDir of periods) {
+      const full = path.join(columnsRoot, periodDir);
+      try {
+        const files = await fs.readdir(full);
+        for (const f of files) {
+          if (f.endsWith('.sidecar.parquet') || f.endsWith('.sidecar.parquet.tmp')) {
+            await rm(path.join(full, f));
+            removed += 1;
+          }
+        }
+      } catch { /* period dir vanished concurrently */ }
+    }
+  } catch { /* columns root doesn't exist yet */ }
+  return removed;
+}

--- a/packages/desktop/src/main/startup-migrate.ts
+++ b/packages/desktop/src/main/startup-migrate.ts
@@ -1,0 +1,62 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getRawDirPrefix, logger } from '@costgoblin/core';
+import type { TagDimension } from '@costgoblin/core';
+import { isSortFresh, isSidecarFresh } from './optimize.js';
+import type { OptimizeQueue } from './optimize-queue.js';
+
+/**
+ * Scan raw Parquet files on disk and enqueue any that aren't fully optimized
+ * (missing a sort marker, or missing a sidecar for any configured tag dim).
+ *
+ * Run once at app startup. optimizeFile is idempotent, so it's safe to
+ * enqueue everything — already-fresh files short-circuit inside.
+ *
+ * Fires and forgets — the queue drains in the background while the user
+ * interacts with the app. Query handlers fall back to element_at mode until
+ * files are optimized, so no query is blocked on this.
+ */
+export async function enqueueStartupMigration(
+  dataDir: string,
+  tags: readonly TagDimension[],
+  queue: OptimizeQueue,
+): Promise<number> {
+  let enqueued = 0;
+  for (const tier of ['daily', 'hourly'] as const) {
+    const prefix = getRawDirPrefix(tier);
+    const rawRoot = join(dataDir, 'aws', 'raw');
+    let periodDirs: string[] = [];
+    try {
+      const entries = await readdir(rawRoot);
+      periodDirs = entries.filter(e => e.startsWith(`${prefix}-`));
+    } catch {
+      continue;
+    }
+    for (const periodDir of periodDirs) {
+      const dir = join(rawRoot, periodDir);
+      let files: string[] = [];
+      try {
+        files = (await readdir(dir)).filter(f => f.endsWith('.parquet'));
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        const path = join(dir, f);
+        if (await needsOptimize(path, tags)) {
+          queue.enqueue(path);
+          enqueued += 1;
+        }
+      }
+    }
+  }
+  if (enqueued > 0) {
+    logger.info(`startup migration: enqueued ${String(enqueued)} files for optimize`);
+  }
+  return enqueued;
+}
+
+async function needsOptimize(rawPath: string, tags: readonly TagDimension[]): Promise<boolean> {
+  if (!(await isSortFresh(rawPath))) return true;
+  if (tags.length > 0 && !(await isSidecarFresh(rawPath))) return true;
+  return false;
+}

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -25,6 +25,8 @@ import type {
   OrgSyncResult,
   OrgSyncProgress,
   AutoSyncStatus,
+  FileActivityEvent,
+  OptimizeStatus,
 } from '@costgoblin/core';
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
@@ -115,6 +117,18 @@ const api: CostApi = {
   },
   saveUIPreferences(prefs: UIPreferences): Promise<void> {
     return invoke<undefined>('ui:save-preferences', prefs).then(() => undefined);
+  },
+  getFileActivity(sinceIso?: string): Promise<FileActivityEvent[]> {
+    return invoke<FileActivityEvent[]>('sync:get-file-activity', sinceIso);
+  },
+  getOptimizeStatus(): Promise<OptimizeStatus> {
+    return invoke<OptimizeStatus>('sync:get-optimize-status');
+  },
+  getOptimizeEnabled(): Promise<boolean> {
+    return invoke<boolean>('optimize:get-enabled');
+  },
+  setOptimizeEnabled(enabled: boolean): Promise<void> {
+    return invoke<undefined>('optimize:set-enabled', enabled).then(() => undefined);
   },
   syncOrgAccounts(profile: string): Promise<OrgSyncResult> {
     return invoke<OrgSyncResult>('org:sync-accounts', profile);

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -130,6 +130,9 @@ const api: CostApi = {
   setOptimizeEnabled(enabled: boolean): Promise<void> {
     return invoke<undefined>('optimize:set-enabled', enabled).then(() => undefined);
   },
+  clearSidecars(): Promise<{ removed: number; requeued: number }> {
+    return invoke<{ removed: number; requeued: number }>('optimize:clear-sidecars');
+  },
   syncOrgAccounts(profile: string): Promise<OrgSyncResult> {
     return invoke<OrgSyncResult>('org:sync-accounts', profile);
   },

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostApiProvider, SetupWizard, ErrorBoundary } from '@costgoblin/ui';
+import { CostOverview, CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostApiProvider, SetupWizard, ErrorBoundary, SyncActivityIndicator } from '@costgoblin/ui';
 import type { CostApi } from '@costgoblin/core/browser';
 
 function getApi(): CostApi {
@@ -186,13 +186,14 @@ export function App(): React.JSX.Element {
                   type="button"
                   onClick={() => { handleNavClick(item.id); }}
                   className={[
-                    'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+                    'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors flex items-center gap-2',
                     view.page === item.id
                       ? 'bg-bg-tertiary text-text-primary'
                       : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
                   ].join(' ')}
                 >
                   {item.label}
+                  {item.id === 'sync' && <SyncActivityIndicator />}
                   {item.id === 'sync' && missingPeriods > 0 && view.page !== 'sync' && (
                     <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-bold text-bg-primary">
                       {String(missingPeriods)}

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -243,6 +243,7 @@ export class MockCostApi implements CostApi {
   getOptimizeStatus(): Promise<{ queued: number; running: boolean }> { return Promise.resolve({ queued: 0, running: false }); }
   getOptimizeEnabled(): Promise<boolean> { return Promise.resolve(true); }
   setOptimizeEnabled(): Promise<void> { return Promise.resolve(); }
+  clearSidecars(): Promise<{ removed: number; requeued: number }> { return Promise.resolve({ removed: 0, requeued: 0 }); }
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -239,6 +239,10 @@ export class MockCostApi implements CostApi {
   saveSavingsPreferences(): Promise<void> { return Promise.resolve(); }
   getUIPreferences(): Promise<{ theme: 'dark' | 'light' }> { return Promise.resolve({ theme: 'dark' }); }
   saveUIPreferences(): Promise<void> { return Promise.resolve(); }
+  getFileActivity(): Promise<[]> { return Promise.resolve([]); }
+  getOptimizeStatus(): Promise<{ queued: number; running: boolean }> { return Promise.resolve({ queued: 0, running: false }); }
+  getOptimizeEnabled(): Promise<boolean> { return Promise.resolve(true); }
+  setOptimizeEnabled(): Promise<void> { return Promise.resolve(); }
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }

--- a/packages/ui/src/__tests__/missing-tags.test.tsx
+++ b/packages/ui/src/__tests__/missing-tags.test.tsx
@@ -40,9 +40,9 @@ describe('MissingTags', () => {
     });
   });
 
-  it('has min cost filter input', () => {
+  it('has min cost filter input defaulting to 0 (show everything)', () => {
     renderMissingTags();
-    const input = screen.getByDisplayValue('50');
+    const input = screen.getByDisplayValue('0');
     expect(input).toBeDefined();
   });
 });

--- a/packages/ui/src/components/sync-activity-indicator.tsx
+++ b/packages/ui/src/components/sync-activity-indicator.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useCostApi } from '../hooks/use-cost-api.js';
+
+/**
+ * Small spinning glyph for the top nav that lights up whenever the
+ * background optimizer is chewing through files. Polled at the same
+ * cadence as the Sync panel itself so the two stay in step.
+ */
+export function SyncActivityIndicator(): React.JSX.Element | null {
+  const api = useCostApi();
+  const [active, setActive] = useState(false);
+  const [queued, setQueued] = useState(0);
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function tick(): Promise<void> {
+      try {
+        const [s, e] = await Promise.all([api.getOptimizeStatus(), api.getOptimizeEnabled()]);
+        if (!cancelled) {
+          setActive(s.running);
+          setQueued(s.queued);
+          setEnabled(e);
+        }
+      } catch { /* transient */ }
+    }
+    void tick();
+    const timer = setInterval(() => { void tick(); }, 1500);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [api]);
+
+  // Hide when paused — a non-spinning queue isn't "activity".
+  if (!enabled) return null;
+  if (!active && queued === 0) return null;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded text-warning text-[11px] tabular-nums"
+      title={`Optimizer ${active ? 'running' : 'idle'} · ${String(queued)} queued`}
+    >
+      <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+        <path d="M21 12a9 9 0 1 1-6.2-8.55" />
+      </svg>
+      {queued > 0 && <span>{String(queued)}</span>}
+    </span>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,7 @@ export { EntityPopup } from './components/entity-popup.js';
 export { ConfirmModal } from './components/confirm-modal.js';
 export { CsvExport } from './components/csv-export.js';
 export { SyncStatusIndicator } from './components/sync-status.js';
+export { SyncActivityIndicator } from './components/sync-activity-indicator.js';
 export { formatDollars, formatPercent, formatDate } from './components/format.js';
 export { FilterBar } from './components/filter-bar.js';
 export { EnvironmentBar } from './components/environment-bar.js';

--- a/packages/ui/src/views/data-management-tier.tsx
+++ b/packages/ui/src/views/data-management-tier.tsx
@@ -43,13 +43,15 @@ interface TierPanelProps {
   syncState: SyncState;
   onConfigure?: (() => void) | undefined;
   onCancelSync?: (() => void) | undefined;
+  deleteDisabled?: boolean | undefined;
+  deleteDisabledTitle?: string | undefined;
 }
 
 export function TierPanel({
   title, configured, bucket, retentionDays,
   localPeriods, diskBytes, oldestPeriod, newestPeriod,
   periods, selected, onToggle, onSelectAll, onDeselectAll, onDownload, onDeletePeriod,
-  syncState, onConfigure, onCancelSync,
+  syncState, onConfigure, onCancelSync, deleteDisabled = false, deleteDisabledTitle,
 }: Readonly<TierPanelProps>) {
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const missingPeriods = periods.filter(p => p.localStatus === 'missing' || p.localStatus === 'stale');
@@ -223,7 +225,13 @@ export function TierPanel({
                 <div className="h-1.5 w-1.5 rounded-full bg-accent" />
                 <span className="text-text-primary w-16">{formatPeriod(p.period)}</span>
                 <span className="text-text-muted tabular-nums ml-auto mr-2">{formatBytes(p.totalSize)}</span>
-                <button type="button" onClick={() => { setPendingDelete(p.period); }} className="text-text-muted hover:text-negative transition-colors">
+                <button
+                  type="button"
+                  onClick={() => { setPendingDelete(p.period); }}
+                  disabled={deleteDisabled}
+                  title={deleteDisabledTitle}
+                  className="text-text-muted hover:text-negative transition-colors disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-text-muted"
+                >
                   &#10005;
                 </button>
               </div>

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -6,6 +6,7 @@ import { ConfirmModal } from '../components/confirm-modal.js';
 import { SetupWizard } from './setup-wizard.js';
 import { OrgAccountsSection } from './data-management-org.js';
 import { TierPanel, type SyncState } from './data-management-tier.js';
+import { RecentFileActivity } from './recent-file-activity.js';
 
 export function DataManagement() {
   const api = useCostApi();
@@ -32,6 +33,27 @@ export function DataManagement() {
   }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
+  const [optimizerBusy, setOptimizerBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function tick(): Promise<void> {
+      try {
+        const s = await api.getOptimizeStatus();
+        // Only block deletes while workers are actually touching files.
+        // A paused optimizer with a pending queue is safe — if the user
+        // deletes a queued file, the worker will just skip it on resume.
+        if (!cancelled) setOptimizerBusy(s.running);
+      } catch { /* transient */ }
+    }
+    void tick();
+    const timer = setInterval(() => { void tick(); }, 1500);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [api]);
+
+  const deleteDisabledTitle = optimizerBusy
+    ? 'Optimizer is running — pause it on the Local optimizer panel to delete data.'
+    : undefined;
 
   const inventory: DataInventoryResult | null =
     inventoryQuery.status === 'success' ? inventoryQuery.data : null;
@@ -111,9 +133,20 @@ export function DataManagement() {
   }
 
   function handleDeleteAll() {
-    const local = inventory?.periods.filter(p => p.localStatus === 'repartitioned') ?? [];
-    const promises = local.map(p => api.deleteLocalPeriod(p.period, 'daily'));
-    void Promise.all(promises).then(() => { setDailyRefreshKey(k => k + 1); setShowDeleteAll(false); }).catch(() => { /* deletion best-effort */ });
+    const daily = (inventory?.periods ?? []).filter(p => p.localStatus === 'repartitioned');
+    const hourly = (hourlyInventory?.periods ?? []).filter(p => p.localStatus === 'repartitioned');
+    const costOpt = (costOptInventory?.periods ?? []).filter(p => p.localStatus === 'repartitioned');
+    const promises: Promise<void>[] = [
+      ...daily.map(p => api.deleteLocalPeriod(p.period, 'daily')),
+      ...hourly.map(p => api.deleteLocalPeriod(p.period, 'hourly')),
+      ...costOpt.map(p => api.deleteLocalPeriod(p.period, 'cost-optimization')),
+    ];
+    void Promise.all(promises).then(() => {
+      setDailyRefreshKey(k => k + 1);
+      setHourlyRefreshKey(k => k + 1);
+      setCostOptRefreshKey(k => k + 1);
+      setShowDeleteAll(false);
+    }).catch(() => { /* deletion best-effort */ });
   }
 
   const isNotConfigured = configQuery.status === 'error' || (configQuery.status === 'success' && config === null);
@@ -329,7 +362,13 @@ export function DataManagement() {
               <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
             </button>
           </div>
-          <button type="button" onClick={() => { setShowDeleteAll(true); }} className="rounded-md border border-negative/50 bg-negative-muted px-3 py-1.5 text-xs font-medium text-negative hover:bg-negative-muted hover:text-negative transition-colors">
+          <button
+            type="button"
+            onClick={() => { setShowDeleteAll(true); }}
+            disabled={optimizerBusy}
+            title={deleteDisabledTitle}
+            className="rounded-md border border-negative/50 bg-negative-muted px-3 py-1.5 text-xs font-medium text-negative hover:bg-negative-muted hover:text-negative transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
             Delete All Data
           </button>
           <button type="button" onClick={() => { void api.openDataFolder(); }} className="rounded-md border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors">
@@ -381,6 +420,8 @@ export function DataManagement() {
             syncState={dailySyncState}
             onCancelSync={() => { void api.cancelSync('daily'); setDailySyncState({ status: 'idle' }); }}
             onConfigure={() => { setConfigureSource('daily'); }}
+            deleteDisabled={optimizerBusy}
+            deleteDisabledTitle={deleteDisabledTitle}
           />
           <TierPanel
             title="Hourly"
@@ -401,6 +442,8 @@ export function DataManagement() {
             syncState={hourlySyncState}
             onCancelSync={() => { void api.cancelSync('hourly'); setHourlySyncState({ status: 'idle' }); }}
             onConfigure={() => { setConfigureSource('hourly'); }}
+            deleteDisabled={optimizerBusy}
+            deleteDisabledTitle={deleteDisabledTitle}
           />
           <TierPanel
             title="Cost Optimization"
@@ -421,9 +464,13 @@ export function DataManagement() {
             syncState={costOptSyncState}
             onCancelSync={() => { void api.cancelSync('cost-optimization'); setCostOptSyncState({ status: 'idle' }); }}
             onConfigure={() => { setConfigureSource('costOptimization'); }}
+            deleteDisabled={optimizerBusy}
+            deleteDisabledTitle={deleteDisabledTitle}
           />
         </div>
       )}
+
+      <RecentFileActivity />
 
       {showDeleteAll && (
         <ConfirmModal

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -67,7 +67,7 @@ export function MissingTags() {
   const api = useCostApi();
   const dimensionsQuery = useQuery(() => api.getDimensions(), []);
 
-  const [minCost, setMinCost] = useState(50);
+  const [minCost, setMinCost] = useState(0);
   const [selectedTag, setSelectedTag] = useState<DimensionId | null>(null);
   const [showLikelyUntaggable, setShowLikelyUntaggable] = useState(false);
   const [nonResourceExpanded, setNonResourceExpanded] = useState(false);

--- a/packages/ui/src/views/recent-file-activity.tsx
+++ b/packages/ui/src/views/recent-file-activity.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { FileActivityEvent, FileActivityStage, OptimizeStatus } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { ConfirmModal } from '../components/confirm-modal.js';
 
 type FilterMode = 'active' | 'all' | 'failed';
 
@@ -65,6 +66,8 @@ export function RecentFileActivity() {
   const [enabledLoaded, setEnabledLoaded] = useState(false);
   const [filter, setFilter] = useState<FilterMode>('active');
   const [now, setNow] = useState(Date.now());
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
     void api.getOptimizeEnabled().then(v => { setEnabled(v); setEnabledLoaded(true); });
@@ -96,6 +99,12 @@ export function RecentFileActivity() {
     void api.setOptimizeEnabled(next);
   }
 
+  function handleClearSidecars(): void {
+    setClearing(true);
+    setConfirmClear(false);
+    void api.clearSidecars().finally(() => { setClearing(false); });
+  }
+
   const latest = latestPerFile(events);
   const filtered = latest.filter(e => {
     if (filter === 'failed') return e.stage === 'failed';
@@ -123,6 +132,15 @@ export function RecentFileActivity() {
           <p className="text-xs text-text-muted mt-1">{stateLine}</p>
         </div>
         <div className="flex items-center gap-3 shrink-0">
+          <button
+            type="button"
+            onClick={() => { setConfirmClear(true); }}
+            disabled={clearing || status.running}
+            title={status.running ? 'Pause the optimizer first.' : 'Delete generated sidecars and rebuild them from scratch.'}
+            className="rounded-md border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {clearing ? 'Clearing…' : 'Clear sidecars'}
+          </button>
           <label className="flex items-center gap-2 cursor-pointer select-none">
             <span className="text-xs text-text-secondary">{enabled ? 'Enabled' : 'Paused'}</span>
             <button
@@ -195,6 +213,16 @@ export function RecentFileActivity() {
             </div>
           ))}
         </div>
+      )}
+
+      {confirmClear && (
+        <ConfirmModal
+          title="Clear sidecars"
+          message="Delete every generated sidecar Parquet and rebuild from the raw files. Raw data and sort markers are kept — this only wipes the pre-computed tag columns. Takes a few seconds per file."
+          confirmLabel="Clear and rebuild"
+          onConfirm={handleClearSidecars}
+          onCancel={() => { setConfirmClear(false); }}
+        />
       )}
     </div>
   );

--- a/packages/ui/src/views/recent-file-activity.tsx
+++ b/packages/ui/src/views/recent-file-activity.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+import type { FileActivityEvent, FileActivityStage, OptimizeStatus } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+
+type FilterMode = 'active' | 'all' | 'failed';
+
+function formatRelative(iso: string, now: number): string {
+  const diff = now - new Date(iso).getTime();
+  if (diff < 1000) return 'now';
+  if (diff < 60_000) return `${String(Math.floor(diff / 1000))}s`;
+  if (diff < 3_600_000) return `${String(Math.floor(diff / 60_000))}m`;
+  if (diff < 86_400_000) return `${String(Math.floor(diff / 3_600_000))}h`;
+  return `${String(Math.floor(diff / 86_400_000))}d`;
+}
+
+function stageLabel(ev: FileActivityEvent): string {
+  switch (ev.stage) {
+    case 'downloaded': return 'downloaded';
+    case 'sorting': return 'sorting';
+    case 'sorted': return 'sorted';
+    case 'building-sidecar': return 'building sidecar';
+    case 'complete': return 'optimized';
+    case 'failed': return 'failed';
+  }
+}
+
+function stageColor(stage: FileActivityStage): string {
+  switch (stage) {
+    case 'complete': return 'text-accent';
+    case 'failed': return 'text-negative';
+    case 'downloaded': return 'text-text-secondary';
+    case 'sorting':
+    case 'building-sidecar':
+      return 'text-warning';
+    case 'sorted': return 'text-text-secondary';
+  }
+}
+
+function stageDot(stage: FileActivityStage): string {
+  switch (stage) {
+    case 'complete': return 'bg-accent';
+    case 'failed': return 'bg-negative';
+    case 'sorting':
+    case 'building-sidecar':
+      return 'bg-warning animate-pulse';
+    default:
+      return 'bg-text-muted';
+  }
+}
+
+function latestPerFile(events: readonly FileActivityEvent[]): FileActivityEvent[] {
+  const byPath = new Map<string, FileActivityEvent>();
+  for (const e of events) {
+    const prev = byPath.get(e.rawPath);
+    if (prev === undefined || e.timestamp >= prev.timestamp) byPath.set(e.rawPath, e);
+  }
+  return [...byPath.values()].sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1));
+}
+
+export function RecentFileActivity() {
+  const api = useCostApi();
+  const [events, setEvents] = useState<FileActivityEvent[]>([]);
+  const [status, setStatus] = useState<OptimizeStatus>({ queued: 0, running: false });
+  const [enabled, setEnabled] = useState(true);
+  const [enabledLoaded, setEnabledLoaded] = useState(false);
+  const [filter, setFilter] = useState<FilterMode>('active');
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    void api.getOptimizeEnabled().then(v => { setEnabled(v); setEnabledLoaded(true); });
+  }, [api]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function tick(): Promise<void> {
+      try {
+        const [ev, s] = await Promise.all([api.getFileActivity(), api.getOptimizeStatus()]);
+        if (!cancelled) {
+          setEvents(ev);
+          setStatus(s);
+          setNow(Date.now());
+        }
+      } catch { /* polling failure is transient */ }
+    }
+    void tick();
+    const timer = setInterval(() => { void tick(); }, 1500);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [api]);
+
+  function toggleEnabled(): void {
+    const next = !enabled;
+    setEnabled(next);
+    void api.setOptimizeEnabled(next);
+  }
+
+  const latest = latestPerFile(events);
+  const filtered = latest.filter(e => {
+    if (filter === 'failed') return e.stage === 'failed';
+    if (filter === 'active') return e.stage !== 'complete' && e.stage !== 'failed';
+    return true;
+  });
+
+  const stateLine = !enabled
+    ? (status.running ? `Pausing — ${String(status.queued)} queued, finishing current file…` : `Paused · ${String(status.queued)} queued`)
+    : status.queued > 0 || status.running
+      ? `${String(status.queued)} queued${status.running ? ' · optimizer running' : ''}`
+      : 'Optimizer idle';
+
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 p-5">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-text-primary">Local optimizer</h3>
+          <p className="text-xs text-text-muted mt-1 leading-relaxed">
+            Sorts each raw Parquet by date so narrow date-range queries can skip most of the file
+            (row-group pruning), and builds a single combined sidecar holding all tag dimensions
+            as flat columns — faster than the per-row <code className="font-mono text-[10px] px-1 rounded bg-bg-tertiary/50">element_at</code> map
+            lookup for long-range queries. Regenerates automatically on re-sync or when you change Dimensions.
+          </p>
+          <p className="text-xs text-text-muted mt-1">{stateLine}</p>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <span className="text-xs text-text-secondary">{enabled ? 'Enabled' : 'Paused'}</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              onClick={toggleEnabled}
+              disabled={!enabledLoaded}
+              className={[
+                'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors',
+                enabled ? 'bg-accent' : 'bg-bg-tertiary border border-border',
+              ].join(' ')}
+            >
+              <span
+                className={[
+                  'inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform',
+                  enabled ? 'translate-x-[18px]' : 'translate-x-[3px]',
+                ].join(' ')}
+              />
+            </button>
+          </label>
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
+            {(['active', 'failed', 'all'] as const).map(m => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => { setFilter(m); }}
+                className={[
+                  'rounded-md px-2.5 py-1 text-xs font-medium transition-colors capitalize',
+                  filter === m
+                    ? 'bg-bg-secondary text-text-primary shadow-sm'
+                    : 'text-text-secondary hover:text-text-primary',
+                ].join(' ')}
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="text-xs text-text-muted py-6 text-center">
+          {filter === 'failed'
+            ? 'No failed files.'
+            : filter === 'active'
+              ? 'Nothing in flight.'
+              : 'No activity yet.'}
+        </p>
+      )}
+
+      {filtered.length > 0 && (
+        <div className="max-h-64 overflow-y-auto divide-y divide-border-subtle">
+          {filtered.map(ev => (
+            <div key={ev.rawPath + ev.timestamp} className="flex items-center gap-3 py-2 text-xs">
+              <div className={`h-1.5 w-1.5 rounded-full shrink-0 ${stageDot(ev.stage)}`} />
+              <span className="text-text-secondary font-mono truncate flex-1" title={ev.rawPath}>
+                {ev.relName}
+              </span>
+              <span className={`${stageColor(ev.stage)} shrink-0`}>{stageLabel(ev)}</span>
+              {ev.durationMs !== undefined && (
+                <span className="text-text-muted tabular-nums shrink-0">{String(ev.durationMs)}ms</span>
+              )}
+              {ev.error !== undefined && (
+                <span className="text-negative truncate max-w-64" title={ev.error}>{ev.error}</span>
+              )}
+              <span className="text-text-muted tabular-nums shrink-0 w-8 text-right">
+                {formatRelative(ev.timestamp, now)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Sort every raw CUR Parquet by date at optimize time (in-place atomic rename) so DuckDB can prune row groups on narrow date-range queries — the real perf win (1-day filter: 48ms vs ~500ms unsorted).
- Build a single combined sidecar per raw file (`<raw>.sidecar.parquet`) with one column per configured tag dim. Queries POSITIONAL-JOIN instead of per-row `element_at` map lookups. Measured 1.3–1.5× on wide-range queries.
- New "Local optimizer" panel under Sync: per-file stage feed, pause toggle, queue depth, 2-way parallel workers.
- Top-nav spinner + queue count inline inside the Sync button while work is active.
- Delete UX: blocks while optimizer is actively writing; Delete All now wipes all three tiers together; per-period deletes purge the in-flight queue/activity log.

## Honest perf numbers (30-file hourly period, 1.7 GB, 3 tag dims)
```
Shape         element_at  sidecar  speedup
no filter       1238ms     809ms    1.53×
full month      1147ms     831ms    1.38×
half month       954ms     740ms    1.29×
1 day             95ms     389ms    0.24× (element_at wins — row-group pruning)
```
Sidecars only kick in when every raw file in the query's periods has a fresh sidecar. Staleness is mtime-based so any re-download invalidates automatically.

## Also in this PR
- Missing Tags min-cost default → $0.
- `listLocalMonths` now requires ≥1 `.parquet` in the period dir (no more poisoning from empty dirs after partial downloads).
- Query handlers short-circuit to empty results when the requested range has zero on-disk overlap.
- Cost Optimization retention default dropped 90 → 30 days for new setups.