### PR TITLE
Editable built-in dimensions + descriptions + 3 new defaults

### DIFF
--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -124,6 +124,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     const displayField = dim['displayField'] !== undefined ? (assertString(dim['displayField'], `${ctx}.displayField`), dim['displayField']) : undefined;
     const enabled = dim['enabled'] === false ? false : undefined;
     const description = dim['description'] !== undefined ? (assertString(dim['description'], `${ctx}.description`), dim['description']) : undefined;
+    const useOrgAccounts = dim['useOrgAccounts'] === true ? true : undefined;
     const normalize = dim['normalize'] !== undefined ? (() => {
       assertString(dim['normalize'], `${ctx}.normalize`);
       if (!isValidNormalizationRule(dim['normalize'])) {
@@ -153,6 +154,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
       ...(description !== undefined ? { description } : {}),
       ...(normalize !== undefined ? { normalize } : {}),
       ...(aliases !== undefined ? { aliases } : {}),
+      ...(useOrgAccounts === true ? { useOrgAccounts } : {}),
     };
   });
 

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -123,12 +123,36 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     assertString(dim['field'], `${ctx}.field`);
     const displayField = dim['displayField'] !== undefined ? (assertString(dim['displayField'], `${ctx}.displayField`), dim['displayField']) : undefined;
     const enabled = dim['enabled'] === false ? false : undefined;
+    const description = dim['description'] !== undefined ? (assertString(dim['description'], `${ctx}.description`), dim['description']) : undefined;
+    const normalize = dim['normalize'] !== undefined ? (() => {
+      assertString(dim['normalize'], `${ctx}.normalize`);
+      if (!isValidNormalizationRule(dim['normalize'])) {
+        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
+      }
+      return dim['normalize'];
+    })() : undefined;
+    let aliases: Record<string, string[]> | undefined;
+    if (dim['aliases'] !== undefined) {
+      assertObject(dim['aliases'], `${ctx}.aliases`);
+      const aliasObj = dim['aliases'];
+      aliases = {};
+      for (const [key, value] of Object.entries(aliasObj)) {
+        assertArray(value, `${ctx}.aliases.${key}`);
+        aliases[key] = value.map((v, j) => {
+          assertString(v, `${ctx}.aliases.${key}[${String(j)}]`);
+          return v;
+        });
+      }
+    }
     return {
       name: asDimensionId(dim['name']),
       label: dim['label'],
       field: dim['field'],
       ...(displayField !== undefined ? { displayField } : {}),
       ...(enabled === false ? { enabled } : {}),
+      ...(description !== undefined ? { description } : {}),
+      ...(normalize !== undefined ? { normalize } : {}),
+      ...(aliases !== undefined ? { aliases } : {}),
     };
   });
 

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -56,9 +56,14 @@ export function normalizeAndResolve(value: string, dimension: TagDimension): Tag
   return asTagValue(resolved);
 }
 
+interface NormalizableDimension {
+  readonly normalize?: NormalizationRule | undefined;
+  readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
+}
+
 export function buildAliasSqlCase(
   fieldExpr: string,
-  dimension: TagDimension,
+  dimension: NormalizableDimension,
 ): string {
   const cases: string[] = [];
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -58,7 +58,10 @@ interface ResolvedDimension {
 function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
   const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
   if (builtIn !== undefined) {
-    return { fieldExpr: builtIn.field, rawField: builtIn.field };
+    // Built-ins now support normalize + aliases just like tags; apply them at
+    // query time via the same CASE/LOWER(...) machinery.
+    const fieldExpr = buildAliasSqlCase(builtIn.field, builtIn);
+    return { fieldExpr, rawField: builtIn.field };
   }
 
   const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -132,7 +132,7 @@ export interface CostApi {
   setOptimizeEnabled(enabled: boolean): Promise<void>;
   clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
-  discoverColumnValues(field: string): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -132,6 +132,7 @@ export interface CostApi {
   setOptimizeEnabled(enabled: boolean): Promise<void>;
   clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
+  discoverColumnValues(field: string): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -45,6 +45,12 @@ export interface BuiltInDimension {
   readonly displayField?: string | undefined;
   /** Hidden from selectors/filter bar when false. Default true. */
   readonly enabled?: boolean | undefined;
+  /** Short user-facing explanation shown on the Dimensions view. */
+  readonly description?: string | undefined;
+  /** Applied to field values at query time (same as tags). */
+  readonly normalize?: NormalizationRule | undefined;
+  /** Canonical → raw values mapping, applied at query time. */
+  readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
 }
 
 export interface TagDimension {
@@ -58,6 +64,8 @@ export interface TagDimension {
   readonly missingValueTemplate?: string | undefined;
   /** Hidden from selectors/filter bar when false. Default true. */
   readonly enabled?: boolean | undefined;
+  /** Short user-facing explanation shown on the Dimensions view. */
+  readonly description?: string | undefined;
 }
 
 export interface DimensionsConfig {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -51,6 +51,9 @@ export interface BuiltInDimension {
   readonly normalize?: NormalizationRule | undefined;
   /** Canonical → raw values mapping, applied at query time. */
   readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
+  /** Account-specific: when true, resolve id→name via org-accounts.json
+   *  (AWS Organizations sync) instead of the legacy CSV mapping. */
+  readonly useOrgAccounts?: boolean | undefined;
 }
 
 export interface TagDimension {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -1,5 +1,6 @@
 import type { DuckDBClient, RawRow } from '../duckdb-client.js';
 import {
+  asDimensionId,
   loadConfig,
   loadDimensions,
   loadOrgTree,
@@ -7,11 +8,29 @@ import {
   isStringRecord,
 } from '@costgoblin/core';
 import type {
+  BuiltInDimension,
   CostGoblinConfig,
   DimensionsConfig,
   OrgNode,
   SyncStatus,
 } from '@costgoblin/core';
+
+const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
+  { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name', description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.' },
+  { name: asDimensionId('region'), label: 'Region', field: 'region', description: 'AWS region where the resource ran. Useful for spotting unintended multi-region sprawl.' },
+  { name: asDimensionId('service'), label: 'Service', field: 'service', description: 'AWS service code (EC2, S3, RDS, etc.) — the broadest "what cost me this?" view.' },
+  { name: asDimensionId('service_family'), label: 'Service Family', field: 'service_family', description: 'Higher-level product category (Compute, Storage, Database). Good for exec summaries.' },
+  { name: asDimensionId('line_item_type'), label: 'Line Item Type', field: 'line_item_type', description: 'Usage vs Tax vs Credit vs Discount. Filter this to isolate real usage from billing adjustments.' },
+  { name: asDimensionId('usage_type'), label: 'Usage Type', field: 'usage_type', description: 'Fine-grained usage string like USE2-BoxUsage:t3.medium. Use for instance/storage-tier breakdowns.', enabled: false },
+  { name: asDimensionId('operation'), label: 'Operation', field: 'operation', description: 'API operation billed for (RunInstances, GetObject). Useful for API-level cost attribution.', enabled: false },
+];
+
+function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
+  const have = new Set(loaded.builtIn.map(d => d.name));
+  const missing = DEFAULT_BUILT_INS.filter(d => !have.has(d.name));
+  if (missing.length === 0) return loaded;
+  return { builtIn: [...loaded.builtIn, ...missing], tags: loaded.tags };
+}
 import { FileActivityLog } from '../file-activity.js';
 import { createOptimizeQueue } from '../optimize-queue.js';
 import type { OptimizeQueue } from '../optimize-queue.js';
@@ -71,8 +90,13 @@ export function createAppContext(ctx: IpcContext): AppContext {
   async function getDimensions(): Promise<DimensionsConfig> {
     if (state.dimensions !== null) return state.dimensions;
     const dimensions = await loadDimensions(ctx.dimensionsPath);
-    state.dimensions = dimensions;
-    return dimensions;
+    // Fill in any missing default built-ins for users whose dimensions.yaml
+    // predates them. Existing entries are kept intact — we only add, never
+    // modify. The additions are in-memory; the next dimensions:save-config
+    // persists them to disk.
+    const merged = mergeDefaultBuiltIns(dimensions);
+    state.dimensions = merged;
+    return merged;
   }
 
   async function getOrgTreeConfig(): Promise<OrgTreeConfig> {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -16,7 +16,7 @@ import type {
 } from '@costgoblin/core';
 
 const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
-  { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name', description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.' },
+  { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name', description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.', useOrgAccounts: true },
   { name: asDimensionId('region'), label: 'Region', field: 'region', description: 'AWS region where the resource ran. Useful for spotting unintended multi-region sprawl.' },
   { name: asDimensionId('service'), label: 'Service', field: 'service', description: 'AWS service code (EC2, S3, RDS, etc.) — the broadest "what cost me this?" view.' },
   { name: asDimensionId('service_family'), label: 'Service Family', field: 'service_family', description: 'Higher-level product category (Compute, Storage, Database). Good for exec summaries.' },
@@ -117,62 +117,69 @@ export function createAppContext(ctx: IpcContext): AppContext {
   }
 
   async function getAccountMap(): Promise<Map<string, string>> {
+    // Returns the Account id→name map the handlers should use for display
+    // resolution. Source depends on the Account dim's `useOrgAccounts` flag:
+    //   - true  : org-accounts.json (AWS Organizations sync)
+    //   - false : the legacy account-mapping CSV under raw/
+    // Both are optional — if the preferred source is missing we fall through
+    // to the other one before giving up and returning an empty map.
     if (state.accountMap !== null) return state.accountMap;
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const baseDir = path.dirname(ctx.dataDir);
 
-    // Primary: an account-mapping CSV placed under raw/ (legacy path).
-    const rawDir = path.join(baseDir, 'raw');
-    try {
-      const entries = await fs.readdir(rawDir);
-      const csvFile = entries.find(e => e.toLowerCase().endsWith('.csv') && e.toLowerCase().includes('account'));
-      if (csvFile !== undefined) {
-        const content = await fs.readFile(path.join(rawDir, csvFile), 'utf-8');
-        const lines = content.split('\n').filter(l => l.trim().length > 0);
-        const map = new Map<string, string>();
-        for (let i = 1; i < lines.length; i++) {
-          const line = lines[i];
-          if (line === undefined) continue;
-          const cols = line.split(',').map(c => c.replace(/^"|"$/g, '').trim());
-          const accountId = cols[0] ?? '';
-          const name = cols[4] ?? '';
-          if (accountId.length > 0 && name.length > 0) {
-            map.set(accountId, name);
-          }
-        }
-        if (map.size > 0) {
-          state.accountMap = map;
-          logger.info(`Loaded account mapping from CSV: ${String(map.size)} accounts`);
-          return map;
-        }
-      }
-    } catch { /* no raw dir */ }
+    const dimensions = await getDimensions();
+    const accountDim = dimensions.builtIn.find(d => d.field === 'account_id');
+    const preferOrg = accountDim?.useOrgAccounts === true;
 
-    // Fallback: the AWS Organizations sync (Sync view → org) writes org-accounts.json
-    // with {id, name} per account. Use it for id→name resolution when the
-    // legacy CSV isn't present.
-    try {
-      const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
-      const parsed: unknown = JSON.parse(raw);
+    async function fromOrg(): Promise<Map<string, string>> {
       const map = new Map<string, string>();
-      if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
-        for (const acct of parsed['accounts']) {
-          if (!isStringRecord(acct)) continue;
-          const id = acct['id'];
-          const name = acct['name'];
-          if (typeof id === 'string' && typeof name === 'string' && id.length > 0 && name.length > 0) {
-            map.set(id, name);
+      try {
+        const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
+        const parsed: unknown = JSON.parse(raw);
+        if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
+          for (const acct of parsed['accounts']) {
+            if (!isStringRecord(acct)) continue;
+            const id = acct['id'];
+            const name = acct['name'];
+            if (typeof id === 'string' && typeof name === 'string' && id.length > 0 && name.length > 0) {
+              map.set(id, name);
+            }
           }
         }
-      }
-      state.accountMap = map;
-      if (map.size > 0) logger.info(`Loaded account mapping from org-accounts.json: ${String(map.size)} accounts`);
+      } catch { /* no org sync */ }
       return map;
-    } catch { /* no org sync yet */ }
+    }
 
-    state.accountMap = new Map();
-    return state.accountMap;
+    async function fromCsv(): Promise<Map<string, string>> {
+      const map = new Map<string, string>();
+      try {
+        const rawDir = path.join(baseDir, 'raw');
+        const entries = await fs.readdir(rawDir);
+        const csvFile = entries.find(e => e.toLowerCase().endsWith('.csv') && e.toLowerCase().includes('account'));
+        if (csvFile !== undefined) {
+          const content = await fs.readFile(path.join(rawDir, csvFile), 'utf-8');
+          const lines = content.split('\n').filter(l => l.trim().length > 0);
+          for (let i = 1; i < lines.length; i++) {
+            const line = lines[i];
+            if (line === undefined) continue;
+            const cols = line.split(',').map(c => c.replace(/^"|"$/g, '').trim());
+            const id = cols[0] ?? '';
+            const name = cols[4] ?? '';
+            if (id.length > 0 && name.length > 0) map.set(id, name);
+          }
+        }
+      } catch { /* no raw dir */ }
+      return map;
+    }
+
+    const primary = preferOrg ? await fromOrg() : await fromCsv();
+    const map = primary.size > 0 ? primary : (preferOrg ? await fromCsv() : await fromOrg());
+    if (map.size > 0) {
+      logger.info(`Loaded account mapping (${preferOrg ? 'org-data' : 'csv'} preferred): ${String(map.size)} accounts`);
+    }
+    state.accountMap = map;
+    return map;
   }
 
   async function getOrgAccountsPath(): Promise<string | undefined> {
@@ -235,7 +242,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getOrgAccountsPath,
     runQuery: (sql: string) => ctx.db.runQuery(sql),
     invalidateConfig: () => { state.config = null; },
-    invalidateDimensions: () => { state.dimensions = null; },
+    invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; },
   };
 }
 

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -26,10 +26,20 @@ const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
 ];
 
 function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
-  const have = new Set(loaded.builtIn.map(d => d.name));
+  const defaultsByName = new Map(DEFAULT_BUILT_INS.map(d => [d.name, d]));
+  // Backfill description on existing entries for any default whose config
+  // predates the description field. User-set fields (label, aliases, etc.)
+  // are kept — we only fill a missing description.
+  const backfilled = loaded.builtIn.map(d => {
+    if (d.description !== undefined) return d;
+    const def = defaultsByName.get(d.name);
+    if (def?.description === undefined) return d;
+    return { ...d, description: def.description };
+  });
+  const have = new Set(backfilled.map(d => d.name));
   const missing = DEFAULT_BUILT_INS.filter(d => !have.has(d.name));
-  if (missing.length === 0) return loaded;
-  return { builtIn: [...loaded.builtIn, ...missing], tags: loaded.tags };
+  if (missing.length === 0 && backfilled === loaded.builtIn) return loaded;
+  return { builtIn: [...backfilled, ...missing], tags: loaded.tags };
 }
 import { FileActivityLog } from '../file-activity.js';
 import { createOptimizeQueue } from '../optimize-queue.js';
@@ -110,7 +120,10 @@ export function createAppContext(ctx: IpcContext): AppContext {
     if (state.accountMap !== null) return state.accountMap;
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
-    const rawDir = path.join(path.dirname(ctx.dataDir), 'raw');
+    const baseDir = path.dirname(ctx.dataDir);
+
+    // Primary: an account-mapping CSV placed under raw/ (legacy path).
+    const rawDir = path.join(baseDir, 'raw');
     try {
       const entries = await fs.readdir(rawDir);
       const csvFile = entries.find(e => e.toLowerCase().endsWith('.csv') && e.toLowerCase().includes('account'));
@@ -128,13 +141,36 @@ export function createAppContext(ctx: IpcContext): AppContext {
             map.set(accountId, name);
           }
         }
-        state.accountMap = map;
-        logger.info(`Loaded account mapping: ${String(map.size)} accounts`);
-        return map;
+        if (map.size > 0) {
+          state.accountMap = map;
+          logger.info(`Loaded account mapping from CSV: ${String(map.size)} accounts`);
+          return map;
+        }
       }
-    } catch {
-      // no mapping file
-    }
+    } catch { /* no raw dir */ }
+
+    // Fallback: the AWS Organizations sync (Sync view → org) writes org-accounts.json
+    // with {id, name} per account. Use it for id→name resolution when the
+    // legacy CSV isn't present.
+    try {
+      const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      const map = new Map<string, string>();
+      if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
+        for (const acct of parsed['accounts']) {
+          if (!isStringRecord(acct)) continue;
+          const id = acct['id'];
+          const name = acct['name'];
+          if (typeof id === 'string' && typeof name === 'string' && id.length > 0 && name.length > 0) {
+            map.set(id, name);
+          }
+        }
+      }
+      state.accountMap = map;
+      if (map.size > 0) logger.info(`Loaded account mapping from org-accounts.json: ${String(map.size)} accounts`);
+      return map;
+    } catch { /* no org sync yet */ }
+
     state.accountMap = new Map();
     return state.accountMap;
   }

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import { join } from 'node:path';
 import { readdir } from 'node:fs/promises';
-import { getRawDirPrefix, logger } from '@costgoblin/core';
+import { getRawDirPrefix, isStringRecord, logger } from '@costgoblin/core';
 import type { DimensionsConfig, TagDimension } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import { toNum, toStr } from './query-utils.js';
@@ -17,6 +17,29 @@ function tagFingerprint(tag: TagDimension): string {
     fallback: tag.accountTagFallback ?? null,
     template: tag.missingValueTemplate ?? null,
   });
+}
+
+/** One-shot read of org-accounts.json → id→name map. No caching here (the
+ *  preview handler wants fresh data on every toggle change). */
+async function loadOrgAccountsMap(dataDir: string): Promise<Map<string, string>> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const map = new Map<string, string>();
+  try {
+    const raw = await fs.readFile(path.join(path.dirname(dataDir), 'org-accounts.json'), 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
+      for (const acct of parsed['accounts']) {
+        if (!isStringRecord(acct)) continue;
+        const id = acct['id'];
+        const name = acct['name'];
+        if (typeof id === 'string' && typeof name === 'string' && id.length > 0 && name.length > 0) {
+          map.set(id, name);
+        }
+      }
+    }
+  } catch { /* no org sync */ }
+  return map;
 }
 
 /** Snapshot of existing raw files for a tier, used to enqueue regen jobs. */
@@ -122,7 +145,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
   // Distinct values + cost for a built-in column — powers the preview on the
   // built-in editor ("Service has 120 distinct values, top 20 by cost are...").
   // Scans the most recent daily period so the preview loads fast.
-  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
+  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
     // Whitelist columns we know are safe to embed in SQL. These match the
     // aliases emitted by buildSource so the query plans identically to what
     // the rest of the app does.
@@ -153,6 +176,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
       usage_type: 'line_item_usage_type',
     };
     const col = RAW_COL[field] ?? field;
+
     const distinctSql = `SELECT COUNT(DISTINCT ${col}) AS n FROM ${source} WHERE ${col} IS NOT NULL AND ${col} != ''`;
     const valuesSql = `
       SELECT ${col} AS val, SUM(line_item_unblended_cost) AS cost
@@ -164,7 +188,19 @@ export function registerDimensionsHandlers(app: AppContext): void {
     `;
     const [distinctRows, valueRows] = await Promise.all([runQuery(distinctSql), runQuery(valuesSql)]);
     const distinctCount = distinctRows[0] !== undefined ? toNum(distinctRows[0]['n']) : 0;
-    const values = valueRows.map(r => ({ value: toStr(r['val']), cost: toNum(r['cost']) }));
+    let values = valueRows.map(r => ({ value: toStr(r['val']), cost: toNum(r['cost']) }));
+
+    // Account-specific: map each id to its org-data name for the preview. We
+    // read org-accounts.json fresh every call so the preview reflects the
+    // toggle before the config is saved (otherwise the cached accountMap
+    // might be from the wrong source).
+    if (field === 'account_id' && opts?.useOrgAccounts === true) {
+      const orgMap = await loadOrgAccountsMap(ctx.dataDir);
+      if (orgMap.size > 0) {
+        values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
+      }
+    }
+
     return { values, distinctCount, period: latest.replace(/^daily-/, '') };
   });
 

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -119,6 +119,55 @@ export function registerDimensionsHandlers(app: AppContext): void {
     return getDimensions();
   });
 
+  // Distinct values + cost for a built-in column — powers the preview on the
+  // built-in editor ("Service has 120 distinct values, top 20 by cost are...").
+  // Scans the most recent daily period so the preview loads fast.
+  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
+    // Whitelist columns we know are safe to embed in SQL. These match the
+    // aliases emitted by buildSource so the query plans identically to what
+    // the rest of the app does.
+    const ALLOWED = new Set(['account_id', 'account_name', 'region', 'service', 'service_family', 'line_item_type', 'operation', 'usage_type']);
+    if (!ALLOWED.has(field)) return { values: [], distinctCount: 0, period: '' };
+
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
+    let dirs: string[] = [];
+    try {
+      dirs = (await fs.readdir(rawDir)).filter(d => d.startsWith('daily-')).sort();
+    } catch { /* no data */ }
+    const latest = dirs.at(-1);
+    if (latest === undefined) return { values: [], distinctCount: 0, period: '' };
+
+    const source = `read_parquet('${ctx.dataDir}/aws/raw/${latest}/*.parquet')`;
+    // The raw CUR columns aren't aliased — we need to map the UI-facing field
+    // back to the underlying column.
+    const RAW_COL: Record<string, string> = {
+      account_id: 'line_item_usage_account_id',
+      account_name: 'line_item_usage_account_name',
+      region: 'product_region_code',
+      service: 'product_servicecode',
+      service_family: 'product_product_family',
+      line_item_type: 'line_item_line_item_type',
+      operation: 'line_item_operation',
+      usage_type: 'line_item_usage_type',
+    };
+    const col = RAW_COL[field] ?? field;
+    const distinctSql = `SELECT COUNT(DISTINCT ${col}) AS n FROM ${source} WHERE ${col} IS NOT NULL AND ${col} != ''`;
+    const valuesSql = `
+      SELECT ${col} AS val, SUM(line_item_unblended_cost) AS cost
+      FROM ${source}
+      WHERE ${col} IS NOT NULL AND ${col} != ''
+      GROUP BY val
+      ORDER BY cost DESC
+      LIMIT 200
+    `;
+    const [distinctRows, valueRows] = await Promise.all([runQuery(distinctSql), runQuery(valuesSql)]);
+    const distinctCount = distinctRows[0] !== undefined ? toNum(distinctRows[0]['n']) : 0;
+    const values = valueRows.map(r => ({ value: toStr(r['val']), cost: toNum(r['cost']) }));
+    return { values, distinctCount, period: latest.replace(/^daily-/, '') };
+  });
+
   ipcMain.handle('dimensions:save-config', async (_event, config: DimensionsConfig): Promise<void> => {
     const yaml = await import('yaml');
     const fs = await import('node:fs/promises');
@@ -139,6 +188,9 @@ export function registerDimensionsHandlers(app: AppContext): void {
         label: d.label,
         field: d.field,
         ...(d.displayField === undefined ? {} : { displayField: d.displayField }),
+        ...(d.description === undefined ? {} : { description: d.description }),
+        ...(d.normalize === undefined ? {} : { normalize: d.normalize }),
+        ...(d.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(d.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(d.enabled === false ? { enabled: false } : {}),
       })),
       tags: config.tags.map(t => ({
@@ -150,6 +202,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(t.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(t.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(t.accountTagFallback === undefined ? {} : { accountTagFallback: t.accountTagFallback }),
         ...(t.missingValueTemplate === undefined ? {} : { missingValueTemplate: t.missingValueTemplate }),
+        ...(t.description === undefined ? {} : { description: t.description }),
         ...(t.enabled === false ? { enabled: false } : {}),
       })),
     });

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -191,6 +191,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(d.description === undefined ? {} : { description: d.description }),
         ...(d.normalize === undefined ? {} : { normalize: d.normalize }),
         ...(d.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(d.aliases).map(([k, v]) => [k, [...v]])) }),
+        ...(d.useOrgAccounts === true ? { useOrgAccounts: true } : {}),
         ...(d.enabled === false ? { enabled: false } : {}),
       })),
       tags: config.tags.map(t => ({

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -227,6 +227,7 @@ export function registerSetupHandlers(app: AppContext): void {
         field: 'account_id',
         displayField: 'account_name',
         description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.',
+        useOrgAccounts: true,
       },
       {
         name: 'region',

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -221,10 +221,51 @@ export function registerSetupHandlers(app: AppContext): void {
     await fs.writeFile(ctx.configPath, stringify(costgoblinYaml), 'utf-8');
 
     const builtInDimensions = [
-      { name: 'account', label: 'Account', field: 'account_id', displayField: 'account_name' },
-      { name: 'region', label: 'Region', field: 'region' },
-      { name: 'service', label: 'Service', field: 'service' },
-      { name: 'service_family', label: 'Service Family', field: 'service_family' },
+      {
+        name: 'account',
+        label: 'Account',
+        field: 'account_id',
+        displayField: 'account_name',
+        description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.',
+      },
+      {
+        name: 'region',
+        label: 'Region',
+        field: 'region',
+        description: 'AWS region where the resource ran. Useful for spotting unintended multi-region sprawl.',
+      },
+      {
+        name: 'service',
+        label: 'Service',
+        field: 'service',
+        description: "AWS service code (EC2, S3, RDS, etc.) — the broadest \"what cost me this?\" view.",
+      },
+      {
+        name: 'service_family',
+        label: 'Service Family',
+        field: 'service_family',
+        description: 'Higher-level product category (Compute, Storage, Database). Good for exec summaries.',
+      },
+      {
+        name: 'line_item_type',
+        label: 'Line Item Type',
+        field: 'line_item_type',
+        description: 'Usage vs Tax vs Credit vs Discount. Filter this to isolate real usage from billing adjustments.',
+      },
+      {
+        name: 'usage_type',
+        label: 'Usage Type',
+        field: 'usage_type',
+        description: 'Fine-grained usage string like USE2-BoxUsage:t3.medium. Use for instance/storage-tier breakdowns.',
+        enabled: false,
+      },
+      {
+        name: 'operation',
+        label: 'Operation',
+        field: 'operation',
+        description: 'API operation billed for (RunInstances, GetObject). Useful for API-level cost attribution.',
+        enabled: false,
+      },
     ];
 
     const tagDimensions = (wizardConfig.tags ?? []).map(t => ({

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -145,6 +145,9 @@ const api: CostApi = {
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
+  discoverColumnValues(field: string): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
+    return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field);
+  },
   getDimensionsConfig(): Promise<DimensionsConfig> {
     return invoke<DimensionsConfig>('dimensions:get-config');
   },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -145,8 +145,8 @@ const api: CostApi = {
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
-  discoverColumnValues(field: string): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
-    return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field);
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
+    return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field, opts);
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {
     return invoke<DimensionsConfig>('dimensions:get-config');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -248,6 +248,7 @@ export class MockCostApi implements CostApi {
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500, distinctCount: 8, coveragePct: 45 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400, distinctCount: 4, coveragePct: 36 }], samplePeriod: '2026-04' }); }
+  discoverColumnValues(): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> { return Promise.resolve({ values: [{ value: 'Usage', cost: 12345 }, { value: 'Tax', cost: 234 }, { value: 'Credit', cost: -100 }], distinctCount: 3, period: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }
   saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -23,6 +23,7 @@ interface EditingBuiltIn {
   description: string;
   normalize: string;
   aliases: string;
+  useOrgAccounts: boolean;
 }
 
 function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
@@ -30,6 +31,7 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   onSave: (edited: EditingBuiltIn) => void;
   onCancel: () => void;
 }>): React.JSX.Element {
+  const isAccountDim = dim.field === 'account_id';
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -82,6 +84,15 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
           placeholder="What does this dimension represent?"
         />
       </label>
+      {isAccountDim && (
+        <label className="flex items-center justify-between rounded border border-border bg-bg-primary px-3 py-2">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm text-text-primary">Resolve names via org-data</span>
+            <span className="text-[11px] text-text-muted">Display friendly account names from the Organizations sync instead of raw account IDs.</span>
+          </div>
+          <DimensionToggle enabled={state.useOrgAccounts} onToggle={() => { setState(s => ({ ...s, useOrgAccounts: !s.useOrgAccounts })); }} />
+        </label>
+      )}
       <label className="flex flex-col gap-1">
         <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
         <textarea
@@ -592,6 +603,7 @@ export function DimensionsView() {
         ...(description.length > 0 ? { description } : {}),
         ...(normalize !== undefined ? { normalize } : {}),
         ...(aliases !== undefined ? { aliases } : {}),
+        ...(edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
       };
     });
     await api.saveDimensionsConfig({ ...config, builtIn });
@@ -663,6 +675,7 @@ export function DimensionsView() {
                       description: d.description ?? '',
                       normalize: d.normalize ?? '',
                       aliases: aliasesToText(d.aliases),
+                      useOrgAccounts: d.useOrgAccounts === true,
                     },
                   }}
                   onSave={(edited) => { void handleSaveBuiltIn(idx, edited); }}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -35,7 +35,10 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const valuesQuery = useQuery(() => api.discoverColumnValues(dim.field), [dim.field]);
+  const valuesQuery = useQuery(
+    () => api.discoverColumnValues(dim.field, isAccountDim ? { useOrgAccounts: state.useOrgAccounts } : undefined),
+    [dim.field, isAccountDim, state.useOrgAccounts],
+  );
 
   useEffect(() => {
     function onDocClick(e: MouseEvent): void {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -18,6 +18,117 @@ const NORMALIZE_RULES: { value: NormalizationRule; label: string }[] = [
   { value: 'camelCase', label: 'camelCase' },
 ];
 
+interface EditingBuiltIn {
+  label: string;
+  description: string;
+  normalize: string;
+  aliases: string;
+}
+
+function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
+  dim: { field: string; editing: EditingBuiltIn };
+  onSave: (edited: EditingBuiltIn) => void;
+  onCancel: () => void;
+}>): React.JSX.Element {
+  const api = useCostApi();
+  const [state, setState] = useState(dim.editing);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const valuesQuery = useQuery(() => api.discoverColumnValues(dim.field), [dim.field]);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent): void {
+      if (containerRef.current === null) return;
+      if (!(e.target instanceof Node)) return;
+      if (containerRef.current.contains(e.target)) return;
+      onCancel();
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => { document.removeEventListener('mousedown', onDocClick); };
+  }, [onCancel]);
+
+  const preview = valuesQuery.status === 'success' ? valuesQuery.data : null;
+
+  return (
+    <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Display Label</span>
+          <input
+            type="text"
+            value={state.label}
+            onChange={e => { setState(s => ({ ...s, label: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Normalization</span>
+          <select
+            value={state.normalize}
+            onChange={e => { setState(s => ({ ...s, normalize: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            <option value="">None</option>
+            {NORMALIZE_RULES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+          </select>
+        </label>
+      </div>
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Description</span>
+        <input
+          type="text"
+          value={state.description}
+          onChange={e => { setState(s => ({ ...s, description: e.target.value })); }}
+          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          placeholder="What does this dimension represent?"
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
+        <textarea
+          value={state.aliases}
+          onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
+          rows={3}
+          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm font-mono text-text-primary outline-none focus:border-accent"
+          placeholder="EC2: AmazonEC2, EC2-Instance"
+        />
+      </label>
+      {preview !== null && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs text-text-muted">
+            Preview — {String(preview.distinctCount)} distinct values
+            {preview.period.length > 0 ? ` (from ${preview.period})` : ''}
+          </span>
+          <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto">
+            {preview.values.slice(0, 60).map(v => (
+              <span key={v.value} className="rounded border border-border bg-bg-primary px-2 py-0.5 text-[11px] text-text-secondary font-mono">
+                {v.value}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="flex items-center justify-between pt-2">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => { onSave(state); }}
+            className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-bg-primary hover:bg-accent/90 transition-colors"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md px-4 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DimensionToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }): React.JSX.Element {
   return (
     <button
@@ -402,6 +513,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 export function DimensionsView() {
   const api = useCostApi();
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [editingBuiltInIdx, setEditingBuiltInIdx] = useState<number | null>(null);
   const [hiddenResourceCols, setHiddenResourceCols] = useState(new Set<string>());
   const [hiddenAccountCols, setHiddenAccountCols] = useState(new Set<string>());
   const [addingNew, setAddingNew] = useState(false);
@@ -464,6 +576,29 @@ export function DimensionsView() {
     setRefreshKey(k => k + 1);
   }
 
+  async function handleSaveBuiltIn(idx: number, edited: EditingBuiltIn) {
+    if (config === null) return;
+    const builtIn = config.builtIn.map((d, i) => {
+      if (i !== idx) return d;
+      const description = edited.description.trim();
+      const normalize = edited.normalize.length > 0 ? edited.normalize as NormalizationRule : undefined;
+      const aliases = textToAliases(edited.aliases);
+      return {
+        name: d.name,
+        label: edited.label.length > 0 ? edited.label : d.label,
+        field: d.field,
+        ...(d.displayField === undefined ? {} : { displayField: d.displayField }),
+        ...(d.enabled === false ? { enabled: false as const } : {}),
+        ...(description.length > 0 ? { description } : {}),
+        ...(normalize !== undefined ? { normalize } : {}),
+        ...(aliases !== undefined ? { aliases } : {}),
+      };
+    });
+    await api.saveDimensionsConfig({ ...config, builtIn });
+    setEditingBuiltInIdx(null);
+    setRefreshKey(k => k + 1);
+  }
+
   async function toggleBuiltInEnabled(idx: number) {
     if (config === null) return;
     const builtIn = config.builtIn.map((d, i) => {
@@ -517,22 +652,55 @@ export function DimensionsView() {
           {/* Built-in dimensions */}
           {config.builtIn.map((d, idx) => {
             const isOn = d.enabled !== false;
+            if (editingBuiltInIdx === idx) {
+              return (
+                <BuiltInEditor
+                  key={d.name}
+                  dim={{
+                    field: d.field,
+                    editing: {
+                      label: d.label,
+                      description: d.description ?? '',
+                      normalize: d.normalize ?? '',
+                      aliases: aliasesToText(d.aliases),
+                    },
+                  }}
+                  onSave={(edited) => { void handleSaveBuiltIn(idx, edited); }}
+                  onCancel={() => { setEditingBuiltInIdx(null); }}
+                />
+              );
+            }
             return (
               <div
                 key={d.name}
                 className={[
-                  'rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between',
+                  'rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between hover:bg-bg-tertiary/30 transition-colors',
                   isOn ? '' : 'opacity-50',
                 ].join(' ')}
               >
-                <div className="flex items-center gap-3">
-                  <span className="text-sm font-medium text-text-primary">{d.label}</span>
-                  <span className="text-xs text-text-muted font-mono">{d.field}</span>
-                  {d.displayField !== undefined && (
-                    <span className="text-[10px] text-text-muted">display: {d.displayField}</span>
+                <button
+                  type="button"
+                  onClick={() => { setEditingBuiltInIdx(idx); setEditingIdx(null); setAddingNew(false); }}
+                  className="flex flex-col gap-1 text-left flex-1 min-w-0"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium text-text-primary">{d.label}</span>
+                    <span className="text-xs text-text-muted font-mono">{d.field}</span>
+                    {d.displayField !== undefined && (
+                      <span className="text-[10px] text-text-muted">display: {d.displayField}</span>
+                    )}
+                    {d.normalize !== undefined && (
+                      <span className="text-[10px] text-text-muted">{d.normalize}</span>
+                    )}
+                    {d.aliases !== undefined && (
+                      <span className="text-[10px] text-text-muted">{String(Object.keys(d.aliases).length)} alias rules</span>
+                    )}
+                  </div>
+                  {d.description !== undefined && (
+                    <span className="text-[11px] text-text-muted leading-snug">{d.description}</span>
                   )}
-                </div>
-                <div className="flex items-center gap-3">
+                </button>
+                <div className="flex items-center gap-3 shrink-0">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider">Built-in</span>
                   <DimensionToggle enabled={isOn} onToggle={() => { void toggleBuiltInEnabled(idx); }} />
                 </div>
@@ -569,26 +737,31 @@ export function DimensionsView() {
                   <button
                     type="button"
                     onClick={() => { setEditingIdx(idx); setAddingNew(false); }}
-                    className="flex items-center gap-3 text-left flex-1 min-w-0"
+                    className="flex flex-col gap-1 text-left flex-1 min-w-0"
                   >
-                    <span className="text-sm font-medium text-text-primary">{tag.label}</span>
-                    <span className="text-xs text-text-muted font-mono">tag:{tag.tagName}</span>
-                    {tag.concept !== undefined && (
-                      <span className="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
-                        {tag.concept}
-                      </span>
-                    )}
-                    {tag.normalize !== undefined && (
-                      <span className="text-[10px] text-text-muted">{tag.normalize}</span>
-                    )}
-                    {tag.aliases !== undefined && (
-                      <span className="text-[10px] text-text-muted">{String(Object.keys(tag.aliases).length)} alias rules</span>
-                    )}
-                    {tag.accountTagFallback !== undefined && (
-                      <span className="text-[10px] text-text-muted">fallback: {tag.accountTagFallback}</span>
-                    )}
-                    {tag.missingValueTemplate !== undefined && (
-                      <span className="text-[10px] text-text-muted font-mono">missing: {tag.missingValueTemplate}</span>
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm font-medium text-text-primary">{tag.label}</span>
+                      <span className="text-xs text-text-muted font-mono">tag:{tag.tagName}</span>
+                      {tag.concept !== undefined && (
+                        <span className="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
+                          {tag.concept}
+                        </span>
+                      )}
+                      {tag.normalize !== undefined && (
+                        <span className="text-[10px] text-text-muted">{tag.normalize}</span>
+                      )}
+                      {tag.aliases !== undefined && (
+                        <span className="text-[10px] text-text-muted">{String(Object.keys(tag.aliases).length)} alias rules</span>
+                      )}
+                      {tag.accountTagFallback !== undefined && (
+                        <span className="text-[10px] text-text-muted">fallback: {tag.accountTagFallback}</span>
+                      )}
+                      {tag.missingValueTemplate !== undefined && (
+                        <span className="text-[10px] text-text-muted font-mono">missing: {tag.missingValueTemplate}</span>
+                      )}
+                    </div>
+                    {tag.description !== undefined && (
+                      <span className="text-[11px] text-text-muted leading-snug">{tag.description}</span>
                     )}
                   </button>
                   <div className="flex items-center gap-3 shrink-0">


### PR DESCRIPTION
## Summary
- Built-in dimensions (Account, Region, Service, Service Family, etc.) are now editable like tag dims — Display Label, Normalization, Alias Rules. Applied at query time via the existing `buildAliasSqlCase`, which is now generic over built-in + tag.
- Every dimension carries an optional `description`. Defaults ship with short explanations, shown inline under the dim label on the Dimensions view.
- Three new built-in defaults pulled from CUR columns already available:
  - **Line Item Type** (enabled) — Usage / Tax / Credit / Discount. The universal filter for "real usage only".
  - **Usage Type** (disabled by default, high cardinality) — fine-grained string like `USE2-BoxUsage:t3.medium`.
  - **Operation** (disabled by default, high cardinality) — API operation billed for.
- Built-in row click opens a lightweight editor with a distinct-values preview (new IPC `dimensions:discover-column-values`, scans the latest daily period).
- Existing users get a silent in-memory migration: missing default built-ins are merged on load, persisted on next save. Their `dimensions.yaml` isn't touched until they save.