### PR TITLE
Dimensions overhaul: Account stripping, drag-reorder, AWS Org + SSM enrichment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -422,23 +422,74 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1032.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1032.0.tgz",
+      "integrity": "sha512-IkFS5VbAuLhyDIwfkeWvBsdY6fQpr9adDaA8q1dBVyW4qZEF8qfNB6Oq7s+NkUStWnkquKlBJtHv0qzW81RuNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/credential-provider-node": "^3.972.32",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.17",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.1.tgz",
+      "integrity": "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -460,15 +511,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.27.tgz",
+      "integrity": "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -476,20 +527,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.29.tgz",
+      "integrity": "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -497,24 +548,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.31.tgz",
+      "integrity": "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/credential-provider-env": "^3.972.27",
+        "@aws-sdk/credential-provider-http": "^3.972.29",
+        "@aws-sdk/credential-provider-login": "^3.972.31",
+        "@aws-sdk/credential-provider-process": "^3.972.27",
+        "@aws-sdk/credential-provider-sso": "^3.972.31",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -522,18 +573,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.31.tgz",
+      "integrity": "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -541,22 +592,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.32.tgz",
+      "integrity": "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/credential-provider-env": "^3.972.27",
+        "@aws-sdk/credential-provider-http": "^3.972.29",
+        "@aws-sdk/credential-provider-ini": "^3.972.31",
+        "@aws-sdk/credential-provider-process": "^3.972.27",
+        "@aws-sdk/credential-provider-sso": "^3.972.31",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -564,16 +615,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.27.tgz",
+      "integrity": "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -581,18 +632,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.31.tgz",
+      "integrity": "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/token-providers": "3.1032.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -600,17 +651,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.31.tgz",
+      "integrity": "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -676,14 +727,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -705,13 +756,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -719,15 +770,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -774,18 +825,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.31.tgz",
+      "integrity": "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -793,47 +844,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "version": "3.996.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.21.tgz",
+      "integrity": "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.17",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -842,15 +893,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
+      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -875,17 +926,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "version": "3.1032.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1032.0.tgz",
+      "integrity": "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -893,12 +944,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -918,15 +969,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
+      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -946,27 +997,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "version": "3.973.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.17.tgz",
+      "integrity": "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -983,12 +1034,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
@@ -3867,16 +3918,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
-      "integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
+      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3884,18 +3935,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.14",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
-      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "version": "3.23.15",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
+      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.23",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -3905,15 +3956,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
-      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3991,14 +4042,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
-      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -4022,12 +4073,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
-      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -4051,12 +4102,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
-      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4090,13 +4141,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
-      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4104,18 +4155,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
-      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "version": "4.4.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
+      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4123,19 +4174,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.0.tgz",
-      "integrity": "sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
+      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -4144,14 +4195,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
-      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
+      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4159,12 +4210,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
-      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4172,14 +4223,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
-      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4187,14 +4238,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
-      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
+      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4202,12 +4253,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
-      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4215,12 +4266,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4228,12 +4279,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
-      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -4242,12 +4293,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
-      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4255,24 +4306,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
-      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
+      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
-      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4280,16 +4331,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -4299,17 +4350,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
-      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
+      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4317,9 +4368,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4329,13 +4380,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
-      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4406,14 +4457,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.45",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
-      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+      "version": "4.3.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
+      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4421,17 +4472,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.49",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
-      "integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
+      "version": "4.2.52",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
+      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4439,13 +4490,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
-      "integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
+      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4465,12 +4516,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
-      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4478,13 +4529,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.0.tgz",
-      "integrity": "sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
+      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4492,14 +4543,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
-      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "version": "4.5.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
+      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/types": "^4.14.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -4536,12 +4587,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.15.tgz",
-      "integrity": "sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7079,9 +7130,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -10131,9 +10182,11 @@
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1029.0",
         "@aws-sdk/client-s3": "^3.1025.0",
+        "@aws-sdk/client-ssm": "^3.1032.0",
         "@costgoblin/core": "*",
         "@costgoblin/ui": "*",
         "@duckdb/node-api": "^1.5.0-r.1",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
         "yaml": "^2.7.0"
       },
       "devDependencies": {

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -125,6 +125,14 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     const enabled = dim['enabled'] === false ? false : undefined;
     const description = dim['description'] !== undefined ? (assertString(dim['description'], `${ctx}.description`), dim['description']) : undefined;
     const useOrgAccounts = dim['useOrgAccounts'] === true ? true : undefined;
+    let nameStripPatterns: string[] | undefined;
+    if (dim['nameStripPatterns'] !== undefined) {
+      assertArray(dim['nameStripPatterns'], `${ctx}.nameStripPatterns`);
+      nameStripPatterns = dim['nameStripPatterns'].map((p, j) => {
+        assertString(p, `${ctx}.nameStripPatterns[${String(j)}]`);
+        return p;
+      });
+    }
     const normalize = dim['normalize'] !== undefined ? (() => {
       assertString(dim['normalize'], `${ctx}.normalize`);
       if (!isValidNormalizationRule(dim['normalize'])) {
@@ -155,6 +163,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
       ...(normalize !== undefined ? { normalize } : {}),
       ...(aliases !== undefined ? { aliases } : {}),
       ...(useOrgAccounts === true ? { useOrgAccounts } : {}),
+      ...(nameStripPatterns !== undefined && nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
     };
   });
 

--- a/packages/core/src/normalize/index.ts
+++ b/packages/core/src/normalize/index.ts
@@ -5,4 +5,5 @@ export {
   normalizeAndResolve,
   buildAliasSqlCase,
   applyStripPatterns,
+  applyRegionFriendlyNames,
 } from './normalize.js';

--- a/packages/core/src/normalize/index.ts
+++ b/packages/core/src/normalize/index.ts
@@ -4,4 +4,5 @@ export {
   resolveAlias,
   normalizeAndResolve,
   buildAliasSqlCase,
+  applyStripPatterns,
 } from './normalize.js';

--- a/packages/core/src/normalize/index.ts
+++ b/packages/core/src/normalize/index.ts
@@ -7,3 +7,4 @@ export {
   applyStripPatterns,
   applyRegionFriendlyNames,
 } from './normalize.js';
+export type { RegionEnrichment } from './normalize.js';

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -50,6 +50,42 @@ export function resolveAlias(
   return normalizedValue;
 }
 
+/** Stuffs an SSM-derived region name map into the Region built-in's aliases.
+ *  Reuses the existing alias machinery (SQL CASE, JS resolveAlias, filter
+ *  expansion) so cost queries, filter dropdowns, and entity drill-ins all
+ *  pick up friendly names without separate plumbing.
+ *
+ *  User-defined aliases take precedence: if a region code is already covered
+ *  by a user alias entry, we don't add a region-map entry that would compete.
+ *  Codes not in the map fall through unchanged (alias CASE has no WHEN for
+ *  them, so the ELSE branch returns the raw code). */
+export function applyRegionFriendlyNames(
+  dims: import('../types/config.js').DimensionsConfig,
+  regionMap: ReadonlyMap<string, string>,
+): import('../types/config.js').DimensionsConfig {
+  if (regionMap.size === 0) return dims;
+  const builtIn = dims.builtIn.map(d => {
+    if (d.field !== 'region') return d;
+    const userAliases = d.aliases ?? {};
+    const userCovered = new Set<string>();
+    for (const list of Object.values(userAliases)) {
+      for (const a of list) userCovered.add(a);
+    }
+    const merged: Record<string, string[]> = {};
+    for (const [canonical, list] of Object.entries(userAliases)) {
+      merged[canonical] = [...list];
+    }
+    for (const [code, name] of regionMap) {
+      if (userCovered.has(code)) continue;
+      const existing = merged[name];
+      if (existing === undefined) merged[name] = [code];
+      else existing.push(code);
+    }
+    return { ...d, aliases: merged };
+  });
+  return { ...dims, builtIn };
+}
+
 export function applyStripPatterns(value: string, patterns: readonly string[] | undefined): string {
   if (patterns === undefined || patterns.length === 0) return value;
   let result = value;

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -50,22 +50,43 @@ export function resolveAlias(
   return normalizedValue;
 }
 
-/** Stuffs an SSM-derived region name map into the Region built-in's aliases.
- *  Reuses the existing alias machinery (SQL CASE, JS resolveAlias, filter
- *  expansion) so cost queries, filter dropdowns, and entity drill-ins all
- *  pick up friendly names without separate plumbing.
+/** Per-region metadata extracted from the SSM global-infrastructure namespace.
+ *  Shared shape for alias injection across the Region, Country, and Continent
+ *  built-ins. */
+export interface RegionEnrichment {
+  readonly longName: string;
+  readonly country: string;
+  readonly continent: string;
+}
+
+/** Injects SSM-derived aliases into the Region-family built-ins, so the same
+ *  raw `region` column powers three distinct groupings:
+ *   - `region`           + useRegionNames   → long names ("Europe (Frankfurt)")
+ *   - `region_country`   → ISO country codes ("DE")
+ *   - `region_continent` → AWS geo buckets ("EU")
+ *
+ *  Reuses the alias machinery (SQL CASE, resolveAlias, filter expansion) so
+ *  cost queries, filter dropdowns, and entity drill-ins pick up enriched
+ *  labels without separate plumbing.
  *
  *  User-defined aliases take precedence: if a region code is already covered
- *  by a user alias entry, we don't add a region-map entry that would compete.
- *  Codes not in the map fall through unchanged (alias CASE has no WHEN for
- *  them, so the ELSE branch returns the raw code). */
+ *  by a user alias entry, we don't add an SSM-sourced entry that would
+ *  compete. Codes with an empty value for the requested field are left alone
+ *  so the raw code surfaces (better than collapsing everything unknown into
+ *  a single bucket). */
 export function applyRegionFriendlyNames(
   dims: import('../types/config.js').DimensionsConfig,
-  regionMap: ReadonlyMap<string, string>,
+  regionMap: ReadonlyMap<string, RegionEnrichment>,
 ): import('../types/config.js').DimensionsConfig {
   if (regionMap.size === 0) return dims;
   const builtIn = dims.builtIn.map(d => {
     if (d.field !== 'region') return d;
+    const pick: ((e: RegionEnrichment) => string) | null =
+      d.name === 'region_country' ? (e) => e.country
+        : d.name === 'region_continent' ? (e) => e.continent
+          : d.useRegionNames === true ? (e) => e.longName
+            : null;
+    if (pick === null) return d;
     const userAliases = d.aliases ?? {};
     const userCovered = new Set<string>();
     for (const list of Object.values(userAliases)) {
@@ -75,10 +96,12 @@ export function applyRegionFriendlyNames(
     for (const [canonical, list] of Object.entries(userAliases)) {
       merged[canonical] = [...list];
     }
-    for (const [code, name] of regionMap) {
+    for (const [code, info] of regionMap) {
       if (userCovered.has(code)) continue;
-      const existing = merged[name];
-      if (existing === undefined) merged[name] = [code];
+      const label = pick(info);
+      if (label.length === 0) continue;
+      const existing = merged[label];
+      if (existing === undefined) merged[label] = [code];
       else existing.push(code);
     }
     return { ...d, aliases: merged };

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -50,6 +50,18 @@ export function resolveAlias(
   return normalizedValue;
 }
 
+export function applyStripPatterns(value: string, patterns: readonly string[] | undefined): string {
+  if (patterns === undefined || patterns.length === 0) return value;
+  let result = value;
+  for (const p of patterns) {
+    if (p.length === 0) continue;
+    try {
+      result = result.replace(new RegExp(p, 'g'), '');
+    } catch { /* invalid regex — skip silently so a typo doesn't blow up resolution */ }
+  }
+  return result.replace(/\s+/g, ' ').trim();
+}
+
 export function normalizeAndResolve(value: string, dimension: TagDimension): TagValue {
   const normalized = normalizeTagValue(value, dimension.normalize);
   const resolved = resolveAlias(normalized, dimension.aliases);

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -73,11 +73,27 @@ function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): R
   return { fieldExpr: dimensionId, rawField: dimensionId };
 }
 
-function buildFilterClauses(filters: FilterMap, dimensions: DimensionsConfig): string[] {
+function buildFilterClauses(
+  filters: FilterMap,
+  dimensions: DimensionsConfig,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+): string[] {
   const clauses: string[] = [];
   for (const [dimId, value] of Object.entries(filters)) {
     if (value === undefined) continue;
     const resolved = resolveField(dimId as DimensionId, dimensions);
+    // Account dim with display-name collisions: the user picks "sre default"
+    // in the filter dropdown, but that collapses N underlying ids. Match any
+    // of them with an IN clause. Falls through to '=' when the value isn't a
+    // known display name (raw id, or no map provided).
+    if (resolved.rawField === 'account_id' && accountReverseMap !== undefined) {
+      const ids = accountReverseMap.get(String(value));
+      if (ids !== undefined && ids.length > 0) {
+        const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+        clauses.push(`${resolved.rawField} IN (${list})`);
+        continue;
+      }
+    }
     clauses.push(`${resolved.fieldExpr} = '${String(value).replaceAll("'", "''")}'`);
   }
   return clauses;
@@ -266,9 +282,10 @@ export function buildCostQuery(
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan);
@@ -334,9 +351,10 @@ export function buildTrendQuery(
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
@@ -421,9 +439,10 @@ export function buildMissingTagsQuery(
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
 ): string {
   const tagResolved = resolveField(params.tagDimension, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
 
@@ -495,8 +514,9 @@ export function buildNonResourceCostQuery(
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
 ): string {
-  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
 
@@ -527,9 +547,10 @@ export function buildDailyCostsQuery(
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan);
@@ -562,17 +583,32 @@ export function buildEntityDetailQuery(
   orgAccountsPath?: string,
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
 ): string {
   const dimResolved = resolveField(params.dimension, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions);
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan);
 
+  // Same display-name collision treatment for the entity selector itself: if
+  // the user clicked into "sre default" we need to match every underlying id,
+  // not just one.
+  const entityClause = (() => {
+    if (dimResolved.rawField === 'account_id' && accountReverseMap !== undefined) {
+      const ids = accountReverseMap.get(String(params.entity));
+      if (ids !== undefined && ids.length > 0) {
+        const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+        return `${dimResolved.rawField} IN (${list})`;
+      }
+    }
+    return `${dimResolved.fieldExpr} = '${String(params.entity).replaceAll("'", "''")}'`;
+  })();
+
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
-    `${dimResolved.fieldExpr} = '${String(params.entity).replaceAll("'", "''")}'`,
+    entityClause,
     ...filterClauses,
   ];
 

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -146,6 +146,9 @@ export interface CostApi {
    *  sync has ever been attempted; when the SSM step failed, returns
    *  count=0 with lastError set so the UI can explain why. */
   getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null } | null>;
+  /** Delete every file produced by the AWS Org sync (accounts, account-tag
+   *  lookup, region-name cache). Idempotent. */
+  clearOrgData(): Promise<void>;
   writeConfig(config: {
     providerName: string;
     profile: string;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -132,7 +132,7 @@ export interface CostApi {
   setOptimizeEnabled(enabled: boolean): Promise<void>;
   clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;
@@ -141,11 +141,13 @@ export interface CostApi {
   syncOrgAccounts(profile: string): Promise<OrgSyncResult>;
   getOrgSyncResult(): Promise<OrgSyncResult | null>;
   getOrgSyncProgress(): Promise<OrgSyncProgress | null>;
-  /** Region-name cache info (count of resolved long-names + last sync time).
+  /** Region-name cache info (count of resolved long-names + last sync time +
+   *  the full per-region metadata map so the UI can display it in an expanded
+   *  view and surface extra dimensions like country/continent).
    *  Populated as a side-effect of syncOrgAccounts. Returns null when no
    *  sync has ever been attempted; when the SSM step failed, returns
    *  count=0 with lastError set so the UI can explain why. */
-  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null } | null>;
+  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null; regions: Record<string, { longName: string; country: string; continent: string }> } | null>;
   /** Delete every file produced by the AWS Org sync (accounts, account-tag
    *  lookup, region-name cache). Idempotent. */
   clearOrgData(): Promise<void>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,4 +1,4 @@
-import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, OrgNode, TagDimension } from './config.js';
+import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, NormalizationRule, OrgNode, TagDimension } from './config.js';
 import type {
   CostQueryParams,
   CostResult,
@@ -132,7 +132,7 @@ export interface CostApi {
   setOptimizeEnabled(enabled: boolean): Promise<void>;
   clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[] }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -132,7 +132,7 @@ export interface CostApi {
   setOptimizeEnabled(enabled: boolean): Promise<void>;
   clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[] }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -71,7 +71,7 @@ export type AutoSyncStatus =
   | { readonly state: 'error'; readonly message: string; readonly lastRun: string | null };
 
 export interface OrgSyncProgress {
-  readonly phase: 'accounts' | 'ous' | 'tags';
+  readonly phase: 'accounts' | 'ous' | 'tags' | 'regions';
   readonly done: number;
   readonly total: number;
 }
@@ -142,9 +142,10 @@ export interface CostApi {
   getOrgSyncResult(): Promise<OrgSyncResult | null>;
   getOrgSyncProgress(): Promise<OrgSyncProgress | null>;
   /** Region-name cache info (count of resolved long-names + last sync time).
-   *  Populated as a side-effect of syncOrgAccounts; null if sync hasn't run
-   *  or the SSM step failed (insufficient permissions, etc). */
-  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string } | null>;
+   *  Populated as a side-effect of syncOrgAccounts. Returns null when no
+   *  sync has ever been attempted; when the SSM step failed, returns
+   *  count=0 with lastError set so the UI can explain why. */
+  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null } | null>;
   writeConfig(config: {
     providerName: string;
     profile: string;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -155,6 +155,9 @@ export interface CostApi {
     costOptBucket?: string | undefined;
     tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined;
   }): Promise<void>;
+  /** Swap the AWS profile used to talk to AWS, leaving bucket paths and
+   *  every other config field untouched. */
+  updateAwsProfile(profile: string): Promise<void>;
 }
 
 export interface AccountMappingEntry {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -149,6 +149,9 @@ export interface CostApi {
   /** Delete every file produced by the AWS Org sync (accounts, account-tag
    *  lookup, region-name cache). Idempotent. */
   clearOrgData(): Promise<void>;
+  /** Re-fetch only the SSM region-name cache, without re-running the slow
+   *  per-account org sync. Surfaces errors directly to the caller. */
+  syncRegionNames(profile: string): Promise<{ count: number; syncedAt: string }>;
   writeConfig(config: {
     providerName: string;
     profile: string;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -141,6 +141,10 @@ export interface CostApi {
   syncOrgAccounts(profile: string): Promise<OrgSyncResult>;
   getOrgSyncResult(): Promise<OrgSyncResult | null>;
   getOrgSyncProgress(): Promise<OrgSyncProgress | null>;
+  /** Region-name cache info (count of resolved long-names + last sync time).
+   *  Populated as a side-effect of syncOrgAccounts; null if sync hasn't run
+   *  or the SSM step failed (insufficient permissions, etc). */
+  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string } | null>;
   writeConfig(config: {
     providerName: string;
     profile: string;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -59,6 +59,10 @@ export interface BuiltInDimension {
    *  trailing " production" or a common org prefix. Invalid patterns are
    *  silently skipped; result is whitespace-collapsed and trimmed. */
   readonly nameStripPatterns?: readonly string[] | undefined;
+  /** Region-specific: when true, resolve raw region codes (eu-central-1) to
+   *  friendly names (Europe (Frankfurt)) via the SSM global-infrastructure
+   *  snapshot. No-op if the snapshot hasn't been synced. */
+  readonly useRegionNames?: boolean | undefined;
 }
 
 export interface TagDimension {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -54,6 +54,11 @@ export interface BuiltInDimension {
   /** Account-specific: when true, resolve id→name via org-accounts.json
    *  (AWS Organizations sync) instead of the legacy CSV mapping. */
   readonly useOrgAccounts?: boolean | undefined;
+  /** Account-specific: regexes (one per array entry) applied to each resolved
+   *  name with empty-string replacement. Lets the user strip noise like
+   *  trailing " production" or a common org prefix. Invalid patterns are
+   *  silently skipped; result is whitespace-collapsed and trimmed. */
+  readonly nameStripPatterns?: readonly string[] | undefined;
 }
 
 export interface TagDimension {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.1029.0",
     "@aws-sdk/client-s3": "^3.1025.0",
+    "@aws-sdk/client-ssm": "^3.1032.0",
     "@costgoblin/core": "*",
     "@costgoblin/ui": "*",
     "@duckdb/node-api": "^1.5.0-r.1",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -17,6 +17,7 @@
     "@costgoblin/core": "*",
     "@costgoblin/ui": "*",
     "@duckdb/node-api": "^1.5.0-r.1",
+    "@smithy/shared-ini-file-loader": "^4.4.9",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/packages/desktop/src/main/aws-ssm-client.ts
+++ b/packages/desktop/src/main/aws-ssm-client.ts
@@ -1,0 +1,75 @@
+import { logger } from '@costgoblin/core';
+
+interface RegionNameMap {
+  /** ISO 8601 timestamp this snapshot was fetched. */
+  syncedAt: string;
+  /** AWS region code → AWS-published long name (e.g. "Europe (Frankfurt)"). */
+  regions: Record<string, string>;
+}
+
+async function getSsmModule(): Promise<typeof import('@aws-sdk/client-ssm')> {
+  return import('@aws-sdk/client-ssm');
+}
+
+/** Pulls the AWS-published friendly region names from SSM Parameter Store.
+ *  These live under /aws/service/global-infrastructure/regions/<code>/longName
+ *  as public parameters — same source the AWS CLI itself uses. We list the
+ *  region codes first, then batch the longName lookups (10 per call, the SSM
+ *  GetParameters limit). Missing or failed regions fall through to no entry,
+ *  which the consumer translates back to the raw code. */
+export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
+  const { SSMClient, GetParametersByPathCommand, GetParametersCommand } = await getSsmModule();
+
+  // SSM is regional but the global-infrastructure namespace is the same
+  // everywhere. us-east-1 is universally reachable.
+  const config = profile === 'default' ? { region: 'us-east-1' } : { profile, region: 'us-east-1' };
+  const client = new SSMClient(config);
+
+  // 1. List all region codes.
+  const codes: string[] = [];
+  let nextToken: string | undefined;
+  do {
+    const resp = await client.send(new GetParametersByPathCommand({
+      Path: '/aws/service/global-infrastructure/regions',
+      NextToken: nextToken,
+    }));
+    for (const p of resp.Parameters ?? []) {
+      // Parameter names look like /aws/service/global-infrastructure/regions/eu-central-1
+      const name = p.Name ?? '';
+      const last = name.slice(name.lastIndexOf('/') + 1);
+      if (last.length > 0) codes.push(last);
+    }
+    nextToken = resp.NextToken;
+  } while (nextToken !== undefined);
+
+  logger.info(`SSM region sync: discovered ${String(codes.length)} regions`);
+
+  // 2. Batch the longName lookups (GetParameters caps at 10 names per call).
+  const regions: Record<string, string> = {};
+  for (let i = 0; i < codes.length; i += 10) {
+    const batch = codes.slice(i, i + 10);
+    const names = batch.map(c => `/aws/service/global-infrastructure/regions/${c}/longName`);
+    try {
+      const resp = await client.send(new GetParametersCommand({ Names: names }));
+      for (const p of resp.Parameters ?? []) {
+        const name = p.Name ?? '';
+        const value = p.Value ?? '';
+        // Recover the code from the parameter name's path.
+        const parts = name.split('/');
+        const code = parts[parts.length - 2] ?? '';
+        if (code.length > 0 && value.length > 0) regions[code] = value;
+      }
+    } catch (err: unknown) {
+      logger.info(`SSM region sync: longName batch ${String(i)} failed: ${String(err)}`);
+    }
+  }
+
+  logger.info(`SSM region sync: resolved ${String(Object.keys(regions).length)} long names`);
+
+  return {
+    syncedAt: new Date().toISOString(),
+    regions,
+  };
+}
+
+export type { RegionNameMap };

--- a/packages/desktop/src/main/aws-ssm-client.ts
+++ b/packages/desktop/src/main/aws-ssm-client.ts
@@ -20,9 +20,13 @@ async function getSsmModule(): Promise<typeof import('@aws-sdk/client-ssm')> {
 export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
   const { SSMClient, GetParametersByPathCommand, GetParametersCommand } = await getSsmModule();
 
-  // SSM is regional but the global-infrastructure namespace is the same
-  // everywhere. us-east-1 is universally reachable.
-  const config = profile === 'default' ? { region: 'us-east-1' } : { profile, region: 'us-east-1' };
+  // SSM is regional but the global-infrastructure namespace is mirrored to
+  // every region. We deliberately don't hardcode a region here — many SCPs
+  // explicitly deny SSM in regions the org doesn't use (commonly us-east-1
+  // for non-US-based shops), and the AWS SDK's default region resolution
+  // (env vars → profile config → IMDS) lands on a region the user already
+  // proved they have access to.
+  const config = profile === 'default' ? {} : { profile };
   const client = new SSMClient(config);
 
   // 1. List all region codes.

--- a/packages/desktop/src/main/aws-ssm-client.ts
+++ b/packages/desktop/src/main/aws-ssm-client.ts
@@ -1,32 +1,61 @@
 import { logger } from '@costgoblin/core';
+import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
+
+/** Per-region metadata AWS publishes under global-infrastructure. We pull
+ *  three fields per region — longName for display, country + continent for
+ *  higher-level cost groupings (data residency, geo chargeback). */
+interface RegionInfo {
+  longName: string;
+  /** ISO 3166-1 alpha-2 country code (e.g. "DE", "US"). */
+  country: string;
+  /** AWS geographic region bucket (e.g. "EU", "NA", "AS"). */
+  continent: string;
+}
 
 interface RegionNameMap {
   /** ISO 8601 timestamp this snapshot was fetched. */
   syncedAt: string;
-  /** AWS region code → AWS-published long name (e.g. "Europe (Frankfurt)"). */
-  regions: Record<string, string>;
+  regions: Record<string, RegionInfo>;
 }
 
 async function getSsmModule(): Promise<typeof import('@aws-sdk/client-ssm')> {
   return import('@aws-sdk/client-ssm');
 }
 
-/** Pulls the AWS-published friendly region names from SSM Parameter Store.
- *  These live under /aws/service/global-infrastructure/regions/<code>/longName
- *  as public parameters — same source the AWS CLI itself uses. We list the
- *  region codes first, then batch the longName lookups (10 per call, the SSM
- *  GetParameters limit). Missing or failed regions fall through to no entry,
- *  which the consumer translates back to the raw code. */
+/** Reads the AWS region configured for a profile in ~/.aws/config. Falls back
+ *  to the profile's linked sso-session `sso_region` since SSO-only profiles
+ *  often omit `region`. We must pass this explicitly to the SDK — env vars
+ *  like AWS_REGION would otherwise take precedence over the profile's own
+ *  config, which bites users whose SCPs deny specific regions (e.g. us-east-1). */
+async function resolveProfileRegion(profile: string): Promise<string> {
+  const { configFile } = await loadSharedConfigFiles();
+  const section = configFile[profile] ?? {};
+  const region = section['region'];
+  if (typeof region === 'string' && region.length > 0) return region;
+  const ssoSession = section['sso_session'];
+  if (typeof ssoSession === 'string' && ssoSession.length > 0) {
+    const sessionSection = configFile[`sso-session.${ssoSession}`] ?? {};
+    const ssoRegion = sessionSection['sso_region'];
+    if (typeof ssoRegion === 'string' && ssoRegion.length > 0) return ssoRegion;
+  }
+  throw new Error(`Profile "${profile}" has no region configured in ~/.aws/config. Add 'region = <aws-region>' to the profile.`);
+}
+
+const FIELDS = ['longName', 'geolocationCountry', 'geolocationRegion'] as const;
+
+/** Pulls AWS-published region metadata from SSM Parameter Store.
+ *  Parameters live under /aws/service/global-infrastructure/regions/<code>/<field>
+ *  as public params — same source the AWS CLI uses. We list the region codes
+ *  first, then batch the per-field lookups (10 names per GetParameters call). */
 export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
   const { SSMClient, GetParametersByPathCommand, GetParametersCommand } = await getSsmModule();
 
   // SSM is regional but the global-infrastructure namespace is mirrored to
-  // every region. We deliberately don't hardcode a region here — many SCPs
-  // explicitly deny SSM in regions the org doesn't use (commonly us-east-1
-  // for non-US-based shops), and the AWS SDK's default region resolution
-  // (env vars → profile config → IMDS) lands on a region the user already
-  // proved they have access to.
-  const config = profile === 'default' ? {} : { profile };
+  // every region. We pin the region to the one configured in the user's
+  // profile — SDK env-var precedence (AWS_REGION > profile config) would
+  // otherwise send calls to a region the org's SCP denies (commonly us-east-1).
+  const region = await resolveProfileRegion(profile);
+  const config = profile === 'default' ? { region } : { region, profile };
   const client = new SSMClient(config);
 
   // 1. List all region codes.
@@ -38,7 +67,6 @@ export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
       NextToken: nextToken,
     }));
     for (const p of resp.Parameters ?? []) {
-      // Parameter names look like /aws/service/global-infrastructure/regions/eu-central-1
       const name = p.Name ?? '';
       const last = name.slice(name.lastIndexOf('/') + 1);
       if (last.length > 0) codes.push(last);
@@ -48,27 +76,53 @@ export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
 
   logger.info(`SSM region sync: discovered ${String(codes.length)} regions`);
 
-  // 2. Batch the longName lookups (GetParameters caps at 10 names per call).
-  const regions: Record<string, string> = {};
-  for (let i = 0; i < codes.length; i += 10) {
-    const batch = codes.slice(i, i + 10);
-    const names = batch.map(c => `/aws/service/global-infrastructure/regions/${c}/longName`);
+  // 2. Build the full list of (code, field) lookups and batch 10 at a time.
+  //    A batch may span multiple regions — we recover the region+field from
+  //    each returned Name rather than tracking it positionally.
+  const partial = new Map<string, Partial<RegionInfo>>();
+  const allNames: string[] = [];
+  for (const c of codes) {
+    for (const f of FIELDS) {
+      allNames.push(`/aws/service/global-infrastructure/regions/${c}/${f}`);
+    }
+  }
+  for (let i = 0; i < allNames.length; i += 10) {
+    const batch = allNames.slice(i, i + 10);
     try {
-      const resp = await client.send(new GetParametersCommand({ Names: names }));
+      const resp = await client.send(new GetParametersCommand({ Names: batch }));
       for (const p of resp.Parameters ?? []) {
         const name = p.Name ?? '';
         const value = p.Value ?? '';
-        // Recover the code from the parameter name's path.
+        if (value.length === 0) continue;
+        // /aws/service/global-infrastructure/regions/<code>/<field>
         const parts = name.split('/');
         const code = parts[parts.length - 2] ?? '';
-        if (code.length > 0 && value.length > 0) regions[code] = value;
+        const field = parts[parts.length - 1] ?? '';
+        if (code.length === 0) continue;
+        const entry = partial.get(code) ?? {};
+        if (field === 'longName') entry.longName = value;
+        else if (field === 'geolocationCountry') entry.country = value;
+        else if (field === 'geolocationRegion') entry.continent = value;
+        partial.set(code, entry);
       }
     } catch (err: unknown) {
-      logger.info(`SSM region sync: longName batch ${String(i)} failed: ${String(err)}`);
+      logger.info(`SSM region sync: batch ${String(i)} failed: ${String(err)}`);
     }
   }
 
-  logger.info(`SSM region sync: resolved ${String(Object.keys(regions).length)} long names`);
+  // Only emit regions that got at least a longName — country/continent default
+  // to empty strings so the consumer can still treat them as present-but-unknown.
+  const regions: Record<string, RegionInfo> = {};
+  for (const [code, entry] of partial) {
+    if (typeof entry.longName !== 'string' || entry.longName.length === 0) continue;
+    regions[code] = {
+      longName: entry.longName,
+      country: entry.country ?? '',
+      continent: entry.continent ?? '',
+    };
+  }
+
+  logger.info(`SSM region sync: resolved ${String(Object.keys(regions).length)} regions with metadata`);
 
   return {
     syncedAt: new Date().toISOString(),
@@ -76,4 +130,4 @@ export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
   };
 }
 
-export type { RegionNameMap };
+export type { RegionNameMap, RegionInfo };

--- a/packages/desktop/src/main/handlers/config.ts
+++ b/packages/desktop/src/main/handlers/config.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { asDimensionId } from '@costgoblin/core';
+import { asDimensionId, isStringRecord, logger } from '@costgoblin/core';
 import type {
   CostGoblinConfig,
   Dimension,
@@ -8,7 +8,7 @@ import type {
 import type { AppContext } from './context.js';
 
 export function registerConfigHandlers(app: AppContext): void {
-  const { getConfig, getDimensions, getOrgTreeConfig } = app;
+  const { ctx, getConfig, getDimensions, getOrgTreeConfig, invalidateConfig } = app;
 
   ipcMain.handle('config:get', async (): Promise<CostGoblinConfig> => {
     return getConfig();
@@ -43,5 +43,28 @@ export function registerConfigHandlers(app: AppContext): void {
   ipcMain.handle('config:org-tree', async (): Promise<OrgNode[]> => {
     const orgTree = await getOrgTreeConfig();
     return [...orgTree.tree];
+  });
+
+  // Surgical update: rewrite ONLY the first provider's credentials.profile,
+  // leaving every other YAML field (buckets, retention, defaults, etc.)
+  // untouched. The full setup wizard already covers re-doing buckets too —
+  // this is the "I just want to swap to a profile with different IAM perms"
+  // shortcut.
+  ipcMain.handle('config:update-aws-profile', async (_event, profile: string): Promise<void> => {
+    const fs = await import('node:fs/promises');
+    const { stringify, parse: parseYaml } = await import('yaml');
+    const raw = await fs.readFile(ctx.configPath, 'utf-8');
+    const parsed: unknown = parseYaml(raw);
+    if (!isStringRecord(parsed)) throw new Error('Config file is not a YAML object');
+    const providersRaw: unknown = parsed['providers'];
+    if (!Array.isArray(providersRaw) || providersRaw.length === 0) throw new Error('No providers configured');
+    const providers: unknown[] = providersRaw;
+    const first = providers[0];
+    if (!isStringRecord(first)) throw new Error('First provider entry is not an object');
+    const credentials = isStringRecord(first['credentials']) ? first['credentials'] : {};
+    const updated = { ...parsed, providers: [{ ...first, credentials: { ...credentials, profile } }, ...providers.slice(1)] };
+    await fs.writeFile(ctx.configPath, stringify(updated), 'utf-8');
+    invalidateConfig();
+    logger.info(`Updated AWS profile to ${profile}`);
   });
 }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -61,7 +61,10 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
       const def = defaultsByName.get(next.name);
       if (def?.description !== undefined) next = { ...next, description: def.description };
     }
-    if (next.field === 'region' && next.useRegionNames === undefined) {
+    // Only the plain Region dim — Country/Continent share field='region' but
+    // their own enrichment branches by name, so useRegionNames would be a
+    // meaningless setting on them (and would pollute the saved YAML).
+    if (next.name === 'region' && next.useRegionNames === undefined) {
       next = { ...next, useRegionNames: true };
     }
     return next;

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -15,12 +15,19 @@ import type {
   CostGoblinConfig,
   DimensionsConfig,
   OrgNode,
+  RegionEnrichment,
   SyncStatus,
 } from '@costgoblin/core';
 
 const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
   { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name', description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.', useOrgAccounts: true },
-  { name: asDimensionId('region'), label: 'Region', field: 'region', description: 'AWS region where the resource ran. Useful for spotting unintended multi-region sprawl.' },
+  { name: asDimensionId('region'), label: 'Region', field: 'region', description: 'AWS region where the resource ran. Useful for spotting unintended multi-region sprawl.', useRegionNames: true },
+  // Two pure-enrichment dims derived from the same `region` column: Country
+  // and Continent group multiple regions into geo buckets via SSM metadata.
+  // Off by default — not everyone needs geo rollups, and without an SSM sync
+  // they'd just mirror the Region dim.
+  { name: asDimensionId('region_country'), label: 'Country', field: 'region', description: 'ISO country code derived from the region (DE, US, IE). Useful for data-residency and geo chargeback.', enabled: false },
+  { name: asDimensionId('region_continent'), label: 'Continent', field: 'region', description: 'AWS geographic bucket (EU, NA, AS) derived from the region. Useful for continent-level summaries.', enabled: false },
   { name: asDimensionId('service'), label: 'AWS Service', field: 'service', description: 'AWS service code (EC2, S3, RDS, etc.) — the broadest "what cost me this?" view.' },
   { name: asDimensionId('service_family'), label: 'Service Category', field: 'service_family', description: 'Higher-level product category (Compute, Storage, Database). Good for exec summaries.' },
   { name: asDimensionId('line_item_type'), label: 'Line Item Type', field: 'line_item_type', description: 'Usage vs Tax vs Credit vs Discount. Filter this to isolate real usage from billing adjustments.' },
@@ -41,6 +48,9 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
   // Backfill description on existing entries for any default whose config
   // predates the description field. User-set fields (label, aliases, etc.)
   // are kept — we only fill a missing description.
+  // Also backfill useRegionNames=true on the Region dim so pre-existing
+  // configs don't regress from friendly names back to raw codes now that the
+  // alias injection is gated on this flag.
   const backfilled = loaded.builtIn.map(d => {
     let next = d;
     const rename = LEGACY_LABEL_RENAMES[d.name];
@@ -50,6 +60,9 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
     if (next.description === undefined) {
       const def = defaultsByName.get(next.name);
       if (def?.description !== undefined) next = { ...next, description: def.description };
+    }
+    if (next.field === 'region' && next.useRegionNames === undefined) {
+      next = { ...next, useRegionNames: true };
     }
     return next;
   });
@@ -82,7 +95,7 @@ export interface AppState {
   orgTree: OrgTreeConfig | null;
   syncStatuses: Record<string, SyncStatus>;
   accountMap: Map<string, string> | null;
-  regionMap: Map<string, string> | null;
+  regionMap: Map<string, RegionEnrichment> | null;
 }
 
 export interface AppContext {
@@ -100,7 +113,7 @@ export interface AppContext {
   readonly getQueryDimensions: () => Promise<DimensionsConfig>;
   readonly getOrgTreeConfig: () => Promise<OrgTreeConfig>;
   readonly getAccountMap: () => Promise<Map<string, string>>;
-  readonly getRegionMap: () => Promise<Map<string, string>>;
+  readonly getRegionMap: () => Promise<Map<string, RegionEnrichment>>;
   readonly getOrgAccountsPath: () => Promise<string | undefined>;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
@@ -264,19 +277,26 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
   }
 
-  async function getRegionMap(): Promise<Map<string, string>> {
-    // SSM-derived region-name lookup. Mirrors the org sync's caching pattern:
+  async function getRegionMap(): Promise<Map<string, RegionEnrichment>> {
+    // SSM-derived per-region metadata. Mirrors the org sync's caching pattern:
     // read once, hold for the session, drop on dimensions invalidation.
+    // The map feeds applyRegionFriendlyNames which picks longName, country,
+    // or continent per dim based on the dim's name.
     if (state.regionMap !== null) return state.regionMap;
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
-    const map = new Map<string, string>();
+    const map = new Map<string, RegionEnrichment>();
     try {
       const raw = await fs.readFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), 'utf-8');
       const parsed: unknown = JSON.parse(raw);
       if (isStringRecord(parsed) && isStringRecord(parsed['regions'])) {
-        for (const [code, name] of Object.entries(parsed['regions'])) {
-          if (typeof name === 'string' && name.length > 0) map.set(code, name);
+        for (const [code, info] of Object.entries(parsed['regions'])) {
+          if (!isStringRecord(info)) continue;
+          const longName = info['longName'];
+          if (typeof longName !== 'string' || longName.length === 0) continue;
+          const country = typeof info['country'] === 'string' ? info['country'] : '';
+          const continent = typeof info['continent'] === 'string' ? info['continent'] : '';
+          map.set(code, { longName, country, continent });
         }
       }
     } catch { /* no region sync yet */ }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -1,6 +1,7 @@
 import type { DuckDBClient, RawRow } from '../duckdb-client.js';
 import {
   asDimensionId,
+  applyNormalizationRule,
   applyStripPatterns,
   loadConfig,
   loadDimensions,
@@ -177,12 +178,19 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const primary = preferOrg ? await fromOrg() : await fromCsv();
     const raw = primary.size > 0 ? primary : (preferOrg ? await fromCsv() : await fromOrg());
 
-    // Apply user-defined regex strip patterns to every resolved name. Done
-    // once here so every downstream caller (queries, preview, sidecars) sees
-    // the cleaned name without re-implementing the rule.
+    // Apply the dim's display-time transforms (normalize then strip) to every
+    // resolved name. Done once here so every downstream caller — queries,
+    // preview, sidecars — sees the cleaned name without re-implementing the
+    // rule. Order matches the preview handler.
     const patterns = accountDim?.nameStripPatterns;
-    const map = patterns !== undefined && patterns.length > 0
-      ? new Map([...raw].map(([id, name]) => [id, applyStripPatterns(name, patterns)]))
+    const normalize = accountDim?.normalize;
+    const map = (normalize !== undefined || (patterns !== undefined && patterns.length > 0))
+      ? new Map([...raw].map(([id, name]) => {
+          let v = name;
+          if (normalize !== undefined) v = applyNormalizationRule(v, normalize);
+          if (patterns !== undefined && patterns.length > 0) v = applyStripPatterns(v, patterns);
+          return [id, v];
+        }))
       : raw;
 
     if (map.size > 0) {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -20,12 +20,20 @@ import type {
 const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
   { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name', description: 'AWS account the cost was charged to. Main axis for org/team-level rollups.', useOrgAccounts: true },
   { name: asDimensionId('region'), label: 'Region', field: 'region', description: 'AWS region where the resource ran. Useful for spotting unintended multi-region sprawl.' },
-  { name: asDimensionId('service'), label: 'Service', field: 'service', description: 'AWS service code (EC2, S3, RDS, etc.) — the broadest "what cost me this?" view.' },
-  { name: asDimensionId('service_family'), label: 'Service Family', field: 'service_family', description: 'Higher-level product category (Compute, Storage, Database). Good for exec summaries.' },
+  { name: asDimensionId('service'), label: 'AWS Service', field: 'service', description: 'AWS service code (EC2, S3, RDS, etc.) — the broadest "what cost me this?" view.' },
+  { name: asDimensionId('service_family'), label: 'Service Category', field: 'service_family', description: 'Higher-level product category (Compute, Storage, Database). Good for exec summaries.' },
   { name: asDimensionId('line_item_type'), label: 'Line Item Type', field: 'line_item_type', description: 'Usage vs Tax vs Credit vs Discount. Filter this to isolate real usage from billing adjustments.' },
   { name: asDimensionId('usage_type'), label: 'Usage Type', field: 'usage_type', description: 'Fine-grained usage string like USE2-BoxUsage:t3.medium. Use for instance/storage-tier breakdowns.', enabled: false },
   { name: asDimensionId('operation'), label: 'Operation', field: 'operation', description: 'API operation billed for (RunInstances, GetObject). Useful for API-level cost attribution.', enabled: false },
 ];
+
+/** Renames we want propagated to existing configs. Only overrides the stored
+ *  label when it still matches the previous default — if the user had typed
+ *  their own label we leave it alone. */
+const LEGACY_LABEL_RENAMES: Record<string, { from: string; to: string }> = {
+  service: { from: 'Service', to: 'AWS Service' },
+  service_family: { from: 'Service Family', to: 'Service Category' },
+};
 
 function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
   const defaultsByName = new Map(DEFAULT_BUILT_INS.map(d => [d.name, d]));
@@ -33,14 +41,21 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
   // predates the description field. User-set fields (label, aliases, etc.)
   // are kept — we only fill a missing description.
   const backfilled = loaded.builtIn.map(d => {
-    if (d.description !== undefined) return d;
-    const def = defaultsByName.get(d.name);
-    if (def?.description === undefined) return d;
-    return { ...d, description: def.description };
+    let next = d;
+    const rename = LEGACY_LABEL_RENAMES[d.name];
+    if (rename !== undefined && next.label === rename.from) {
+      next = { ...next, label: rename.to };
+    }
+    if (next.description === undefined) {
+      const def = defaultsByName.get(next.name);
+      if (def?.description !== undefined) next = { ...next, description: def.description };
+    }
+    return next;
   });
   const have = new Set(backfilled.map(d => d.name));
   const missing = DEFAULT_BUILT_INS.filter(d => !have.has(d.name));
-  if (missing.length === 0 && backfilled === loaded.builtIn) return loaded;
+  const changed = backfilled.some((d, i) => d !== loaded.builtIn[i]);
+  if (missing.length === 0 && !changed) return loaded;
   return { builtIn: [...backfilled, ...missing], tags: loaded.tags };
 }
 import { FileActivityLog } from '../file-activity.js';

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -2,6 +2,7 @@ import type { DuckDBClient, RawRow } from '../duckdb-client.js';
 import {
   asDimensionId,
   applyNormalizationRule,
+  applyRegionFriendlyNames,
   applyStripPatterns,
   loadConfig,
   loadDimensions,
@@ -81,6 +82,7 @@ export interface AppState {
   orgTree: OrgTreeConfig | null;
   syncStatuses: Record<string, SyncStatus>;
   accountMap: Map<string, string> | null;
+  regionMap: Map<string, string> | null;
 }
 
 export interface AppContext {
@@ -89,9 +91,16 @@ export interface AppContext {
   readonly activity: FileActivityLog;
   readonly optimizeQueue: OptimizeQueue;
   readonly getConfig: () => Promise<CostGoblinConfig>;
+  /** Raw user-facing dimensions config — used by the editor IPC handlers
+   *  (the alias textarea must show ONLY user aliases, not the SSM-derived
+   *  region name entries we splice in for queries). */
   readonly getDimensions: () => Promise<DimensionsConfig>;
+  /** Dimensions enriched for query-time use: Region's aliases get the
+   *  SSM-derived friendly names mixed in. Use this in every query handler. */
+  readonly getQueryDimensions: () => Promise<DimensionsConfig>;
   readonly getOrgTreeConfig: () => Promise<OrgTreeConfig>;
   readonly getAccountMap: () => Promise<Map<string, string>>;
+  readonly getRegionMap: () => Promise<Map<string, string>>;
   readonly getOrgAccountsPath: () => Promise<string | undefined>;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
@@ -105,6 +114,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     orgTree: null,
     syncStatuses: {},
     accountMap: null,
+    regionMap: null,
   };
 
   async function getConfig(): Promise<CostGoblinConfig> {
@@ -254,6 +264,32 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
   }
 
+  async function getRegionMap(): Promise<Map<string, string>> {
+    // SSM-derived region-name lookup. Mirrors the org sync's caching pattern:
+    // read once, hold for the session, drop on dimensions invalidation.
+    if (state.regionMap !== null) return state.regionMap;
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const map = new Map<string, string>();
+    try {
+      const raw = await fs.readFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (isStringRecord(parsed) && isStringRecord(parsed['regions'])) {
+        for (const [code, name] of Object.entries(parsed['regions'])) {
+          if (typeof name === 'string' && name.length > 0) map.set(code, name);
+        }
+      }
+    } catch { /* no region sync yet */ }
+    state.regionMap = map;
+    return map;
+  }
+
+  async function getQueryDimensions(): Promise<DimensionsConfig> {
+    const dims = await getDimensions();
+    const regionMap = await getRegionMap();
+    return applyRegionFriendlyNames(dims, regionMap);
+  }
+
   const activity = new FileActivityLog();
   async function prefsPath(): Promise<string> {
     const path = await import('node:path');
@@ -274,12 +310,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
     optimizeQueue,
     getConfig,
     getDimensions,
+    getQueryDimensions,
     getOrgTreeConfig,
     getAccountMap,
+    getRegionMap,
     getOrgAccountsPath,
     runQuery: (sql: string) => ctx.db.runQuery(sql),
     invalidateConfig: () => { state.config = null; },
-    invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; },
+    invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; state.regionMap = null; },
   };
 }
 

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -1,6 +1,7 @@
 import type { DuckDBClient, RawRow } from '../duckdb-client.js';
 import {
   asDimensionId,
+  applyStripPatterns,
   loadConfig,
   loadDimensions,
   loadOrgTree,
@@ -174,7 +175,16 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
 
     const primary = preferOrg ? await fromOrg() : await fromCsv();
-    const map = primary.size > 0 ? primary : (preferOrg ? await fromCsv() : await fromOrg());
+    const raw = primary.size > 0 ? primary : (preferOrg ? await fromCsv() : await fromOrg());
+
+    // Apply user-defined regex strip patterns to every resolved name. Done
+    // once here so every downstream caller (queries, preview, sidecars) sees
+    // the cleaned name without re-implementing the rule.
+    const patterns = accountDim?.nameStripPatterns;
+    const map = patterns !== undefined && patterns.length > 0
+      ? new Map([...raw].map(([id, name]) => [id, applyStripPatterns(name, patterns)]))
+      : raw;
+
     if (map.size > 0) {
       logger.info(`Loaded account mapping (${preferOrg ? 'org-data' : 'csv'} preferred): ${String(map.size)} accounts`);
     }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -178,10 +178,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const primary = preferOrg ? await fromOrg() : await fromCsv();
     const raw = primary.size > 0 ? primary : (preferOrg ? await fromCsv() : await fromOrg());
 
-    // Apply the dim's display-time transforms (normalize then strip) to every
-    // resolved name. Done once here so every downstream caller — queries,
-    // preview, sidecars — sees the cleaned name without re-implementing the
-    // rule. Order matches the preview handler.
+    // Apply the dim's display-time transforms to every resolved name. Done
+    // once here so every downstream caller — queries, preview, sidecars —
+    // sees the cleaned name without re-implementing the rule.
+    //
+    // Order matches the editor's visual top-down flow: normalize first, then
+    // strip. Users writing strip patterns under kebab/snake normalization
+    // need to anchor against the post-normalize form (e.g. '-production$'
+    // rather than '\s+production$').
     const patterns = accountDim?.nameStripPatterns;
     const normalize = accountDim?.normalize;
     const map = (normalize !== undefined || (patterns !== undefined && patterns.length > 0))

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -269,6 +269,11 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(d.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(d.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(d.useOrgAccounts === true ? { useOrgAccounts: true } : {}),
         ...(d.nameStripPatterns !== undefined && d.nameStripPatterns.length > 0 ? { nameStripPatterns: [...d.nameStripPatterns] } : {}),
+        // Persist useRegionNames whenever the user has set it explicitly
+        // (either value), so toggling off sticks past a reload. Leaving it
+        // unset lets mergeDefaultBuiltIns backfill `true` for the Region dim
+        // on legacy configs — we only want that for first-time migration.
+        ...(d.useRegionNames === undefined ? {} : { useRegionNames: d.useRegionNames }),
         ...(d.enabled === false ? { enabled: false } : {}),
       })),
       tags: config.tags.map(t => ({

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -63,7 +63,7 @@ async function listRawFilesForTier(dataDir: string, tier: 'daily' | 'hourly'): P
 }
 
 export function registerDimensionsHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, invalidateDimensions, runQuery, optimizeQueue } = app;
+  const { ctx, getConfig, getDimensions, getRegionMap, invalidateDimensions, runQuery, optimizeQueue } = app;
 
   ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
@@ -198,6 +198,14 @@ export function registerDimensionsHandlers(app: AppContext): void {
       const orgMap = await loadOrgAccountsMap(ctx.dataDir);
       if (orgMap.size > 0) {
         values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
+      }
+    }
+    // Region: always-on friendly-name resolution from region-names.json. No
+    // opt needed — codes not in the map fall through unchanged.
+    if (field === 'region') {
+      const regionMap = await getRegionMap();
+      if (regionMap.size > 0) {
+        values = values.map(v => ({ value: regionMap.get(v.value) ?? v.value, cost: v.cost }));
       }
     }
     // Apply the same display-time transforms the live queries use. Order

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -145,7 +145,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
   // Distinct values + cost for a built-in column — powers the preview on the
   // built-in editor ("Service has 120 distinct values, top 20 by cost are...").
   // Scans the most recent daily period so the preview loads fast.
-  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
+  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
     // Whitelist columns we know are safe to embed in SQL. These match the
     // aliases emitted by buildSource so the query plans identically to what
     // the rest of the app does.
@@ -200,12 +200,28 @@ export function registerDimensionsHandlers(app: AppContext): void {
         values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
       }
     }
-    // Region: always-on friendly-name resolution from region-names.json. No
-    // opt needed — codes not in the map fall through unchanged.
+    // Region: facet the preview by the dim the user is editing.
+    //   - region (with useRegionNames=true): long names from SSM
+    //   - region_country: ISO country code
+    //   - region_continent: AWS geo bucket
+    //   - anything else: raw codes fall through
+    // Rows with an empty value for the requested facet get collapsed together
+    // so the preview chips match what the live query will produce.
     if (field === 'region') {
       const regionMap = await getRegionMap();
-      if (regionMap.size > 0) {
-        values = values.map(v => ({ value: regionMap.get(v.value) ?? v.value, cost: v.cost }));
+      const pick: ((info: { longName: string; country: string; continent: string }) => string) | null =
+        opts?.dimName === 'region_country' ? (i) => i.country
+          : opts?.dimName === 'region_continent' ? (i) => i.continent
+            : opts?.useRegionNames === true ? (i) => i.longName
+              : null;
+      if (pick !== null && regionMap.size > 0) {
+        const merged = new Map<string, number>();
+        for (const v of values) {
+          const info = regionMap.get(v.value);
+          const label = info === undefined ? v.value : (pick(info).length > 0 ? pick(info) : v.value);
+          merged.set(label, (merged.get(label) ?? 0) + v.cost);
+        }
+        values = [...merged.entries()].map(([value, cost]) => ({ value, cost })).sort((a, b) => b.cost - a.cost);
       }
     }
     // Apply the same display-time transforms the live queries use. Order

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron';
 import { join } from 'node:path';
 import { readdir } from 'node:fs/promises';
-import { applyStripPatterns, getRawDirPrefix, isStringRecord, logger } from '@costgoblin/core';
-import type { DimensionsConfig, TagDimension } from '@costgoblin/core';
+import { applyNormalizationRule, applyStripPatterns, getRawDirPrefix, isStringRecord, logger } from '@costgoblin/core';
+import type { DimensionsConfig, NormalizationRule, TagDimension } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import { toNum, toStr } from './query-utils.js';
 import { removeAllSidecars } from '../optimize.js';
@@ -145,7 +145,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
   // Distinct values + cost for a built-in column — powers the preview on the
   // built-in editor ("Service has 120 distinct values, top 20 by cost are...").
   // Scans the most recent daily period so the preview loads fast.
-  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[] }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
+  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
     // Whitelist columns we know are safe to embed in SQL. These match the
     // aliases emitted by buildSource so the query plans identically to what
     // the rest of the app does.
@@ -200,11 +200,21 @@ export function registerDimensionsHandlers(app: AppContext): void {
         values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
       }
     }
-    // Strip patterns apply to whatever name we ended up with — useful even if
-    // the user wants to scrub raw IDs (rare) but mostly meaningful when paired
-    // with the org-data toggle above.
-    if (field === 'account_id' && opts?.nameStripPatterns !== undefined && opts.nameStripPatterns.length > 0) {
-      values = values.map(v => ({ value: applyStripPatterns(v.value, opts.nameStripPatterns), cost: v.cost }));
+    // Apply the same display-time transforms the live queries use. Order
+    // matches getAccountMap (and the table renderer): normalize → strip. After
+    // either runs, we re-aggregate by the resulting key so two raw values that
+    // collapse to the same display value don't show up as duplicate chips.
+    const stripPatterns = field === 'account_id' ? opts?.nameStripPatterns : undefined;
+    const normalize = opts?.normalize;
+    if (normalize !== undefined || (stripPatterns !== undefined && stripPatterns.length > 0)) {
+      const merged = new Map<string, number>();
+      for (const v of values) {
+        let key = v.value;
+        if (normalize !== undefined) key = applyNormalizationRule(key, normalize);
+        if (stripPatterns !== undefined && stripPatterns.length > 0) key = applyStripPatterns(key, stripPatterns);
+        merged.set(key, (merged.get(key) ?? 0) + v.cost);
+      }
+      values = [...merged.entries()].map(([value, cost]) => ({ value, cost })).sort((a, b) => b.cost - a.cost);
     }
 
     return { values, distinctCount, period: latest.replace(/^daily-/, '') };

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -201,9 +201,9 @@ export function registerDimensionsHandlers(app: AppContext): void {
       }
     }
     // Apply the same display-time transforms the live queries use. Order
-    // matches getAccountMap (and the table renderer): normalize → strip. After
-    // either runs, we re-aggregate by the resulting key so two raw values that
-    // collapse to the same display value don't show up as duplicate chips.
+    // matches the editor's visual top-down flow: normalize first, then strip.
+    // After either runs, re-aggregate by the resulting key so two raw values
+    // that collapse to the same display value don't show up as duplicate chips.
     const stripPatterns = field === 'account_id' ? opts?.nameStripPatterns : undefined;
     const normalize = opts?.normalize;
     if (normalize !== undefined || (stripPatterns !== undefined && stripPatterns.length > 0)) {

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import { join } from 'node:path';
 import { readdir } from 'node:fs/promises';
-import { getRawDirPrefix, isStringRecord, logger } from '@costgoblin/core';
+import { applyStripPatterns, getRawDirPrefix, isStringRecord, logger } from '@costgoblin/core';
 import type { DimensionsConfig, TagDimension } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import { toNum, toStr } from './query-utils.js';
@@ -145,7 +145,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
   // Distinct values + cost for a built-in column — powers the preview on the
   // built-in editor ("Service has 120 distinct values, top 20 by cost are...").
   // Scans the most recent daily period so the preview loads fast.
-  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
+  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[] }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
     // Whitelist columns we know are safe to embed in SQL. These match the
     // aliases emitted by buildSource so the query plans identically to what
     // the rest of the app does.
@@ -200,6 +200,12 @@ export function registerDimensionsHandlers(app: AppContext): void {
         values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
       }
     }
+    // Strip patterns apply to whatever name we ended up with — useful even if
+    // the user wants to scrub raw IDs (rare) but mostly meaningful when paired
+    // with the org-data toggle above.
+    if (field === 'account_id' && opts?.nameStripPatterns !== undefined && opts.nameStripPatterns.length > 0) {
+      values = values.map(v => ({ value: applyStripPatterns(v.value, opts.nameStripPatterns), cost: v.cost }));
+    }
 
     return { values, distinctCount, period: latest.replace(/^daily-/, '') };
   });
@@ -228,6 +234,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(d.normalize === undefined ? {} : { normalize: d.normalize }),
         ...(d.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(d.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(d.useOrgAccounts === true ? { useOrgAccounts: true } : {}),
+        ...(d.nameStripPatterns !== undefined && d.nameStripPatterns.length > 0 ? { nameStripPatterns: [...d.nameStripPatterns] } : {}),
         ...(d.enabled === false ? { enabled: false } : {}),
       })),
       tags: config.tags.map(t => ({

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -91,6 +91,29 @@ export function registerOrgHandlers(app: AppContext): void {
     return orgSyncProgress;
   });
 
+  // Standalone SSM resync — same syncRegionNames(), same destination file,
+  // but doesn't drag the org sync along. Lets the user fix a transient SSM
+  // failure (perm denied, network blip) without redoing the slow per-account
+  // tag fetch loop. lastRegionSyncError mirrors the merged sync's tracking.
+  ipcMain.handle('ssm:sync-region-names', async (_event, profile: string): Promise<{ count: number; syncedAt: string }> => {
+    orgSyncProgress = { phase: 'regions', done: 0, total: 0 };
+    try {
+      const regionMap = await syncRegionNames(profile);
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      await fs.writeFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), JSON.stringify(regionMap, null, 2));
+      lastRegionSyncError = null;
+      invalidateDimensions();
+      orgSyncProgress = null;
+      return { count: Object.keys(regionMap.regions).length, syncedAt: regionMap.syncedAt };
+    } catch (err: unknown) {
+      orgSyncProgress = null;
+      const msg = err instanceof Error ? err.message : String(err);
+      lastRegionSyncError = msg;
+      throw err;
+    }
+  });
+
   ipcMain.handle('org:clear-data', async (): Promise<void> => {
     // Wipes everything the org sync produced — accounts, the flat tag
     // lookup used for resource-tag fallback, and the SSM region-name cache.

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -80,4 +80,20 @@ export function registerOrgHandlers(app: AppContext): void {
   ipcMain.handle('org:get-progress', (): OrgSyncProgress | null => {
     return orgSyncProgress;
   });
+
+  ipcMain.handle('org:get-region-names-info', async (): Promise<{ count: number; syncedAt: string } | null> => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    try {
+      const raw = await fs.readFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (!isStringRecord(parsed)) return null;
+      const regions = parsed['regions'];
+      const syncedAt = parsed['syncedAt'];
+      if (!isStringRecord(regions) || typeof syncedAt !== 'string') return null;
+      return { count: Object.keys(regions).length, syncedAt };
+    } catch {
+      return null;
+    }
+  });
 }

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -33,6 +33,10 @@ function decodeOrgSyncResult(raw: string): OrgSyncResult | null {
 export function registerOrgHandlers(app: AppContext): void {
   const { ctx } = app;
   let orgSyncProgress: OrgSyncProgress | null = null;
+  // Latest result of the SSM region-name sync. Lets the UI tell the user why
+  // region friendly names didn't populate (typically: missing IAM permission)
+  // instead of the silent "not synced" we showed before.
+  let lastRegionSyncError: string | null = null;
 
   async function orgResultPath(): Promise<string> {
     const path = await import('node:path');
@@ -51,12 +55,18 @@ export function registerOrgHandlers(app: AppContext): void {
 
       // Piggyback the SSM region-name sync onto the existing org-sync flow.
       // Failures here are non-fatal — region names are a display nicety and
-      // the user has already paid the auth cost for the org sync.
+      // the user has already paid the auth cost for the org sync. Capture
+      // the error so the UI can hint at the cause (most often: profile
+      // lacks ssm:GetParametersByPath).
+      orgSyncProgress = { phase: 'regions', done: 0, total: 0 };
       try {
         const regionMap = await syncRegionNames(profile);
         await fs.writeFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), JSON.stringify(regionMap, null, 2));
+        lastRegionSyncError = null;
       } catch (err: unknown) {
-        logger.info(`Region-name sync failed (non-fatal): ${String(err)}`);
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.info(`Region-name sync failed (non-fatal): ${msg}`);
+        lastRegionSyncError = msg;
       }
 
       orgSyncProgress = null;
@@ -81,7 +91,7 @@ export function registerOrgHandlers(app: AppContext): void {
     return orgSyncProgress;
   });
 
-  ipcMain.handle('org:get-region-names-info', async (): Promise<{ count: number; syncedAt: string } | null> => {
+  ipcMain.handle('org:get-region-names-info', async (): Promise<{ count: number; syncedAt: string; lastError: string | null } | null> => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     try {
@@ -91,8 +101,12 @@ export function registerOrgHandlers(app: AppContext): void {
       const regions = parsed['regions'];
       const syncedAt = parsed['syncedAt'];
       if (!isStringRecord(regions) || typeof syncedAt !== 'string') return null;
-      return { count: Object.keys(regions).length, syncedAt };
+      return { count: Object.keys(regions).length, syncedAt, lastError: lastRegionSyncError };
     } catch {
+      // No file yet, but we may still know why from the most recent attempt.
+      if (lastRegionSyncError !== null) {
+        return { count: 0, syncedAt: '', lastError: lastRegionSyncError };
+      }
       return null;
     }
   });

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -1,7 +1,8 @@
 import { ipcMain } from 'electron';
-import { isStringRecord } from '@costgoblin/core';
+import { isStringRecord, logger } from '@costgoblin/core';
 import type { OrgSyncResult, OrgSyncProgress, OrgAccount } from '@costgoblin/core';
 import { syncOrgAccounts } from '../aws-org-client.js';
+import { syncRegionNames } from '../aws-ssm-client.js';
 import type { AppContext } from './context.js';
 
 function isOrgAccount(v: unknown): v is OrgAccount {
@@ -47,6 +48,17 @@ export function registerOrgHandlers(app: AppContext): void {
       const path = await import('node:path');
       const tagLookup = result.accounts.map(a => ({ id: a.id, tags: a.tags }));
       await fs.writeFile(path.join(path.dirname(ctx.dataDir), 'org-account-tags.json'), JSON.stringify(tagLookup));
+
+      // Piggyback the SSM region-name sync onto the existing org-sync flow.
+      // Failures here are non-fatal — region names are a display nicety and
+      // the user has already paid the auth cost for the org sync.
+      try {
+        const regionMap = await syncRegionNames(profile);
+        await fs.writeFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), JSON.stringify(regionMap, null, 2));
+      } catch (err: unknown) {
+        logger.info(`Region-name sync failed (non-fatal): ${String(err)}`);
+      }
+
       orgSyncProgress = null;
       return result;
     } catch (err: unknown) {

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -138,7 +138,7 @@ export function registerOrgHandlers(app: AppContext): void {
     invalidateDimensions();
   });
 
-  ipcMain.handle('org:get-region-names-info', async (): Promise<{ count: number; syncedAt: string; lastError: string | null } | null> => {
+  ipcMain.handle('org:get-region-names-info', async (): Promise<{ count: number; syncedAt: string; lastError: string | null; regions: Record<string, { longName: string; country: string; continent: string }> } | null> => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     try {
@@ -148,11 +148,20 @@ export function registerOrgHandlers(app: AppContext): void {
       const regions = parsed['regions'];
       const syncedAt = parsed['syncedAt'];
       if (!isStringRecord(regions) || typeof syncedAt !== 'string') return null;
-      return { count: Object.keys(regions).length, syncedAt, lastError: lastRegionSyncError };
+      const out: Record<string, { longName: string; country: string; continent: string }> = {};
+      for (const [code, info] of Object.entries(regions)) {
+        if (!isStringRecord(info)) continue;
+        const longName = info['longName'];
+        if (typeof longName !== 'string' || longName.length === 0) continue;
+        const country = typeof info['country'] === 'string' ? info['country'] : '';
+        const continent = typeof info['continent'] === 'string' ? info['continent'] : '';
+        out[code] = { longName, country, continent };
+      }
+      return { count: Object.keys(out).length, syncedAt, lastError: lastRegionSyncError, regions: out };
     } catch {
       // No file yet, but we may still know why from the most recent attempt.
       if (lastRegionSyncError !== null) {
-        return { count: 0, syncedAt: '', lastError: lastRegionSyncError };
+        return { count: 0, syncedAt: '', lastError: lastRegionSyncError, regions: {} };
       }
       return null;
     }

--- a/packages/desktop/src/main/handlers/org.ts
+++ b/packages/desktop/src/main/handlers/org.ts
@@ -31,7 +31,7 @@ function decodeOrgSyncResult(raw: string): OrgSyncResult | null {
 }
 
 export function registerOrgHandlers(app: AppContext): void {
-  const { ctx } = app;
+  const { ctx, invalidateDimensions } = app;
   let orgSyncProgress: OrgSyncProgress | null = null;
   // Latest result of the SSM region-name sync. Lets the UI tell the user why
   // region friendly names didn't populate (typically: missing IAM permission)
@@ -89,6 +89,30 @@ export function registerOrgHandlers(app: AppContext): void {
 
   ipcMain.handle('org:get-progress', (): OrgSyncProgress | null => {
     return orgSyncProgress;
+  });
+
+  ipcMain.handle('org:clear-data', async (): Promise<void> => {
+    // Wipes everything the org sync produced — accounts, the flat tag
+    // lookup used for resource-tag fallback, and the SSM region-name cache.
+    // Each unlink swallows ENOENT so the call is idempotent (clicking twice
+    // doesn't error). The next sync re-creates whichever files succeed.
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const baseDir = path.dirname(ctx.dataDir);
+    const files = ['org-accounts.json', 'org-account-tags.json', 'region-names.json'];
+    for (const f of files) {
+      try {
+        await fs.unlink(path.join(baseDir, f));
+        logger.info(`Cleared ${f}`);
+      } catch (err: unknown) {
+        const e = err as { code?: string };
+        if (e.code !== 'ENOENT') logger.info(`Failed to clear ${f}: ${String(err)}`);
+      }
+    }
+    lastRegionSyncError = null;
+    // Drop the cached id→name + region maps so subsequent queries re-load
+    // (they'll find nothing and treat all values as raw).
+    invalidateDimensions();
   });
 
   ipcMain.handle('org:get-region-names-info', async (): Promise<{ count: number; syncedAt: string; lastError: string | null } | null> => {

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -56,6 +56,71 @@ export function resolveEntityName(entity: string, accountMap: Map<string, string
   return mapped === undefined ? entity : mapped;
 }
 
+/** Reverse view of the id→name account map. When the user's strip/normalize
+ *  rules collapse multiple ids to the same display name, the reverse map
+ *  groups them so a single filter or rollup can target all underlying ids. */
+export function buildAccountReverseMap(accountMap: Map<string, string>): Map<string, readonly string[]> {
+  const reverse = new Map<string, string[]>();
+  for (const [id, name] of accountMap) {
+    const ids = reverse.get(name);
+    if (ids === undefined) reverse.set(name, [id]);
+    else ids.push(id);
+  }
+  return reverse;
+}
+
+/** Sums two CostRows assumed to share the same entity. Service breakdowns
+ *  are merged additively; isVirtual is preserved if either side has it. */
+export function mergeCostRowsByEntity(rows: readonly CostRow[]): CostRow[] {
+  const map = new Map<string, { totalCost: number; serviceCosts: Record<string, number>; isVirtual: boolean }>();
+  for (const r of rows) {
+    const key = r.entity as string;
+    const existing = map.get(key);
+    if (existing === undefined) {
+      const serviceCosts: Record<string, number> = {};
+      for (const [svc, cost] of Object.entries(r.serviceCosts)) serviceCosts[svc] = cost;
+      map.set(key, { totalCost: r.totalCost, serviceCosts, isVirtual: r.isVirtual === true });
+    } else {
+      existing.totalCost += r.totalCost;
+      for (const [svc, cost] of Object.entries(r.serviceCosts)) {
+        existing.serviceCosts[svc] = (existing.serviceCosts[svc] ?? 0) + cost;
+      }
+      if (r.isVirtual === true) existing.isVirtual = true;
+    }
+  }
+  return [...map.entries()].map(([entity, d]) => ({
+    entity: asEntityRef(entity),
+    totalCost: asDollars(d.totalCost),
+    serviceCosts: Object.fromEntries(Object.entries(d.serviceCosts).map(([k, v]) => [k, asDollars(v)])),
+    ...(d.isVirtual ? { isVirtual: true as const } : {}),
+  })).sort((a, b) => b.totalCost - a.totalCost);
+}
+
+/** Sum delta + costs for trend rows sharing the same entity, then recompute
+ *  percentChange against the merged previous total (avoids averaging
+ *  percentages, which would lie when one merged side is much larger). */
+export function mergeTrendRowsByEntity(rows: readonly TrendRow[]): TrendRow[] {
+  const map = new Map<string, { currentCost: number; previousCost: number; delta: number }>();
+  for (const r of rows) {
+    const key = r.entity as string;
+    const existing = map.get(key);
+    if (existing === undefined) {
+      map.set(key, { currentCost: r.currentCost, previousCost: r.previousCost, delta: r.delta });
+    } else {
+      existing.currentCost += r.currentCost;
+      existing.previousCost += r.previousCost;
+      existing.delta += r.delta;
+    }
+  }
+  return [...map.entries()].map(([entity, d]) => ({
+    entity: asEntityRef(entity),
+    currentCost: asDollars(d.currentCost),
+    previousCost: asDollars(d.previousCost),
+    delta: asDollars(d.delta),
+    percentChange: d.previousCost === 0 ? (d.currentCost === 0 ? 0 : 100) : (d.delta / d.previousCost) * 100,
+  })).sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+}
+
 export function buildCostResult(rows: RawRow[], dateRange: DateRange): CostResult {
   const entityMap = new Map<string, { totalCost: number; serviceCosts: Record<string, number> }>();
   const serviceTotals = new Map<string, number>();

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -36,11 +36,14 @@ import type { AppContext } from './context.js';
 import type { RawRow } from '../duckdb-client.js';
 import {
   applyOrgTreeRollup,
+  buildAccountReverseMap,
   buildCostResult,
   buildEntityDetailResult,
   buildMissingTagsResult,
   buildTrendResult,
   isOwnerGroupBy,
+  mergeCostRowsByEntity,
+  mergeTrendRowsByEntity,
   resolveEntityName,
   toEffort,
   toNum,
@@ -92,20 +95,24 @@ export function registerQueryHandlers(app: AppContext): void {
   ipcMain.handle('query:costs', async (_event, params: CostQueryParams): Promise<CostResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
+    const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan);
+    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan, accountReverseMap);
     logger.info('query:costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
     let result = buildCostResult(rows, params.dateRange);
 
     if (params.groupBy === 'account' || params.groupBy === 'account_id') {
+      // Resolve raw account_id → display name, then merge any rows whose
+      // resolved name collides (strip patterns / normalize on the Account dim
+      // can intentionally collapse N ids into one logical entity).
       result = {
         ...result,
-        rows: result.rows.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
+        rows: mergeCostRowsByEntity(result.rows.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) }))),
       };
     }
 
@@ -121,11 +128,13 @@ export function registerQueryHandlers(app: AppContext): void {
 
   ipcMain.handle('query:daily-costs', async (_event, params: DailyCostsParams): Promise<DailyCostsResult> => {
     const dimensions = await getDimensions();
+    const accountMap = await getAccountMap();
+    const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
+    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -176,10 +185,11 @@ export function registerQueryHandlers(app: AppContext): void {
   ipcMain.handle('query:trends', async (_event, params: TrendQueryParams): Promise<TrendResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
+    const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     const { available, plan, empty } = await planQuery('daily', params.dateRange);
     if (empty) return { increases: [], savings: [], totalIncrease: asDollars(0), totalSavings: asDollars(0) };
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
+    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
     logger.info('query:trends', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -187,8 +197,8 @@ export function registerQueryHandlers(app: AppContext): void {
     if (params.groupBy === 'account' || params.groupBy === 'account_id') {
       return {
         ...result,
-        increases: result.increases.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
-        savings: result.savings.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) })),
+        increases: mergeTrendRowsByEntity(result.increases.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) }))),
+        savings: mergeTrendRowsByEntity(result.savings.map(r => ({ ...r, entity: asEntityRef(resolveEntityName(r.entity, accountMap)) }))),
       };
     }
     return result;
@@ -197,6 +207,7 @@ export function registerQueryHandlers(app: AppContext): void {
   ipcMain.handle('query:missing-tags', async (_event, params: MissingTagsParams): Promise<MissingTagsResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
+    const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
@@ -212,8 +223,8 @@ export function registerQueryHandlers(app: AppContext): void {
         nonResourceRows: [],
       };
     }
-    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
-    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
+    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
+    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
     const [resourceRows, nonResourceRows] = await Promise.all([
       runQuery(resourceSql),
       runQuery(nonResourceSql),
@@ -295,6 +306,7 @@ export function registerQueryHandlers(app: AppContext): void {
   ipcMain.handle('query:entity-detail', async (_event, params: EntityDetailParams): Promise<EntityDetailResult> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
+    const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
@@ -310,7 +322,7 @@ export function registerQueryHandlers(app: AppContext): void {
         bySubEntity: [],
       };
     }
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan);
+    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
     logger.info('query:entity-detail', { entity: params.entity });
 
     const rows = await runQuery(sql);
@@ -327,6 +339,7 @@ export function registerQueryHandlers(app: AppContext): void {
   ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, string>, dateRange?: { start: string; end: string }): Promise<{ value: string; label: string; count: number }[]> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
+    const accountReverseMap = buildAccountReverseMap(accountMap);
 
     const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
     const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);
@@ -345,6 +358,16 @@ export function registerQueryHandlers(app: AppContext): void {
       let ffExpr = ff;
       if (ft !== undefined) {
         ffExpr = buildAliasSqlCase(ff, ft);
+      }
+      // Account filters carry display names that may collapse N ids — same
+      // expansion the SQL builder does in buildFilterClauses.
+      if (ff === 'account_id') {
+        const ids = accountReverseMap.get(value);
+        if (ids !== undefined && ids.length > 0) {
+          const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+          whereClauses.push(`${ff} IN (${list})`);
+          continue;
+        }
       }
       whereClauses.push(`${ffExpr} = '${value.replaceAll("'", "''")}'`);
     }
@@ -369,11 +392,25 @@ export function registerQueryHandlers(app: AppContext): void {
     `;
 
     const rows = await runQuery(sql);
+    const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
+    if (isAccountDim) {
+      // Roll N raw ids that resolve to the same display name into one entry —
+      // value AND label are the display name so the picker shows a single row
+      // and downstream filter matching uses the same display name (which the
+      // SQL builder expands back to all underlying ids).
+      const merged = new Map<string, number>();
+      for (const r of rows) {
+        const rawVal = toStr(r['val']);
+        const name = accountMap.get(rawVal) ?? rawVal;
+        merged.set(name, (merged.get(name) ?? 0) + toNum(r['total_cost']));
+      }
+      return [...merged.entries()]
+        .map(([name, cost]) => ({ value: name, label: name, count: cost }))
+        .sort((a, b) => b.count - a.count);
+    }
     return rows.map(r => {
       const rawVal = toStr(r['val']);
-      const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
-      const label = isAccountDim ? (accountMap.get(rawVal) ?? rawVal) : rawVal;
-      return { value: rawVal, label, count: toNum(r['total_cost']) };
+      return { value: rawVal, label: rawVal, count: toNum(r['total_cost']) };
     });
   });
 }

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -51,7 +51,7 @@ import {
 } from './query-utils.js';
 
 export function registerQueryHandlers(app: AppContext): void {
-  const { ctx, getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, runQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, runQuery } = app;
 
   // Intersect the query's date range with the months actually on disk so
   // buildSource only globs directories that exist — DuckDB errors on empty
@@ -345,8 +345,13 @@ export function registerQueryHandlers(app: AppContext): void {
     const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);
 
     const field = builtIn === undefined ? dimensionId : builtIn.field;
+    // Apply alias/normalize CASE for both built-ins and tags so the SQL
+    // returns the same display values the cost queries see — including the
+    // SSM-derived friendly region names spliced into Region's aliases.
     let fieldExpr = field;
-    if (tag !== undefined) {
+    if (builtIn !== undefined) {
+      fieldExpr = buildAliasSqlCase(field, builtIn);
+    } else if (tag !== undefined) {
       fieldExpr = buildAliasSqlCase(field, tag);
     }
 
@@ -356,7 +361,9 @@ export function registerQueryHandlers(app: AppContext): void {
       const ft = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === key);
       const ff = fb === undefined ? key : fb.field;
       let ffExpr = ff;
-      if (ft !== undefined) {
+      if (fb !== undefined) {
+        ffExpr = buildAliasSqlCase(ff, fb);
+      } else if (ft !== undefined) {
         ffExpr = buildAliasSqlCase(ff, ft);
       }
       // Account filters carry display names that may collapse N ids — same

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -149,6 +149,9 @@ const api: CostApi = {
   getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null } | null> {
     return invoke<{ count: number; syncedAt: string; lastError: string | null } | null>('org:get-region-names-info');
   },
+  clearOrgData(): Promise<void> {
+    return invoke<undefined>('org:clear-data').then(() => undefined);
+  },
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -145,7 +145,7 @@ const api: CostApi = {
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[] }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
     return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field, opts);
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -107,6 +107,9 @@ const api: CostApi = {
   writeConfig(config: { providerName: string; profile: string; dailyBucket: string; retentionDays?: number | undefined; hourlyBucket?: string | undefined; costOptBucket?: string | undefined; tags?: { tagName: string; label: string; concept?: string | undefined }[] | undefined }): Promise<void> {
     return invoke<undefined>('setup:write-config', config).then(() => undefined);
   },
+  updateAwsProfile(profile: string): Promise<void> {
+    return invoke<undefined>('config:update-aws-profile', profile).then(() => undefined);
+  },
   getSavingsPreferences(): Promise<SavingsPreferences> {
     return invoke<SavingsPreferences>('savings:get-preferences');
   },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -146,8 +146,8 @@ const api: CostApi = {
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
   },
-  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null } | null> {
-    return invoke<{ count: number; syncedAt: string; lastError: string | null } | null>('org:get-region-names-info');
+  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null; regions: Record<string, { longName: string; country: string; continent: string }> } | null> {
+    return invoke<{ count: number; syncedAt: string; lastError: string | null; regions: Record<string, { longName: string; country: string; continent: string }> } | null>('org:get-region-names-info');
   },
   clearOrgData(): Promise<void> {
     return invoke<undefined>('org:clear-data').then(() => undefined);
@@ -158,7 +158,7 @@ const api: CostApi = {
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
     return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field, opts);
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -143,6 +143,9 @@ const api: CostApi = {
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
   },
+  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string } | null> {
+    return invoke<{ count: number; syncedAt: string } | null>('org:get-region-names-info');
+  },
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -143,8 +143,8 @@ const api: CostApi = {
   getOrgSyncProgress(): Promise<OrgSyncProgress | null> {
     return invoke<OrgSyncProgress | null>('org:get-progress');
   },
-  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string } | null> {
-    return invoke<{ count: number; syncedAt: string } | null>('org:get-region-names-info');
+  getRegionNamesInfo(): Promise<{ count: number; syncedAt: string; lastError: string | null } | null> {
+    return invoke<{ count: number; syncedAt: string; lastError: string | null } | null>('org:get-region-names-info');
   },
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -152,6 +152,9 @@ const api: CostApi = {
   clearOrgData(): Promise<void> {
     return invoke<undefined>('org:clear-data').then(() => undefined);
   },
+  syncRegionNames(profile: string): Promise<{ count: number; syncedAt: string }> {
+    return invoke<{ count: number; syncedAt: string }>('ssm:sync-region-names', profile);
+  },
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -22,6 +22,7 @@ import type {
   SavingsPreferences,
   UIPreferences,
   DimensionsConfig,
+  NormalizationRule,
   OrgSyncResult,
   OrgSyncProgress,
   AutoSyncStatus,
@@ -145,7 +146,7 @@ const api: CostApi = {
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[] }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
     return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field, opts);
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -249,6 +249,7 @@ export class MockCostApi implements CostApi {
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
   getRegionNamesInfo(): Promise<null> { return Promise.resolve(null); }
+  clearOrgData(): Promise<void> { return Promise.resolve(); }
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500, distinctCount: 8, coveragePct: 45 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400, distinctCount: 4, coveragePct: 36 }], samplePeriod: '2026-04' }); }
   discoverColumnValues(): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> { return Promise.resolve({ values: [{ value: 'Usage', cost: 12345 }, { value: 'Tax', cost: 234 }, { value: 'Credit', cost: -100 }], distinctCount: 3, period: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -250,6 +250,7 @@ export class MockCostApi implements CostApi {
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
   getRegionNamesInfo(): Promise<null> { return Promise.resolve(null); }
   clearOrgData(): Promise<void> { return Promise.resolve(); }
+  syncRegionNames(): Promise<{ count: number; syncedAt: string }> { return Promise.resolve({ count: 0, syncedAt: '' }); }
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500, distinctCount: 8, coveragePct: 45 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400, distinctCount: 4, coveragePct: 36 }], samplePeriod: '2026-04' }); }
   discoverColumnValues(): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> { return Promise.resolve({ values: [{ value: 'Usage', cost: 12345 }, { value: 'Tax', cost: 234 }, { value: 'Credit', cost: -100 }], distinctCount: 3, period: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -247,6 +247,7 @@ export class MockCostApi implements CostApi {
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }
   getOrgSyncProgress(): Promise<null> { return Promise.resolve(null); }
+  getRegionNamesInfo(): Promise<null> { return Promise.resolve(null); }
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> { return Promise.resolve({ tags: [{ key: 'team', sampleValues: ['platform', 'payments'], rowCount: 500, distinctCount: 8, coveragePct: 45 }, { key: 'environment', sampleValues: ['production', 'staging'], rowCount: 400, distinctCount: 4, coveragePct: 36 }], samplePeriod: '2026-04' }); }
   discoverColumnValues(): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> { return Promise.resolve({ values: [{ value: 'Usage', cost: 12345 }, { value: 'Tax', cost: 234 }, { value: 'Credit', cost: -100 }], distinctCount: 3, period: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -235,6 +235,7 @@ export class MockCostApi implements CostApi {
   browseS3(): Promise<{ prefixes: string[]; isCurReport: boolean; detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] }> { return Promise.resolve({ prefixes: ['data', 'metadata'], isCurReport: true, detectedType: 'daily', missingColumns: [] }); }
   scaffoldConfig(): Promise<void> { return Promise.resolve(); }
   writeConfig(): Promise<void> { return Promise.resolve(); }
+  updateAwsProfile(): Promise<void> { return Promise.resolve(); }
   getSavingsPreferences(): Promise<{ hiddenActionTypes: readonly string[] }> { return Promise.resolve({ hiddenActionTypes: [] }); }
   saveSavingsPreferences(): Promise<void> { return Promise.resolve(); }
   getUIPreferences(): Promise<{ theme: 'dark' | 'light' }> { return Promise.resolve({ theme: 'dark' }); }

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -8,6 +8,19 @@ type OrgSyncState =
   | { status: 'done'; count: number }
   | { status: 'error'; message: string };
 
+// Map the backend's terse phase keys to user-facing sentences. The 'tags'
+// phase iterates ListTagsForResource per account (so total = account count,
+// NOT the eventual number of distinct tag keys — that's discovered after).
+function phaseLabel(phase: string, total: number): string {
+  switch (phase) {
+    case 'accounts': return 'Listing accounts';
+    case 'ous':      return 'Discovering organizational units';
+    case 'tags':     return total > 0 ? 'Fetching tags from each account' : 'Fetching tags';
+    case 'regions':  return 'Fetching region friendly names from SSM';
+    default:         return phase;
+  }
+}
+
 export function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
   const api = useCostApi();
   const [refreshKey, setRefreshKey] = useState(0);
@@ -141,42 +154,11 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
         )}
       </div>
 
-      {/* What got pulled in the last successful sync. Region names are sourced
-          from the SSM piggyback step; missing means insufficient permissions
-          or sync hasn't run since the feature was added. */}
-      <ul className="px-4 pb-3 flex flex-col gap-1 text-xs">
-        <li className="flex items-center gap-2 text-text-secondary">
-          <span className="text-accent">✓</span>
-          <span>{String(orgData.accounts.length)} accounts</span>
-        </li>
-        <li className="flex items-center gap-2 text-text-secondary">
-          <span className="text-accent">✓</span>
-          <span>{String(ouCount)} organizational units</span>
-        </li>
-        <li className="flex items-center gap-2 text-text-secondary">
-          <span className="text-accent">✓</span>
-          <span>{String(allTagKeys.length)} tag keys</span>
-        </li>
-        <li className="flex items-center gap-2">
-          {regionInfo !== null ? (
-            <>
-              <span className="text-accent">✓</span>
-              <span className="text-text-secondary">{String(regionInfo.count)} region friendly names</span>
-            </>
-          ) : (
-            <>
-              <span className="text-text-muted">○</span>
-              <span className="text-text-muted">region friendly names not synced (re-sync to populate)</span>
-            </>
-          )}
-        </li>
-      </ul>
-
       {syncState.status === 'syncing' && (
         <div className="px-4 pb-2">
           <div className="flex items-center gap-2 text-xs text-accent">
             <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
-            <span className="capitalize">{syncState.phase}</span>
+            <span>{phaseLabel(syncState.phase, syncState.total)}</span>
             {syncState.total > 0 && <span>— {String(syncState.done)}/{String(syncState.total)}</span>}
           </div>
         </div>
@@ -184,6 +166,41 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
 
       {expanded && (
         <div className="border-t border-border">
+          {/* What got pulled in the last successful sync. Region names are
+              sourced from the SSM piggyback step; missing means insufficient
+              permissions or sync hasn't run since the feature was added. */}
+          <ul className="px-4 pt-3 pb-1 flex flex-col gap-1 text-xs">
+            <li className="flex items-center gap-2 text-text-secondary">
+              <span className="text-accent">✓</span>
+              <span>{String(orgData.accounts.length)} accounts</span>
+            </li>
+            <li className="flex items-center gap-2 text-text-secondary">
+              <span className="text-accent">✓</span>
+              <span>{String(ouCount)} organizational units</span>
+            </li>
+            <li className="flex items-center gap-2 text-text-secondary">
+              <span className="text-accent">✓</span>
+              <span>{String(allTagKeys.length)} tag keys (across all accounts, used as fallback when resources are under-tagged)</span>
+            </li>
+            <li className="flex items-center gap-2">
+              {regionInfo !== null && regionInfo.count > 0 ? (
+                <>
+                  <span className="text-accent">✓</span>
+                  <span className="text-text-secondary">{String(regionInfo.count)} region friendly names</span>
+                </>
+              ) : regionInfo?.lastError !== undefined && regionInfo.lastError !== null ? (
+                <>
+                  <span className="text-negative">✗</span>
+                  <span className="text-negative" title={regionInfo.lastError}>region friendly names — {regionInfo.lastError}</span>
+                </>
+              ) : (
+                <>
+                  <span className="text-text-muted">○</span>
+                  <span className="text-text-muted">region friendly names not synced (re-sync to populate)</span>
+                </>
+              )}
+            </li>
+          </ul>
           <div className="flex items-center justify-between px-4 py-2">
             <span className="text-[10px] text-text-muted">
               Synced {new Date(orgData.syncedAt).toLocaleDateString()} · Org {orgData.orgId}

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -10,13 +10,16 @@ type OrgSyncState =
 
 export function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
   const api = useCostApi();
-  const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const orgQuery = useQuery(() => api.getOrgSyncResult(), [refreshKey]);
+  const regionInfoQuery = useQuery(() => api.getRegionNamesInfo(), [refreshKey]);
   const [expanded, setExpanded] = useState(false);
   const [syncState, setSyncState] = useState<OrgSyncState>({ status: 'idle' });
   const [accountSearch, setAccountSearch] = useState('');
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
 
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
+  const regionInfo = regionInfoQuery.status === 'success' ? regionInfoQuery.data : null;
   const selectedAccount = orgData !== null && selectedAccountId !== null
     ? orgData.accounts.find(a => a.id === selectedAccountId) ?? null
     : null;
@@ -37,6 +40,10 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
       const result = await api.syncOrgAccounts(profile);
       clearInterval(pollInterval);
       setSyncState({ status: 'done', count: result.accounts.length });
+      // Force the org + region-names queries to re-fetch so the bullet list
+      // reflects the new data without waiting for the user to navigate away
+      // and back.
+      setRefreshKey(k => k + 1);
     } catch (err: unknown) {
       clearInterval(pollInterval);
       setSyncState({ status: 'error', message: err instanceof Error ? err.message : String(err) });
@@ -46,6 +53,11 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
   const allTagKeys = orgData !== null
     ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort()
     : [];
+  // OU count is derivable from the per-account ouPath. Distinct non-empty
+  // paths approximate the number of OUs the user has placed accounts into.
+  const ouCount = orgData !== null
+    ? new Set(orgData.accounts.map(a => a.ouPath).filter(p => p.length > 0)).size
+    : 0;
 
   const filteredAccounts = orgData !== null && accountSearch.length > 0
     ? orgData.accounts.filter(a =>
@@ -114,8 +126,6 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
         >
           <div className="h-2 w-2 rounded-full bg-accent" />
           <span className="text-sm font-medium text-text-primary">AWS Organization</span>
-          <span className="text-xs text-text-secondary">{String(orgData.accounts.length)} accounts</span>
-          <span className="text-xs text-text-muted">{String(allTagKeys.length)} tag keys</span>
           <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>
         </button>
         {profile !== null && (
@@ -130,6 +140,37 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
           </button>
         )}
       </div>
+
+      {/* What got pulled in the last successful sync. Region names are sourced
+          from the SSM piggyback step; missing means insufficient permissions
+          or sync hasn't run since the feature was added. */}
+      <ul className="px-4 pb-3 flex flex-col gap-1 text-xs">
+        <li className="flex items-center gap-2 text-text-secondary">
+          <span className="text-accent">✓</span>
+          <span>{String(orgData.accounts.length)} accounts</span>
+        </li>
+        <li className="flex items-center gap-2 text-text-secondary">
+          <span className="text-accent">✓</span>
+          <span>{String(ouCount)} organizational units</span>
+        </li>
+        <li className="flex items-center gap-2 text-text-secondary">
+          <span className="text-accent">✓</span>
+          <span>{String(allTagKeys.length)} tag keys</span>
+        </li>
+        <li className="flex items-center gap-2">
+          {regionInfo !== null ? (
+            <>
+              <span className="text-accent">✓</span>
+              <span className="text-text-secondary">{String(regionInfo.count)} region friendly names</span>
+            </>
+          ) : (
+            <>
+              <span className="text-text-muted">○</span>
+              <span className="text-text-muted">region friendly names not synced (re-sync to populate)</span>
+            </>
+          )}
+        </li>
+      </ul>
 
       {syncState.status === 'syncing' && (
         <div className="px-4 pb-2">

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
+import { ConfirmModal } from '../components/confirm-modal.js';
 
 type OrgSyncState =
   | { status: 'idle' }
@@ -33,6 +34,15 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
 
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
   const regionInfo = regionInfoQuery.status === 'success' ? regionInfoQuery.data : null;
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+
+  async function handleClear(): Promise<void> {
+    setShowClearConfirm(false);
+    setSelectedAccountId(null);
+    setExpanded(false);
+    await api.clearOrgData();
+    setRefreshKey(k => k + 1);
+  }
   const selectedAccount = orgData !== null && selectedAccountId !== null
     ? orgData.accounts.find(a => a.id === selectedAccountId) ?? null
     : null;
@@ -152,6 +162,15 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
             ↻
           </button>
         )}
+        <button
+          type="button"
+          onClick={() => { setShowClearConfirm(true); }}
+          disabled={syncState.status === 'syncing'}
+          className="text-xs text-text-muted hover:text-negative transition-colors disabled:opacity-50"
+          title="Delete all org-sync data (accounts, account tags, region names)"
+        >
+          Clear
+        </button>
       </div>
 
       {syncState.status === 'syncing' && (
@@ -306,6 +325,18 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
             </div>
           )}
         </div>
+      )}
+
+      {showClearConfirm && (
+        <ConfirmModal
+          title="Clear AWS Org sync data?"
+          message="Removes locally cached accounts, account-tag lookups, and SSM region names. Your CUR data is untouched. Re-sync any time to repopulate."
+          confirmLabel="Clear"
+          cancelLabel="Cancel"
+          destructive
+          onConfirm={() => { void handleClear(); }}
+          onCancel={() => { setShowClearConfirm(false); }}
+        />
       )}
     </div>
   );

--- a/packages/ui/src/views/data-management-ssm.tsx
+++ b/packages/ui/src/views/data-management-ssm.tsx
@@ -10,13 +10,16 @@ type SyncState =
 
 /** Cached SSM Parameter Store data — lives separately from the AWS Org sync
  *  conceptually (different API, different IAM perms) so it gets its own UI
- *  block + own re-sync action. Right now the only thing we cache is region
- *  long names; geographic / country fields would slot in here too. */
+ *  block + own re-sync action. We cache per-region metadata published under
+ *  /aws/service/global-infrastructure: longName, geolocationCountry,
+ *  geolocationRegion. */
 export function SsmParameterSection({ profile }: Readonly<{ profile: string | null }>) {
   const api = useCostApi();
   const [refreshKey, setRefreshKey] = useState(0);
   const infoQuery = useQuery(() => api.getRegionNamesInfo(), [refreshKey]);
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
+  const [expanded, setExpanded] = useState(false);
+  const [regionSearch, setRegionSearch] = useState('');
 
   const info = infoQuery.status === 'success' ? infoQuery.data : null;
 
@@ -33,24 +36,43 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
     }
   }
 
-  // Source-of-truth for the dot color and the "have we got data" check.
   const hasData = info !== null && info.count > 0;
   const hasError = info?.lastError !== null && info?.lastError !== undefined;
+
+  const regionEntries = info !== null
+    ? Object.entries(info.regions).sort(([a], [b]) => a.localeCompare(b))
+    : [];
+  const needle = regionSearch.toLowerCase();
+  const filteredRegions = regionSearch.length > 0
+    ? regionEntries.filter(([code, r]) =>
+      code.toLowerCase().includes(needle) ||
+      r.longName.toLowerCase().includes(needle) ||
+      r.country.toLowerCase().includes(needle) ||
+      r.continent.toLowerCase().includes(needle))
+    : regionEntries;
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
       <div className="flex items-center gap-2 px-4 py-3">
-        <div className={[
-          'h-2 w-2 rounded-full',
-          hasData ? 'bg-accent' : hasError ? 'bg-negative' : 'bg-text-muted',
-        ].join(' ')} />
-        <span className="text-sm font-medium text-text-primary">SSM Parameter Store</span>
+        <button
+          type="button"
+          onClick={() => { if (hasData) setExpanded(v => !v); }}
+          disabled={!hasData}
+          className="flex items-center gap-2 flex-1 text-left hover:bg-bg-tertiary/30 transition-colors rounded -mx-1 px-1 disabled:hover:bg-transparent disabled:cursor-default"
+        >
+          <div className={[
+            'h-2 w-2 rounded-full',
+            hasData ? 'bg-accent' : hasError ? 'bg-negative' : 'bg-text-muted',
+          ].join(' ')} />
+          <span className="text-sm font-medium text-text-primary">SSM Parameter Store</span>
+          {hasData && <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>}
+        </button>
         {profile !== null && (
           <button
             type="button"
             onClick={() => { void handleSync(); }}
             disabled={syncState.status === 'syncing'}
-            className="ml-auto text-xs text-text-muted hover:text-accent transition-colors disabled:opacity-50"
+            className="text-xs text-text-muted hover:text-accent transition-colors disabled:opacity-50"
             title={hasData ? 'Re-sync SSM region names' : 'Fetch SSM region names'}
           >
             {hasData ? '↻' : 'Sync'}
@@ -72,7 +94,7 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
           {hasData ? (
             <>
               <span className="text-accent">✓</span>
-              <span className="text-text-secondary">{String(info.count)} region friendly names</span>
+              <span className="text-text-secondary">{String(info.count)} regions enriched with longName + country + continent</span>
               {info.syncedAt.length > 0 && (
                 <span className="text-text-muted ml-auto">
                   Synced {new Date(info.syncedAt).toLocaleString()}
@@ -81,9 +103,9 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
             </>
           ) : hasError ? (
             <>
-              <span className="text-negative">✗</span>
-              <span className="text-negative" title={info.lastError ?? undefined}>
-                Last sync failed: {(info.lastError ?? '').length > 100 ? `${(info.lastError ?? '').slice(0, 100)}…` : (info.lastError ?? '')}
+              <span className="text-negative shrink-0">✗</span>
+              <span className="text-negative break-words">
+                Last sync failed: {info.lastError ?? ''}
               </span>
             </>
           ) : (
@@ -94,6 +116,45 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
           )}
         </li>
       </ul>
+
+      {expanded && hasData && (
+        <div className="border-t border-border">
+          <div className="flex items-center justify-between px-4 py-2">
+            <span className="text-[10px] text-text-muted">
+              From /aws/service/global-infrastructure/regions
+            </span>
+            <input
+              type="text"
+              placeholder="Search regions..."
+              value={regionSearch}
+              onChange={e => { setRegionSearch(e.target.value); }}
+              className="w-48 rounded border border-border bg-bg-primary px-2 py-1 text-[10px] text-text-primary outline-none focus:border-accent"
+            />
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-left text-text-muted sticky top-0 bg-bg-secondary">
+                  <th className="px-4 py-2 font-medium">Region Code</th>
+                  <th className="px-4 py-2 font-medium">Friendly Name</th>
+                  <th className="px-4 py-2 font-medium">Country</th>
+                  <th className="px-4 py-2 font-medium">Continent</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border-subtle">
+                {filteredRegions.map(([code, r]) => (
+                  <tr key={code} className="hover:bg-bg-tertiary/20">
+                    <td className="px-4 py-1.5 font-mono text-text-secondary">{code}</td>
+                    <td className="px-4 py-1.5 text-text-primary">{r.longName}</td>
+                    <td className="px-4 py-1.5 text-text-muted font-mono">{r.country.length > 0 ? r.country : '—'}</td>
+                    <td className="px-4 py-1.5 text-text-muted">{r.continent.length > 0 ? r.continent : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/views/data-management-ssm.tsx
+++ b/packages/ui/src/views/data-management-ssm.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useQuery } from '../hooks/use-query.js';
+
+type SyncState =
+  | { status: 'idle' }
+  | { status: 'syncing' }
+  | { status: 'done'; count: number }
+  | { status: 'error'; message: string };
+
+/** Cached SSM Parameter Store data — lives separately from the AWS Org sync
+ *  conceptually (different API, different IAM perms) so it gets its own UI
+ *  block + own re-sync action. Right now the only thing we cache is region
+ *  long names; geographic / country fields would slot in here too. */
+export function SsmParameterSection({ profile }: Readonly<{ profile: string | null }>) {
+  const api = useCostApi();
+  const [refreshKey, setRefreshKey] = useState(0);
+  const infoQuery = useQuery(() => api.getRegionNamesInfo(), [refreshKey]);
+  const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
+
+  const info = infoQuery.status === 'success' ? infoQuery.data : null;
+
+  async function handleSync(): Promise<void> {
+    if (profile === null) return;
+    setSyncState({ status: 'syncing' });
+    try {
+      const result = await api.syncRegionNames(profile);
+      setSyncState({ status: 'done', count: result.count });
+      setRefreshKey(k => k + 1);
+    } catch (err: unknown) {
+      setSyncState({ status: 'error', message: err instanceof Error ? err.message : String(err) });
+      setRefreshKey(k => k + 1);
+    }
+  }
+
+  // Source-of-truth for the dot color and the "have we got data" check.
+  const hasData = info !== null && info.count > 0;
+  const hasError = info?.lastError !== null && info?.lastError !== undefined;
+
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3">
+        <div className={[
+          'h-2 w-2 rounded-full',
+          hasData ? 'bg-accent' : hasError ? 'bg-negative' : 'bg-text-muted',
+        ].join(' ')} />
+        <span className="text-sm font-medium text-text-primary">SSM Parameter Store</span>
+        {profile !== null && (
+          <button
+            type="button"
+            onClick={() => { void handleSync(); }}
+            disabled={syncState.status === 'syncing'}
+            className="ml-auto text-xs text-text-muted hover:text-accent transition-colors disabled:opacity-50"
+            title={hasData ? 'Re-sync SSM region names' : 'Fetch SSM region names'}
+          >
+            {hasData ? '↻' : 'Sync'}
+          </button>
+        )}
+      </div>
+
+      {syncState.status === 'syncing' && (
+        <div className="px-4 pb-2">
+          <div className="flex items-center gap-2 text-xs text-accent">
+            <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+            <span>Fetching region friendly names…</span>
+          </div>
+        </div>
+      )}
+
+      <ul className="px-4 pb-3 flex flex-col gap-1 text-xs">
+        <li className="flex items-center gap-2">
+          {hasData ? (
+            <>
+              <span className="text-accent">✓</span>
+              <span className="text-text-secondary">{String(info.count)} region friendly names</span>
+              {info.syncedAt.length > 0 && (
+                <span className="text-text-muted ml-auto">
+                  Synced {new Date(info.syncedAt).toLocaleString()}
+                </span>
+              )}
+            </>
+          ) : hasError ? (
+            <>
+              <span className="text-negative">✗</span>
+              <span className="text-negative" title={info.lastError ?? undefined}>
+                Last sync failed: {(info.lastError ?? '').length > 100 ? `${(info.lastError ?? '').slice(0, 100)}…` : (info.lastError ?? '')}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="text-text-muted">○</span>
+              <span className="text-text-muted">No region names cached — click Sync to fetch from SSM Parameter Store</span>
+            </>
+          )}
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -33,6 +33,9 @@ export function DataManagement() {
   }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
+  // Independent flag for the full re-run-from-scratch wizard so we don't have
+  // to overload configureSource with a sentinel value.
+  const [showFullWizard, setShowFullWizard] = useState(false);
   const [optimizerBusy, setOptimizerBusy] = useState(false);
 
   useEffect(() => {
@@ -364,6 +367,14 @@ export function DataManagement() {
           </div>
           <button
             type="button"
+            onClick={() => { setShowFullWizard(true); }}
+            className="rounded-md border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors"
+            title="Re-run the setup wizard — useful for switching AWS profile or reconfiguring buckets"
+          >
+            Re-run Setup
+          </button>
+          <button
+            type="button"
             onClick={() => { setShowDeleteAll(true); }}
             disabled={optimizerBusy}
             title={deleteDisabledTitle}
@@ -493,6 +504,19 @@ export function DataManagement() {
               source={configureSource}
               profile={awsProfile}
               onComplete={() => { setConfigureSource(null); setConfigRefreshKey(k => k + 1); setDailyRefreshKey(k => k + 1); setHourlyRefreshKey(k => k + 1); setCostOptRefreshKey(k => k + 1); }}
+            />
+          </div>
+        </div>
+      )}
+
+      {showFullWizard && (
+        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={(e) => { if (e.target === e.currentTarget) setShowFullWizard(false); }} aria-hidden="true">
+          <div className="relative">
+            <button type="button" onClick={() => { setShowFullWizard(false); }} className="absolute -top-2 -right-2 z-10 rounded-full bg-bg-tertiary border border-border w-7 h-7 flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-secondary transition-colors" title="Close">
+              &#10005;
+            </button>
+            <SetupWizard
+              onComplete={() => { setShowFullWizard(false); setConfigRefreshKey(k => k + 1); setDailyRefreshKey(k => k + 1); setHourlyRefreshKey(k => k + 1); setCostOptRefreshKey(k => k + 1); }}
             />
           </div>
         </div>

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -33,9 +33,12 @@ export function DataManagement() {
   }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
-  // Independent flag for the full re-run-from-scratch wizard so we don't have
-  // to overload configureSource with a sentinel value.
-  const [showFullWizard, setShowFullWizard] = useState(false);
+  // Lightweight profile-only swap: a tiny modal that lists ~/.aws profiles
+  // and rewrites only credentials.profile in costgoblin.yaml. Useful when
+  // the current role lacks an IAM permission (e.g. ssm:GetParametersByPath)
+  // and the user wants to retry with a different role without redoing the
+  // bucket setup.
+  const [showProfileSwap, setShowProfileSwap] = useState(false);
   const [optimizerBusy, setOptimizerBusy] = useState(false);
 
   useEffect(() => {
@@ -367,11 +370,11 @@ export function DataManagement() {
           </div>
           <button
             type="button"
-            onClick={() => { setShowFullWizard(true); }}
+            onClick={() => { setShowProfileSwap(true); }}
             className="rounded-md border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors"
-            title="Re-run the setup wizard — useful for switching AWS profile or reconfiguring buckets"
+            title={awsProfile === null ? 'Pick the AWS profile to use' : `Currently using profile: ${awsProfile}`}
           >
-            Re-run Setup
+            Change AWS Profile
           </button>
           <button
             type="button"
@@ -509,18 +512,102 @@ export function DataManagement() {
         </div>
       )}
 
-      {showFullWizard && (
-        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={(e) => { if (e.target === e.currentTarget) setShowFullWizard(false); }} aria-hidden="true">
-          <div className="relative">
-            <button type="button" onClick={() => { setShowFullWizard(false); }} className="absolute -top-2 -right-2 z-10 rounded-full bg-bg-tertiary border border-border w-7 h-7 flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-secondary transition-colors" title="Close">
-              &#10005;
-            </button>
-            <SetupWizard
-              onComplete={() => { setShowFullWizard(false); setConfigRefreshKey(k => k + 1); setDailyRefreshKey(k => k + 1); setHourlyRefreshKey(k => k + 1); setCostOptRefreshKey(k => k + 1); }}
-            />
-          </div>
-        </div>
+      {showProfileSwap && (
+        <ProfileSwapModal
+          currentProfile={awsProfile}
+          onClose={() => { setShowProfileSwap(false); }}
+          onSaved={() => { setShowProfileSwap(false); setConfigRefreshKey(k => k + 1); setDailyRefreshKey(k => k + 1); setHourlyRefreshKey(k => k + 1); setCostOptRefreshKey(k => k + 1); }}
+        />
       )}
+    </div>
+  );
+}
+
+function ProfileSwapModal({ currentProfile, onClose, onSaved }: Readonly<{
+  currentProfile: string | null;
+  onClose: () => void;
+  onSaved: () => void;
+}>) {
+  const api = useCostApi();
+  const profilesQuery = useQuery(() => api.listAwsProfiles(), []);
+  const [selected, setSelected] = useState(currentProfile ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const profiles = profilesQuery.status === 'success' ? profilesQuery.data : [];
+
+  async function handleSave(): Promise<void> {
+    if (selected.length === 0 || selected === currentProfile) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateAwsProfile(selected);
+      onSaved();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }} aria-hidden="true">
+      <div className="relative rounded-xl border border-border bg-bg-secondary p-6 shadow-2xl max-w-md w-full">
+        <h3 className="text-base font-semibold text-text-primary">Change AWS Profile</h3>
+        <p className="text-xs text-text-muted mt-1">
+          Buckets and other config stay as-is — this only swaps the profile used to talk to AWS.
+        </p>
+
+        {profilesQuery.status === 'loading' && (
+          <p className="text-sm text-text-secondary mt-4">Loading profiles…</p>
+        )}
+        {profilesQuery.status === 'error' && (
+          <p className="text-sm text-negative mt-4">{profilesQuery.error.message}</p>
+        )}
+        {profilesQuery.status === 'success' && profiles.length === 0 && (
+          <p className="text-sm text-warning mt-4">No AWS profiles found in ~/.aws.</p>
+        )}
+        {profilesQuery.status === 'success' && profiles.length > 0 && (
+          <div className="mt-4 flex flex-col gap-2 max-h-64 overflow-y-auto">
+            {profiles.map(p => (
+              <label key={p} className="flex items-center gap-2 rounded border border-border bg-bg-primary px-3 py-2 cursor-pointer hover:border-accent">
+                <input
+                  type="radio"
+                  name="profile"
+                  value={p}
+                  checked={selected === p}
+                  onChange={() => { setSelected(p); }}
+                />
+                <span className="text-sm text-text-primary">{p}</span>
+                {p === currentProfile && (
+                  <span className="ml-auto text-[10px] text-text-muted uppercase tracking-wider">Current</span>
+                )}
+              </label>
+            ))}
+          </div>
+        )}
+
+        {error !== null && (
+          <p className="text-xs text-negative mt-3">{error}</p>
+        )}
+
+        <div className="flex items-center justify-end gap-2 mt-5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => { void handleSave(); }}
+            disabled={saving || selected.length === 0 || selected === currentProfile}
+            className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '../hooks/use-query.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
 import { SetupWizard } from './setup-wizard.js';
 import { OrgAccountsSection } from './data-management-org.js';
+import { SsmParameterSection } from './data-management-ssm.js';
 import { TierPanel, type SyncState } from './data-management-tier.js';
 import { RecentFileActivity } from './recent-file-activity.js';
 
@@ -396,6 +397,9 @@ export function DataManagement() {
 
       {/* Account mapping */}
       <OrgAccountsSection profile={awsProfile} />
+
+      {/* SSM Parameter Store enrichment data — independent of Org sync */}
+      <SsmParameterSection profile={awsProfile} />
 
       {inventoryQuery.status === 'loading' && (
         <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center text-text-secondary">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -68,71 +68,90 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
 
   const preview = valuesQuery.status === 'success' ? valuesQuery.data : null;
 
+  const labelField = (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs text-text-muted">Display Label</span>
+      <input
+        type="text"
+        value={state.label}
+        onChange={e => { setState(s => ({ ...s, label: e.target.value })); }}
+        className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+      />
+    </label>
+  );
+  const descriptionField = (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs text-text-muted">Description</span>
+      <input
+        type="text"
+        value={state.description}
+        onChange={e => { setState(s => ({ ...s, description: e.target.value })); }}
+        className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+        placeholder="What does this dimension represent?"
+      />
+    </label>
+  );
+  const orgToggleField = (
+    <label className="flex items-center justify-between rounded border border-border bg-bg-primary px-3 py-2 h-full">
+      <div className="flex flex-col gap-0.5 min-w-0 pr-3">
+        <span className="text-sm text-text-primary">Resolve names via org-data</span>
+        <span className="text-[11px] text-text-muted leading-tight">Use friendly names from the Organizations sync.</span>
+      </div>
+      <DimensionToggle enabled={state.useOrgAccounts} onToggle={() => { setState(s => ({ ...s, useOrgAccounts: !s.useOrgAccounts })); }} />
+    </label>
+  );
+  const normalizationField = (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs text-text-muted">Normalization</span>
+      <select
+        value={state.normalize}
+        onChange={e => { setState(s => ({ ...s, normalize: e.target.value })); }}
+        className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+      >
+        <option value="">None</option>
+        {NORMALIZE_RULES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+      </select>
+    </label>
+  );
+  const stripPatternsField = (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs text-text-muted">Name strip patterns (one regex per line)</span>
+      <textarea
+        value={state.nameStripPatterns}
+        onChange={e => { setState(s => ({ ...s, nameStripPatterns: e.target.value })); }}
+        rows={3}
+        className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm font-mono text-text-primary outline-none focus:border-accent"
+        placeholder={'\\s+(production|staging|sandbox)$\n^DiBa Cards '}
+      />
+    </label>
+  );
+  const aliasField = (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
+      <textarea
+        value={state.aliases}
+        onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
+        rows={3}
+        className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm font-mono text-text-primary outline-none focus:border-accent"
+        placeholder="EC2: AmazonEC2, EC2-Instance"
+      />
+    </label>
+  );
+
   return (
     <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-4">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Display Label</span>
-          <input
-            type="text"
-            value={state.label}
-            onChange={e => { setState(s => ({ ...s, label: e.target.value })); }}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Normalization</span>
-          <select
-            value={state.normalize}
-            onChange={e => { setState(s => ({ ...s, normalize: e.target.value })); }}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-          >
-            <option value="">None</option>
-            {NORMALIZE_RULES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
-          </select>
-        </label>
+        {labelField}
+        {descriptionField}
       </div>
-      <label className="flex flex-col gap-1">
-        <span className="text-xs text-text-muted">Description</span>
-        <input
-          type="text"
-          value={state.description}
-          onChange={e => { setState(s => ({ ...s, description: e.target.value })); }}
-          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-          placeholder="What does this dimension represent?"
-        />
-      </label>
-      {isAccountDim && (
-        <label className="flex items-center justify-between rounded border border-border bg-bg-primary px-3 py-2">
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm text-text-primary">Resolve names via org-data</span>
-            <span className="text-[11px] text-text-muted">Display friendly account names from the Organizations sync instead of raw account IDs.</span>
-          </div>
-          <DimensionToggle enabled={state.useOrgAccounts} onToggle={() => { setState(s => ({ ...s, useOrgAccounts: !s.useOrgAccounts })); }} />
-        </label>
-      )}
-      {isAccountDim && (
-        <label className="flex flex-col gap-1">
-          <span className="text-xs text-text-muted">Name strip patterns (one regex per line, applied to resolved names)</span>
-          <textarea
-            value={state.nameStripPatterns}
-            onChange={e => { setState(s => ({ ...s, nameStripPatterns: e.target.value })); }}
-            rows={3}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm font-mono text-text-primary outline-none focus:border-accent"
-            placeholder={'\\s+(production|staging|sandbox)$\n^DiBa Cards '}
-          />
-        </label>
-      )}
-      <label className="flex flex-col gap-1">
-        <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
-        <textarea
-          value={state.aliases}
-          onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
-          rows={3}
-          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm font-mono text-text-primary outline-none focus:border-accent"
-          placeholder="EC2: AmazonEC2, EC2-Instance"
-        />
-      </label>
+      <div className="grid grid-cols-2 gap-4 items-stretch">
+        {isAccountDim ? orgToggleField : <div />}
+        {normalizationField}
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {isAccountDim ? stripPatternsField : <div />}
+        {aliasField}
+      </div>
       {preview !== null && (
         <div className="flex flex-col gap-2">
           <span className="text-xs text-text-muted">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -827,7 +827,10 @@ export function DimensionsView() {
         ...(aliases !== undefined ? { aliases } : {}),
         ...(edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
         ...(nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
-        ...(edited.useRegionNames ? { useRegionNames: true as const } : {}),
+        // Only the Region dim surfaces a useRegionNames toggle — write it
+        // explicitly (both true AND false) so toggling off sticks past the
+        // mergeDefaultBuiltIns backfill that would otherwise re-enable it.
+        ...(d.name === 'region' ? { useRegionNames: edited.useRegionNames } : {}),
       };
     });
     await api.saveDimensionsConfig({ ...config, builtIn });

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { GripVertical } from 'lucide-react';
+import { ChevronUp, ChevronDown, GripVertical } from 'lucide-react';
 import type { DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -783,6 +783,33 @@ export function DimensionsView() {
     );
   }
 
+  function ReorderArrows({ type, idx, total }: { type: DragGroup; idx: number; total: number }): React.JSX.Element {
+    const canUp = idx > 0;
+    const canDown = idx < total - 1;
+    return (
+      <div className="flex flex-col -space-y-1">
+        <button
+          type="button"
+          disabled={!canUp}
+          onClick={(e) => { e.stopPropagation(); void applyReorder(type, idx, idx - 1); }}
+          title="Move up"
+          className="flex items-center justify-center text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          <ChevronUp size={14} />
+        </button>
+        <button
+          type="button"
+          disabled={!canDown}
+          onClick={(e) => { e.stopPropagation(); void applyReorder(type, idx, idx + 1); }}
+          title="Move down"
+          className="flex items-center justify-center text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          <ChevronDown size={14} />
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6 p-6">
       <div>
@@ -862,6 +889,7 @@ export function DimensionsView() {
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider">Built-in</span>
                   <DimensionToggle enabled={isOn} onToggle={() => { void toggleBuiltInEnabled(idx); }} />
+                  <ReorderArrows type="builtIn" idx={idx} total={config.builtIn.length} />
                   <GripHandle attrs={dnd.grip} />
                 </div>
               </div>
@@ -934,6 +962,7 @@ export function DimensionsView() {
                       Edit →
                     </button>
                     <DimensionToggle enabled={isOn} onToggle={() => { void toggleTagEnabled(idx); }} />
+                    <ReorderArrows type="tag" idx={idx} total={config.tags.length} />
                     <GripHandle attrs={dnd.grip} />
                   </div>
                 </div>

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -38,6 +38,7 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   onCancel: () => void;
 }>): React.JSX.Element {
   const isAccountDim = dim.field === 'account_id';
+  const isRegionDim = dim.field === 'region';
   // AWS-controlled values arrive in a single canonical form — normalize/strip
   // would only chip at the labels users already recognize. Aliases stay
   // visible since folding "AmazonEC2 → EC2" is a reasonable user choice.
@@ -45,6 +46,18 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   const showTransforms = !TRANSFORM_FREE_FIELDS.has(dim.field);
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
+  // Surface missing enrichment data: Region needs SSM region-names sync,
+  // Account (with org-data toggle) needs the AWS Org sync. Both ship as
+  // side-effects of the org sync on the Sync tab — without them the dim's
+  // values render as raw codes / IDs.
+  const regionInfoQuery = useQuery(
+    () => isRegionDim ? api.getRegionNamesInfo() : Promise.resolve(null),
+    [isRegionDim],
+  );
+  const orgQuery = useQuery(
+    () => isAccountDim ? api.getOrgSyncResult() : Promise.resolve(null),
+    [isAccountDim],
+  );
   const initialRef = useRef(dim.editing);
   const [discardConfirm, setDiscardConfirm] = useState(false);
   const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
@@ -160,12 +173,58 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
     </label>
   );
 
+  // Compute enrichment-data warnings:
+  //   - Region dim ships raw codes ('eu-central-1') unless region-names.json
+  //     was synced from SSM. Warn either way: missing entirely, or last
+  //     attempt errored (typically: profile lacks ssm:GetParametersByPath).
+  //   - Account dim's org-data toggle resolves IDs → names from the AWS Org
+  //     sync. Warn when toggle is on but the sync result file is missing.
+  const regionInfo = regionInfoQuery.status === 'success' ? regionInfoQuery.data : null;
+  const orgInfo = orgQuery.status === 'success' ? orgQuery.data : null;
+  const regionWarning: { kind: 'missing' | 'error'; message?: string } | null =
+    isRegionDim && regionInfoQuery.status === 'success'
+      ? regionInfo === null
+        ? { kind: 'missing' }
+        : regionInfo.lastError !== null
+          ? { kind: 'error', message: regionInfo.lastError }
+          : regionInfo.count === 0
+            ? { kind: 'missing' }
+            : null
+      : null;
+  const accountWarning: boolean =
+    isAccountDim && state.useOrgAccounts && orgQuery.status === 'success' && orgInfo === null;
+
   return (
     <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-4">
         {labelField}
         {descriptionField}
       </div>
+      {regionWarning !== null && (
+        <div className="rounded-md border border-warning/50 bg-warning-muted px-3 py-2 text-xs flex flex-col gap-1">
+          <p className="font-medium text-warning">Region friendly names not available</p>
+          {regionWarning.kind === 'error' ? (
+            <p className="text-text-secondary">
+              Last sync attempt failed: <span className="font-mono text-text-primary">{regionWarning.message}</span>
+            </p>
+          ) : (
+            <p className="text-text-secondary">
+              Region values will display as raw codes (e.g. <span className="font-mono">eu-central-1</span>).
+              Run the AWS Organization sync from the <span className="font-medium">Sync</span> tab to fetch the
+              friendly names from SSM Parameter Store.
+            </p>
+          )}
+        </div>
+      )}
+      {accountWarning && (
+        <div className="rounded-md border border-warning/50 bg-warning-muted px-3 py-2 text-xs flex flex-col gap-1">
+          <p className="font-medium text-warning">Org-data not synced</p>
+          <p className="text-text-secondary">
+            The "Resolve names via org-data" toggle is on but no AWS Organization sync has run yet —
+            account values will display as raw 12-digit IDs. Run the sync from the <span className="font-medium">Sync</span> tab to populate.
+          </p>
+        </div>
+      )}
       {showTransforms && (
         <div className="grid grid-cols-2 gap-4 items-stretch">
           {isAccountDim ? orgToggleField : <div />}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -33,6 +33,11 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   onCancel: () => void;
 }>): React.JSX.Element {
   const isAccountDim = dim.field === 'account_id';
+  // AWS-controlled values arrive in a single canonical form — normalize/strip
+  // would only chip at the labels users already recognize. Aliases stay
+  // visible since folding "AmazonEC2 → EC2" is a reasonable user choice.
+  const TRANSFORM_FREE_FIELDS = new Set(['service', 'service_family']);
+  const showTransforms = !TRANSFORM_FREE_FIELDS.has(dim.field);
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -144,14 +149,18 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
         {labelField}
         {descriptionField}
       </div>
-      <div className="grid grid-cols-2 gap-4 items-stretch">
-        {isAccountDim ? orgToggleField : <div />}
-        {normalizationField}
-      </div>
-      <div className="grid grid-cols-2 gap-4">
-        {isAccountDim ? stripPatternsField : <div />}
-        {aliasField}
-      </div>
+      {showTransforms && (
+        <div className="grid grid-cols-2 gap-4 items-stretch">
+          {isAccountDim ? orgToggleField : <div />}
+          {normalizationField}
+        </div>
+      )}
+      {showTransforms ? (
+        <div className="grid grid-cols-2 gap-4">
+          {isAccountDim ? stripPatternsField : <div />}
+          {aliasField}
+        </div>
+      ) : aliasField}
       {preview !== null && (
         <div className="flex flex-col gap-2">
           <span className="text-xs text-text-muted">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -690,7 +690,15 @@ export function DimensionsView() {
     setRefreshKey(k => k + 1);
   }
 
-  async function toggleBuiltInEnabled(idx: number) {
+  // Optimistic save: paint the new config locally first, then persist in the
+  // background. Skips the refetch — local state is already correct, and the
+  // backend write is the source of truth for the next mount.
+  function applyOptimistic(next: DimensionsConfig): void {
+    setConfig(next);
+    void api.saveDimensionsConfig(next);
+  }
+
+  function toggleBuiltInEnabled(idx: number): void {
     if (config === null) return;
     const builtIn = config.builtIn.map((d, i) => {
       if (i !== idx) return d;
@@ -699,11 +707,10 @@ export function DimensionsView() {
       delete (rest as { enabled?: boolean }).enabled;
       return nextEnabled === undefined ? rest : { ...rest, enabled: nextEnabled };
     });
-    await api.saveDimensionsConfig({ ...config, builtIn });
-    setRefreshKey(k => k + 1);
+    applyOptimistic({ ...config, builtIn });
   }
 
-  async function toggleTagEnabled(idx: number) {
+  function toggleTagEnabled(idx: number): void {
     if (config === null) return;
     const tags = config.tags.map((t, i) => {
       if (i !== idx) return t;
@@ -712,29 +719,27 @@ export function DimensionsView() {
       delete (rest as { enabled?: boolean }).enabled;
       return nextEnabled === undefined ? rest : { ...rest, enabled: nextEnabled };
     });
-    await api.saveDimensionsConfig({ ...config, tags });
-    setRefreshKey(k => k + 1);
+    applyOptimistic({ ...config, tags });
   }
 
   // Quick-add a discovered tag as a dimension
   const [quickAddState, setQuickAddState] = useState<EditingTag | null>(null);
 
-  async function applyReorder(type: DragGroup, fromIdx: number, toIdx: number) {
+  function applyReorder(type: DragGroup, fromIdx: number, toIdx: number): void {
     if (config === null || fromIdx === toIdx) return;
     if (type === 'builtIn') {
       const builtIn = [...config.builtIn];
       const moved = builtIn.splice(fromIdx, 1)[0];
       if (moved === undefined) return;
       builtIn.splice(toIdx, 0, moved);
-      await api.saveDimensionsConfig({ ...config, builtIn });
+      applyOptimistic({ ...config, builtIn });
     } else {
       const tags = [...config.tags];
       const moved = tags.splice(fromIdx, 1)[0];
       if (moved === undefined) return;
       tags.splice(toIdx, 0, moved);
-      await api.saveDimensionsConfig({ ...config, tags });
+      applyOptimistic({ ...config, tags });
     }
-    setRefreshKey(k => k + 1);
   }
 
   // One factory per row: returns the drag/drop attrs for the row container and
@@ -764,7 +769,7 @@ export function DimensionsView() {
         onDragLeave: () => { setDragOver(curr => (curr?.type === type && curr.idx === idx ? null : curr)); },
         onDrop: (e) => {
           e.preventDefault();
-          if (dragFrom?.type === type) void applyReorder(type, dragFrom.idx, idx);
+          if (dragFrom?.type === type) applyReorder(type, dragFrom.idx, idx);
           setArmed(null); setDragFrom(null); setDragOver(null);
         },
         style: isFrom ? { opacity: 0.4 } : isOver ? { boxShadow: 'inset 0 2px 0 var(--color-accent, #34d399)' } : undefined,
@@ -797,7 +802,7 @@ export function DimensionsView() {
         <button
           type="button"
           disabled={!canUp}
-          onClick={(e) => { e.stopPropagation(); void applyReorder(type, idx, idx - 1); }}
+          onClick={(e) => { e.stopPropagation(); applyReorder(type, idx, idx - 1); }}
           title="Move up"
           className="flex items-center justify-center text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
         >
@@ -806,7 +811,7 @@ export function DimensionsView() {
         <button
           type="button"
           disabled={!canDown}
-          onClick={(e) => { e.stopPropagation(); void applyReorder(type, idx, idx + 1); }}
+          onClick={(e) => { e.stopPropagation(); applyReorder(type, idx, idx + 1); }}
           title="Move down"
           className="flex items-center justify-center text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
         >
@@ -894,7 +899,7 @@ export function DimensionsView() {
                 </button>
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider">Built-in</span>
-                  <DimensionToggle enabled={isOn} onToggle={() => { void toggleBuiltInEnabled(idx); }} />
+                  <DimensionToggle enabled={isOn} onToggle={() => { toggleBuiltInEnabled(idx); }} />
                   <ReorderArrows type="builtIn" idx={idx} total={config.builtIn.length} />
                   <GripHandle attrs={dnd.grip} />
                 </div>
@@ -967,7 +972,7 @@ export function DimensionsView() {
                     >
                       Edit →
                     </button>
-                    <DimensionToggle enabled={isOn} onToggle={() => { void toggleTagEnabled(idx); }} />
+                    <DimensionToggle enabled={isOn} onToggle={() => { toggleTagEnabled(idx); }} />
                     <ReorderArrows type="tag" idx={idx} total={config.tags.length} />
                     <GripHandle attrs={dnd.grip} />
                   </div>

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -43,9 +43,16 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
     .map(l => l.trim())
     .filter(l => l.length > 0);
   const stripPatternsKey = stripPatternList.join('\u0001');
+  const normalize: NormalizationRule | undefined = state.normalize.length > 0 ? state.normalize as NormalizationRule : undefined;
   const valuesQuery = useQuery(
-    () => api.discoverColumnValues(dim.field, isAccountDim ? { useOrgAccounts: state.useOrgAccounts, nameStripPatterns: stripPatternList } : undefined),
-    [dim.field, isAccountDim, state.useOrgAccounts, stripPatternsKey],
+    () => api.discoverColumnValues(
+      dim.field,
+      {
+        ...(normalize !== undefined ? { normalize } : {}),
+        ...(isAccountDim ? { useOrgAccounts: state.useOrgAccounts, nameStripPatterns: stripPatternList } : {}),
+      },
+    ),
+    [dim.field, isAccountDim, state.useOrgAccounts, stripPatternsKey, normalize],
   );
 
   useEffect(() => {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -604,7 +604,13 @@ export function DimensionsView() {
   const tagsResult = tagsQuery.status === 'success' ? tagsQuery.data : null;
   const discoveredTags = tagsResult?.tags ?? [];
   const samplePeriod = tagsResult?.samplePeriod ?? '';
-  const config: DimensionsConfig | null = configQuery.status === 'success' ? configQuery.data : null;
+  // Keep the last good config visible while a refetch is in flight — useQuery
+  // resets to status=loading on every dep change, which would otherwise blank
+  // the dimensions list for a frame after every reorder/toggle/save.
+  const [config, setConfig] = useState<DimensionsConfig | null>(null);
+  useEffect(() => {
+    if (configQuery.status === 'success') setConfig(configQuery.data);
+  }, [configQuery]);
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
 
   // Account tag keys from org sync

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -30,15 +30,22 @@ interface EditingBuiltIn {
   aliases: string;
   useOrgAccounts: boolean;
   nameStripPatterns: string;
+  useRegionNames: boolean;
 }
 
 function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
-  dim: { field: string; editing: EditingBuiltIn };
+  dim: { name: string; field: string; editing: EditingBuiltIn };
   onSave: (edited: EditingBuiltIn) => void;
   onCancel: () => void;
 }>): React.JSX.Element {
   const isAccountDim = dim.field === 'account_id';
-  const isRegionDim = dim.field === 'region';
+  // Three dims share field='region' — distinguish by name so only the Region
+  // dim gets the longName toggle, while Country/Continent are pure derived
+  // views with no user toggle (SSM data is either there or not).
+  const isRegionDim = dim.name === 'region';
+  const isRegionCountryDim = dim.name === 'region_country';
+  const isRegionContinentDim = dim.name === 'region_continent';
+  const isAnyRegionDim = dim.field === 'region';
   // AWS-controlled values arrive in a single canonical form — normalize/strip
   // would only chip at the labels users already recognize. Aliases stay
   // visible since folding "AmazonEC2 → EC2" is a reasonable user choice.
@@ -51,8 +58,8 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   // side-effects of the org sync on the Sync tab — without them the dim's
   // values render as raw codes / IDs.
   const regionInfoQuery = useQuery(
-    () => isRegionDim ? api.getRegionNamesInfo() : Promise.resolve(null),
-    [isRegionDim],
+    () => isAnyRegionDim ? api.getRegionNamesInfo() : Promise.resolve(null),
+    [isAnyRegionDim],
   );
   const orgQuery = useQuery(
     () => isAccountDim ? api.getOrgSyncResult() : Promise.resolve(null),
@@ -80,9 +87,10 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
       {
         ...(normalize !== undefined ? { normalize } : {}),
         ...(isAccountDim ? { useOrgAccounts: state.useOrgAccounts, nameStripPatterns: stripPatternList } : {}),
+        ...(isAnyRegionDim ? { dimName: dim.name, useRegionNames: state.useRegionNames } : {}),
       },
     ),
-    [dim.field, isAccountDim, state.useOrgAccounts, stripPatternsKey, normalize],
+    [dim.field, dim.name, isAccountDim, isAnyRegionDim, state.useOrgAccounts, state.useRegionNames, stripPatternsKey, normalize],
   );
 
   useEffect(() => {
@@ -135,6 +143,32 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
       <DimensionToggle enabled={state.useOrgAccounts} onToggle={() => { setState(s => ({ ...s, useOrgAccounts: !s.useOrgAccounts })); }} />
     </label>
   );
+  // Region equivalent of the org toggle. Disabled (and forced-off in preview)
+  // when the SSM region snapshot isn't present — the toggle's whole point is
+  // to swap raw codes for the SSM-sourced friendly names, so without data
+  // it's a no-op. We gate on query.status so we don't flash a disabled toggle
+  // while the info is still loading.
+  const regionInfoLoaded = regionInfoQuery.status === 'success';
+  const regionDataAvailable = regionInfoLoaded && regionInfoQuery.data !== null && regionInfoQuery.data.count > 0;
+  const regionToggleField = (
+    <label className={['flex items-center justify-between rounded border border-border bg-bg-primary px-3 py-2 h-full', regionDataAvailable ? '' : 'opacity-60'].join(' ')}>
+      <div className="flex flex-col gap-0.5 min-w-0 pr-3">
+        <span className="text-sm text-text-primary">Resolve codes via SSM region names</span>
+        <span className="text-[11px] text-text-muted leading-tight">
+          {regionDataAvailable
+            ? 'Use friendly names (e.g. "Europe (Frankfurt)") from the SSM snapshot.'
+            : 'Sync SSM Parameter Store from Data Management to enable.'}
+        </span>
+      </div>
+      <DimensionToggle
+        enabled={state.useRegionNames && regionDataAvailable}
+        onToggle={() => {
+          if (!regionDataAvailable) return;
+          setState(s => ({ ...s, useRegionNames: !s.useRegionNames }));
+        }}
+      />
+    </label>
+  );
   const normalizationField = (
     <label className="flex flex-col gap-1">
       <span className="text-xs text-text-muted">Normalization</span>
@@ -181,8 +215,14 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   //     sync. Warn when toggle is on but the sync result file is missing.
   const regionInfo = regionInfoQuery.status === 'success' ? regionInfoQuery.data : null;
   const orgInfo = orgQuery.status === 'success' ? orgQuery.data : null;
+  // Warn when the user's editing a dim that needs SSM data but the snapshot
+  // isn't there. Region: only when the friendly-names toggle is on (off is a
+  // valid state — raw codes). Country/Continent: always, since these dims
+  // are defined entirely in terms of SSM enrichment and collapse to raw
+  // codes otherwise.
+  const wantsRegionEnrichment = (isRegionDim && state.useRegionNames) || isRegionCountryDim || isRegionContinentDim;
   const regionWarning: { kind: 'missing' | 'error'; message?: string } | null =
-    isRegionDim && regionInfoQuery.status === 'success'
+    wantsRegionEnrichment && regionInfoQuery.status === 'success'
       ? regionInfo === null
         ? { kind: 'missing' }
         : regionInfo.lastError !== null
@@ -210,8 +250,8 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
           ) : (
             <p className="text-text-secondary">
               Region values will display as raw codes (e.g. <span className="font-mono">eu-central-1</span>).
-              Run the AWS Organization sync from the <span className="font-medium">Sync</span> tab to fetch the
-              friendly names from SSM Parameter Store.
+              Sync the <span className="font-medium">SSM Parameter Store</span> section on Data Management to
+              fetch the friendly names.
             </p>
           )}
         </div>
@@ -227,7 +267,7 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
       )}
       {showTransforms && (
         <div className="grid grid-cols-2 gap-4 items-stretch">
-          {isAccountDim ? orgToggleField : <div />}
+          {isAccountDim ? orgToggleField : isRegionDim ? regionToggleField : <div />}
           {normalizationField}
         </div>
       )}
@@ -787,6 +827,7 @@ export function DimensionsView() {
         ...(aliases !== undefined ? { aliases } : {}),
         ...(edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
         ...(nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
+        ...(edited.useRegionNames ? { useRegionNames: true as const } : {}),
       };
     });
     await api.saveDimensionsConfig({ ...config, builtIn });
@@ -954,6 +995,7 @@ export function DimensionsView() {
                 <BuiltInEditor
                   key={d.name}
                   dim={{
+                    name: d.name,
                     field: d.field,
                     editing: {
                       label: d.label,
@@ -962,6 +1004,7 @@ export function DimensionsView() {
                       aliases: aliasesToText(d.aliases),
                       useOrgAccounts: d.useOrgAccounts === true,
                       nameStripPatterns: d.nameStripPatterns?.join('\n') ?? '',
+                      useRegionNames: d.useRegionNames === true,
                     },
                   }}
                   onSave={(edited) => { void handleSaveBuiltIn(idx, edited); }}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
+import { GripVertical } from 'lucide-react';
 import type { DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
+
+type DragGroup = 'builtIn' | 'tag';
+interface DragRef { type: DragGroup; idx: number }
 
 const CONCEPTS: { value: ConceptType; label: string }[] = [
   { value: 'owner', label: 'Owner (team)' },
@@ -587,6 +591,12 @@ export function DimensionsView() {
   const [hiddenAccountCols, setHiddenAccountCols] = useState(new Set<string>());
   const [addingNew, setAddingNew] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  // Drag-to-reorder state. `armed` flips draggable=true on a row only after
+  // the user mousedowns its grip handle, so clicks elsewhere don't accidentally
+  // start a drag. `from`/`over` drive the visual feedback during the drag.
+  const [armed, setArmed] = useState<DragRef | null>(null);
+  const [dragFrom, setDragFrom] = useState<DragRef | null>(null);
+  const [dragOver, setDragOver] = useState<DragRef | null>(null);
   const tagsQuery = useQuery(() => api.discoverTagKeys(), []);
   const configQuery = useQuery(() => api.getDimensionsConfig(), [refreshKey]);
   const orgQuery = useQuery(() => api.getOrgSyncResult(), []);
@@ -703,6 +713,76 @@ export function DimensionsView() {
   // Quick-add a discovered tag as a dimension
   const [quickAddState, setQuickAddState] = useState<EditingTag | null>(null);
 
+  async function applyReorder(type: DragGroup, fromIdx: number, toIdx: number) {
+    if (config === null || fromIdx === toIdx) return;
+    if (type === 'builtIn') {
+      const builtIn = [...config.builtIn];
+      const moved = builtIn.splice(fromIdx, 1)[0];
+      if (moved === undefined) return;
+      builtIn.splice(toIdx, 0, moved);
+      await api.saveDimensionsConfig({ ...config, builtIn });
+    } else {
+      const tags = [...config.tags];
+      const moved = tags.splice(fromIdx, 1)[0];
+      if (moved === undefined) return;
+      tags.splice(toIdx, 0, moved);
+      await api.saveDimensionsConfig({ ...config, tags });
+    }
+    setRefreshKey(k => k + 1);
+  }
+
+  // One factory per row: returns the drag/drop attrs for the row container and
+  // the mousedown attr for the grip handle. Centralizes the "only allow drag
+  // when grip was pressed" + "only accept drop within the same group" rules so
+  // the row JSX stays light.
+  function dragProps(type: DragGroup, idx: number): { row: React.HTMLAttributes<HTMLDivElement> & { draggable: boolean }; grip: React.HTMLAttributes<HTMLButtonElement> } {
+    const isArmed = armed?.type === type && armed.idx === idx;
+    const isFrom = dragFrom?.type === type && dragFrom.idx === idx;
+    const isOver = dragOver?.type === type && dragOver.idx === idx && !isFrom;
+    return {
+      row: {
+        draggable: isArmed,
+        onDragStart: (e) => {
+          setDragFrom({ type, idx });
+          e.dataTransfer.effectAllowed = 'move';
+          // Required for Firefox to actually start the drag.
+          e.dataTransfer.setData('text/plain', `${type}:${String(idx)}`);
+        },
+        onDragEnd: () => { setArmed(null); setDragFrom(null); setDragOver(null); },
+        onDragOver: (e) => {
+          if (dragFrom?.type !== type) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+          setDragOver({ type, idx });
+        },
+        onDragLeave: () => { setDragOver(curr => (curr?.type === type && curr.idx === idx ? null : curr)); },
+        onDrop: (e) => {
+          e.preventDefault();
+          if (dragFrom?.type === type) void applyReorder(type, dragFrom.idx, idx);
+          setArmed(null); setDragFrom(null); setDragOver(null);
+        },
+        style: isFrom ? { opacity: 0.4 } : isOver ? { boxShadow: 'inset 0 2px 0 var(--color-accent, #34d399)' } : undefined,
+      },
+      grip: {
+        onMouseDown: () => { setArmed({ type, idx }); },
+        onMouseUp: () => { setArmed(curr => (curr?.type === type && curr.idx === idx ? null : curr)); },
+      },
+    };
+  }
+
+  function GripHandle({ attrs }: { attrs: React.HTMLAttributes<HTMLButtonElement> }): React.JSX.Element {
+    return (
+      <button
+        type="button"
+        {...attrs}
+        title="Drag to reorder"
+        className="flex items-center justify-center text-text-muted hover:text-text-primary cursor-grab active:cursor-grabbing"
+      >
+        <GripVertical size={16} />
+      </button>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6 p-6">
       <div>
@@ -747,9 +827,11 @@ export function DimensionsView() {
                 />
               );
             }
+            const dnd = dragProps('builtIn', idx);
             return (
               <div
                 key={d.name}
+                {...dnd.row}
                 className={[
                   'rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between hover:bg-bg-tertiary/30 transition-colors',
                   isOn ? '' : 'opacity-50',
@@ -780,6 +862,7 @@ export function DimensionsView() {
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider">Built-in</span>
                   <DimensionToggle enabled={isOn} onToggle={() => { void toggleBuiltInEnabled(idx); }} />
+                  <GripHandle attrs={dnd.grip} />
                 </div>
               </div>
             );
@@ -788,6 +871,7 @@ export function DimensionsView() {
           {/* Tag dimensions (editable) */}
           {config.tags.map((tag, idx) => {
             const isOn = tag.enabled !== false;
+            const dnd = dragProps('tag', idx);
             return (
             <div key={tag.tagName} className={isOn ? '' : 'opacity-50'}>
               {editingIdx === idx ? (
@@ -810,7 +894,7 @@ export function DimensionsView() {
                   orgAccounts={orgData?.accounts ?? []}
                 />
               ) : (
-                <div className="w-full rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between hover:bg-bg-tertiary/30 transition-colors">
+                <div {...dnd.row} className="w-full rounded-xl border border-border bg-bg-secondary/50 px-5 py-3 flex items-center justify-between hover:bg-bg-tertiary/30 transition-colors">
                   <button
                     type="button"
                     onClick={() => { setEditingIdx(idx); setAddingNew(false); }}
@@ -850,6 +934,7 @@ export function DimensionsView() {
                       Edit →
                     </button>
                     <DimensionToggle enabled={isOn} onToggle={() => { void toggleTagEnabled(idx); }} />
+                    <GripHandle attrs={dnd.grip} />
                   </div>
                 </div>
               )}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -4,6 +4,7 @@ import type { DimensionsConfig, TagDimension, ConceptType, NormalizationRule } f
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
+import { ConfirmModal } from '../components/confirm-modal.js';
 
 type DragGroup = 'builtIn' | 'tag';
 interface DragRef { type: DragGroup; idx: number }
@@ -44,6 +45,13 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   const showTransforms = !TRANSFORM_FREE_FIELDS.has(dim.field);
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
+  const initialRef = useRef(dim.editing);
+  const [discardConfirm, setDiscardConfirm] = useState(false);
+  const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
+  function requestCancel(): void {
+    if (isDirty) setDiscardConfirm(true);
+    else onCancel();
+  }
   const containerRef = useRef<HTMLDivElement | null>(null);
   // Parse the textarea once per render — empty lines and trailing whitespace
   // are dropped so a stray Enter doesn't make the regex .replace() a no-op.
@@ -69,11 +77,16 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
       if (containerRef.current === null) return;
       if (!(e.target instanceof Node)) return;
       if (containerRef.current.contains(e.target)) return;
-      onCancel();
+      // Don't dismiss while the discard-confirm modal is open — the modal
+      // lives outside the editor's DOM tree and would otherwise count as
+      // an outside click.
+      if (discardConfirm) return;
+      if (isDirty) setDiscardConfirm(true);
+      else onCancel();
     }
     document.addEventListener('mousedown', onDocClick);
     return () => { document.removeEventListener('mousedown', onDocClick); };
-  }, [onCancel]);
+  }, [onCancel, isDirty, discardConfirm]);
 
   const preview = valuesQuery.status === 'success' ? valuesQuery.data : null;
 
@@ -191,13 +204,24 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
           </button>
           <button
             type="button"
-            onClick={onCancel}
+            onClick={requestCancel}
             className="rounded-md px-4 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary transition-colors"
           >
             Cancel
           </button>
         </div>
       </div>
+      {discardConfirm && (
+        <ConfirmModal
+          title="Discard unsaved changes?"
+          message="You have edits that haven't been saved. Closing the editor will discard them."
+          confirmLabel="Discard"
+          cancelLabel="Keep editing"
+          destructive
+          onConfirm={() => { setDiscardConfirm(false); onCancel(); }}
+          onCancel={() => { setDiscardConfirm(false); }}
+        />
+      )}
     </div>
   );
 }
@@ -268,22 +292,32 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   orgAccounts: readonly { tags: Readonly<Record<string, string>> }[];
 }>) {
   const [state, setState] = useState(tag);
+  const initialRef = useRef(tag);
+  const [discardConfirm, setDiscardConfirm] = useState(false);
+  const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
+  function requestCancel(): void {
+    if (isDirty) setDiscardConfirm(true);
+    else onCancel();
+  }
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Click outside the editor panel closes it (matches the collapse-on-outside
   // pattern the rest of the app uses for popovers). A native 'click' listener
   // on document fires after onClick handlers, so clicks on Save/Cancel/Remove
-  // inside the panel still work as expected.
+  // inside the panel still work as expected. When the form is dirty we
+  // intercept and route through the discard-confirm modal instead.
   useEffect(() => {
     function onDocClick(e: MouseEvent): void {
       if (containerRef.current === null) return;
       if (!(e.target instanceof Node)) return;
       if (containerRef.current.contains(e.target)) return;
-      onCancel();
+      if (discardConfirm) return;
+      if (isDirty) setDiscardConfirm(true);
+      else onCancel();
     }
     document.addEventListener('mousedown', onDocClick);
     return () => { document.removeEventListener('mousedown', onDocClick); };
-  }, [onCancel]);
+  }, [onCancel, isDirty, discardConfirm]);
 
   const tagOptions = state.tagName.length > 0 && !availableTags.includes(state.tagName)
     ? [state.tagName, ...availableTags]
@@ -569,7 +603,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           <button type="button" onClick={() => { onSave(state); }} className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white hover:bg-accent-hover transition-colors">
             Save
           </button>
-          <button type="button" onClick={onCancel} className="rounded-md px-4 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary transition-colors">
+          <button type="button" onClick={requestCancel} className="rounded-md px-4 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary transition-colors">
             Cancel
           </button>
         </div>
@@ -579,6 +613,17 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           </button>
         )}
       </div>
+      {discardConfirm && (
+        <ConfirmModal
+          title="Discard unsaved changes?"
+          message="You have edits that haven't been saved. Closing the editor will discard them."
+          confirmLabel="Discard"
+          cancelLabel="Keep editing"
+          destructive
+          onConfirm={() => { setDiscardConfirm(false); onCancel(); }}
+          onCancel={() => { setDiscardConfirm(false); }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -24,6 +24,7 @@ interface EditingBuiltIn {
   normalize: string;
   aliases: string;
   useOrgAccounts: boolean;
+  nameStripPatterns: string;
 }
 
 function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
@@ -35,9 +36,16 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // Parse the textarea once per render — empty lines and trailing whitespace
+  // are dropped so a stray Enter doesn't make the regex .replace() a no-op.
+  const stripPatternList = state.nameStripPatterns
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0);
+  const stripPatternsKey = stripPatternList.join('\u0001');
   const valuesQuery = useQuery(
-    () => api.discoverColumnValues(dim.field, isAccountDim ? { useOrgAccounts: state.useOrgAccounts } : undefined),
-    [dim.field, isAccountDim, state.useOrgAccounts],
+    () => api.discoverColumnValues(dim.field, isAccountDim ? { useOrgAccounts: state.useOrgAccounts, nameStripPatterns: stripPatternList } : undefined),
+    [dim.field, isAccountDim, state.useOrgAccounts, stripPatternsKey],
   );
 
   useEffect(() => {
@@ -94,6 +102,18 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
             <span className="text-[11px] text-text-muted">Display friendly account names from the Organizations sync instead of raw account IDs.</span>
           </div>
           <DimensionToggle enabled={state.useOrgAccounts} onToggle={() => { setState(s => ({ ...s, useOrgAccounts: !s.useOrgAccounts })); }} />
+        </label>
+      )}
+      {isAccountDim && (
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Name strip patterns (one regex per line, applied to resolved names)</span>
+          <textarea
+            value={state.nameStripPatterns}
+            onChange={e => { setState(s => ({ ...s, nameStripPatterns: e.target.value })); }}
+            rows={3}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm font-mono text-text-primary outline-none focus:border-accent"
+            placeholder={'\\s+(production|staging|sandbox)$\n^DiBa Cards '}
+          />
         </label>
       )}
       <label className="flex flex-col gap-1">
@@ -597,6 +617,10 @@ export function DimensionsView() {
       const description = edited.description.trim();
       const normalize = edited.normalize.length > 0 ? edited.normalize as NormalizationRule : undefined;
       const aliases = textToAliases(edited.aliases);
+      const nameStripPatterns = edited.nameStripPatterns
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l.length > 0);
       return {
         name: d.name,
         label: edited.label.length > 0 ? edited.label : d.label,
@@ -607,6 +631,7 @@ export function DimensionsView() {
         ...(normalize !== undefined ? { normalize } : {}),
         ...(aliases !== undefined ? { aliases } : {}),
         ...(edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
+        ...(nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
       };
     });
     await api.saveDimensionsConfig({ ...config, builtIn });
@@ -679,6 +704,7 @@ export function DimensionsView() {
                       normalize: d.normalize ?? '',
                       aliases: aliasesToText(d.aliases),
                       useOrgAccounts: d.useOrgAccounts === true,
+                      nameStripPatterns: d.nameStripPatterns?.join('\n') ?? '',
                     },
                   }}
                   onSave={(edited) => { void handleSaveBuiltIn(idx, edited); }}


### PR DESCRIPTION
## Summary

What began as a small tweak to the Account dimension grew into a broader overhaul of the Dimensions view, AWS Organization sync, and SSM-backed region enrichment. The common thread: make the built-in dimensions actually useful out-of-the-box by pulling in the AWS-side metadata users already have, and let them be reshaped without editing YAML.

## Account dimension

- **Regex name-strip patterns** — one regex per line applied to each resolved account name with empty-string replacement. Typical use: strip trailing `\s+(production|staging|sandbox)` noise that duplicates your env tag.
- **Normalize → strip order** documented; both applied uniformly to org-resolved and CUR-derived names.
- **Duplicate collapsing** — multiple account IDs that produce the same display name after normalize+strip get folded into one logical account in queries and drill-ins.

## AWS Organization sync

- Sync hits `ListAccounts`, the OU tree, and per-account tags in one click. Progress bar with real phase names ("Fetching tags from each account") and counts.
- Data Management block with the full account list (ID, name, OU path, status, tag count), searchable, expandable into a per-account detail card showing every tag.
- **Clear** button wipes accounts + account-tag lookup + SSM region cache (idempotent).
- Editor warning when the Account dim's org-data toggle is on but no sync has run.

## SSM Parameter Store enrichment

- Piggybacked on the Org sync initially, now a **standalone block** with its own sync action — SSM needs a different IAM permission (`ssm:GetParametersByPath`) so failures are independent.
- **Region pinned to the profile's configured region** — reads `~/.aws/config` (and `sso-session.sso_region` for SSO-only profiles) directly. Previous default-resolution let `AWS_REGION` override the profile, which sent calls to us-east-1 in orgs whose SCP denies it.
- Fetches three fields per region: `longName` + `geolocationCountry` + `geolocationRegion`.
- Expandable data table: code, friendly name, country, continent. Searchable across all four.
- Sync errors surface in full (no 100-char truncation).

## New & reworked dimensions

- **Region** — existing dim, now has a _Resolve codes via SSM region names_ toggle (mirrors Account's org-data toggle). Greyed out with a prompt to sync when SSM data is missing.
- **Country** (`region_country`) — new built-in, groups costs by ISO country code (DE, US, IE). Derived from the SSM country field.
- **Continent** (`region_continent`) — new built-in, groups by AWS geo bucket (EU, NA, AS).
- Both new dims share `field: 'region'` and reuse the alias-CASE machinery — one SSM snapshot powers three distinct groupings.

## Dimensions view UX

- **Drag-to-reorder** via a grip handle, with ↑↓ arrow fallbacks for keyboard users.
- **Optimistic updates** on reorder + enable-toggle — UI paints the new state immediately, persists in the background.
- Last-good config held during refetch to stop the list from flickering mid-save.
- Built-in editor compressed into a 4-row 2-column grid; transform controls hidden for dims where they don't apply (AWS Service, Service Category).
- **Discard-confirm modal** on outside-click when the editor has unsaved edits.
- Inline warnings for missing enrichment data (Region without SSM, Account without Org sync).
- Renames: Service → AWS Service, Service Family → Service Category.

## Infra / fit-and-finish

- **Change AWS Profile** modal on Data Management (focused swap; doesn't redo bucket setup).
- Re-run Setup button for full re-configuration when profile/buckets both need to change.