### PR TITLE
Dimensions view: pills + enabled list, unified ordering, account name-source picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ e2e/*.txt
 
 # Editor backups
 *~
+
+# Claude Code local state
+.claude/

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -125,6 +125,9 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     const enabled = dim['enabled'] === false ? false : undefined;
     const description = dim['description'] !== undefined ? (assertString(dim['description'], `${ctx}.description`), dim['description']) : undefined;
     const useOrgAccounts = dim['useOrgAccounts'] === true ? true : undefined;
+    const accountNameFromTag = typeof dim['accountNameFromTag'] === 'string' && dim['accountNameFromTag'].length > 0
+      ? dim['accountNameFromTag']
+      : undefined;
     let nameStripPatterns: string[] | undefined;
     if (dim['nameStripPatterns'] !== undefined) {
       assertArray(dim['nameStripPatterns'], `${ctx}.nameStripPatterns`);
@@ -163,6 +166,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
       ...(normalize !== undefined ? { normalize } : {}),
       ...(aliases !== undefined ? { aliases } : {}),
       ...(useOrgAccounts === true ? { useOrgAccounts } : {}),
+      ...(accountNameFromTag !== undefined ? { accountNameFromTag } : {}),
       ...(nameStripPatterns !== undefined && nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
     };
   });

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -132,7 +132,7 @@ export interface CostApi {
   setOptimizeEnabled(enabled: boolean): Promise<void>;
   clearSidecars(): Promise<{ removed: number; requeued: number }>;
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>;
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; accountNameFromTag?: string; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -54,6 +54,11 @@ export interface BuiltInDimension {
   /** Account-specific: when true, resolve id→name via org-accounts.json
    *  (AWS Organizations sync) instead of the legacy CSV mapping. */
   readonly useOrgAccounts?: boolean | undefined;
+  /** Account-specific: when set, resolve id→name by reading this account-level
+   *  tag from the AWS Organizations sync instead of the account's Name field.
+   *  Implies the org-sync source; falls back to the Name field when the tag
+   *  is missing on a given account. */
+  readonly accountNameFromTag?: string | undefined;
   /** Account-specific: regexes (one per array entry) applied to each resolved
    *  name with empty-string replacement. Lets the user strip noise like
    *  trailing " production" or a common org prefix. Invalid patterns are

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -165,11 +165,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
 
   async function getAccountMap(): Promise<Map<string, string>> {
     // Returns the Account id→name map the handlers should use for display
-    // resolution. Source depends on the Account dim's `useOrgAccounts` flag:
-    //   - true  : org-accounts.json (AWS Organizations sync)
-    //   - false : the legacy account-mapping CSV under raw/
-    // Both are optional — if the preferred source is missing we fall through
-    // to the other one before giving up and returning an empty map.
+    // resolution. Source depends on the Account dim's config:
+    //   - useOrgAccounts=true + accountNameFromTag set  : org-sync tag value
+    //   - useOrgAccounts=true                           : org-sync Name field
+    //   - otherwise                                     : legacy account CSV
+    // Both org and CSV are optional — if the preferred source is missing we
+    // fall through to the other one before giving up and returning an empty
+    // map. Tag-based names silently fall back to the Name field for accounts
+    // that don't carry the tag.
     if (state.accountMap !== null) return state.accountMap;
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
@@ -178,6 +181,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const dimensions = await getDimensions();
     const accountDim = dimensions.builtIn.find(d => d.field === 'account_id');
     const preferOrg = accountDim?.useOrgAccounts === true;
+    const tagKey = accountDim?.accountNameFromTag;
 
     async function fromOrg(): Promise<Map<string, string>> {
       const map = new Map<string, string>();
@@ -189,9 +193,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
             if (!isStringRecord(acct)) continue;
             const id = acct['id'];
             const name = acct['name'];
-            if (typeof id === 'string' && typeof name === 'string' && id.length > 0 && name.length > 0) {
-              map.set(id, name);
+            if (typeof id !== 'string' || id.length === 0) continue;
+            let resolved: string | undefined;
+            if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
+              const tagVal = acct['tags'][tagKey];
+              if (typeof tagVal === 'string' && tagVal.length > 0) resolved = tagVal;
             }
+            if (resolved === undefined && typeof name === 'string' && name.length > 0) resolved = name;
+            if (resolved !== undefined) map.set(id, resolved);
           }
         }
       } catch { /* no org sync */ }

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -20,8 +20,11 @@ function tagFingerprint(tag: TagDimension): string {
 }
 
 /** One-shot read of org-accounts.json → id→name map. No caching here (the
- *  preview handler wants fresh data on every toggle change). */
-async function loadOrgAccountsMap(dataDir: string): Promise<Map<string, string>> {
+ *  preview handler wants fresh data on every toggle change). When tagKey is
+ *  set, the "name" for each account is the value of that account-level tag;
+ *  accounts missing the tag fall back to the account's Name field so the
+ *  preview never drops rows. */
+async function loadOrgAccountsMap(dataDir: string, tagKey?: string): Promise<Map<string, string>> {
   const fs = await import('node:fs/promises');
   const path = await import('node:path');
   const map = new Map<string, string>();
@@ -33,9 +36,14 @@ async function loadOrgAccountsMap(dataDir: string): Promise<Map<string, string>>
         if (!isStringRecord(acct)) continue;
         const id = acct['id'];
         const name = acct['name'];
-        if (typeof id === 'string' && typeof name === 'string' && id.length > 0 && name.length > 0) {
-          map.set(id, name);
+        if (typeof id !== 'string' || id.length === 0) continue;
+        let resolved: string | undefined;
+        if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
+          const tagVal = acct['tags'][tagKey];
+          if (typeof tagVal === 'string' && tagVal.length > 0) resolved = tagVal;
         }
+        if (resolved === undefined && typeof name === 'string' && name.length > 0) resolved = name;
+        if (resolved !== undefined) map.set(id, resolved);
       }
     }
   } catch { /* no org sync */ }
@@ -145,7 +153,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
   // Distinct values + cost for a built-in column — powers the preview on the
   // built-in editor ("Service has 120 distinct values, top 20 by cost are...").
   // Scans the most recent daily period so the preview loads fast.
-  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
+  ipcMain.handle('dimensions:discover-column-values', async (_event, field: string, opts?: { useOrgAccounts?: boolean; accountNameFromTag?: string; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> => {
     // Whitelist columns we know are safe to embed in SQL. These match the
     // aliases emitted by buildSource so the query plans identically to what
     // the rest of the app does.
@@ -195,7 +203,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     // toggle before the config is saved (otherwise the cached accountMap
     // might be from the wrong source).
     if (field === 'account_id' && opts?.useOrgAccounts === true) {
-      const orgMap = await loadOrgAccountsMap(ctx.dataDir);
+      const orgMap = await loadOrgAccountsMap(ctx.dataDir, opts.accountNameFromTag);
       if (orgMap.size > 0) {
         values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
       }
@@ -268,6 +276,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(d.normalize === undefined ? {} : { normalize: d.normalize }),
         ...(d.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(d.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(d.useOrgAccounts === true ? { useOrgAccounts: true } : {}),
+        ...(typeof d.accountNameFromTag === 'string' && d.accountNameFromTag.length > 0 ? { accountNameFromTag: d.accountNameFromTag } : {}),
         ...(d.nameStripPatterns !== undefined && d.nameStripPatterns.length > 0 ? { nameStripPatterns: [...d.nameStripPatterns] } : {}),
         // Persist useRegionNames whenever the user has set it explicitly
         // (either value), so toggling off sticks past a reload. Leaving it

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -158,7 +158,7 @@ const api: CostApi = {
   discoverTagKeys(): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> {
     return invoke<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }>('dimensions:discover-tags');
   },
-  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
+  discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; accountNameFromTag?: string; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> {
     return invoke<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>('dimensions:discover-column-values', field, opts);
   },
   getDimensionsConfig(): Promise<DimensionsConfig> {

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -79,14 +79,18 @@ interface EditingBuiltIn {
   normalize: string;
   aliases: string;
   useOrgAccounts: boolean;
+  /** Empty string = use the account's Name field. Non-empty = use this
+   *  account-level tag from the AWS Org sync. */
+  accountNameFromTag: string;
   nameStripPatterns: string;
   useRegionNames: boolean;
 }
 
-function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
+function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
   dim: { name: string; field: string; editing: EditingBuiltIn };
   onSave: (edited: EditingBuiltIn) => void;
   onCancel: () => void;
+  accountTagKeys: readonly string[];
 }>): React.JSX.Element {
   const isAccountDim = dim.field === 'account_id';
   // Three dims share field='region' — distinguish by name so only the Region
@@ -136,11 +140,18 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
       dim.field,
       {
         ...(normalize !== undefined ? { normalize } : {}),
-        ...(isAccountDim ? { useOrgAccounts: state.useOrgAccounts, nameStripPatterns: stripPatternList } : {}),
+        ...(isAccountDim ? {
+          // Both "Account Name" and "Account Tag" are org-sync-sourced, so
+          // the preview always wants useOrgAccounts=true regardless of any
+          // legacy value on the saved dim.
+          useOrgAccounts: true,
+          nameStripPatterns: stripPatternList,
+          ...(state.accountNameFromTag.length > 0 ? { accountNameFromTag: state.accountNameFromTag } : {}),
+        } : {}),
         ...(isAnyRegionDim ? { dimName: dim.name, useRegionNames: state.useRegionNames } : {}),
       },
     ),
-    [dim.field, dim.name, isAccountDim, isAnyRegionDim, state.useOrgAccounts, state.useRegionNames, stripPatternsKey, normalize],
+    [dim.field, dim.name, isAccountDim, isAnyRegionDim, state.useOrgAccounts, state.useRegionNames, state.accountNameFromTag, stripPatternsKey, normalize],
   );
 
   useEffect(() => {
@@ -184,14 +195,51 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
       />
     </label>
   );
-  const orgToggleField = (
-    <label className="flex items-center justify-between rounded border border-border bg-bg-primary px-3 py-2 h-full">
-      <div className="flex flex-col gap-0.5 min-w-0 pr-3">
-        <span className="text-sm text-text-primary">Resolve names via org-data</span>
-        <span className="text-[11px] text-text-muted leading-tight">Use friendly names from the Organizations sync.</span>
-      </div>
-      <DimensionToggle enabled={state.useOrgAccounts} onToggle={() => { setState(s => ({ ...s, useOrgAccounts: !s.useOrgAccounts })); }} />
-    </label>
+  // Account-name source is always the AWS Org sync — the user picks between
+  // the account's Name field and any account-level tag. When the tag key is
+  // unknown (no sync data) we still let the user pre-select it from the
+  // saved value, but the dropdown won't have suggestions.
+  const nameSource: 'name' | 'tag' = state.accountNameFromTag.length > 0 ? 'tag' : 'name';
+  const tagKeyOptions = state.accountNameFromTag.length > 0 && !accountTagKeys.includes(state.accountNameFromTag)
+    ? [state.accountNameFromTag, ...accountTagKeys]
+    : [...accountTagKeys];
+  const nameSourceField = (
+    <div className="flex flex-col gap-2">
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Name source (from org-sync)</span>
+        <select
+          value={nameSource}
+          onChange={e => {
+            const v = e.target.value;
+            if (v === 'name') setState(s => ({ ...s, accountNameFromTag: '' }));
+            else setState(s => ({ ...s, accountNameFromTag: s.accountNameFromTag.length > 0 ? s.accountNameFromTag : (accountTagKeys[0] ?? '') }));
+          }}
+          className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+        >
+          <option value="name">Account Name</option>
+          <option value="tag">Account Tag</option>
+        </select>
+      </label>
+      {nameSource === 'tag' && (
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Tag key</span>
+          <select
+            value={state.accountNameFromTag}
+            onChange={e => { setState(s => ({ ...s, accountNameFromTag: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            {tagKeyOptions.length === 0 ? (
+              <option value="">No account tags synced</option>
+            ) : (
+              <>
+                {state.accountNameFromTag.length === 0 && <option value="">Select a tag...</option>}
+                {tagKeyOptions.map(t => <option key={t} value={t}>{t}</option>)}
+              </>
+            )}
+          </select>
+        </label>
+      )}
+    </div>
   );
   // Region equivalent of the org toggle. Disabled (and forced-off in preview)
   // when the SSM region snapshot isn't present — the toggle's whole point is
@@ -281,8 +329,10 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
             ? { kind: 'missing' }
             : null
       : null;
+  // Both "Account Name" and "Account Tag" sources resolve via the Org sync,
+  // so if it hasn't run yet the dim will display raw 12-digit IDs regardless.
   const accountWarning: boolean =
-    isAccountDim && state.useOrgAccounts && orgQuery.status === 'success' && orgInfo === null;
+    isAccountDim && orgQuery.status === 'success' && orgInfo === null;
 
   return (
     <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
@@ -310,14 +360,14 @@ function BuiltInEditor({ dim, onSave, onCancel }: Readonly<{
         <div className="rounded-md border border-warning/50 bg-warning-muted px-3 py-2 text-xs flex flex-col gap-1">
           <p className="font-medium text-warning">Org-data not synced</p>
           <p className="text-text-secondary">
-            The "Resolve names via org-data" toggle is on but no AWS Organization sync has run yet —
+            Account names and tags come from the AWS Organization sync, which hasn't run yet —
             account values will display as raw 12-digit IDs. Run the sync from the <span className="font-medium">Sync</span> tab to populate.
           </p>
         </div>
       )}
       {showTransforms && (
         <div className="grid grid-cols-2 gap-4 items-stretch">
-          {isAccountDim ? orgToggleField : isRegionDim ? regionToggleField : <div />}
+          {isAccountDim ? nameSourceField : isRegionDim ? regionToggleField : <div />}
           {normalizationField}
         </div>
       )}
@@ -920,7 +970,12 @@ export function DimensionsView() {
         ...(description.length > 0 ? { description } : {}),
         ...(normalize !== undefined ? { normalize } : {}),
         ...(aliases !== undefined ? { aliases } : {}),
-        ...(edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
+        // The account dim's picker always implies org-sync (both sources come
+        // from it); force useOrgAccounts=true so legacy configs that had it
+        // off get migrated the first time the dim is saved.
+        ...(d.field === 'account_id' ? { useOrgAccounts: true as const }
+          : edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
+        ...(edited.accountNameFromTag.length > 0 ? { accountNameFromTag: edited.accountNameFromTag } : {}),
         ...(nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
         // Only the Region dim surfaces a useRegionNames toggle — write it
         // explicitly (both true AND false) so toggling off sticks past the
@@ -1197,12 +1252,14 @@ export function DimensionsView() {
                         normalize: d.normalize ?? '',
                         aliases: aliasesToText(d.aliases),
                         useOrgAccounts: d.useOrgAccounts === true,
+                        accountNameFromTag: d.accountNameFromTag ?? '',
                         nameStripPatterns: d.nameStripPatterns?.join('\n') ?? '',
                         useRegionNames: d.useRegionNames === true,
                       },
                     }}
                     onSave={(edited) => { void handleSaveBuiltIn(row.idx, edited); }}
                     onCancel={() => { setEditingBuiltInIdx(null); }}
+                    accountTagKeys={accountTagKeys}
                   />
                 );
               }


### PR DESCRIPTION
## Summary

Three related changes on top of #52:

- **Reorganize the Dimensions view** into a pills-for-availability + cards-for-config layout, with collapsible debug panels at the bottom for the tag-discovery pivots.
- **Unified ordering** so built-ins and tag dims live in a single drag/arrow-reorderable list — a tag can now sit above a built-in (or vice versa) in the selector.
- **Account dim: Name vs Tag picker**, replacing the old "Resolve names via org-data" boolean toggle. Both options resolve from the AWS Org sync — "Account Name" uses the account's Name field, "Account Tag" uses a chosen account-level tag (with fallback to Name for accounts missing the tag).

## Notes

- Legacy `useOrgAccounts: false` configs are migrated to `true` on first save of the Account dim, since both picker options imply the Org sync.
- Preview (`loadOrgAccountsMap`) and runtime (`getAccountMap`) share the same tag-with-name-fallback logic.
- New optional field `accountNameFromTag: string` on `BuiltInDimension`; round-trips through validator + YAML save.