### PR TITLE
Strip builtIn on view export/import + Open folder button

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -141,6 +141,8 @@ export interface CostApi {
   getViewsConfig(): Promise<ViewsConfig>;
   saveViewsConfig(config: ViewsConfig): Promise<void>;
   resetViewsConfig(): Promise<ViewsConfig>;
+  /** Reveal `views.yaml` in the OS file manager (Finder / Explorer). */
+  revealViewsFolder(): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;
   setAutoSyncEnabled(enabled: boolean): Promise<void>;
   getAutoSyncStatus(): Promise<AutoSyncStatus>;

--- a/packages/desktop/src/main/handlers/views.ts
+++ b/packages/desktop/src/main/handlers/views.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { ipcMain, shell } from 'electron';
 import { writeFile } from 'node:fs/promises';
 import { stringify } from 'yaml';
 import { SEED_VIEWS_CONFIG, validateViews, viewsConfigToYaml } from '@costgoblin/core';
@@ -30,5 +30,9 @@ export function registerViewsHandlers(app: AppContext): void {
     await writeFile(ctx.viewsPath, stringify(viewsConfigToYaml(SEED_VIEWS_CONFIG)));
     invalidateViews();
     return SEED_VIEWS_CONFIG;
+  });
+
+  ipcMain.handle('views:reveal-folder', (): void => {
+    shell.showItemInFolder(ctx.viewsPath);
   });
 }

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -186,6 +186,9 @@ const api: CostApi = {
   resetViewsConfig(): Promise<ViewsConfig> {
     return invoke<ViewsConfig>('views:reset-defaults');
   },
+  revealViewsFolder(): Promise<void> {
+    return invoke<undefined>('views:reveal-folder').then(() => undefined);
+  },
 };
 
 contextBridge.exposeInMainWorld('costgoblin', api);

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -262,6 +262,7 @@ export class MockCostApi implements CostApi {
   getViewsConfig(): Promise<ViewsConfig> { return Promise.resolve(MOCK_VIEWS_CONFIG); }
   saveViewsConfig(): Promise<void> { return Promise.resolve(); }
   resetViewsConfig(): Promise<ViewsConfig> { return Promise.resolve(MOCK_VIEWS_CONFIG); }
+  revealViewsFolder(): Promise<void> { return Promise.resolve(); }
 }
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {

--- a/packages/ui/src/components/view-yaml-modal.tsx
+++ b/packages/ui/src/components/view-yaml-modal.tsx
@@ -18,10 +18,21 @@ interface ImportProps {
 
 type ViewYamlModalProps = ExportProps | ImportProps;
 
+/** Strip `builtIn: true` so exports round-trip as custom views. Otherwise
+ *  re-importing a built-in export creates a second undeletable view. */
+function asCustomView(v: ViewSpec): ViewSpec {
+  return {
+    id: v.id,
+    name: v.name,
+    rows: v.rows,
+    ...(v.icon !== undefined ? { icon: v.icon } : {}),
+  };
+}
+
 export function ViewYamlModal(props: ViewYamlModalProps): React.JSX.Element {
   const closeRef = useRef<HTMLButtonElement>(null);
   const [text, setText] = useState(() =>
-    props.mode === 'export' ? stringify(viewToYaml(props.view)) : '',
+    props.mode === 'export' ? stringify(viewToYaml(asCustomView(props.view))) : '',
   );
   const [copied, setCopied] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
@@ -60,7 +71,9 @@ export function ViewYamlModal(props: ViewYamlModalProps): React.JSX.Element {
         setImportError(`A view with id "${first.id}" already exists. Rename it in the YAML before importing.`);
         return;
       }
-      props.onImport(first);
+      // Always land imports as custom views — hand-edited YAML with
+      // `builtIn: true` would otherwise create an undeletable duplicate.
+      props.onImport(asCustomView(first));
     } catch (err: unknown) {
       setImportError(err instanceof ConfigValidationError ? err.message : err instanceof Error ? err.message : String(err));
     }

--- a/packages/ui/src/views/views-editor.tsx
+++ b/packages/ui/src/views/views-editor.tsx
@@ -262,6 +262,14 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
         <div className="flex items-center gap-2">
           <button
             type="button"
+            onClick={() => { void api.revealViewsFolder(); }}
+            className="px-3 py-1.5 text-sm rounded-md border border-border text-text-secondary hover:text-text-primary"
+            title="Reveal views.yaml in Finder"
+          >
+            Open folder
+          </button>
+          <button
+            type="button"
             onClick={() => { setModal({ mode: 'import' }); }}
             disabled={saving}
             className="px-3 py-1.5 text-sm rounded-md border border-border text-text-secondary hover:text-text-primary disabled:opacity-50"


### PR DESCRIPTION
## Summary

- Exporting a built-in view preserved `builtIn: true` in the YAML so re-importing it created a second undeletable view. `asCustomView` strips it on both the export and import paths in [view-yaml-modal.tsx](packages/ui/src/components/view-yaml-modal.tsx). Disk persistence still keeps `builtIn` — the seed view stays protected across restarts.
- New **Open folder** button in the Views header reveals `views.yaml` in Finder/Explorer via `shell.showItemInFolder`. Wired through a `views:reveal-folder` IPC handler and `CostApi.revealViewsFolder`.