### PR TITLE
Cost Scope: cost metric picker + exclusion rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,25 @@ If you don't have a CUR report yet, create one in the [AWS Console](https://docs
 | `pricing_public_on_demand_cost` | On-demand list price |
 | `resource_tags` | Tag key-value pairs |
 
-**Optional cost-metric columns** — enable these to unlock the full Cost Scope metric picker:
+**Optional cost-metric columns** — enable these to unlock the full Cost Scope metric + perspective picker:
 
-| Column | Unlocks | Notes |
-|--------|---------|-------|
-| `line_item_blended_cost` | **Blended** metric | Usually shipped by default; absent only in stripped-down exports. If missing, Blended silently falls back to Unblended. |
-| `reservation_effective_cost` | **Amortized** metric (RI portion) | Ships only when **Include Resource IDs** is enabled on the CUR report. |
-| `savings_plan_savings_plan_effective_cost` | **Amortized** metric (SP portion) | Ships only with **Include Resource IDs**. Note the double prefix — AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost`. |
+| Column | Unlocks | Requires |
+|--------|---------|----------|
+| `line_item_blended_cost` | **Blended** metric | Usually shipped by default. |
+| `reservation_effective_cost` | **Amortized** metric (RI portion) | *Include resource IDs* |
+| `savings_plan_savings_plan_effective_cost` | **Amortized** metric (SP portion) | *Include resource IDs*. Note the double prefix — AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost`. |
+| `line_item_net_unblended_cost` | **Net** perspective toggle | *Include net columns* |
+| `reservation_net_effective_cost` | **Net + Amortized** (RI portion) | *Include resource IDs* AND *Include net columns* |
+| `savings_plan_net_savings_plan_effective_cost` | **Net + Amortized** (SP portion) | *Include resource IDs* AND *Include net columns* |
 
-The app probes your parquet schema on first launch and shows a warning in the Cost Scope view if Amortized is degraded — no error, but the view falls back to Unblended for rows that would otherwise carry an effective-cost value.
+The app probes your parquet schema on first launch and shows warnings in the Cost Scope view when a metric or perspective is degraded — no errors, the view silently falls back to the closest available column.
 
-**How to enable `Include Resource IDs`:**
+**Recommended: enable BOTH settings on your CUR report.** Without them the Amortized metric and Net perspective both fall back to Unblended-gross:
 
-AWS Billing → Cost and Usage Reports → your report → **Edit** → check *Include resource IDs*. CUR reports are immutable, so the edit typically requires creating a new report pointed at the same (or a fresh) S3 prefix. Allow one billing cycle for the columns to appear in the data.
+1. AWS Billing → **Cost and Usage Reports** → your report → **Edit**
+2. Check *Include resource IDs* and *Include net columns*
+3. CUR reports are immutable, so the edit typically requires creating a new report pointed at the same (or a fresh) S3 prefix
+4. Allow one billing cycle for the new columns to appear in the data
 
 The S3 export should look like:
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If you don't have a CUR report yet, create one in the [AWS Console](https://docs
 | `line_item_usage_start_date` | Date partitioning |
 | `line_item_usage_account_id` | Account dimension |
 | `line_item_usage_account_name` | Account display name |
-| `line_item_unblended_cost` | Primary cost metric |
-| `line_item_line_item_type` | Charge type (Usage/Fee/Credit/Tax) |
+| `line_item_unblended_cost` | Primary cost metric (Unblended) |
+| `line_item_line_item_type` | Charge type (Usage/Fee/Credit/Tax) — drives Cost Scope exclusion rules |
 | `line_item_line_item_description` | Line item description |
 | `line_item_operation` | AWS operation |
 | `line_item_usage_type` | Usage details |
@@ -48,6 +48,20 @@ If you don't have a CUR report yet, create one in the [AWS Console](https://docs
 | `product_region_code` | AWS region |
 | `pricing_public_on_demand_cost` | On-demand list price |
 | `resource_tags` | Tag key-value pairs |
+
+**Optional cost-metric columns** — enable these to unlock the full Cost Scope metric picker:
+
+| Column | Unlocks | Notes |
+|--------|---------|-------|
+| `line_item_blended_cost` | **Blended** metric | Usually shipped by default; absent only in stripped-down exports. If missing, Blended silently falls back to Unblended. |
+| `reservation_effective_cost` | **Amortized** metric (RI portion) | Ships only when **Include Resource IDs** is enabled on the CUR report. |
+| `savings_plan_savings_plan_effective_cost` | **Amortized** metric (SP portion) | Ships only with **Include Resource IDs**. Note the double prefix — AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost`. |
+
+The app probes your parquet schema on first launch and shows a warning in the Cost Scope view if Amortized is degraded — no error, but the view falls back to Unblended for rows that would otherwise carry an effective-cost value.
+
+**How to enable `Include Resource IDs`:**
+
+AWS Billing → Cost and Usage Reports → your report → **Edit** → check *Include resource IDs*. CUR reports are immutable, so the edit typically requires creating a new report pointed at the same (or a fresh) S3 prefix. Allow one billing cycle for the columns to appear in the data.
 
 The S3 export should look like:
 ```

--- a/README.md
+++ b/README.md
@@ -20,54 +20,74 @@ On first launch, the setup wizard guides you through connecting to your AWS CUR 
 
 ### Setting Up a CUR Report
 
-If you don't have a CUR report yet, create one in the [AWS Console](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html):
+If you don't have a CUR report yet, create one in the [AWS Console](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html).
+
+**Report settings:**
 
 | Setting | Value |
 |---------|-------|
-| Report type | CUR 2.0 |
+| Report type | CUR 2.0 (Data Exports) |
 | Time granularity | Daily |
-| Additional content | Include resource IDs |
 | Format | Parquet |
+| Compression | Parquet (Snappy) |
+| Additional content | **Include resource IDs** + **Include net columns** (both) |
 
-**Required columns:**
+**Why both "additional content" boxes.** Each ticks on a family of columns that the app uses for a specific metric / perspective. Tick only one and you get half the matrix — the app still runs, but Amortized and/or Net silently fall back to Unblended.
+
+| Setting | Unlocks | Without it |
+|---------|---------|------------|
+| *Include resource IDs* | Amortized metric (accurate RI/SP smoothing) + the resource_id column Missing-Tags analysis needs | Amortized degrades to Unblended; Missing Tags view can't isolate resources |
+| *Include net columns* | Net perspective (credits / refunds / promotional discounts applied) | Net falls back to Gross on every metric |
+
+**Required columns** — the base set the app needs to function:
 
 | Column | Purpose |
 |--------|---------|
 | `line_item_usage_start_date` | Date partitioning |
 | `line_item_usage_account_id` | Account dimension |
 | `line_item_usage_account_name` | Account display name |
-| `line_item_unblended_cost` | Primary cost metric (Unblended) |
-| `line_item_line_item_type` | Charge type (Usage/Fee/Credit/Tax) — drives Cost Scope exclusion rules |
+| `line_item_line_item_type` | Charge type (Usage / Fee / Credit / Tax / RIFee / ...). Drives Cost Scope exclusion rules |
 | `line_item_line_item_description` | Line item description |
 | `line_item_operation` | AWS operation |
 | `line_item_usage_type` | Usage details |
 | `line_item_usage_amount` | Usage quantity |
-| `line_item_resource_id` | Resource ARN (missing tags analysis) |
-| `product_servicecode` | AWS service (e.g. AmazonEC2) |
-| `product_product_family` | Service family (e.g. Compute Instance) |
+| `line_item_resource_id` | Resource ARN (Missing-Tags analysis) |
+| `line_item_unblended_cost` | Primary cost metric. **Always required** — the universal fallback for every metric / perspective combination |
+| `pricing_public_on_demand_cost` | On-demand list price (shown alongside cost in Line Items table) |
+| `product_servicecode` | AWS service code (e.g. `AmazonEC2`) |
+| `product_product_family` | Service family (e.g. `Compute Instance`) |
 | `product_region_code` | AWS region |
-| `pricing_public_on_demand_cost` | On-demand list price |
 | `resource_tags` | Tag key-value pairs |
 
-**Optional cost-metric columns** — enable these to unlock the full Cost Scope metric + perspective picker:
+**Cost-metric columns** — pick both variants of each pair so Gross *and* Net views stay accurate:
 
-| Column | Unlocks | Requires |
-|--------|---------|----------|
-| `line_item_blended_cost` | **Blended** metric | Usually shipped by default. |
-| `reservation_effective_cost` | **Amortized** metric (RI portion) | *Include resource IDs* |
-| `savings_plan_savings_plan_effective_cost` | **Amortized** metric (SP portion) | *Include resource IDs*. Note the double prefix — AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost`. |
-| `line_item_net_unblended_cost` | **Net** perspective toggle | *Include net columns* |
-| `reservation_net_effective_cost` | **Net + Amortized** (RI portion) | *Include resource IDs* AND *Include net columns* |
-| `savings_plan_net_savings_plan_effective_cost` | **Net + Amortized** (SP portion) | *Include resource IDs* AND *Include net columns* |
+| Column | Unlocks |
+|--------|---------|
+| `line_item_blended_cost` | **Blended** metric (consolidated-billing weighted average) |
+| `line_item_net_unblended_cost` | **Net** perspective for every metric |
+| `reservation_effective_cost` | **Amortized** metric, Gross — RI-covered usage |
+| `reservation_net_effective_cost` | **Amortized** metric, Net — RI-covered usage |
+| `savings_plan_savings_plan_effective_cost` | **Amortized** metric, Gross — SP-covered usage |
+| `savings_plan_net_savings_plan_effective_cost` | **Amortized** metric, Net — SP-covered usage |
 
-The app probes your parquet schema on first launch and shows warnings in the Cost Scope view when a metric or perspective is degraded — no errors, the view silently falls back to the closest available column.
+> The doubled prefix on the SP columns is AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost` — not a typo.
 
-**Recommended: enable BOTH settings on your CUR report.** Without them the Amortized metric and Net perspective both fall back to Unblended-gross:
+**Metric × Perspective matrix** — the column the app actually reads for each UI selection (first available, in priority order):
 
-1. AWS Billing → **Cost and Usage Reports** → your report → **Edit**
-2. Check *Include resource IDs* and *Include net columns*
-3. CUR reports are immutable, so the edit typically requires creating a new report pointed at the same (or a fresh) S3 prefix
-4. Allow one billing cycle for the new columns to appear in the data
+| Selection | Reads from (first available wins) |
+|-----------|-----------------------------------|
+| Unblended · Gross | `line_item_unblended_cost` |
+| Unblended · Net | `line_item_net_unblended_cost` → `line_item_unblended_cost` |
+| Blended · Gross | `line_item_blended_cost` → `line_item_unblended_cost` |
+| Blended · Net | `line_item_net_unblended_cost` → `line_item_blended_cost` → `line_item_unblended_cost` [^1] |
+| Amortized · Gross | `reservation_effective_cost` → `savings_plan_savings_plan_effective_cost` → `line_item_unblended_cost` |
+| Amortized · Net | `reservation_net_effective_cost` → `savings_plan_net_savings_plan_effective_cost` → `line_item_net_unblended_cost` → `line_item_unblended_cost` |
+
+[^1]: AWS doesn't publish a standalone `line_item_net_blended_cost` — Blended × Net uses the next-closest net accounting column.
+
+**What the app does on first launch.** It probes your parquet schema once (cached per session) and shows an inline warning next to any degraded metric / perspective combination in the Cost Scope view. Queries never fail with a missing-column error; they fall back down the chain.
+
+**Changing the settings.** CUR reports are immutable, so enabling *Include resource IDs* / *Include net columns* on an existing report requires creating a new report. Point it at the same (or a fresh) S3 prefix, wait one billing cycle for the new columns to land, then point CostGoblin at the updated prefix.
 
 The S3 export should look like:
 ```

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1322,8 +1322,8 @@ test.describe('Cost Scope', () => {
     const costText = await firstCostCell.textContent();
     expect(costText).toContain('$');
 
-    // "Top N of M rows" count line is visible
-    await expect(page.getByText(/rows, sorted by \|cost\| desc/)).toBeVisible();
+    // Count summary line is visible
+    await expect(lineItemsCard.getByText(/sorted by \|cost\| desc/)).toBeVisible();
 
     await screenshot(page, 'cost-scope-table');
   });

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1227,8 +1227,10 @@ test.describe('Cost Scope', () => {
     await expect(page.locator('input[type="radio"][value="amortized"]')).toBeVisible();
     await expect(page.locator('input[type="radio"][value="list"]')).toHaveCount(0);
 
-    // Unblended should be selected by default
-    await expect(page.locator('input[type="radio"][value="unblended"]')).toBeChecked();
+    // Exactly one metric radio is selected — the specific one depends on
+    // what the user has saved to cost-scope.yaml, so we don't assume a
+    // default beyond "something is checked".
+    await expect(page.locator('input[type="radio"][name="costMetric"]:checked')).toHaveCount(1);
     await screenshot(page, 'cost-scope-metric');
   });
 

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1242,39 +1242,46 @@ test.describe('Cost Scope', () => {
     expect(await builtInPills.count()).toBeGreaterThanOrEqual(2);
   });
 
-  test('preview card renders summary tiles + histogram + line-items table', async () => {
-    // Scroll to the Preview card (it's below a potentially tall rules list)
+  test('preview card renders summary tiles + histogram', async () => {
+    // Preview is sticky on the right column at lg+; scrollIntoView just
+    // ensures it's reachable regardless of breakpoint.
     const card = page.getByTestId('cost-scope-preview');
     await card.scrollIntoViewIfNeeded();
     await expect(card).toBeVisible();
     await expect(card.getByRole('heading', { name: 'Preview' })).toBeVisible();
 
-    // Summary tiles — scope to the card so headings/body copy elsewhere
-    // (e.g. "Rows matching any enabled rule are excluded") don't collide.
-    await expect(card.getByText('Unscoped total', { exact: true })).toBeVisible();
-    await expect(card.getByText('After scope', { exact: true })).toBeVisible();
-    await expect(card.getByText('Excluded', { exact: true })).toBeVisible();
+    // Summary tiles — scope to the card so "Rows matching any enabled rule
+    // are excluded" in the rules section header doesn't collide. At lg+ the
+    // card also appears twice (hidden mobile copy + sticky aside), so we
+    // use `.first()` on the match.
+    await expect(card.getByText('Unscoped total', { exact: true }).first()).toBeVisible();
+    await expect(card.getByText('After scope', { exact: true }).first()).toBeVisible();
+    await expect(card.getByText('Excluded', { exact: true }).first()).toBeVisible();
 
     // Daily cost label appears only when the histogram is rendered
-    await expect(card.getByText('Daily cost', { exact: true })).toBeVisible();
-
-    // Line items label + the table itself
-    await expect(card.getByText('Line items', { exact: true })).toBeVisible();
+    await expect(card.getByText('Daily cost', { exact: true }).first()).toBeVisible();
 
     await screenshot(page, 'cost-scope-preview');
   });
 
+  test('line-items card has its own heading + table', async () => {
+    const card = page.getByTestId('cost-scope-line-items');
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toBeVisible();
+    await expect(card.getByRole('heading', { name: 'Line items' })).toBeVisible();
+  });
+
   test('preview histogram has at least one bar when data exists', async () => {
-    // Each day is a flex-1 div with role="generic"; look for ones inside the
-    // preview histogram container — they live under the "Daily cost" label.
-    const previewCard = page.locator('div').filter({ has: page.getByRole('heading', { name: 'Preview' }) }).first();
+    // The preview card renders twice on lg+ (mobile fallback hidden, sticky
+    // aside visible). .first() targets whichever the page put first in DOM.
+    const previewCard = page.getByTestId('cost-scope-preview').first();
     const dayBars = previewCard.locator('div[title*="kept:"]');
     const count = await dayBars.count();
 
     if (count === 0) {
       // No data synced at all — acceptable state; verify the empty-state
-      // message is shown.
-      await expect(page.getByText(/No data in the last 30 days/)).toBeVisible();
+      // message is shown inside the preview card.
+      await expect(previewCard.getByText(/No data in the last 30 days/)).toBeVisible();
     } else {
       // When data is present, at least one bar should carry a tooltip.
       expect(count).toBeGreaterThan(0);
@@ -1284,9 +1291,10 @@ test.describe('Cost Scope', () => {
   });
 
   test('line-items table renders rows when data exists', async () => {
-    // Scope to the table inside the preview card.
-    const previewCard = page.locator('div').filter({ has: page.getByRole('heading', { name: 'Preview' }) }).first();
-    const table = previewCard.locator('table');
+    // Scope to the table inside the line-items card.
+    const lineItemsCard = page.getByTestId('cost-scope-line-items');
+    await lineItemsCard.scrollIntoViewIfNeeded();
+    const table = lineItemsCard.locator('table');
     const tableVisible = await table.isVisible().catch(() => false);
 
     if (!tableVisible) {

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -71,6 +71,26 @@ async function waitForQuerySettle(page: Page): Promise<void> {
   await assertNoReactCrash(page);
 }
 
+/** Wait for the Cost Scope preview to finish its debounced first load. The
+ *  preview effect debounces 300ms and then runs several IPC queries
+ *  serially (per-rule + totals + daily + sample + count). Polling for the
+ *  in-header "loading…" marker to disappear is the only reliable settle
+ *  signal — waitForQuerySettle's generic "Loading" check doesn't fire here
+ *  because the preview uses its own marker to stay scoped to this view. */
+async function waitForCostScopePreview(page: Page): Promise<void> {
+  // The marker only appears once the first debounce fires (~300ms). Give
+  // it a little room to show up before checking for its disappearance.
+  await page.waitForTimeout(400);
+  const marker = page.getByTestId('preview-loading');
+  try {
+    await expect(marker).toBeHidden({ timeout: LOAD_TIMEOUT });
+  } catch {
+    // Marker may have finished before we attached the locator; that's fine.
+  }
+  await page.waitForTimeout(200);
+  await assertNoReactCrash(page);
+}
+
 async function hasVisibleData(page: Page): Promise<boolean> {
   // Check if there are any table rows with dollar amounts
   const dollarCells = page.locator('.tabular-nums');
@@ -101,7 +121,7 @@ test.describe('App shell', () => {
   });
 
   test('shows all navigation buttons', async () => {
-    for (const label of ['Cost Overview', 'Trends', 'Missing Tags', 'Savings', 'Dimensions', 'Views', 'Sync']) {
+    for (const label of ['Cost Overview', 'Trends', 'Missing Tags', 'Savings', 'Cost Scope', 'Dimensions', 'Views', 'Sync']) {
       await expect(page.getByRole('button', { name: label })).toBeVisible();
     }
   });
@@ -131,19 +151,24 @@ test.describe('App shell', () => {
       { button: 'Trends', heading: 'Cost Trends' },
       { button: 'Missing Tags', heading: 'Missing Tags' },
       { button: 'Savings', heading: 'Savings Opportunities' },
+      { button: 'Cost Scope', heading: 'Cost Scope' },
       { button: 'Dimensions', heading: 'Dimensions' },
       { button: 'Sync', heading: 'Data Management' },
     ];
 
     for (const { button, heading } of views) {
-      await page.getByRole('button', { name: button }).click();
+      // Nav buttons are matched with exact:true — some views (Dimensions'
+      // account-tags card, for example) render buttons whose accessible
+      // names contain "Sync" as a substring, which otherwise resolves
+      // to multiple elements and fails strict mode.
+      await page.getByRole('button', { name: button, exact: true }).first().click();
       await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(500);
       await assertNoReactCrash(page);
     }
 
     // go back to overview for subsequent tests
-    await page.getByRole('button', { name: 'Cost Overview' }).click();
+    await page.getByRole('button', { name: 'Cost Overview', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible();
   });
 });
@@ -1168,6 +1193,167 @@ test.describe('Views editor', () => {
   test('Export and Import buttons are present', async () => {
     await expect(page.getByRole('button', { name: 'Export', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Import', exact: true })).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cost Scope — metric picker, exclusion rules, preview histogram + table
+// ---------------------------------------------------------------------------
+test.describe('Cost Scope', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    app = await launchApp();
+    page = await app.firstWindow();
+    await expect(page).toHaveTitle('CostGoblin');
+    await page.getByRole('button', { name: 'Cost Scope' }).click();
+    await expect(page.getByRole('heading', { name: 'Cost Scope' })).toBeVisible();
+    await waitForCostScopePreview(page);
+  });
+
+  test.afterAll(async () => { await app.close(); });
+
+  test('shows heading and intro copy', async () => {
+    await expect(page.getByText(/Define what counts as cost/)).toBeVisible();
+  });
+
+  test('cost metric picker lists Unblended, Blended, Amortized (no List)', async () => {
+    await expect(page.getByRole('heading', { name: 'Cost metric' })).toBeVisible();
+    // Check the actual radio values, which are unique — the labels repeat
+    // in adjacent description copy so role/name queries are ambiguous.
+    await expect(page.locator('input[type="radio"][value="unblended"]')).toBeVisible();
+    await expect(page.locator('input[type="radio"][value="blended"]')).toBeVisible();
+    await expect(page.locator('input[type="radio"][value="amortized"]')).toBeVisible();
+    await expect(page.locator('input[type="radio"][value="list"]')).toHaveCount(0);
+
+    // Unblended should be selected by default
+    await expect(page.locator('input[type="radio"][value="unblended"]')).toBeChecked();
+    await screenshot(page, 'cost-scope-metric');
+  });
+
+  test('exclusion rules section lists both built-in rules', async () => {
+    await expect(page.getByRole('heading', { name: 'Exclusion rules' })).toBeVisible();
+    // Rule names are rendered in inputs (they're editable).
+    await expect(page.locator('input[value="AWS Premium Support"]')).toBeVisible();
+    await expect(page.locator('input[value="RI & Savings Plan purchases"]')).toBeVisible();
+    // Built-in pill appears next to each
+    const builtInPills = page.getByText('built-in', { exact: true });
+    expect(await builtInPills.count()).toBeGreaterThanOrEqual(2);
+  });
+
+  test('preview card renders summary tiles + histogram + line-items table', async () => {
+    // Scroll to the Preview card (it's below a potentially tall rules list)
+    const card = page.getByTestId('cost-scope-preview');
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toBeVisible();
+    await expect(card.getByRole('heading', { name: 'Preview' })).toBeVisible();
+
+    // Summary tiles — scope to the card so headings/body copy elsewhere
+    // (e.g. "Rows matching any enabled rule are excluded") don't collide.
+    await expect(card.getByText('Unscoped total', { exact: true })).toBeVisible();
+    await expect(card.getByText('After scope', { exact: true })).toBeVisible();
+    await expect(card.getByText('Excluded', { exact: true })).toBeVisible();
+
+    // Daily cost label appears only when the histogram is rendered
+    await expect(card.getByText('Daily cost', { exact: true })).toBeVisible();
+
+    // Line items label + the table itself
+    await expect(card.getByText('Line items', { exact: true })).toBeVisible();
+
+    await screenshot(page, 'cost-scope-preview');
+  });
+
+  test('preview histogram has at least one bar when data exists', async () => {
+    // Each day is a flex-1 div with role="generic"; look for ones inside the
+    // preview histogram container — they live under the "Daily cost" label.
+    const previewCard = page.locator('div').filter({ has: page.getByRole('heading', { name: 'Preview' }) }).first();
+    const dayBars = previewCard.locator('div[title*="kept:"]');
+    const count = await dayBars.count();
+
+    if (count === 0) {
+      // No data synced at all — acceptable state; verify the empty-state
+      // message is shown.
+      await expect(page.getByText(/No data in the last 30 days/)).toBeVisible();
+    } else {
+      // When data is present, at least one bar should carry a tooltip.
+      expect(count).toBeGreaterThan(0);
+      await dayBars.first().hover();
+      await screenshot(page, 'cost-scope-histogram-hover');
+    }
+  });
+
+  test('line-items table renders rows when data exists', async () => {
+    // Scope to the table inside the preview card.
+    const previewCard = page.locator('div').filter({ has: page.getByRole('heading', { name: 'Preview' }) }).first();
+    const table = previewCard.locator('table');
+    const tableVisible = await table.isVisible().catch(() => false);
+
+    if (!tableVisible) {
+      // No data in the window — verify the empty message is shown instead.
+      await expect(page.getByText(/No line items in the window/)).toBeVisible();
+      return;
+    }
+
+    // Header columns we expect to see
+    for (const header of ['Date', 'Account', 'Region', 'Service', 'Cost', 'List']) {
+      await expect(table.getByRole('columnheader', { name: header, exact: true })).toBeVisible();
+    }
+
+    // At least one data row
+    const rows = table.locator('tbody tr');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThan(0);
+
+    // The first-row cost cell (second column — Date, Cost, ...) should be
+    // a formatted dollar string. Absolute-value sort means the top row
+    // could be a credit/refund, so we don't assert sign.
+    const firstCostCell = rows.first().locator('td').nth(1);
+    const costText = await firstCostCell.textContent();
+    expect(costText).toContain('$');
+
+    // "Top N of M rows" count line is visible
+    await expect(page.getByText(/rows, sorted by \|cost\| desc/)).toBeVisible();
+
+    await screenshot(page, 'cost-scope-table');
+  });
+
+  test('toggling a built-in rule updates the save button + preview state', async () => {
+    // The first rule card is AWS Premium Support (seed order). Its
+    // enable/disable switch is the first role=switch on the page.
+    const toggle = page.getByRole('switch').first();
+    await expect(toggle).toBeVisible();
+
+    const wasChecked = (await toggle.getAttribute('aria-checked')) === 'true';
+    await toggle.click();
+    const nowChecked = (await toggle.getAttribute('aria-checked')) === 'true';
+    expect(nowChecked).toBe(!wasChecked);
+
+    // Save button should appear now (draft is dirty)
+    await expect(page.getByRole('button', { name: /Save/ })).toBeVisible();
+
+    // Cancel to keep the saved state untouched
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(toggle).toHaveAttribute('aria-checked', wasChecked ? 'true' : 'false');
+  });
+
+  test('rule name and description fields are editable', async () => {
+    // Find the first rule's name input — it's the input currently showing the
+    // built-in name. Add a suffix, verify Save appears, Cancel reverts.
+    const nameInput = page.locator('input[value="AWS Premium Support"]');
+    await nameInput.fill('AWS Premium Support (edited)');
+    await expect(page.getByRole('button', { name: /Save/ })).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.locator('input[value="AWS Premium Support"]')).toBeVisible();
+
+    // Description textarea: fill, expect Save button, revert.
+    const descBox = page.locator('textarea[placeholder^="Optional description"]').first();
+    await expect(descBox).toBeVisible();
+    const before = await descBox.inputValue();
+    await descBox.fill(`${before} [edit]`);
+    await expect(page.getByRole('button', { name: /Save/ })).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(descBox).toHaveValue(before);
   });
 });
 

--- a/packages/core/src/__fixtures__/setup.ts
+++ b/packages/core/src/__fixtures__/setup.ts
@@ -130,7 +130,7 @@ export async function setup(): Promise<void> {
       line_item_blended_cost DOUBLE,
       pricing_public_on_demand_cost DOUBLE,
       reservation_effective_cost DOUBLE,
-      savings_plan_effective_cost DOUBLE,
+      savings_plan_savings_plan_effective_cost DOUBLE,
       line_item_line_item_type VARCHAR,
       line_item_operation VARCHAR,
       line_item_usage_type VARCHAR,

--- a/packages/core/src/__fixtures__/setup.ts
+++ b/packages/core/src/__fixtures__/setup.ts
@@ -107,7 +107,11 @@ export async function setup(): Promise<void> {
       if (product !== null) tagEntries.push(`'user_system': '${product}'`);
       if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
 
-      rows.push(`(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', 'Usage', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(listCost)}, 'Usage', 'RunInstances', 'Usage', MAP {${tagEntries.join(', ')}})`);
+      // Synthetic fixture: blended = unblended (no consolidated-billing
+      // variance), RI/SP effective cost NULL so amortized falls through to
+      // unblended via COALESCE. Real CUR has these columns populated for
+      // rows covered by an RI or SP.
+      rows.push(`(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', 'Usage', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(cost)}, ${String(listCost)}, NULL, NULL, 'Usage', 'RunInstances', 'Usage', MAP {${tagEntries.join(', ')}})`);
     }
   }
 
@@ -123,7 +127,10 @@ export async function setup(): Promise<void> {
       line_item_resource_id VARCHAR,
       line_item_usage_amount DOUBLE,
       line_item_unblended_cost DOUBLE,
+      line_item_blended_cost DOUBLE,
       pricing_public_on_demand_cost DOUBLE,
+      reservation_effective_cost DOUBLE,
+      savings_plan_effective_cost DOUBLE,
       line_item_line_item_type VARCHAR,
       line_item_operation VARCHAR,
       line_item_usage_type VARCHAR,

--- a/packages/core/src/__fixtures__/setup.ts
+++ b/packages/core/src/__fixtures__/setup.ts
@@ -107,11 +107,15 @@ export async function setup(): Promise<void> {
       if (product !== null) tagEntries.push(`'user_system': '${product}'`);
       if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
 
-      // Synthetic fixture: blended = unblended (no consolidated-billing
-      // variance), RI/SP effective cost NULL so amortized falls through to
-      // unblended via COALESCE. Real CUR has these columns populated for
-      // rows covered by an RI or SP.
-      rows.push(`(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', 'Usage', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(cost)}, ${String(listCost)}, NULL, NULL, 'Usage', 'RunInstances', 'Usage', MAP {${tagEntries.join(', ')}})`);
+      // Synthetic fixture:
+      //  - blended = unblended (no consolidated-billing variance)
+      //  - net_unblended = unblended * 0.97 (simulates 3% promotional credit)
+      //  - RI/SP effective cost NULL so amortized falls through to
+      //    unblended via COALESCE; same for net variants.
+      // Real CUR has these columns populated for rows covered by an RI
+      // or SP and when "Include Net Columns" is enabled.
+      const netCost = Math.round(cost * 0.97 * 100) / 100;
+      rows.push(`(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', 'Usage', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(cost)}, ${String(netCost)}, ${String(listCost)}, NULL, NULL, NULL, NULL, 'Usage', 'RunInstances', 'Usage', MAP {${tagEntries.join(', ')}})`);
     }
   }
 
@@ -128,9 +132,12 @@ export async function setup(): Promise<void> {
       line_item_usage_amount DOUBLE,
       line_item_unblended_cost DOUBLE,
       line_item_blended_cost DOUBLE,
+      line_item_net_unblended_cost DOUBLE,
       pricing_public_on_demand_cost DOUBLE,
       reservation_effective_cost DOUBLE,
+      reservation_net_effective_cost DOUBLE,
       savings_plan_savings_plan_effective_cost DOUBLE,
+      savings_plan_net_savings_plan_effective_cost DOUBLE,
       line_item_line_item_type VARCHAR,
       line_item_operation VARCHAR,
       line_item_usage_type VARCHAR,

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCostQuery,
+  buildDailyCostsQuery,
+} from '../query/builder.js';
+import type { DimensionsConfig } from '../types/config.js';
+import type { CostScopeConfig } from '../types/cost-scope.js';
+import { DEFAULT_COST_SCOPE } from '../config/cost-scope-seed.js';
+import { asDimensionId, asDateString } from '../types/branded.js';
+
+const dimensions: DimensionsConfig = {
+  builtIn: [
+    { name: asDimensionId('service'), label: 'Service', field: 'service' },
+    { name: asDimensionId('service_family'), label: 'Service Category', field: 'service_family' },
+    { name: asDimensionId('line_item_type'), label: 'Line Item Type', field: 'line_item_type' },
+    { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' },
+  ],
+  tags: [
+    {
+      tagName: 'org:team',
+      label: 'Team',
+      concept: 'owner',
+      normalize: 'lowercase-kebab',
+      aliases: { 'core-banking': ['core_banking', 'corebanking'] },
+    },
+  ],
+};
+
+const dateRange = { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') };
+const baseParams = {
+  groupBy: asDimensionId('service'),
+  dateRange,
+  filters: {},
+};
+
+function buildQuery(costScope?: CostScopeConfig): string {
+  return buildCostQuery(baseParams, '/data', dimensions, 5, undefined, undefined, undefined, undefined, costScope);
+}
+
+describe('cost metric column selection', () => {
+  it('defaults to unblended when no costScope given', () => {
+    const sql = buildQuery();
+    expect(sql).toContain('line_item_unblended_cost');
+  });
+
+  it('uses unblended when metric is unblended', () => {
+    const sql = buildQuery({ costMetric: 'unblended', rules: [] });
+    expect(sql).toContain('line_item_unblended_cost');
+    expect(sql).not.toContain('line_item_blended_cost');
+  });
+
+  it('uses blended when metric is blended', () => {
+    const sql = buildQuery({ costMetric: 'blended', rules: [] });
+    expect(sql).toContain('line_item_blended_cost');
+    expect(sql).not.toContain('line_item_unblended_cost, 0) AS cost');
+  });
+
+  it('uses pricing_public_on_demand_cost when metric is list', () => {
+    const sql = buildQuery({ costMetric: 'list', rules: [] });
+    // list metric picks pricing_public_on_demand_cost as the cost alias
+    // (list_cost still appears as a separate column, so we check the AS cost alias position)
+    expect(sql).toMatch(/pricing_public_on_demand_cost, 0\) AS cost/);
+  });
+});
+
+describe('exclusion clauses', () => {
+  it('produces no exclusion when rules array is empty', () => {
+    const sql = buildQuery({ costMetric: 'unblended', rules: [] });
+    expect(sql).not.toContain('NOT (');
+  });
+
+  it('disabled rule produces no clause', () => {
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'test',
+          name: 'Test',
+          enabled: false,
+          builtIn: false,
+          conditions: [{ dimensionId: asDimensionId('service'), values: ['EC2'] }],
+        },
+      ],
+    });
+    expect(sql).not.toContain('NOT (');
+  });
+
+  it('enabled rule with one condition produces NOT IN clause', () => {
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'test',
+          name: 'Test',
+          enabled: true,
+          builtIn: false,
+          conditions: [{ dimensionId: asDimensionId('service'), values: ['AWSSupport'] }],
+        },
+      ],
+    });
+    expect(sql).toContain("NOT (service IN ('AWSSupport'))");
+  });
+
+  it('rule with multiple values uses IN list', () => {
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'test',
+          name: 'Test',
+          enabled: true,
+          builtIn: false,
+          conditions: [
+            { dimensionId: asDimensionId('line_item_type'), values: ['RIFee', 'SavingsPlanRecurringFee'] },
+          ],
+        },
+      ],
+    });
+    expect(sql).toContain("line_item_type IN ('RIFee', 'SavingsPlanRecurringFee')");
+    expect(sql).toContain('NOT (');
+  });
+
+  it('rule with multiple conditions uses AND', () => {
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'test',
+          name: 'Test',
+          enabled: true,
+          builtIn: false,
+          conditions: [
+            { dimensionId: asDimensionId('service'), values: ['EC2'] },
+            { dimensionId: asDimensionId('service_family'), values: ['Compute'] },
+          ],
+        },
+      ],
+    });
+    expect(sql).toContain("NOT (service IN ('EC2') AND service_family IN ('Compute'))");
+  });
+
+  it('tag dimension resolves through alias CASE', () => {
+    const sql = buildCostQuery(
+      { ...baseParams, groupBy: asDimensionId('service') },
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'test',
+            name: 'Test',
+            enabled: true,
+            builtIn: false,
+            conditions: [
+              { dimensionId: asDimensionId('tag_org_team'), values: ['core-banking'] },
+            ],
+          },
+        ],
+      },
+    );
+    // Tag dim resolves via CASE expression
+    expect(sql).toContain('CASE');
+    expect(sql).toContain("'core-banking'");
+    expect(sql).toContain('NOT (');
+  });
+
+  it('escapes single quotes in values', () => {
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'test',
+          name: 'Test',
+          enabled: true,
+          builtIn: false,
+          conditions: [
+            { dimensionId: asDimensionId('service'), values: ["it's a service"] },
+          ],
+        },
+      ],
+    });
+    expect(sql).toContain("it''s a service");
+    expect(sql).not.toContain("it's a service");
+  });
+
+  it('DEFAULT_COST_SCOPE built-in rules are disabled by default — no exclusions', () => {
+    const sql = buildQuery(DEFAULT_COST_SCOPE);
+    expect(sql).not.toContain('NOT (');
+  });
+
+  it('skips rule when dimensionId does not exist in current config', () => {
+    // Stale rule: references a dimension that was deleted/renamed. Must
+    // become a no-op rather than emitting a bogus column reference that
+    // would crash every query.
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'stale',
+          name: 'Stale',
+          enabled: true,
+          builtIn: false,
+          conditions: [{ dimensionId: asDimensionId('nonexistent_dim'), values: ['foo'] }],
+        },
+      ],
+    });
+    expect(sql).not.toContain('NOT (');
+    expect(sql).not.toContain('nonexistent_dim');
+  });
+
+  it('partially applies a rule when only some conditions are resolvable', () => {
+    const sql = buildQuery({
+      costMetric: 'unblended',
+      rules: [
+        {
+          id: 'mixed',
+          name: 'Mixed',
+          enabled: true,
+          builtIn: false,
+          conditions: [
+            { dimensionId: asDimensionId('service'), values: ['EC2'] },
+            { dimensionId: asDimensionId('nonexistent_dim'), values: ['foo'] },
+          ],
+        },
+      ],
+    });
+    // Resolvable condition still applies; dangling one is silently dropped.
+    expect(sql).toContain("NOT (service IN ('EC2'))");
+    expect(sql).not.toContain('nonexistent_dim');
+  });
+});
+
+describe('buildDailyCostsQuery with costScope', () => {
+  it('injects exclusion clause in daily costs query', () => {
+    const sql = buildDailyCostsQuery(
+      { ...baseParams, granularity: 'daily' },
+      '/data',
+      dimensions,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'blended',
+        rules: [
+          {
+            id: 'support',
+            name: 'Support',
+            enabled: true,
+            builtIn: true,
+            conditions: [{ dimensionId: asDimensionId('service_family'), values: ['Support'] }],
+          },
+        ],
+      },
+    );
+    expect(sql).toContain("NOT (service_family IN ('Support'))");
+    expect(sql).toContain('line_item_blended_cost');
+  });
+});

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -61,6 +61,86 @@ describe('cost metric column selection', () => {
     // Amortized layers effective-cost columns over unblended via COALESCE.
     expect(sql).toMatch(/COALESCE\(reservation_effective_cost, savings_plan_savings_plan_effective_cost, line_item_unblended_cost, 0\) AS cost/);
   });
+
+  it('net perspective uses line_item_net_unblended_cost when available', () => {
+    // Manually call buildCostQuery with a costScope that has costPerspective='net'
+    // and a full availableColumns set including net columns. The generated
+    // SQL should prefer the net variant.
+    const sql = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { costMetric: 'unblended', costPerspective: 'net', rules: [] },
+      new Set(['line_item_unblended_cost', 'line_item_net_unblended_cost']),
+    );
+    expect(sql).toContain('line_item_net_unblended_cost');
+  });
+
+  it('net perspective falls back to gross column when net column missing', () => {
+    // availableColumns omits line_item_net_unblended_cost — the expression
+    // should degrade to the gross unblended column rather than reference
+    // a missing column (which would error at query time).
+    const sql = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { costMetric: 'unblended', costPerspective: 'net', rules: [] },
+      new Set(['line_item_unblended_cost']),
+    );
+    expect(sql).not.toContain('line_item_net_unblended_cost');
+    expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
+  });
+
+  it('amortized + net uses net effective-cost columns when available', () => {
+    const sql = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { costMetric: 'amortized', costPerspective: 'net', rules: [] },
+      new Set([
+        'line_item_unblended_cost',
+        'line_item_net_unblended_cost',
+        'reservation_net_effective_cost',
+        'savings_plan_net_savings_plan_effective_cost',
+      ]),
+    );
+    expect(sql).toMatch(/COALESCE\(reservation_net_effective_cost, savings_plan_net_savings_plan_effective_cost, line_item_net_unblended_cost, line_item_unblended_cost, 0\) AS cost/);
+  });
+
+  it('amortized + net degrades to unblended when no net/effective columns present', () => {
+    // No resource IDs (no effective_cost) and no net columns — amortized
+    // degrades all the way down to line_item_unblended_cost.
+    const sql = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { costMetric: 'amortized', costPerspective: 'net', rules: [] },
+      new Set(['line_item_unblended_cost']),
+    );
+    expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
+    expect(sql).not.toContain('net_effective_cost');
+    expect(sql).not.toContain('net_unblended_cost');
+  });
 });
 
 describe('exclusion clauses', () => {

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -59,7 +59,7 @@ describe('cost metric column selection', () => {
   it('falls back through effective cost → unblended when metric is amortized', () => {
     const sql = buildQuery({ costMetric: 'amortized', rules: [] });
     // Amortized layers effective-cost columns over unblended via COALESCE.
-    expect(sql).toMatch(/COALESCE\(reservation_effective_cost, savings_plan_effective_cost, line_item_unblended_cost, 0\) AS cost/);
+    expect(sql).toMatch(/COALESCE\(reservation_effective_cost, savings_plan_savings_plan_effective_cost, line_item_unblended_cost, 0\) AS cost/);
   });
 });
 

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -40,26 +40,26 @@ function buildQuery(costScope?: CostScopeConfig): string {
 describe('cost metric column selection', () => {
   it('defaults to unblended when no costScope given', () => {
     const sql = buildQuery();
-    expect(sql).toContain('line_item_unblended_cost');
+    // `AS cost` alias is backed by unblended; pricing_public_on_demand_cost
+    // still appears as `AS list_cost` which is a separate column.
+    expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
   });
 
   it('uses unblended when metric is unblended', () => {
     const sql = buildQuery({ costMetric: 'unblended', rules: [] });
-    expect(sql).toContain('line_item_unblended_cost');
+    expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
     expect(sql).not.toContain('line_item_blended_cost');
   });
 
   it('uses blended when metric is blended', () => {
     const sql = buildQuery({ costMetric: 'blended', rules: [] });
-    expect(sql).toContain('line_item_blended_cost');
-    expect(sql).not.toContain('line_item_unblended_cost, 0) AS cost');
+    expect(sql).toMatch(/COALESCE\(line_item_blended_cost, 0\) AS cost/);
   });
 
-  it('uses pricing_public_on_demand_cost when metric is list', () => {
-    const sql = buildQuery({ costMetric: 'list', rules: [] });
-    // list metric picks pricing_public_on_demand_cost as the cost alias
-    // (list_cost still appears as a separate column, so we check the AS cost alias position)
-    expect(sql).toMatch(/pricing_public_on_demand_cost, 0\) AS cost/);
+  it('falls back through effective cost → unblended when metric is amortized', () => {
+    const sql = buildQuery({ costMetric: 'amortized', rules: [] });
+    // Amortized layers effective-cost columns over unblended via COALESCE.
+    expect(sql).toMatch(/COALESCE\(reservation_effective_cost, savings_plan_effective_cost, line_item_unblended_cost, 0\) AS cost/);
   });
 });
 

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -214,6 +214,54 @@ describe('exclusion clauses', () => {
     expect(sql).not.toContain('nonexistent_dim');
   });
 
+  it('applies the target dim normalize + alias to rule values', () => {
+    // User normalises line_item_type to lowercase and aliases 'rifee' to
+    // include 'reserved_instance_fee'. The built-in rule still stores the
+    // raw CUR codes ('RIFee'); at SQL-build time those should be
+    // normalised+alias-resolved to match the column's transformed output.
+    const dimsWithNormalize: DimensionsConfig = {
+      builtIn: [
+        ...dimensions.builtIn.filter(d => d.name !== 'line_item_type'),
+        {
+          name: asDimensionId('line_item_type'),
+          label: 'Line Item Type',
+          field: 'line_item_type',
+          normalize: 'lowercase',
+          aliases: { rifee: ['reserved_instance_fee'] },
+        },
+      ],
+      tags: dimensions.tags,
+    };
+    const sql = buildCostQuery(
+      baseParams,
+      '/data',
+      dimsWithNormalize,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'test',
+            name: 'Test',
+            enabled: true,
+            builtIn: false,
+            conditions: [{ dimensionId: asDimensionId('line_item_type'), values: ['RIFee', 'Tax'] }],
+          },
+        ],
+      },
+    );
+    // Values become 'rifee' (lowercase + alias canonicalises to itself) and
+    // 'tax' (lowercase). The raw 'RIFee' / 'Tax' must not appear in the
+    // IN-list — that would never match the LOWER(...) column.
+    expect(sql).toContain("IN ('rifee', 'tax')");
+    expect(sql).not.toContain("'RIFee'");
+    expect(sql).not.toContain("'Tax'");
+  });
+
   it('partially applies a rule when only some conditions are resolvable', () => {
     const sql = buildQuery({
       costMetric: 'unblended',

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -4,3 +4,4 @@ export * from './models/index.js';
 export { validateViews } from './config/views-validator.js';
 export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './config/views-serialize.js';
 export { ConfigValidationError } from './config/validator.js';
+export { DEFAULT_COST_SCOPE, BUILTIN_EXCLUSION_RULES } from './config/cost-scope-seed.js';

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -6,11 +6,20 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
     id: 'builtin:aws-premium-support',
     name: 'AWS Premium Support',
     description:
-      'AWS Enterprise / Business / Developer support subscription fees. Usually a flat line item outside per-resource usage.',
+      'AWS Enterprise / Business / Developer support subscription fees. Flat-rate monthly billing outside per-resource usage.',
     enabled: false,
     builtIn: true,
     conditions: [
-      { dimensionId: asDimensionId('service_family'), values: ['Support'] },
+      {
+        // Match by service code, not service_family. `Support` as a
+        // product_family groups in things some users don't consider
+        // premium support (e.g. some training / API-call support lines),
+        // and isn't populated consistently across CUR revisions. The
+        // three AWSSupport* service codes are the authoritative
+        // premium-support line items.
+        dimensionId: asDimensionId('service'),
+        values: ['AWSSupportEnterprise', 'AWSSupportBusiness', 'AWSSupportDeveloper'],
+      },
     ],
   },
   {

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -59,6 +59,17 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
     ],
   },
   {
+    id: 'builtin:bundled-discount',
+    name: 'Bundled discount',
+    description:
+      'Negative discount line items applied automatically by AWS bundle pricing rules (e.g. support-tier bundle credits). Like EDP, standalone — not paired with a specific usage row. Toggle on to see pre-bundle cost.',
+    enabled: false,
+    builtIn: true,
+    conditions: [
+      { dimensionId: asDimensionId('line_item_type'), values: ['BundledDiscount'] },
+    ],
+  },
+  {
     id: 'builtin:commitment-covered-usage',
     name: 'RI & SP covered usage',
     description:

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -17,13 +17,13 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
     id: 'builtin:ri-sp-purchases',
     name: 'RI & Savings Plan purchases',
     description:
-      'Upfront and recurring fees for Reserved Instances and Savings Plans. Usage covered by them still appears as DiscountedUsage and is not affected by this rule.',
+      'Upfront/recurring fees for Reserved Instances and Savings Plans, plus SP negation adjustments. RI/SP-covered usage still appears under DiscountedUsage / SavingsPlanCoveredUsage and is not affected by this rule.',
     enabled: false,
     builtIn: true,
     conditions: [
       {
         dimensionId: asDimensionId('line_item_type'),
-        values: ['RIFee', 'SavingsPlanRecurringFee', 'SavingsPlanUpfrontFee'],
+        values: ['RIFee', 'SavingsPlanRecurringFee', 'SavingsPlanUpfrontFee', 'SavingsPlanNegation'],
       },
     ],
   },
@@ -36,6 +36,17 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
     builtIn: true,
     conditions: [
       { dimensionId: asDimensionId('line_item_type'), values: ['Tax'] },
+    ],
+  },
+  {
+    id: 'builtin:edp-discount',
+    name: 'EDP discount',
+    description:
+      'Negative line items from the AWS Enterprise Discount Program (contractual volume discount). Toggle on to view gross / pre-negotiation cost; leave off to see the effective bill after the EDP credit.',
+    enabled: false,
+    builtIn: true,
+    conditions: [
+      { dimensionId: asDimensionId('line_item_type'), values: ['EdpDiscount'] },
     ],
   },
 ];

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -27,6 +27,17 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
       },
     ],
   },
+  {
+    id: 'builtin:tax',
+    name: 'Tax',
+    description:
+      'VAT / GST / sales-tax line items. Toggle on to compare pre-tax run-rate across regions or exclude tax from forecasts; leave off to see the all-in bill.',
+    enabled: false,
+    builtIn: true,
+    conditions: [
+      { dimensionId: asDimensionId('line_item_type'), values: ['Tax'] },
+    ],
+  },
 ];
 
 export const DEFAULT_COST_SCOPE: CostScopeConfig = {

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -58,6 +58,20 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
       { dimensionId: asDimensionId('line_item_type'), values: ['EdpDiscount'] },
     ],
   },
+  {
+    id: 'builtin:commitment-covered-usage',
+    name: 'RI & SP covered usage',
+    description:
+      'Usage already covered by a Reserved Instance (DiscountedUsage) or Savings Plan (SavingsPlanCoveredUsage paired with SavingsPlanNegation). Toggle on to isolate on-demand spend — the workloads NOT yet covered by a commitment. SP negation is bundled so its discount does not leak when the usage it offsets is removed.',
+    enabled: false,
+    builtIn: true,
+    conditions: [
+      {
+        dimensionId: asDimensionId('line_item_type'),
+        values: ['DiscountedUsage', 'SavingsPlanCoveredUsage', 'SavingsPlanNegation'],
+      },
+    ],
+  },
 ];
 
 export const DEFAULT_COST_SCOPE: CostScopeConfig = {

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -1,0 +1,45 @@
+import { asDimensionId } from '../types/branded.js';
+import type { CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
+
+export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
+  {
+    id: 'builtin:aws-premium-support',
+    name: 'AWS Premium Support',
+    description:
+      'AWS Enterprise / Business / Developer support subscription fees. Usually a flat line item outside per-resource usage.',
+    enabled: false,
+    builtIn: true,
+    conditions: [
+      { dimensionId: asDimensionId('service_family'), values: ['Support'] },
+    ],
+  },
+  {
+    id: 'builtin:ri-sp-purchases',
+    name: 'RI & Savings Plan purchases',
+    description:
+      'Upfront and recurring fees for Reserved Instances and Savings Plans. Usage covered by them still appears as DiscountedUsage and is not affected by this rule.',
+    enabled: false,
+    builtIn: true,
+    conditions: [
+      {
+        dimensionId: asDimensionId('line_item_type'),
+        values: ['RIFee', 'SavingsPlanRecurringFee', 'SavingsPlanUpfrontFee'],
+      },
+    ],
+  },
+];
+
+export const DEFAULT_COST_SCOPE: CostScopeConfig = {
+  costMetric: 'unblended',
+  rules: BUILTIN_EXCLUSION_RULES,
+};
+
+/** Merge shipped built-in rules into a loaded config. Mirrors
+ *  mergeDefaultBuiltIns for dimensions: preserve user edits on existing
+ *  built-ins, add any that are missing. User rules are untouched. */
+export function mergeBuiltInExclusionRules(loaded: CostScopeConfig): CostScopeConfig {
+  const loadedById = new Map(loaded.rules.map(r => [r.id, r]));
+  const missingBuiltins = BUILTIN_EXCLUSION_RULES.filter(b => !loadedById.has(b.id));
+  if (missingBuiltins.length === 0) return loaded;
+  return { ...loaded, rules: [...loaded.rules, ...missingBuiltins] };
+}

--- a/packages/core/src/config/cost-scope-serialize.ts
+++ b/packages/core/src/config/cost-scope-serialize.ts
@@ -12,6 +12,7 @@ interface YamlRule {
 
 export interface YamlCostScope {
   costMetric: string;
+  costPerspective?: string;
   rules: YamlRule[];
 }
 
@@ -31,5 +32,13 @@ function ruleToYaml(r: ExclusionRule): YamlRule {
 }
 
 export function costScopeToYaml(cfg: CostScopeConfig): YamlCostScope {
-  return { costMetric: cfg.costMetric, rules: cfg.rules.map(ruleToYaml) };
+  return {
+    costMetric: cfg.costMetric,
+    // Only emit when non-default — keeps legacy YAMLs from churning
+    // when the serializer round-trips them.
+    ...(cfg.costPerspective !== undefined && cfg.costPerspective !== 'gross'
+      ? { costPerspective: cfg.costPerspective }
+      : {}),
+    rules: cfg.rules.map(ruleToYaml),
+  };
 }

--- a/packages/core/src/config/cost-scope-serialize.ts
+++ b/packages/core/src/config/cost-scope-serialize.ts
@@ -1,0 +1,35 @@
+import type { CostScopeConfig, ExclusionCondition, ExclusionRule } from '../types/cost-scope.js';
+
+interface YamlCondition { dimensionId: string; values: string[] }
+interface YamlRule {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  builtIn: boolean;
+  conditions: YamlCondition[];
+}
+
+export interface YamlCostScope {
+  costMetric: string;
+  rules: YamlRule[];
+}
+
+function conditionToYaml(c: ExclusionCondition): YamlCondition {
+  return { dimensionId: String(c.dimensionId), values: [...c.values] };
+}
+
+function ruleToYaml(r: ExclusionRule): YamlRule {
+  return {
+    id: r.id,
+    name: r.name,
+    ...(r.description !== undefined ? { description: r.description } : {}),
+    enabled: r.enabled,
+    builtIn: r.builtIn,
+    conditions: r.conditions.map(conditionToYaml),
+  };
+}
+
+export function costScopeToYaml(cfg: CostScopeConfig): YamlCostScope {
+  return { costMetric: cfg.costMetric, rules: cfg.rules.map(ruleToYaml) };
+}

--- a/packages/core/src/config/cost-scope-validator.ts
+++ b/packages/core/src/config/cost-scope-validator.ts
@@ -2,14 +2,19 @@ import { assertArray, assertObject, assertString, ConfigValidationError } from '
 import { asDimensionId } from '../types/branded.js';
 import type {
   CostMetric,
+  CostPerspective,
   CostScopeConfig,
   ExclusionCondition,
   ExclusionRule,
 } from '../types/cost-scope.js';
-import { COST_METRICS } from '../types/cost-scope.js';
+import { COST_METRICS, COST_PERSPECTIVES } from '../types/cost-scope.js';
 
 function isCostMetric(v: string): v is CostMetric {
   return (COST_METRICS as readonly string[]).includes(v);
+}
+
+function isCostPerspective(v: string): v is CostPerspective {
+  return (COST_PERSPECTIVES as readonly string[]).includes(v);
 }
 
 function validateCondition(raw: unknown, ctx: string): ExclusionCondition {
@@ -61,7 +66,23 @@ export function validateCostScope(raw: unknown): CostScopeConfig {
       `costScope.costMetric must be one of: ${COST_METRICS.join(', ')}`,
     );
   }
+  // costPerspective is optional — missing key defaults to 'gross' so older
+  // on-disk configs keep working unchanged.
+  let costPerspective: CostPerspective | undefined;
+  if (raw['costPerspective'] !== undefined) {
+    assertString(raw['costPerspective'], 'costScope.costPerspective');
+    if (!isCostPerspective(raw['costPerspective'])) {
+      throw new ConfigValidationError(
+        `costScope.costPerspective must be one of: ${COST_PERSPECTIVES.join(', ')}`,
+      );
+    }
+    costPerspective = raw['costPerspective'];
+  }
   assertArray(raw['rules'], 'costScope.rules');
   const rules = raw['rules'].map((r, i) => validateRule(r, `costScope.rules[${String(i)}]`));
-  return { costMetric: raw['costMetric'], rules };
+  return {
+    costMetric: raw['costMetric'],
+    ...(costPerspective !== undefined ? { costPerspective } : {}),
+    rules,
+  };
 }

--- a/packages/core/src/config/cost-scope-validator.ts
+++ b/packages/core/src/config/cost-scope-validator.ts
@@ -1,0 +1,67 @@
+import { assertArray, assertObject, assertString, ConfigValidationError } from './validator.js';
+import { asDimensionId } from '../types/branded.js';
+import type {
+  CostMetric,
+  CostScopeConfig,
+  ExclusionCondition,
+  ExclusionRule,
+} from '../types/cost-scope.js';
+import { COST_METRICS } from '../types/cost-scope.js';
+
+function isCostMetric(v: string): v is CostMetric {
+  return (COST_METRICS as readonly string[]).includes(v);
+}
+
+function validateCondition(raw: unknown, ctx: string): ExclusionCondition {
+  assertObject(raw, ctx);
+  assertString(raw['dimensionId'], `${ctx}.dimensionId`);
+  assertArray(raw['values'], `${ctx}.values`);
+  const values = raw['values'].map((v, i) => {
+    assertString(v, `${ctx}.values[${String(i)}]`);
+    return v;
+  });
+  if (values.length === 0) {
+    throw new ConfigValidationError(`${ctx}.values must have at least one entry`);
+  }
+  return { dimensionId: asDimensionId(raw['dimensionId']), values };
+}
+
+function validateRule(raw: unknown, ctx: string): ExclusionRule {
+  assertObject(raw, ctx);
+  assertString(raw['id'], `${ctx}.id`);
+  assertString(raw['name'], `${ctx}.name`);
+  assertArray(raw['conditions'], `${ctx}.conditions`);
+  if (raw['conditions'].length === 0) {
+    throw new ConfigValidationError(`${ctx}.conditions must have at least one entry`);
+  }
+  const conditions = raw['conditions'].map((c, i) =>
+    validateCondition(c, `${ctx}.conditions[${String(i)}]`),
+  );
+  const description =
+    raw['description'] !== undefined
+      ? (assertString(raw['description'], `${ctx}.description`), raw['description'])
+      : undefined;
+  const enabled = raw['enabled'] === true;
+  const builtIn = raw['builtIn'] === true;
+  return {
+    id: raw['id'],
+    name: raw['name'],
+    ...(description !== undefined ? { description } : {}),
+    enabled,
+    builtIn,
+    conditions,
+  };
+}
+
+export function validateCostScope(raw: unknown): CostScopeConfig {
+  assertObject(raw, 'costScope');
+  assertString(raw['costMetric'], 'costScope.costMetric');
+  if (!isCostMetric(raw['costMetric'])) {
+    throw new ConfigValidationError(
+      `costScope.costMetric must be one of: ${COST_METRICS.join(', ')}`,
+    );
+  }
+  assertArray(raw['rules'], 'costScope.rules');
+  const rules = raw['rules'].map((r, i) => validateRule(r, `costScope.rules[${String(i)}]`));
+  return { costMetric: raw['costMetric'], rules };
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,4 +1,7 @@
-export { loadConfig, loadDimensions, loadOrgTree, loadViews } from './loader.js';
-export { validateConfig, validateDimensions, validateOrgTree, ConfigValidationError } from './validator.js';
+export { loadConfig, loadDimensions, loadOrgTree, loadViews, loadCostScope } from './loader.js';
+export { validateConfig, validateDimensions, validateOrgTree, ConfigValidationError, assertObject, assertArray, assertString, assertNumber } from './validator.js';
 export { validateViews } from './views-validator.js';
+export { validateCostScope } from './cost-scope-validator.js';
 export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './views-serialize.js';
+export { costScopeToYaml } from './cost-scope-serialize.js';
+export { BUILTIN_EXCLUSION_RULES, DEFAULT_COST_SCOPE, mergeBuiltInExclusionRules } from './cost-scope-seed.js';

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -2,8 +2,10 @@ import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
 import type { CostGoblinConfig, DimensionsConfig, OrgTreeConfig } from '../types/index.js';
 import type { ViewsConfig } from '../types/views.js';
+import type { CostScopeConfig } from '../types/cost-scope.js';
 import { validateConfig, validateDimensions, validateOrgTree } from './validator.js';
 import { validateViews } from './views-validator.js';
+import { validateCostScope } from './cost-scope-validator.js';
 
 export async function loadConfig(path: string): Promise<CostGoblinConfig> {
   const content = await readFile(path, 'utf-8');
@@ -27,4 +29,10 @@ export async function loadViews(path: string): Promise<ViewsConfig> {
   const content = await readFile(path, 'utf-8');
   const raw: unknown = parse(content);
   return validateViews(raw);
+}
+
+export async function loadCostScope(path: string): Promise<CostScopeConfig> {
+  const content = await readFile(path, 'utf-8');
+  const raw: unknown = parse(content);
+  return validateCostScope(raw);
 }

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,7 +1,7 @@
 import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
-import type { CostMetric, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
+import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
 
@@ -208,8 +208,8 @@ function quoteList(paths: readonly string[]): string {
  * Drops the org-accounts JOIN entirely — fallback logic was baked into each
  * sidecar column at generation time.
  */
-function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costMetric: CostMetric, availableColumns?: ReadonlySet<string>): string {
-  const costExpr = costExprFor(costMetric, 'cur.', availableColumns);
+function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costMetric: CostMetric, availableColumns?: ReadonlySet<string>, costPerspective?: CostPerspective): string {
+  const costExpr = costExprFor(costMetric, 'cur.', costPerspective, availableColumns);
   const rawList = quoteList(plan.rawFiles);
   const sidecarList = quoteList(plan.sidecarFiles);
 
@@ -267,9 +267,10 @@ export function buildSource(
   sidecarPlan?: SidecarPlan,
   costMetric: CostMetric = 'unblended',
   availableColumns?: ReadonlySet<string>,
+  costPerspective?: CostPerspective,
 ): string {
   if (sidecarPlan !== undefined) {
-    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costMetric, availableColumns);
+    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costMetric, availableColumns, costPerspective);
   }
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
@@ -338,7 +339,7 @@ export function buildSource(
     : parquetSource;
 
   const tablePrefix = needsOrgJoin ? 'cur.' : '';
-  const costExpr = costExprFor(costMetric, tablePrefix, availableColumns);
+  const costExpr = costExprFor(costMetric, tablePrefix, costPerspective, availableColumns);
 
   return `(
     SELECT
@@ -392,9 +393,10 @@ export function buildCostQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns, costPerspective);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -466,6 +468,7 @@ export function buildTrendQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
@@ -483,7 +486,7 @@ export function buildTrendQuery(
   const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
   const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
   const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns, costPerspective);
 
   const allFilterClauses = [...filterClauses, ...exclusionClauses];
   const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
@@ -559,8 +562,9 @@ export function buildMissingTagsQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns, costPerspective);
 
   // Date + user filters apply to the resource aggregation.
   const whereConditions = [
@@ -638,8 +642,9 @@ export function buildNonResourceCostQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns, costPerspective);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -677,9 +682,10 @@ export function buildDailyCostsQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns, costPerspective);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -718,10 +724,11 @@ export function buildEntityDetailQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns, costPerspective);
 
   // Same display-name collision treatment for the entity selector itself: if
   // the user clicked into "sre default" we need to match every underlying id,

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,8 +1,8 @@
-import type { DimensionsConfig, TagDimension } from '../types/config.js';
+import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
 import type { CostMetric, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
-import { buildAliasSqlCase } from '../normalize/normalize.js';
+import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
 
 /**
@@ -55,6 +55,11 @@ export function computePeriodsInRange(dateRange: { readonly start: string; reado
 interface ResolvedDimension {
   readonly fieldExpr: string;
   readonly rawField: string;
+  /** The backing dim, when the id resolves to a known built-in or tag.
+   *  Carries `normalize` and `aliases` so callers that compare literal
+   *  values against the CASE-wrapped field expression can apply the
+   *  same transformation to their values and stay in agreement. */
+  readonly dim: BuiltInDimension | TagDimension | null;
 }
 
 function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension | null {
@@ -63,16 +68,28 @@ function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig)
     // Built-ins now support normalize + aliases just like tags; apply them at
     // query time via the same CASE/LOWER(...) machinery.
     const fieldExpr = buildAliasSqlCase(builtIn.field, builtIn);
-    return { fieldExpr, rawField: builtIn.field };
+    return { fieldExpr, rawField: builtIn.field, dim: builtIn };
   }
 
   const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);
   if (tag !== undefined) {
     const rawField = `tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
-    return { fieldExpr: buildAliasSqlCase(rawField, tag), rawField };
+    return { fieldExpr: buildAliasSqlCase(rawField, tag), rawField, dim: tag };
   }
 
   return null;
+}
+
+/** Apply the same normalize + alias transformation that `buildAliasSqlCase`
+ *  bakes into the field expression, but to a literal value on the JS side.
+ *  Required when the SQL compares a normalized/alias-resolved column
+ *  against hard-coded values like the built-in rules' service codes — the
+ *  values need to be moved into the same namespace as the column output or
+ *  the match will silently miss. */
+function normalizeRuleValue(value: string, dim: BuiltInDimension | TagDimension | null): string {
+  if (dim === null) return value;
+  const normalized = normalizeTagValue(value, dim.normalize);
+  return resolveAlias(normalized, dim.aliases);
 }
 
 function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
@@ -82,7 +99,7 @@ function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): R
   // validated the id exists. For exclusion rules we go through
   // tryResolveField directly so a stale reference doesn't emit a bogus
   // column name that would crash every query.
-  return { fieldExpr: dimensionId, rawField: dimensionId };
+  return { fieldExpr: dimensionId, rawField: dimensionId, dim: null };
 }
 
 function buildFilterClauses(
@@ -148,7 +165,15 @@ export function buildRuleMatchExpr(
         continue;
       }
     }
-    const list = cond.values.map(v => `'${v.replaceAll("'", "''")}'`).join(', ');
+    // Apply the dim's normalize + alias transformation to each value so
+    // rule conditions stay correct when the user normalises the target
+    // dimension (e.g. a lowercase rule on `line_item_type` would otherwise
+    // turn 'RIFee' in the built-in rule into a silent no-match). The
+    // field expression already bakes in the same transformation.
+    const list = cond.values
+      .map(v => normalizeRuleValue(v, resolved.dim))
+      .map(v => `'${v.replaceAll("'", "''")}'`)
+      .join(', ');
     conditionSqls.push(`${resolved.fieldExpr} IN (${list})`);
   }
   if (conditionSqls.length === 0) return null;

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,9 +1,9 @@
 import type { DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
-import type { CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
+import type { CostMetric, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase } from '../normalize/normalize.js';
-import { costColumnFor } from './cost-metric.js';
+import { costExprFor } from './cost-metric.js';
 
 /**
  * When all raw files for a query's periods have fresh combined sidecars, the
@@ -183,7 +183,8 @@ function quoteList(paths: readonly string[]): string {
  * Drops the org-accounts JOIN entirely — fallback logic was baked into each
  * sidecar column at generation time.
  */
-function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costColumn: string): string {
+function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costMetric: CostMetric): string {
+  const costExpr = costExprFor(costMetric, 'cur.');
   const rawList = quoteList(plan.rawFiles);
   const sidecarList = quoteList(plan.sidecarFiles);
 
@@ -211,7 +212,7 @@ function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, pla
       COALESCE(cur.line_item_line_item_description, '') AS description,
       COALESCE(cur.line_item_resource_id, '') AS resource_id,
       COALESCE(cur.line_item_usage_amount, 0) AS usage_amount,
-      COALESCE(cur.${costColumn}, 0) AS cost,
+      ${costExpr} AS cost,
       COALESCE(cur.pricing_public_on_demand_cost, 0) AS list_cost,
       COALESCE(cur.line_item_line_item_type, '') AS line_item_type,
       COALESCE(cur.line_item_operation, '') AS operation,
@@ -239,10 +240,10 @@ export function buildSource(
   orgAccountsPath?: string,
   periods?: readonly string[],
   sidecarPlan?: SidecarPlan,
-  costColumn: string = 'line_item_unblended_cost',
+  costMetric: CostMetric = 'unblended',
 ): string {
   if (sidecarPlan !== undefined) {
-    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costColumn);
+    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costMetric);
   }
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
@@ -310,22 +311,25 @@ export function buildSource(
       ) AS acct_tags ON cur.line_item_usage_account_id = acct_tags.id`
     : parquetSource;
 
+  const tablePrefix = needsOrgJoin ? 'cur.' : '';
+  const costExpr = costExprFor(costMetric, tablePrefix);
+
   return `(
     SELECT
       ${dateExpr},
-      ${needsOrgJoin ? 'cur.' : ''}line_item_usage_account_id AS account_id,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_account_name, '') AS account_name,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}product_region_code, '') AS region,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}product_servicecode, '') AS service,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}product_product_family, '') AS service_family,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_line_item_description, '') AS description,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_resource_id, '') AS resource_id,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_amount, 0) AS usage_amount,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}${costColumn}, 0) AS cost,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}pricing_public_on_demand_cost, 0) AS list_cost,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_line_item_type, '') AS line_item_type,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_operation, '') AS operation,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_type, '') AS usage_type${tagClause}
+      ${tablePrefix}line_item_usage_account_id AS account_id,
+      COALESCE(${tablePrefix}line_item_usage_account_name, '') AS account_name,
+      COALESCE(${tablePrefix}product_region_code, '') AS region,
+      COALESCE(${tablePrefix}product_servicecode, '') AS service,
+      COALESCE(${tablePrefix}product_product_family, '') AS service_family,
+      COALESCE(${tablePrefix}line_item_line_item_description, '') AS description,
+      COALESCE(${tablePrefix}line_item_resource_id, '') AS resource_id,
+      COALESCE(${tablePrefix}line_item_usage_amount, 0) AS usage_amount,
+      ${costExpr} AS cost,
+      COALESCE(${tablePrefix}pricing_public_on_demand_cost, 0) AS list_cost,
+      COALESCE(${tablePrefix}line_item_line_item_type, '') AS line_item_type,
+      COALESCE(${tablePrefix}line_item_operation, '') AS operation,
+      COALESCE(${tablePrefix}line_item_usage_type, '') AS usage_type${tagClause}
     FROM ${fromClause}
   )`;
 }
@@ -360,10 +364,10 @@ export function buildCostQuery(
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
-  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
+  const costMetric = costScope?.costMetric ?? 'unblended';
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -433,7 +437,7 @@ export function buildTrendQuery(
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
-  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
+  const costMetric = costScope?.costMetric ?? 'unblended';
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
@@ -451,7 +455,7 @@ export function buildTrendQuery(
   const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
   const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
   const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
 
   const allFilterClauses = [...filterClauses, ...exclusionClauses];
   const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
@@ -525,9 +529,9 @@ export function buildMissingTagsQuery(
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
-  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
+  const costMetric = costScope?.costMetric ?? 'unblended';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
 
   // Date + user filters apply to the resource aggregation.
   const whereConditions = [
@@ -603,9 +607,9 @@ export function buildNonResourceCostQuery(
 ): string {
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
-  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
+  const costMetric = costScope?.costMetric ?? 'unblended';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -641,10 +645,10 @@ export function buildDailyCostsQuery(
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
-  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
+  const costMetric = costScope?.costMetric ?? 'unblended';
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -681,11 +685,11 @@ export function buildEntityDetailQuery(
   const dimResolved = resolveField(params.dimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
-  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
+  const costMetric = costScope?.costMetric ?? 'unblended';
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
 
   // Same display-name collision treatment for the entity selector itself: if
   // the user clicked into "sre default" we need to match every underlying id,

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,7 +1,9 @@
 import type { DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
+import type { CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase } from '../normalize/normalize.js';
+import { costColumnFor } from './cost-metric.js';
 
 /**
  * When all raw files for a query's periods have fresh combined sidecars, the
@@ -55,7 +57,7 @@ interface ResolvedDimension {
   readonly rawField: string;
 }
 
-function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
+function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension | null {
   const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
   if (builtIn !== undefined) {
     // Built-ins now support normalize + aliases just like tags; apply them at
@@ -70,6 +72,16 @@ function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): R
     return { fieldExpr: buildAliasSqlCase(rawField, tag), rawField };
   }
 
+  return null;
+}
+
+function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
+  const resolved = tryResolveField(dimensionId, dimensions);
+  if (resolved !== null) return resolved;
+  // Fallback: used by filter/orgNode paths where the caller has already
+  // validated the id exists. For exclusion rules we go through
+  // tryResolveField directly so a stale reference doesn't emit a bogus
+  // column name that would crash every query.
   return { fieldExpr: dimensionId, rawField: dimensionId };
 }
 
@@ -99,6 +111,65 @@ function buildFilterClauses(
   return clauses;
 }
 
+/** Build the positive match expression for a single rule (AND of conditions,
+ *  OR within each condition's values). Used both for NOT-exclusion in queries
+ *  and for the positive preview queries. Returns null when the rule has no
+ *  valid conditions (all empty values). */
+export function buildRuleMatchExpr(
+  rule: ExclusionRule,
+  dimensions: DimensionsConfig,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+): string | null {
+  const conditionSqls: string[] = [];
+  for (const cond of rule.conditions) {
+    if (cond.values.length === 0) continue;
+    // Skip conditions whose dimension no longer exists — happens if a user
+    // deletes/renames a dimension while a rule references it. Emitting a
+    // bogus column reference here would crash every query that threads cost
+    // scope through (which is all of them). Save-time validation prevents
+    // this on new edits; this guard covers legacy on-disk rules.
+    const resolved = tryResolveField(cond.dimensionId, dimensions);
+    if (resolved === null) continue;
+    if (resolved.rawField === 'account_id' && accountReverseMap !== undefined) {
+      const expandedIds = new Set<string>();
+      let usedReverse = false;
+      for (const v of cond.values) {
+        const ids = accountReverseMap.get(v);
+        if (ids !== undefined && ids.length > 0) {
+          for (const id of ids) expandedIds.add(id);
+          usedReverse = true;
+        } else {
+          expandedIds.add(v);
+        }
+      }
+      if (usedReverse) {
+        const list = [...expandedIds].map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+        conditionSqls.push(`${resolved.rawField} IN (${list})`);
+        continue;
+      }
+    }
+    const list = cond.values.map(v => `'${v.replaceAll("'", "''")}'`).join(', ');
+    conditionSqls.push(`${resolved.fieldExpr} IN (${list})`);
+  }
+  if (conditionSqls.length === 0) return null;
+  return conditionSqls.join(' AND ');
+}
+
+function buildExclusionClauses(
+  rules: readonly ExclusionRule[],
+  dimensions: DimensionsConfig,
+  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  const clauses: string[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+    if (matchExpr === null) continue;
+    clauses.push(`NOT (${matchExpr})`);
+  }
+  return clauses;
+}
+
 function quoteList(paths: readonly string[]): string {
   return `[${paths.map(p => `'${p}'`).join(', ')}]`;
 }
@@ -112,7 +183,7 @@ function quoteList(paths: readonly string[]): string {
  * Drops the org-accounts JOIN entirely — fallback logic was baked into each
  * sidecar column at generation time.
  */
-function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan): string {
+function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costColumn: string): string {
   const rawList = quoteList(plan.rawFiles);
   const sidecarList = quoteList(plan.sidecarFiles);
 
@@ -140,7 +211,7 @@ function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, pla
       COALESCE(cur.line_item_line_item_description, '') AS description,
       COALESCE(cur.line_item_resource_id, '') AS resource_id,
       COALESCE(cur.line_item_usage_amount, 0) AS usage_amount,
-      COALESCE(cur.line_item_unblended_cost, 0) AS cost,
+      COALESCE(cur.${costColumn}, 0) AS cost,
       COALESCE(cur.pricing_public_on_demand_cost, 0) AS list_cost,
       COALESCE(cur.line_item_line_item_type, '') AS line_item_type,
       COALESCE(cur.line_item_operation, '') AS operation,
@@ -168,9 +239,10 @@ export function buildSource(
   orgAccountsPath?: string,
   periods?: readonly string[],
   sidecarPlan?: SidecarPlan,
+  costColumn: string = 'line_item_unblended_cost',
 ): string {
   if (sidecarPlan !== undefined) {
-    return buildSourceFromSidecars(tier, dimensions, sidecarPlan);
+    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costColumn);
   }
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
@@ -249,7 +321,7 @@ export function buildSource(
       COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_line_item_description, '') AS description,
       COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_resource_id, '') AS resource_id,
       COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_usage_amount, 0) AS usage_amount,
-      COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_unblended_cost, 0) AS cost,
+      COALESCE(${needsOrgJoin ? 'cur.' : ''}${costColumn}, 0) AS cost,
       COALESCE(${needsOrgJoin ? 'cur.' : ''}pricing_public_on_demand_cost, 0) AS list_cost,
       COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_line_item_type, '') AS line_item_type,
       COALESCE(${needsOrgJoin ? 'cur.' : ''}line_item_operation, '') AS operation,
@@ -283,16 +355,20 @@ export function buildCostQuery(
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  costScope?: CostScopeConfig,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
     ...filterClauses,
+    ...exclusionClauses,
   ];
 
   if (params.orgNodeValues !== undefined && params.orgNodeValues.length > 0) {
@@ -352,9 +428,12 @@ export function buildTrendQuery(
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  costScope?: CostScopeConfig,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
@@ -372,9 +451,10 @@ export function buildTrendQuery(
   const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
   const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
   const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
 
-  const filterWhere = filterClauses.length > 0 ? ` AND ${filterClauses.join(' AND ')}` : '';
+  const allFilterClauses = [...filterClauses, ...exclusionClauses];
+  const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
 
   return `
     WITH current_period AS (
@@ -440,11 +520,14 @@ export function buildMissingTagsQuery(
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  costScope?: CostScopeConfig,
 ): string {
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
 
   // Date + user filters apply to the resource aggregation.
   const whereConditions = [
@@ -452,6 +535,7 @@ export function buildMissingTagsQuery(
     `line_item_type IN ('Usage', 'DiscountedUsage')`,
     `resource_id IS NOT NULL AND resource_id != ''`,
     ...filterClauses,
+    ...exclusionClauses,
   ];
 
   return `
@@ -515,15 +599,19 @@ export function buildNonResourceCostQuery(
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  costScope?: CostScopeConfig,
 ): string {
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
     `(line_item_type NOT IN ('Usage', 'DiscountedUsage') OR resource_id IS NULL OR resource_id = '')`,
     ...filterClauses,
+    ...exclusionClauses,
   ];
 
   return `
@@ -548,16 +636,20 @@ export function buildDailyCostsQuery(
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  costScope?: CostScopeConfig,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
     ...filterClauses,
+    ...exclusionClauses,
   ];
 
   const dateExpr = dailyTier === 'hourly'
@@ -584,13 +676,16 @@ export function buildEntityDetailQuery(
   availablePeriods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  costScope?: CostScopeConfig,
 ): string {
   const dimResolved = resolveField(params.dimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const costColumn = costScope !== undefined ? costColumnFor(costScope.costMetric) : 'line_item_unblended_cost';
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costColumn);
 
   // Same display-name collision treatment for the entity selector itself: if
   // the user clicked into "sre default" we need to match every underlying id,
@@ -610,6 +705,7 @@ export function buildEntityDetailQuery(
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
     entityClause,
     ...filterClauses,
+    ...exclusionClauses,
   ];
 
   // Group by hour for hourly tier so the entity detail histogram doesn't

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -208,8 +208,8 @@ function quoteList(paths: readonly string[]): string {
  * Drops the org-accounts JOIN entirely — fallback logic was baked into each
  * sidecar column at generation time.
  */
-function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costMetric: CostMetric): string {
-  const costExpr = costExprFor(costMetric, 'cur.');
+function buildSourceFromSidecars(tier: string, dimensions: DimensionsConfig, plan: SidecarPlan, costMetric: CostMetric, availableColumns?: ReadonlySet<string>): string {
+  const costExpr = costExprFor(costMetric, 'cur.', availableColumns);
   const rawList = quoteList(plan.rawFiles);
   const sidecarList = quoteList(plan.sidecarFiles);
 
@@ -266,9 +266,10 @@ export function buildSource(
   periods?: readonly string[],
   sidecarPlan?: SidecarPlan,
   costMetric: CostMetric = 'unblended',
+  availableColumns?: ReadonlySet<string>,
 ): string {
   if (sidecarPlan !== undefined) {
-    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costMetric);
+    return buildSourceFromSidecars(tier, dimensions, sidecarPlan, costMetric, availableColumns);
   }
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
@@ -337,7 +338,7 @@ export function buildSource(
     : parquetSource;
 
   const tablePrefix = needsOrgJoin ? 'cur.' : '';
-  const costExpr = costExprFor(costMetric, tablePrefix);
+  const costExpr = costExprFor(costMetric, tablePrefix, availableColumns);
 
   return `(
     SELECT
@@ -385,6 +386,7 @@ export function buildCostQuery(
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
+  availableColumns?: ReadonlySet<string>,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
@@ -392,7 +394,7 @@ export function buildCostQuery(
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
+  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -458,6 +460,7 @@ export function buildTrendQuery(
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
+  availableColumns?: ReadonlySet<string>,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
@@ -480,7 +483,7 @@ export function buildTrendQuery(
   const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
   const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
   const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
 
   const allFilterClauses = [...filterClauses, ...exclusionClauses];
   const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
@@ -550,13 +553,14 @@ export function buildMissingTagsQuery(
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
+  availableColumns?: ReadonlySet<string>,
 ): string {
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
 
   // Date + user filters apply to the resource aggregation.
   const whereConditions = [
@@ -629,12 +633,13 @@ export function buildNonResourceCostQuery(
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
+  availableColumns?: ReadonlySet<string>,
 ): string {
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
+  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -666,6 +671,7 @@ export function buildDailyCostsQuery(
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
+  availableColumns?: ReadonlySet<string>,
 ): string {
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
@@ -673,7 +679,7 @@ export function buildDailyCostsQuery(
   const costMetric = costScope?.costMetric ?? 'unblended';
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
+  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
 
   const whereConditions = [
     `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
@@ -706,6 +712,7 @@ export function buildEntityDetailQuery(
   sidecarPlan?: SidecarPlan,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
+  availableColumns?: ReadonlySet<string>,
 ): string {
   const dimResolved = resolveField(params.dimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
@@ -714,7 +721,7 @@ export function buildEntityDetailQuery(
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, sidecarPlan, costMetric, availableColumns);
 
   // Same display-name collision treatment for the entity selector itself: if
   // the user clicked into "sre default" we need to match every underlying id,

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -37,16 +37,18 @@ export function costExprFor(
       }
       return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
     case 'amortized': {
-      // Covered usage rows carry a reservation_effective_cost or
-      // savings_plan_effective_cost; non-covered rows fall back to
-      // unblended. Effective-cost columns only ship when the CUR has
-      // "Include Resource IDs" enabled — detect presence and only
-      // reference those we actually have. If neither is available,
-      // amortized degrades to unblended (unavoidable — no way to
-      // recover amortization from data we weren't given).
+      // Covered usage rows carry a reservation_effective_cost
+      // (RI-covered) or savings_plan_savings_plan_effective_cost
+      // (SP-covered — the double prefix is AWS's snake_case conversion
+      // of savingsPlan/SavingsPlanEffectiveCost); non-covered rows
+      // fall back to unblended. Effective-cost columns only ship when
+      // the CUR has "Include Resource IDs" enabled — detect presence
+      // and only reference those we actually have. If neither is
+      // available, amortized degrades to unblended (unavoidable — no
+      // way to recover amortization from data we weren't given).
       const parts: string[] = [];
       if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
-      if (has('savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_effective_cost`);
+      if (has('savings_plan_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_savings_plan_effective_cost`);
       parts.push(`${prefix}line_item_unblended_cost`);
       return `COALESCE(${parts.join(', ')}, 0)`;
     }

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -8,20 +8,47 @@ import type { CostMetric } from '../types/cost-scope.js';
  *
  *  `prefix` is the table qualifier ('cur.' when the source JOINs org
  *  accounts, '' otherwise) — mirrors what buildSource already does for
- *  other column references. */
-export function costExprFor(metric: CostMetric, prefix: string): string {
+ *  other column references.
+ *
+ *  `availableColumns` lists the columns the probing code found in the
+ *  user's parquet files. Optional: `undefined` means "assume every
+ *  column is present" (preserves historic behaviour and keeps this
+ *  function usable from places without probe access — e.g. SQL-shape
+ *  unit tests). When provided, optional columns missing from the set
+ *  are dropped from the expression so the query doesn't error on CURs
+ *  that ship without resource IDs / net columns / etc. */
+export function costExprFor(
+  metric: CostMetric,
+  prefix: string,
+  availableColumns?: ReadonlySet<string>,
+): string {
+  const has = (col: string): boolean => availableColumns === undefined || availableColumns.has(col);
   switch (metric) {
     case 'unblended':
+      // line_item_unblended_cost is the one universal CUR column — if
+      // it's missing, every query in the app is broken anyway, so no
+      // fallback here.
       return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
     case 'blended':
-      return `COALESCE(${prefix}line_item_blended_cost, 0)`;
-    case 'amortized':
+      // Blended cost is usually present but can be excluded in some CUR
+      // configurations. Fall back to unblended when missing.
+      if (has('line_item_blended_cost')) {
+        return `COALESCE(${prefix}line_item_blended_cost, 0)`;
+      }
+      return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
+    case 'amortized': {
       // Covered usage rows carry a reservation_effective_cost or
-      // savings_plan_effective_cost; non-covered rows fall back to the
-      // unblended amount. Upfront RIFee / SavingsPlanUpfrontFee line items
-      // are typically excluded from an amortized view via an exclusion
-      // rule — the default built-in "RI & Savings Plan purchases" handles
-      // that when enabled.
-      return `COALESCE(${prefix}reservation_effective_cost, ${prefix}savings_plan_effective_cost, ${prefix}line_item_unblended_cost, 0)`;
+      // savings_plan_effective_cost; non-covered rows fall back to
+      // unblended. Effective-cost columns only ship when the CUR has
+      // "Include Resource IDs" enabled — detect presence and only
+      // reference those we actually have. If neither is available,
+      // amortized degrades to unblended (unavoidable — no way to
+      // recover amortization from data we weren't given).
+      const parts: string[] = [];
+      if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
+      if (has('savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_effective_cost`);
+      parts.push(`${prefix}line_item_unblended_cost`);
+      return `COALESCE(${parts.join(', ')}, 0)`;
+    }
   }
 }

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -1,4 +1,4 @@
-import type { CostMetric } from '../types/cost-scope.js';
+import type { CostMetric, CostPerspective } from '../types/cost-scope.js';
 
 /** SQL expression that becomes the `cost` alias in buildSource. A function
  *  rather than a column name so amortized can fold RI/SP effective-cost
@@ -10,6 +10,11 @@ import type { CostMetric } from '../types/cost-scope.js';
  *  accounts, '' otherwise) — mirrors what buildSource already does for
  *  other column references.
  *
+ *  `perspective` toggles between gross (as-billed) and net (after
+ *  credits/refunds). Net variants ship only when the CUR has "Include
+ *  Net Columns" enabled; when missing we fall back to gross so the
+ *  query still runs.
+ *
  *  `availableColumns` lists the columns the probing code found in the
  *  user's parquet files. Optional: `undefined` means "assume every
  *  column is present" (preserves historic behaviour and keeps this
@@ -20,35 +25,55 @@ import type { CostMetric } from '../types/cost-scope.js';
 export function costExprFor(
   metric: CostMetric,
   prefix: string,
+  perspective: CostPerspective = 'gross',
   availableColumns?: ReadonlySet<string>,
 ): string {
   const has = (col: string): boolean => availableColumns === undefined || availableColumns.has(col);
+  const net = perspective === 'net';
   switch (metric) {
-    case 'unblended':
-      // line_item_unblended_cost is the one universal CUR column — if
-      // it's missing, every query in the app is broken anyway, so no
-      // fallback here.
+    case 'unblended': {
+      // Unblended + net: line_item_net_unblended_cost if available,
+      // otherwise fall back to the gross column (universal). Unblended +
+      // gross: the one column every CUR has.
+      if (net && has('line_item_net_unblended_cost')) {
+        return `COALESCE(${prefix}line_item_net_unblended_cost, 0)`;
+      }
       return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
-    case 'blended':
-      // Blended cost is usually present but can be excluded in some CUR
-      // configurations. Fall back to unblended when missing.
+    }
+    case 'blended': {
+      // AWS doesn't publish a `line_item_net_blended_cost` — the net
+      // variant of blended isn't a first-class CUR column. Best we can
+      // do for blended+net is use net_unblended (closest semantics for
+      // net accounting) when available, or fall through to gross
+      // blended otherwise. Gross blended falls back to unblended when
+      // the column is missing (some stripped-down CURs omit it).
+      if (net && has('line_item_net_unblended_cost')) {
+        return `COALESCE(${prefix}line_item_net_unblended_cost, 0)`;
+      }
       if (has('line_item_blended_cost')) {
         return `COALESCE(${prefix}line_item_blended_cost, 0)`;
       }
       return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
+    }
     case 'amortized': {
-      // Covered usage rows carry a reservation_effective_cost
-      // (RI-covered) or savings_plan_savings_plan_effective_cost
-      // (SP-covered — the double prefix is AWS's snake_case conversion
-      // of savingsPlan/SavingsPlanEffectiveCost); non-covered rows
-      // fall back to unblended. Effective-cost columns only ship when
-      // the CUR has "Include Resource IDs" enabled — detect presence
-      // and only reference those we actually have. If neither is
-      // available, amortized degrades to unblended (unavoidable — no
-      // way to recover amortization from data we weren't given).
+      // Covered usage rows carry reservation_effective_cost (RI) or
+      // savings_plan_savings_plan_effective_cost (SP — the double
+      // prefix is AWS's snake_case conversion of
+      // savingsPlan/SavingsPlanEffectiveCost); non-covered rows fall
+      // back to unblended. Net variants are reservation_net_effective_cost
+      // and savings_plan_net_savings_plan_effective_cost, paired with
+      // line_item_net_unblended_cost as the fall-through. Any columns
+      // missing are dropped from the COALESCE chain.
       const parts: string[] = [];
-      if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
-      if (has('savings_plan_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_savings_plan_effective_cost`);
+      if (net) {
+        if (has('reservation_net_effective_cost')) parts.push(`${prefix}reservation_net_effective_cost`);
+        if (has('savings_plan_net_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_net_savings_plan_effective_cost`);
+        if (has('line_item_net_unblended_cost')) parts.push(`${prefix}line_item_net_unblended_cost`);
+      } else {
+        if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
+        if (has('savings_plan_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_savings_plan_effective_cost`);
+      }
+      // line_item_unblended_cost is the final, universal fall-through.
       parts.push(`${prefix}line_item_unblended_cost`);
       return `COALESCE(${parts.join(', ')}, 0)`;
     }

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -1,17 +1,27 @@
 import type { CostMetric } from '../types/cost-scope.js';
 
-const COLUMN_BY_METRIC: Readonly<Record<CostMetric, string>> = {
-  unblended: 'line_item_unblended_cost',
-  blended: 'line_item_blended_cost',
-  list: 'pricing_public_on_demand_cost',
-  // TODO: amortized / net_* — need CUR column presence detection first,
-  // and a decision on how to handle RI/SP effective cost columns that
-  // some users won't have in their export. Keep that work out of the
-  // critical path for MVP.
-};
-
-/** Raw Parquet column name for a metric. Used only by buildSource to pick
- *  which column becomes the `cost` alias. */
-export function costColumnFor(metric: CostMetric): string {
-  return COLUMN_BY_METRIC[metric];
+/** SQL expression that becomes the `cost` alias in buildSource. A function
+ *  rather than a column name so amortized can fold RI/SP effective-cost
+ *  columns together via COALESCE — those columns exist only when the CUR
+ *  includes resource IDs. Expression is COALESCE-wrapped so a null falls
+ *  through to 0, matching the legacy `COALESCE(col, 0) AS cost` shape.
+ *
+ *  `prefix` is the table qualifier ('cur.' when the source JOINs org
+ *  accounts, '' otherwise) — mirrors what buildSource already does for
+ *  other column references. */
+export function costExprFor(metric: CostMetric, prefix: string): string {
+  switch (metric) {
+    case 'unblended':
+      return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
+    case 'blended':
+      return `COALESCE(${prefix}line_item_blended_cost, 0)`;
+    case 'amortized':
+      // Covered usage rows carry a reservation_effective_cost or
+      // savings_plan_effective_cost; non-covered rows fall back to the
+      // unblended amount. Upfront RIFee / SavingsPlanUpfrontFee line items
+      // are typically excluded from an amortized view via an exclusion
+      // rule — the default built-in "RI & Savings Plan purchases" handles
+      // that when enabled.
+      return `COALESCE(${prefix}reservation_effective_cost, ${prefix}savings_plan_effective_cost, ${prefix}line_item_unblended_cost, 0)`;
+  }
 }

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -1,0 +1,17 @@
+import type { CostMetric } from '../types/cost-scope.js';
+
+const COLUMN_BY_METRIC: Readonly<Record<CostMetric, string>> = {
+  unblended: 'line_item_unblended_cost',
+  blended: 'line_item_blended_cost',
+  list: 'pricing_public_on_demand_cost',
+  // TODO: amortized / net_* — need CUR column presence detection first,
+  // and a decision on how to handle RI/SP effective cost columns that
+  // some users won't have in their export. Keep that work out of the
+  // critical path for MVP.
+};
+
+/** Raw Parquet column name for a metric. Used only by buildSource to pick
+ *  which column becomes the `cost` alias. */
+export function costColumnFor(metric: CostMetric): string {
+  return COLUMN_BY_METRIC[metric];
+}

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -6,7 +6,10 @@ export {
   buildNonResourceCostQuery,
   buildEntityDetailQuery,
   buildSource,
+  buildRuleMatchExpr,
   computePeriodsInRange,
 } from './builder.js';
 
 export type { SidecarPlan } from './builder.js';
+
+export { costColumnFor } from './cost-metric.js';

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -12,4 +12,4 @@ export {
 
 export type { SidecarPlan } from './builder.js';
 
-export { costColumnFor } from './cost-metric.js';
+export { costExprFor } from './cost-metric.js';

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,5 +1,6 @@
 import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, NormalizationRule, OrgNode, TagDimension } from './config.js';
 import type { ViewsConfig } from './views.js';
+import type { CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
 import type {
   CostQueryParams,
   CostResult,
@@ -143,6 +144,10 @@ export interface CostApi {
   resetViewsConfig(): Promise<ViewsConfig>;
   /** Reveal `views.yaml` in the OS file manager (Finder / Explorer). */
   revealViewsFolder(): Promise<void>;
+  getCostScope(): Promise<CostScopeConfig>;
+  saveCostScope(config: CostScopeConfig): Promise<void>;
+  previewCostScope(config: CostScopeConfig): Promise<CostScopePreviewResult>;
+  revealCostScopeFolder(): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;
   setAutoSyncEnabled(enabled: boolean): Promise<void>;
   getAutoSyncStatus(): Promise<AutoSyncStatus>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,6 +1,6 @@
 import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, NormalizationRule, OrgNode, TagDimension } from './config.js';
 import type { ViewsConfig } from './views.js';
-import type { CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
+import type { CostScopeCapabilities, CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
 import type {
   CostQueryParams,
   CostResult,
@@ -147,6 +147,9 @@ export interface CostApi {
   getCostScope(): Promise<CostScopeConfig>;
   saveCostScope(config: CostScopeConfig): Promise<void>;
   previewCostScope(config: CostScopeConfig): Promise<CostScopePreviewResult>;
+  /** Which optional CUR columns exist — drives UI warnings (e.g.
+   *  degraded Amortized when effective-cost columns are missing). */
+  getCostScopeCapabilities(): Promise<CostScopeCapabilities>;
   revealCostScopeFolder(): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;
   setAutoSyncEnabled(enabled: boolean): Promise<void>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -114,7 +114,7 @@ export interface CostApi {
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult>;
   syncPeriods(files: readonly { key: string; contentHash: string; size: number }[], syncId?: string): Promise<{ filesDownloaded: number; rowsProcessed: number }>;
   cancelSync(syncId?: string): Promise<void>;
-  getFilterValues(dimensionId: string, filters: Record<string, string>, dateRange?: { start: string; end: string }): Promise<{ value: string; label: string; count: number }[]>;
+  getFilterValues(dimensionId: string, filters: Record<string, string>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]>;
   deleteLocalPeriod(period: string, tier?: DataTier): Promise<void>;
   openDataFolder(): Promise<void>;
   getAccountMapping(): Promise<AccountMappingStatus>;

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -16,6 +16,15 @@ export type CostMetric = 'unblended' | 'blended' | 'amortized';
 
 export const COST_METRICS: readonly CostMetric[] = ['unblended', 'blended', 'amortized'] as const;
 
+/** Whether the cost column should be the as-billed ("gross") value or the
+ *  post-credit/refund ("net") value. Orthogonal to the metric axis —
+ *  every metric has a net variant in CUR when "Include Net Columns" is
+ *  enabled on the report. When net columns are missing, the expression
+ *  falls back to the gross column for that metric. */
+export type CostPerspective = 'gross' | 'net';
+
+export const COST_PERSPECTIVES: readonly CostPerspective[] = ['gross', 'net'] as const;
+
 /** One AND-ed condition inside an exclusion rule. Matches when the row's
  *  value for `dimensionId` is in `values` (OR within values). Empty `values`
  *  is invalid — reject it in the validator. */
@@ -43,6 +52,9 @@ export interface ExclusionRule {
 
 export interface CostScopeConfig {
   readonly costMetric: CostMetric;
+  /** Optional. Defaults to 'gross' when omitted (back-compat with
+   *  earlier on-disk configs that predate the perspective axis). */
+  readonly costPerspective?: CostPerspective;
   readonly rules: readonly ExclusionRule[];
 }
 
@@ -102,6 +114,10 @@ export interface CostScopeCapabilities {
    *  configurations omit it — when missing we degrade Blended to
    *  Unblended. */
   readonly hasBlendedColumn: boolean;
+  /** `line_item_net_unblended_cost` is present. Ships only when the
+   *  CUR has "Include Net Columns" enabled. Without it, the Net
+   *  perspective toggle falls back to Gross. */
+  readonly hasNetColumns: boolean;
 }
 
 export interface CostScopePreviewResult {

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -87,6 +87,22 @@ export interface CostScopeSampleRow {
   readonly tags: Readonly<Record<string, string>>;
 }
 
+/** Which optional CUR columns exist in the user's export. Drives UI
+ *  warnings (e.g. "Amortized is degraded — your CUR lacks the
+ *  effective-cost columns"). The probe runs once per tier, cached for
+ *  the session. */
+export interface CostScopeCapabilities {
+  /** `reservation_effective_cost` AND `savings_plan_effective_cost` are
+   *  both present. Required for an accurate Amortized metric; when
+   *  missing we degrade to Unblended. Both columns ship only when the
+   *  CUR has "Include Resource IDs" enabled. */
+  readonly hasEffectiveCostColumns: boolean;
+  /** `line_item_blended_cost` is present. Usually true, but some CUR
+   *  configurations omit it — when missing we degrade Blended to
+   *  Unblended. */
+  readonly hasBlendedColumn: boolean;
+}
+
 export interface CostScopePreviewResult {
   readonly windowDays: number;
   readonly startDate: string;

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -62,6 +62,31 @@ export interface CostScopeDailyRow {
   readonly excludedCost: number;
 }
 
+/** A single billing line item from the preview window, surfaced in the raw
+ *  inspection table. `excluded` indicates whether the current exclusion
+ *  rules would drop this row. `cost` reflects the chosen cost metric.
+ *  `tags` carries the row's value for every configured tag dimension so the
+ *  UI can render an arbitrary number of tag columns without adding new
+ *  fields. */
+export interface CostScopeSampleRow {
+  readonly date: string;
+  readonly accountId: string;
+  readonly accountName: string;
+  readonly region: string;
+  readonly service: string;
+  readonly serviceFamily: string;
+  readonly lineItemType: string;
+  readonly operation: string;
+  readonly usageType: string;
+  readonly description: string;
+  readonly resourceId: string;
+  readonly usageAmount: number;
+  readonly cost: number;
+  readonly listCost: number;
+  readonly excluded: boolean;
+  readonly tags: Readonly<Record<string, string>>;
+}
+
 export interface CostScopePreviewResult {
   readonly windowDays: number;
   readonly startDate: string;
@@ -76,4 +101,14 @@ export interface CostScopePreviewResult {
   /** Daily breakdown for the window — one entry per day. Empty when no
    *  months in range are on disk yet. */
   readonly dailyTotals: readonly CostScopeDailyRow[];
+  /** Top-|cost| line items in the window, sorted by absolute cost desc so
+   *  the largest credits/refunds and the largest charges sit at the top.
+   *  Capped so the IPC payload stays bounded. */
+  readonly sampleRows: readonly CostScopeSampleRow[];
+  /** Total underlying line-item count in the window (before the sample cap).
+   *  Lets the UI say "showing 500 of 128,902 rows" honestly. */
+  readonly sampleTotalRowCount: number;
+  /** Names of configured tag dimensions in the order the UI should render
+   *  them as columns. Extracted from dimensions config at query time. */
+  readonly tagColumns: readonly { readonly id: string; readonly label: string }[];
 }

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -1,11 +1,20 @@
 import type { DimensionId } from './branded.js';
 
-/** Which Parquet cost column backs the `cost` alias in every query.
- *  Extend the switch in packages/core/src/query/cost-metric.ts when adding
- *  new metrics (amortized, net_*). */
-export type CostMetric = 'unblended' | 'blended' | 'list';
+/** Which cost perspective backs the `cost` alias in every query.
+ *  - `unblended`  — what you were actually billed; upfront RI/SP fees land
+ *                   as a lump in their month.
+ *  - `blended`    — consolidated-billing blended rate (weighted average of
+ *                   usage rates across the accounts in the org). Reporting
+ *                   construct; makes linked-account costs comparable.
+ *  - `amortized`  — spreads RI/SP upfront payments over their term and uses
+ *                   effective cost for covered usage. Best for run-rate and
+ *                   forecasting.
+ *  The SQL expression that each value resolves to lives in
+ *  packages/core/src/query/cost-metric.ts. Net-of-credits is a separate
+ *  axis we haven't shipped yet; see `costPerspective` below when it lands. */
+export type CostMetric = 'unblended' | 'blended' | 'amortized';
 
-export const COST_METRICS: readonly CostMetric[] = ['unblended', 'blended', 'list'] as const;
+export const COST_METRICS: readonly CostMetric[] = ['unblended', 'blended', 'amortized'] as const;
 
 /** One AND-ed condition inside an exclusion rule. Matches when the row's
  *  value for `dimensionId` is in `values` (OR within values). Empty `values`
@@ -43,10 +52,28 @@ export interface CostScopePreviewRow {
   readonly excludedRows: number;
 }
 
+/** One day of the preview histogram. `keptCost` is what survives the enabled
+ *  exclusion rules under the chosen metric. `excludedCost` is what the same
+ *  rules removed. They sum to the pre-exclusion total for that day under the
+ *  chosen metric — useful for showing the "bite" as a stacked bar. */
+export interface CostScopeDailyRow {
+  readonly date: string;
+  readonly keptCost: number;
+  readonly excludedCost: number;
+}
+
 export interface CostScopePreviewResult {
   readonly windowDays: number;
   readonly startDate: string;
   readonly endDate: string;
   readonly perRule: readonly CostScopePreviewRow[];
   readonly combined: { readonly excludedCost: number; readonly excludedRows: number };
+  /** Total cost over the window under the chosen metric, with no exclusions
+   *  applied. Lets the UI show a "base" figure for comparison. */
+  readonly unscopedTotalCost: number;
+  /** Total under the chosen metric AND the enabled exclusion rules. */
+  readonly scopedTotalCost: number;
+  /** Daily breakdown for the window — one entry per day. Empty when no
+   *  months in range are on disk yet. */
+  readonly dailyTotals: readonly CostScopeDailyRow[];
 }

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -1,0 +1,52 @@
+import type { DimensionId } from './branded.js';
+
+/** Which Parquet cost column backs the `cost` alias in every query.
+ *  Extend the switch in packages/core/src/query/cost-metric.ts when adding
+ *  new metrics (amortized, net_*). */
+export type CostMetric = 'unblended' | 'blended' | 'list';
+
+export const COST_METRICS: readonly CostMetric[] = ['unblended', 'blended', 'list'] as const;
+
+/** One AND-ed condition inside an exclusion rule. Matches when the row's
+ *  value for `dimensionId` is in `values` (OR within values). Empty `values`
+ *  is invalid — reject it in the validator. */
+export interface ExclusionCondition {
+  readonly dimensionId: DimensionId;
+  readonly values: readonly string[];
+}
+
+export interface ExclusionRule {
+  /** Stable id. Built-ins use `builtin:<slug>`; user rules get a uuid-v4
+   *  minted by the UI on creation. */
+  readonly id: string;
+  /** User-editable. For built-ins, on-disk name is preferred so edits stick. */
+  readonly name: string;
+  /** Free-form. Optional. */
+  readonly description?: string | undefined;
+  /** When false, the rule has no effect on queries. */
+  readonly enabled: boolean;
+  /** True for rules shipped with the app. Cannot be deleted, only toggled. */
+  readonly builtIn: boolean;
+  /** AND-ed conditions. At least one condition; each condition has at least
+   *  one value. Enforced by the validator. */
+  readonly conditions: readonly ExclusionCondition[];
+}
+
+export interface CostScopeConfig {
+  readonly costMetric: CostMetric;
+  readonly rules: readonly ExclusionRule[];
+}
+
+export interface CostScopePreviewRow {
+  readonly ruleId: string;
+  readonly excludedCost: number;
+  readonly excludedRows: number;
+}
+
+export interface CostScopePreviewResult {
+  readonly windowDays: number;
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly perRule: readonly CostScopePreviewRow[];
+  readonly combined: { readonly excludedCost: number; readonly excludedRows: number };
+}

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -92,10 +92,11 @@ export interface CostScopeSampleRow {
  *  effective-cost columns"). The probe runs once per tier, cached for
  *  the session. */
 export interface CostScopeCapabilities {
-  /** `reservation_effective_cost` AND `savings_plan_effective_cost` are
-   *  both present. Required for an accurate Amortized metric; when
-   *  missing we degrade to Unblended. Both columns ship only when the
-   *  CUR has "Include Resource IDs" enabled. */
+  /** `reservation_effective_cost` AND
+   *  `savings_plan_savings_plan_effective_cost` are both present.
+   *  Required for an accurate Amortized metric; when missing we
+   *  degrade to Unblended. Both columns ship only when the CUR has
+   *  "Include Resource IDs" enabled. */
   readonly hasEffectiveCostColumns: boolean;
   /** `line_item_blended_cost` is present. Usually true, but some CUR
    *  configurations omit it — when missing we degrade Blended to

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -84,5 +84,6 @@ export type {
   CostScopeDailyRow,
   CostScopePreviewRow,
   CostScopePreviewResult,
+  CostScopeSampleRow,
 } from './cost-scope.js';
 export { COST_METRICS } from './cost-scope.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -78,6 +78,7 @@ export { OVERVIEW_SEED_VIEW, SEED_VIEWS_CONFIG } from './seed-views.js';
 
 export type {
   CostMetric,
+  CostScopeCapabilities,
   CostScopeConfig,
   ExclusionRule,
   ExclusionCondition,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -75,3 +75,13 @@ export type {
   ViewsConfig,
 } from './views.js';
 export { OVERVIEW_SEED_VIEW, SEED_VIEWS_CONFIG } from './seed-views.js';
+
+export type {
+  CostMetric,
+  CostScopeConfig,
+  ExclusionRule,
+  ExclusionCondition,
+  CostScopePreviewRow,
+  CostScopePreviewResult,
+} from './cost-scope.js';
+export { COST_METRICS } from './cost-scope.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -78,6 +78,7 @@ export { OVERVIEW_SEED_VIEW, SEED_VIEWS_CONFIG } from './seed-views.js';
 
 export type {
   CostMetric,
+  CostPerspective,
   CostScopeCapabilities,
   CostScopeConfig,
   ExclusionRule,
@@ -87,4 +88,4 @@ export type {
   CostScopePreviewResult,
   CostScopeSampleRow,
 } from './cost-scope.js';
-export { COST_METRICS } from './cost-scope.js';
+export { COST_METRICS, COST_PERSPECTIVES } from './cost-scope.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -81,6 +81,7 @@ export type {
   CostScopeConfig,
   ExclusionRule,
   ExclusionCondition,
+  CostScopeDailyRow,
   CostScopePreviewRow,
   CostScopePreviewResult,
 } from './cost-scope.js';

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -136,8 +136,8 @@ export interface AppContext {
   /** Columns present in the user's CUR parquet files for the given tier.
    *  CUR exports vary by version and by "Include Resource IDs" / "Include
    *  Net Columns" settings — not every export has
-   *  reservation_effective_cost, savings_plan_effective_cost, or
-   *  line_item_net_*. Cached per-tier for the session; invalidated on
+   *  reservation_effective_cost, savings_plan_savings_plan_effective_cost,
+   *  or line_item_net_*. Cached per-tier for the session; invalidated on
    *  explicit reset via invalidateColumnCache. */
   readonly getAvailableColumns: (tier: 'daily' | 'hourly') => Promise<ReadonlySet<string>>;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
@@ -366,10 +366,11 @@ export function createAppContext(ctx: IpcContext): AppContext {
 
   // Probe parquet columns once per tier and cache. Used to gate
   // optional cost columns (reservation_effective_cost,
-  // savings_plan_effective_cost, etc.) that ship only when the user's
-  // CUR has "Include Resource IDs" enabled. Without the probe, every
-  // query that references those columns errors out for CURs that omit
-  // them — even though we could degrade to unblended.
+  // savings_plan_savings_plan_effective_cost, etc.) that ship only
+  // when the user's CUR has "Include Resource IDs" enabled. Without
+  // the probe, every query that references those columns errors out
+  // for CURs that omit them — even though we could degrade to
+  // unblended.
   const columnCache = new Map<string, Promise<ReadonlySet<string>>>();
 
   async function getAvailableColumns(tier: 'daily' | 'hourly'): Promise<ReadonlySet<string>> {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -133,11 +133,19 @@ export interface AppContext {
   readonly getAccountMap: () => Promise<Map<string, string>>;
   readonly getRegionMap: () => Promise<Map<string, RegionEnrichment>>;
   readonly getOrgAccountsPath: () => Promise<string | undefined>;
+  /** Columns present in the user's CUR parquet files for the given tier.
+   *  CUR exports vary by version and by "Include Resource IDs" / "Include
+   *  Net Columns" settings — not every export has
+   *  reservation_effective_cost, savings_plan_effective_cost, or
+   *  line_item_net_*. Cached per-tier for the session; invalidated on
+   *  explicit reset via invalidateColumnCache. */
+  readonly getAvailableColumns: (tier: 'daily' | 'hourly') => Promise<ReadonlySet<string>>;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
   readonly invalidateDimensions: () => void;
   readonly invalidateViews: () => void;
   readonly invalidateCostScope: () => void;
+  readonly invalidateColumnCache: () => void;
 }
 
 export function createAppContext(ctx: IpcContext): AppContext {
@@ -356,6 +364,45 @@ export function createAppContext(ctx: IpcContext): AppContext {
     return applyRegionFriendlyNames(dims, regionMap);
   }
 
+  // Probe parquet columns once per tier and cache. Used to gate
+  // optional cost columns (reservation_effective_cost,
+  // savings_plan_effective_cost, etc.) that ship only when the user's
+  // CUR has "Include Resource IDs" enabled. Without the probe, every
+  // query that references those columns errors out for CURs that omit
+  // them — even though we could degrade to unblended.
+  const columnCache = new Map<string, Promise<ReadonlySet<string>>>();
+
+  async function getAvailableColumns(tier: 'daily' | 'hourly'): Promise<ReadonlySet<string>> {
+    const cached = columnCache.get(tier);
+    if (cached !== undefined) return cached;
+    const fetch = (async (): Promise<ReadonlySet<string>> => {
+      try {
+        const { listLocalMonths } = await import('@costgoblin/core');
+        const months = await listLocalMonths(ctx.dataDir, tier);
+        if (months.length === 0) return new Set<string>();
+        // First-month sample is enough — CUR schema is stable across
+        // months within a billing report (AWS bumps schema on CUR
+        // version changes, which is rare and user-initiated).
+        const month = months[months.length - 1];
+        const glob = `${ctx.dataDir}/aws/raw/${tier}-${String(month)}/*.parquet`;
+        const rows = await ctx.db.runQuery(`DESCRIBE SELECT * FROM read_parquet('${glob}') LIMIT 0`);
+        const cols = new Set<string>();
+        for (const r of rows) {
+          const name = r['column_name'];
+          if (typeof name === 'string') cols.add(name);
+        }
+        return cols;
+      } catch {
+        // If the probe fails, return an empty set. Downstream code treats
+        // "unknown columns" as "assume present" to preserve previous
+        // behaviour — we only gate columns when we KNOW they're missing.
+        return new Set<string>();
+      }
+    })();
+    columnCache.set(tier, fetch);
+    return fetch;
+  }
+
   const activity = new FileActivityLog();
   async function prefsPath(): Promise<string> {
     const path = await import('node:path');
@@ -383,11 +430,13 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getAccountMap,
     getRegionMap,
     getOrgAccountsPath,
+    getAvailableColumns,
     runQuery: (sql: string) => ctx.db.runQuery(sql),
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; state.regionMap = null; },
     invalidateViews: () => { state.views = null; },
     invalidateCostScope: () => { state.costScope = null; },
+    invalidateColumnCache: () => { columnCache.clear(); },
   };
 }
 

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -8,12 +8,15 @@ import {
   loadDimensions,
   loadOrgTree,
   loadViews,
+  loadCostScope,
+  mergeBuiltInExclusionRules,
   logger,
   isStringRecord,
 } from '@costgoblin/core';
 import type {
   BuiltInDimension,
   CostGoblinConfig,
+  CostScopeConfig,
   DimensionsConfig,
   OrgNode,
   RegionEnrichment,
@@ -92,6 +95,7 @@ export interface IpcContext {
   readonly dimensionsPath: string;
   readonly orgTreePath: string;
   readonly viewsPath: string;
+  readonly costScopePath: string;
   readonly dataDir: string;
 }
 
@@ -104,6 +108,7 @@ export interface AppState {
   dimensions: DimensionsConfig | null;
   orgTree: OrgTreeConfig | null;
   views: ViewsConfig | null;
+  costScope: CostScopeConfig | null;
   syncStatuses: Record<string, SyncStatus>;
   accountMap: Map<string, string> | null;
   regionMap: Map<string, RegionEnrichment> | null;
@@ -124,6 +129,7 @@ export interface AppContext {
   readonly getQueryDimensions: () => Promise<DimensionsConfig>;
   readonly getOrgTreeConfig: () => Promise<OrgTreeConfig>;
   readonly getViews: () => Promise<ViewsConfig>;
+  readonly getCostScope: () => Promise<CostScopeConfig>;
   readonly getAccountMap: () => Promise<Map<string, string>>;
   readonly getRegionMap: () => Promise<Map<string, RegionEnrichment>>;
   readonly getOrgAccountsPath: () => Promise<string | undefined>;
@@ -131,6 +137,7 @@ export interface AppContext {
   readonly invalidateConfig: () => void;
   readonly invalidateDimensions: () => void;
   readonly invalidateViews: () => void;
+  readonly invalidateCostScope: () => void;
 }
 
 export function createAppContext(ctx: IpcContext): AppContext {
@@ -139,6 +146,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     dimensions: null,
     orgTree: null,
     views: null,
+    costScope: null,
     syncStatuses: {},
     accountMap: null,
     regionMap: null,
@@ -175,6 +183,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const views = await loadViews(ctx.viewsPath);
     state.views = views;
     return views;
+  }
+
+  async function getCostScope(): Promise<CostScopeConfig> {
+    if (state.costScope !== null) return state.costScope;
+    const loaded = await loadCostScope(ctx.costScopePath);
+    const merged = mergeBuiltInExclusionRules(loaded);
+    state.costScope = merged;
+    return merged;
   }
 
   async function getAccountMap(): Promise<Map<string, string>> {
@@ -363,6 +379,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getQueryDimensions,
     getOrgTreeConfig,
     getViews,
+    getCostScope,
     getAccountMap,
     getRegionMap,
     getOrgAccountsPath,
@@ -370,6 +387,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; state.regionMap = null; },
     invalidateViews: () => { state.views = null; },
+    invalidateCostScope: () => { state.costScope = null; },
   };
 }
 

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -12,13 +12,13 @@ import {
 } from '@costgoblin/core';
 import type {
   CostScopeConfig,
+  CostScopeDailyRow,
   CostScopePreviewResult,
   CostScopePreviewRow,
   DimensionsConfig,
 } from '@costgoblin/core';
 import { listLocalMonths } from '@costgoblin/core';
 import type { AppContext } from './context.js';
-import { costColumnFor } from '@costgoblin/core';
 import { toNum } from './query-utils.js';
 
 // Every rule's dimensionId must resolve to a known built-in or tag dimension.
@@ -86,6 +86,9 @@ export function registerCostScopeHandlers(app: AppContext): void {
       endDate: endStr,
       perRule: enabledRules.map(r => ({ ruleId: r.id, excludedCost: 0, excludedRows: 0 })),
       combined: { excludedCost: 0, excludedRows: 0 },
+      unscopedTotalCost: 0,
+      scopedTotalCost: 0,
+      dailyTotals: [],
     };
 
     const available = await listLocalMonths(ctx.dataDir, 'daily');
@@ -95,8 +98,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
 
     const dimensions = await getQueryDimensions();
     const orgPath = await getOrgAccountsPath();
-    const costColumn = costColumnFor(config.costMetric);
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, undefined, costColumn);
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, undefined, config.costMetric);
 
     const perRule: CostScopePreviewRow[] = [];
 
@@ -160,7 +162,68 @@ export function registerCostScopeHandlers(app: AppContext): void {
       }
     }
 
-    return { windowDays, startDate: startStr, endDate: endStr, perRule, combined };
+    // Build the `excluded` predicate (OR of every enabled rule's match expr)
+    // for the daily breakdown + totals. If no rules or no expressible rules,
+    // `excludedPredicate` is the literal `FALSE` — nothing excluded — which
+    // keeps the SQL uniform and lets the kept/excluded split still work.
+    const matchExprs = enabledRules
+      .map(r => buildRuleMatchExpr(r, dimensions))
+      .filter((e): e is string => e !== null);
+    const excludedPredicate = matchExprs.length > 0
+      ? matchExprs.map(e => `(${e})`).join(' OR ')
+      : 'FALSE';
+
+    let unscopedTotalCost = 0;
+    let scopedTotalCost = 0;
+    let dailyTotals: readonly CostScopeDailyRow[] = [];
+    try {
+      const totalsSql = `
+        SELECT
+          CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS unscoped_total,
+          CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 0 ELSE cost END), 0) AS DOUBLE) AS scoped_total
+        FROM ${source}
+        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+      `.trim();
+      const totalsRows = await runQuery(totalsSql);
+      const t = totalsRows[0];
+      unscopedTotalCost = toNum(t?.['unscoped_total']);
+      scopedTotalCost = toNum(t?.['scoped_total']);
+
+      const dailySql = `
+        SELECT
+          usage_date::VARCHAR AS date,
+          CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 0 ELSE cost END), 0) AS DOUBLE) AS kept_cost,
+          CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN cost ELSE 0 END), 0) AS DOUBLE) AS excluded_cost
+        FROM ${source}
+        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+        GROUP BY usage_date
+        ORDER BY usage_date
+      `.trim();
+      const dailyRows = await runQuery(dailySql);
+      dailyTotals = dailyRows.map(r => {
+        const raw = r['date'];
+        const date = typeof raw === 'string' ? raw : raw instanceof Date ? raw.toISOString().slice(0, 10) : '';
+        return {
+          date,
+          keptCost: toNum(r['kept_cost']),
+          excludedCost: toNum(r['excluded_cost']),
+        };
+      });
+    } catch {
+      // Data-dir transient error — fall through with zeros. Per-rule totals
+      // were computed in their own try-blocks so they stand on their own.
+    }
+
+    return {
+      windowDays,
+      startDate: startStr,
+      endDate: endStr,
+      perRule,
+      combined,
+      unscopedTotalCost,
+      scopedTotalCost,
+      dailyTotals,
+    };
   });
 
   ipcMain.handle('cost-scope:reveal-folder', (): void => {

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -1,0 +1,169 @@
+import { ipcMain, shell } from 'electron';
+import { writeFile } from 'node:fs/promises';
+import { stringify } from 'yaml';
+import {
+  DEFAULT_COST_SCOPE,
+  ConfigValidationError,
+  costScopeToYaml,
+  validateCostScope,
+  buildSource,
+  buildRuleMatchExpr,
+  computePeriodsInRange,
+} from '@costgoblin/core';
+import type {
+  CostScopeConfig,
+  CostScopePreviewResult,
+  CostScopePreviewRow,
+  DimensionsConfig,
+} from '@costgoblin/core';
+import { listLocalMonths } from '@costgoblin/core';
+import type { AppContext } from './context.js';
+import { costColumnFor } from '@costgoblin/core';
+import { toNum } from './query-utils.js';
+
+// Every rule's dimensionId must resolve to a known built-in or tag dimension.
+// Dangling references silently become a bogus column reference in SQL, which
+// errors *every* query (exclusion clauses are threaded into all of them), so
+// catch it at save time rather than letting the whole app fail at query time.
+function assertRuleDimensionsExist(config: CostScopeConfig, dimensions: DimensionsConfig): void {
+  const knownIds = new Set<string>();
+  for (const d of dimensions.builtIn) knownIds.add(String(d.name));
+  for (const t of dimensions.tags) knownIds.add(`tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`);
+  for (const rule of config.rules) {
+    for (const cond of rule.conditions) {
+      const id = String(cond.dimensionId);
+      if (!knownIds.has(id)) {
+        throw new ConfigValidationError(
+          `Rule '${rule.name}' references unknown dimension '${id}'. Available: ${[...knownIds].join(', ')}`,
+        );
+      }
+    }
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+}
+
+export function registerCostScopeHandlers(app: AppContext): void {
+  const { ctx, getCostScope, invalidateCostScope, getQueryDimensions, getOrgAccountsPath, runQuery } = app;
+
+  ipcMain.handle('cost-scope:get-config', async (): Promise<CostScopeConfig> => {
+    try {
+      return await getCostScope();
+    } catch (err) {
+      // Seed the file only when it's missing. Validation / YAML errors bubble
+      // up to the UI so the user can fix their hand-edit — silently
+      // overwriting would destroy their custom rules.
+      if (!isEnoent(err)) throw err;
+      await writeFile(ctx.costScopePath, stringify(costScopeToYaml(DEFAULT_COST_SCOPE)));
+      invalidateCostScope();
+      return DEFAULT_COST_SCOPE;
+    }
+  });
+
+  ipcMain.handle('cost-scope:save-config', async (_event, raw: unknown): Promise<void> => {
+    const validated = validateCostScope(raw);
+    const dimensions = await getQueryDimensions();
+    assertRuleDimensionsExist(validated, dimensions);
+    await writeFile(ctx.costScopePath, stringify(costScopeToYaml(validated)));
+    invalidateCostScope();
+  });
+
+  ipcMain.handle('cost-scope:preview', async (_event, payload: unknown): Promise<CostScopePreviewResult> => {
+    const config = validateCostScope(payload);
+    const enabledRules = config.rules.filter(r => r.enabled);
+
+    const windowDays = 30;
+    const endDate = new Date();
+    const startDate = new Date(endDate.getTime() - (windowDays - 1) * 24 * 60 * 60 * 1000);
+    const endStr = endDate.toISOString().slice(0, 10);
+    const startStr = startDate.toISOString().slice(0, 10);
+
+    const zero: CostScopePreviewResult = {
+      windowDays,
+      startDate: startStr,
+      endDate: endStr,
+      perRule: enabledRules.map(r => ({ ruleId: r.id, excludedCost: 0, excludedRows: 0 })),
+      combined: { excludedCost: 0, excludedRows: 0 },
+    };
+
+    const available = await listLocalMonths(ctx.dataDir, 'daily');
+    const required = computePeriodsInRange({ start: startStr, end: endStr });
+    const periods = required.filter(p => available.includes(p));
+    if (periods.length === 0) return zero;
+
+    const dimensions = await getQueryDimensions();
+    const orgPath = await getOrgAccountsPath();
+    const costColumn = costColumnFor(config.costMetric);
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, undefined, costColumn);
+
+    const perRule: CostScopePreviewRow[] = [];
+
+    for (const rule of enabledRules) {
+      const matchExpr = buildRuleMatchExpr(rule, dimensions);
+      if (matchExpr === null) {
+        perRule.push({ ruleId: rule.id, excludedCost: 0, excludedRows: 0 });
+        continue;
+      }
+      // CAST both aggregates to DOUBLE so the Node binding returns plain
+      // numbers — SUM over DECIMAL (CUR 2.0) comes back as a Decimal object
+      // and COUNT(*) as a BigInt, neither of which pass a `typeof === 'number'`
+      // check. toNum handles the BigInt fallback for safety.
+      const sql = `
+        SELECT
+          CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS excluded_cost,
+          CAST(COUNT(*) AS DOUBLE) AS excluded_rows
+        FROM ${source}
+        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+          AND (${matchExpr})
+      `.trim();
+      try {
+        const rows = await runQuery(sql);
+        const row = rows[0];
+        perRule.push({
+          ruleId: rule.id,
+          excludedCost: toNum(row?.['excluded_cost']),
+          excludedRows: toNum(row?.['excluded_rows']),
+        });
+      } catch {
+        perRule.push({ ruleId: rule.id, excludedCost: 0, excludedRows: 0 });
+      }
+    }
+
+    let combined = { excludedCost: 0, excludedRows: 0 };
+    if (enabledRules.length > 0) {
+      const matchExprs = enabledRules
+        .map(r => buildRuleMatchExpr(r, dimensions))
+        .filter((e): e is string => e !== null);
+
+      if (matchExprs.length > 0) {
+        const combinedExpr = matchExprs.map(e => `(${e})`).join(' OR ');
+        const combinedSql = `
+          SELECT
+            CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS excluded_cost,
+            CAST(COUNT(*) AS DOUBLE) AS excluded_rows
+          FROM ${source}
+          WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+            AND (${combinedExpr})
+        `.trim();
+        try {
+          const rows = await runQuery(combinedSql);
+          const row = rows[0];
+          combined = {
+            excludedCost: toNum(row?.['excluded_cost']),
+            excludedRows: toNum(row?.['excluded_rows']),
+          };
+        } catch {
+          // empty data dir — return zeros
+        }
+      }
+    }
+
+    return { windowDays, startDate: startStr, endDate: endStr, perRule, combined };
+  });
+
+  ipcMain.handle('cost-scope:reveal-folder', (): void => {
+    shell.showItemInFolder(ctx.costScopePath);
+  });
+}

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -179,6 +179,11 @@ export function registerCostScopeHandlers(app: AppContext): void {
     // CAST numerics to DOUBLE inside the CTE so DECIMAL-typed CUR columns
     // come back as plain numbers — bare source.cost would return a
     // DuckDBDecimalValue object and toNum would yield 0 for every row.
+    // Partition-rank the rows so we always return up to SAMPLE_ROW_LIMIT
+    // from EACH bucket (kept vs excluded) rather than top-|cost| of the
+    // combined set. Otherwise a few very large excluded rows (tax, EDP
+    // discount, RI upfront) eat the whole limit and the table looks
+    // empty when the user toggles "Hide excluded" on.
     const tagSelectSql = tagColumns.length > 0
       ? tagColumns.map(t => `COALESCE(${t.id}, '') AS ${t.id}`).join(',\n          ')
       : null;
@@ -194,15 +199,20 @@ export function registerCostScopeHandlers(app: AppContext): void {
           CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END AS excluded${tagSelectSql === null ? '' : `,\n          ${tagSelectSql}`}
         FROM ${source}
         WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+      ),
+      ranked AS (
+        SELECT *,
+          ROW_NUMBER() OVER (PARTITION BY excluded ORDER BY ABS(cost) DESC) AS rn
+        FROM scoped
       )
       SELECT
         usage_date::VARCHAR AS usage_date,
         account_id, account_name, region, service, service_family,
         line_item_type, operation, usage_type, description, resource_id,
         usage_amount, cost, list_cost, excluded${tagSelectSql === null ? '' : ',\n        ' + tagColumns.map(t => t.id).join(', ')}
-      FROM scoped
-      ORDER BY ABS(cost) DESC
-      LIMIT ${String(SAMPLE_ROW_LIMIT)}
+      FROM ranked
+      WHERE rn <= ${String(SAMPLE_ROW_LIMIT)}
+      ORDER BY excluded ASC, ABS(cost) DESC
     `.trim();
 
     // Run all three in parallel. The DuckDB worker pool (default size 4)

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -49,7 +49,9 @@ function assertRuleDimensionsExist(config: CostScopeConfig, dimensions: Dimensio
 }
 
 function isEnoent(err: unknown): boolean {
-  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+  if (typeof err !== 'object' || err === null) return false;
+  if (!('code' in err)) return false;
+  return err.code === 'ENOENT';
 }
 
 export function registerCostScopeHandlers(app: AppContext): void {

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -123,7 +123,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
     } catch {
       sidecarPlan = undefined;
     }
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, sidecarPlan, config.costMetric, availableColumns);
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, sidecarPlan, config.costMetric, availableColumns, config.costPerspective);
 
     // Pre-compute each rule's positive match expression once — used to
     // build the `excluded` predicate for the main aggregate query, each
@@ -324,6 +324,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
       hasEffectiveCostColumns:
         cols.has('reservation_effective_cost') && cols.has('savings_plan_savings_plan_effective_cost'),
       hasBlendedColumn: cols.has('line_item_blended_cost'),
+      hasNetColumns: cols.has('line_item_net_unblended_cost'),
     };
   });
 

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -322,7 +322,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
     const cols = await getAvailableColumns('daily');
     return {
       hasEffectiveCostColumns:
-        cols.has('reservation_effective_cost') && cols.has('savings_plan_effective_cost'),
+        cols.has('reservation_effective_cost') && cols.has('savings_plan_savings_plan_effective_cost'),
       hasBlendedColumn: cols.has('line_item_blended_cost'),
     };
   });

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -15,8 +15,11 @@ import type {
   CostScopeDailyRow,
   CostScopePreviewResult,
   CostScopePreviewRow,
+  CostScopeSampleRow,
   DimensionsConfig,
 } from '@costgoblin/core';
+
+const SAMPLE_ROW_LIMIT = 500;
 import { listLocalMonths } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import { toNum } from './query-utils.js';
@@ -89,6 +92,9 @@ export function registerCostScopeHandlers(app: AppContext): void {
       unscopedTotalCost: 0,
       scopedTotalCost: 0,
       dailyTotals: [],
+      sampleRows: [],
+      sampleTotalRowCount: 0,
+      tagColumns: [],
     };
 
     const available = await listLocalMonths(ctx.dataDir, 'daily');
@@ -214,6 +220,84 @@ export function registerCostScopeHandlers(app: AppContext): void {
       // were computed in their own try-blocks so they stand on their own.
     }
 
+    // Top-|cost| raw line items for the inspection table. One column per
+    // configured tag dim so the UI can render arbitrary tag columns without
+    // bespoke per-tag wiring. Cap at SAMPLE_ROW_LIMIT — the payload is
+    // transient, but the IPC boundary should stay bounded.
+    const tagColumns = dimensions.tags.map(t => ({
+      id: `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`,
+      label: t.label,
+    }));
+    const tagSelectSql = tagColumns.length > 0
+      ? tagColumns.map(t => `COALESCE(${t.id}, '') AS ${t.id}`).join(',\n          ')
+      : null;
+
+    let sampleRows: readonly CostScopeSampleRow[] = [];
+    let sampleTotalRowCount = 0;
+    try {
+      const countRows = await runQuery(`
+        SELECT CAST(COUNT(*) AS DOUBLE) AS n
+        FROM ${source}
+        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+      `.trim());
+      sampleTotalRowCount = toNum(countRows[0]?.['n']);
+
+      const sampleSql = `
+        SELECT
+          usage_date::VARCHAR AS usage_date,
+          account_id,
+          account_name,
+          region,
+          service,
+          service_family,
+          line_item_type,
+          operation,
+          usage_type,
+          description,
+          resource_id,
+          CAST(COALESCE(usage_amount, 0) AS DOUBLE) AS usage_amount,
+          CAST(COALESCE(cost, 0) AS DOUBLE) AS cost,
+          CAST(COALESCE(list_cost, 0) AS DOUBLE) AS list_cost,
+          CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END AS excluded${tagSelectSql === null ? '' : `,\n          ${tagSelectSql}`}
+        FROM ${source}
+        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+        ORDER BY ABS(cost) DESC
+        LIMIT ${String(SAMPLE_ROW_LIMIT)}
+      `.trim();
+      const rows = await runQuery(sampleSql);
+      sampleRows = rows.map(r => {
+        const tags: Record<string, string> = {};
+        for (const t of tagColumns) {
+          const v = r[t.id];
+          tags[t.id] = typeof v === 'string' ? v : '';
+        }
+        const rawDate = r['usage_date'];
+        const date = typeof rawDate === 'string'
+          ? rawDate
+          : rawDate instanceof Date ? rawDate.toISOString().slice(0, 10) : '';
+        return {
+          date,
+          accountId: typeof r['account_id'] === 'string' ? r['account_id'] : '',
+          accountName: typeof r['account_name'] === 'string' ? r['account_name'] : '',
+          region: typeof r['region'] === 'string' ? r['region'] : '',
+          service: typeof r['service'] === 'string' ? r['service'] : '',
+          serviceFamily: typeof r['service_family'] === 'string' ? r['service_family'] : '',
+          lineItemType: typeof r['line_item_type'] === 'string' ? r['line_item_type'] : '',
+          operation: typeof r['operation'] === 'string' ? r['operation'] : '',
+          usageType: typeof r['usage_type'] === 'string' ? r['usage_type'] : '',
+          description: typeof r['description'] === 'string' ? r['description'] : '',
+          resourceId: typeof r['resource_id'] === 'string' ? r['resource_id'] : '',
+          usageAmount: toNum(r['usage_amount']),
+          cost: toNum(r['cost']),
+          listCost: toNum(r['list_cost']),
+          excluded: toNum(r['excluded']) === 1,
+          tags,
+        };
+      });
+    } catch {
+      // Sample is a best-effort inspection; fall through with empty rows.
+    }
+
     return {
       windowDays,
       startDate: startStr,
@@ -223,6 +307,9 @@ export function registerCostScopeHandlers(app: AppContext): void {
       unscopedTotalCost,
       scopedTotalCost,
       dailyTotals,
+      sampleRows,
+      sampleTotalRowCount,
+      tagColumns,
     };
   });
 

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -9,6 +9,7 @@ import {
   buildSource,
   buildRuleMatchExpr,
   computePeriodsInRange,
+  logger,
 } from '@costgoblin/core';
 import type {
   CostScopeConfig,
@@ -215,9 +216,10 @@ export function registerCostScopeHandlers(app: AppContext): void {
           excludedCost: toNum(r['excluded_cost']),
         };
       });
-    } catch {
+    } catch (err) {
       // Data-dir transient error — fall through with zeros. Per-rule totals
       // were computed in their own try-blocks so they stand on their own.
+      logger.warn(`cost-scope: daily/totals query failed: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     // Top-|cost| raw line items for the inspection table. One column per
@@ -242,25 +244,39 @@ export function registerCostScopeHandlers(app: AppContext): void {
       `.trim());
       sampleTotalRowCount = toNum(countRows[0]?.['n']);
 
+      // CAST numerics to DOUBLE so DECIMAL-typed CUR columns come back as
+      // plain numbers — bare references to source.cost would return a
+      // DuckDBDecimalValue object and toNum would yield 0 for every row,
+      // producing a table full of blank numbers. Columns are projected out
+      // of a CTE so the outer ORDER BY ABS(cost) unambiguously references
+      // the source's cost column (not a shadowed output alias).
       const sampleSql = `
+        WITH scoped AS (
+          SELECT
+            usage_date,
+            account_id,
+            account_name,
+            region,
+            service,
+            service_family,
+            line_item_type,
+            operation,
+            usage_type,
+            description,
+            resource_id,
+            CAST(usage_amount AS DOUBLE) AS usage_amount,
+            CAST(cost AS DOUBLE) AS cost,
+            CAST(list_cost AS DOUBLE) AS list_cost,
+            CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END AS excluded${tagSelectSql === null ? '' : `,\n            ${tagSelectSql}`}
+          FROM ${source}
+          WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+        )
         SELECT
           usage_date::VARCHAR AS usage_date,
-          account_id,
-          account_name,
-          region,
-          service,
-          service_family,
-          line_item_type,
-          operation,
-          usage_type,
-          description,
-          resource_id,
-          CAST(COALESCE(usage_amount, 0) AS DOUBLE) AS usage_amount,
-          CAST(COALESCE(cost, 0) AS DOUBLE) AS cost,
-          CAST(COALESCE(list_cost, 0) AS DOUBLE) AS list_cost,
-          CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END AS excluded${tagSelectSql === null ? '' : `,\n          ${tagSelectSql}`}
-        FROM ${source}
-        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+          account_id, account_name, region, service, service_family,
+          line_item_type, operation, usage_type, description, resource_id,
+          usage_amount, cost, list_cost, excluded${tagSelectSql === null ? '' : ',\n          ' + tagColumns.map(t => t.id).join(', ')}
+        FROM scoped
         ORDER BY ABS(cost) DESC
         LIMIT ${String(SAMPLE_ROW_LIMIT)}
       `.trim();
@@ -294,7 +310,8 @@ export function registerCostScopeHandlers(app: AppContext): void {
           tags,
         };
       });
-    } catch {
+    } catch (err) {
+      logger.warn(`cost-scope: sample-rows query failed: ${err instanceof Error ? err.message : String(err)}`);
       // Sample is a best-effort inspection; fall through with empty rows.
     }
 

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -13,6 +13,7 @@ import {
   listLocalMonths,
 } from '@costgoblin/core';
 import type {
+  CostScopeCapabilities,
   CostScopeConfig,
   CostScopeDailyRow,
   CostScopePreviewResult,
@@ -52,7 +53,7 @@ function isEnoent(err: unknown): boolean {
 }
 
 export function registerCostScopeHandlers(app: AppContext): void {
-  const { ctx, getCostScope, invalidateCostScope, getQueryDimensions, getOrgAccountsPath, runQuery } = app;
+  const { ctx, getCostScope, invalidateCostScope, getQueryDimensions, getOrgAccountsPath, getAvailableColumns, runQuery } = app;
 
   ipcMain.handle('cost-scope:get-config', async (): Promise<CostScopeConfig> => {
     try {
@@ -107,6 +108,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
 
     const dimensions = await getQueryDimensions();
     const orgPath = await getOrgAccountsPath();
+    const availableColumns = await getAvailableColumns('daily');
 
     // Optimised source — positional JOIN against pre-built sidecars when
     // every parquet file in the window has a fresh sidecar for every
@@ -121,7 +123,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
     } catch {
       sidecarPlan = undefined;
     }
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, sidecarPlan, config.costMetric);
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, sidecarPlan, config.costMetric, availableColumns);
 
     // Pre-compute each rule's positive match expression once — used to
     // build the `excluded` predicate for the main aggregate query, each
@@ -313,6 +315,15 @@ export function registerCostScopeHandlers(app: AppContext): void {
       sampleRows,
       sampleTotalRowCount,
       tagColumns,
+    };
+  });
+
+  ipcMain.handle('cost-scope:get-capabilities', async (): Promise<CostScopeCapabilities> => {
+    const cols = await getAvailableColumns('daily');
+    return {
+      hasEffectiveCostColumns:
+        cols.has('reservation_effective_cost') && cols.has('savings_plan_effective_cost'),
+      hasBlendedColumn: cols.has('line_item_blended_cost'),
     };
   });
 

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -10,6 +10,7 @@ import {
   buildRuleMatchExpr,
   computePeriodsInRange,
   logger,
+  listLocalMonths,
 } from '@costgoblin/core';
 import type {
   CostScopeConfig,
@@ -18,12 +19,13 @@ import type {
   CostScopePreviewRow,
   CostScopeSampleRow,
   DimensionsConfig,
+  SidecarPlan,
 } from '@costgoblin/core';
-
-const SAMPLE_ROW_LIMIT = 500;
-import { listLocalMonths } from '@costgoblin/core';
+import { resolveSidecarPlan } from '../optimize.js';
 import type { AppContext } from './context.js';
 import { toNum } from './query-utils.js';
+
+const SAMPLE_ROW_LIMIT = 500;
 
 // Every rule's dimensionId must resolve to a known built-in or tag dimension.
 // Dangling references silently become a bogus column reference in SQL, which
@@ -105,183 +107,158 @@ export function registerCostScopeHandlers(app: AppContext): void {
 
     const dimensions = await getQueryDimensions();
     const orgPath = await getOrgAccountsPath();
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, undefined, config.costMetric);
 
-    const perRule: CostScopePreviewRow[] = [];
-
-    for (const rule of enabledRules) {
-      const matchExpr = buildRuleMatchExpr(rule, dimensions);
-      if (matchExpr === null) {
-        perRule.push({ ruleId: rule.id, excludedCost: 0, excludedRows: 0 });
-        continue;
-      }
-      // CAST both aggregates to DOUBLE so the Node binding returns plain
-      // numbers — SUM over DECIMAL (CUR 2.0) comes back as a Decimal object
-      // and COUNT(*) as a BigInt, neither of which pass a `typeof === 'number'`
-      // check. toNum handles the BigInt fallback for safety.
-      const sql = `
-        SELECT
-          CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS excluded_cost,
-          CAST(COUNT(*) AS DOUBLE) AS excluded_rows
-        FROM ${source}
-        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
-          AND (${matchExpr})
-      `.trim();
-      try {
-        const rows = await runQuery(sql);
-        const row = rows[0];
-        perRule.push({
-          ruleId: rule.id,
-          excludedCost: toNum(row?.['excluded_cost']),
-          excludedRows: toNum(row?.['excluded_rows']),
-        });
-      } catch {
-        perRule.push({ ruleId: rule.id, excludedCost: 0, excludedRows: 0 });
-      }
+    // Optimised source — positional JOIN against pre-built sidecars when
+    // every parquet file in the window has a fresh sidecar for every
+    // configured tag dim. Falls back to element_at() otherwise. The sample
+    // query is the expensive one (it materialises tag columns for up to
+    // 500 rows), so skipping element_at in favour of a column scan makes
+    // the whole preview noticeably faster for tag-heavy configs.
+    let sidecarPlan: SidecarPlan | undefined;
+    try {
+      const resolved = await resolveSidecarPlan(ctx.dataDir, 'daily', periods, dimensions.tags);
+      sidecarPlan = resolved ?? undefined;
+    } catch {
+      sidecarPlan = undefined;
     }
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, sidecarPlan, config.costMetric);
 
-    let combined = { excludedCost: 0, excludedRows: 0 };
-    if (enabledRules.length > 0) {
-      const matchExprs = enabledRules
-        .map(r => buildRuleMatchExpr(r, dimensions))
-        .filter((e): e is string => e !== null);
-
-      if (matchExprs.length > 0) {
-        const combinedExpr = matchExprs.map(e => `(${e})`).join(' OR ');
-        const combinedSql = `
-          SELECT
-            CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS excluded_cost,
-            CAST(COUNT(*) AS DOUBLE) AS excluded_rows
-          FROM ${source}
-          WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
-            AND (${combinedExpr})
-        `.trim();
-        try {
-          const rows = await runQuery(combinedSql);
-          const row = rows[0];
-          combined = {
-            excludedCost: toNum(row?.['excluded_cost']),
-            excludedRows: toNum(row?.['excluded_rows']),
-          };
-        } catch {
-          // empty data dir — return zeros
-        }
-      }
-    }
-
-    // Build the `excluded` predicate (OR of every enabled rule's match expr)
-    // for the daily breakdown + totals. If no rules or no expressible rules,
-    // `excludedPredicate` is the literal `FALSE` — nothing excluded — which
-    // keeps the SQL uniform and lets the kept/excluded split still work.
-    const matchExprs = enabledRules
-      .map(r => buildRuleMatchExpr(r, dimensions))
-      .filter((e): e is string => e !== null);
-    const excludedPredicate = matchExprs.length > 0
-      ? matchExprs.map(e => `(${e})`).join(' OR ')
+    // Pre-compute each rule's positive match expression once — used to
+    // build the `excluded` predicate for the main aggregate query, each
+    // per-rule tally, the daily breakdown, and the sample row flag. Rules
+    // whose expression is null (all conditions empty) are treated as
+    // no-ops and don't appear in the SQL at all.
+    const ruleExprs: { readonly rule: typeof enabledRules[number]; readonly expr: string | null }[] =
+      enabledRules.map(rule => ({ rule, expr: buildRuleMatchExpr(rule, dimensions) }));
+    const liveExprs = ruleExprs.filter(e => e.expr !== null).map(e => e.expr as string);
+    const excludedPredicate = liveExprs.length > 0
+      ? liveExprs.map(e => `(${e})`).join(' OR ')
       : 'FALSE';
 
-    let unscopedTotalCost = 0;
-    let scopedTotalCost = 0;
-    let dailyTotals: readonly CostScopeDailyRow[] = [];
-    try {
-      const totalsSql = `
-        SELECT
-          CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS unscoped_total,
-          CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 0 ELSE cost END), 0) AS DOUBLE) AS scoped_total
-        FROM ${source}
-        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
-      `.trim();
-      const totalsRows = await runQuery(totalsSql);
-      const t = totalsRows[0];
-      unscopedTotalCost = toNum(t?.['unscoped_total']);
-      scopedTotalCost = toNum(t?.['scoped_total']);
-
-      const dailySql = `
-        SELECT
-          usage_date::VARCHAR AS date,
-          CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 0 ELSE cost END), 0) AS DOUBLE) AS kept_cost,
-          CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN cost ELSE 0 END), 0) AS DOUBLE) AS excluded_cost
-        FROM ${source}
-        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
-        GROUP BY usage_date
-        ORDER BY usage_date
-      `.trim();
-      const dailyRows = await runQuery(dailySql);
-      dailyTotals = dailyRows.map(r => {
-        const raw = r['date'];
-        const date = typeof raw === 'string' ? raw : raw instanceof Date ? raw.toISOString().slice(0, 10) : '';
-        return {
-          date,
-          keptCost: toNum(r['kept_cost']),
-          excludedCost: toNum(r['excluded_cost']),
-        };
-      });
-    } catch (err) {
-      // Data-dir transient error — fall through with zeros. Per-rule totals
-      // were computed in their own try-blocks so they stand on their own.
-      logger.warn(`cost-scope: daily/totals query failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-
-    // Top-|cost| raw line items for the inspection table. One column per
-    // configured tag dim so the UI can render arbitrary tag columns without
-    // bespoke per-tag wiring. Cap at SAMPLE_ROW_LIMIT — the payload is
-    // transient, but the IPC boundary should stay bounded.
     const tagColumns = dimensions.tags.map(t => ({
       id: `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`,
       label: t.label,
     }));
+
+    // === Query 1: every aggregate in one scan ===
+    // Merges what used to be 5 separate queries (per-rule + combined +
+    // unscoped total + scoped total + total row count) into a single pass.
+    // DuckDB evaluates each SUM(CASE...) during the same scan, so the cost
+    // is roughly one full scan regardless of how many rules are enabled.
+    const ruleAggSelects = ruleExprs.map((entry, i) => {
+      if (entry.expr === null) return `CAST(0 AS DOUBLE) AS rule_${String(i)}_cost,
+          CAST(0 AS DOUBLE) AS rule_${String(i)}_rows`;
+      return `CAST(COALESCE(SUM(CASE WHEN (${entry.expr}) THEN cost ELSE 0 END), 0) AS DOUBLE) AS rule_${String(i)}_cost,
+          CAST(COALESCE(SUM(CASE WHEN (${entry.expr}) THEN 1 ELSE 0 END), 0) AS DOUBLE) AS rule_${String(i)}_rows`;
+    }).join(',\n          ');
+
+    const aggSql = `
+      SELECT
+        CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS unscoped_total,
+        CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 0 ELSE cost END), 0) AS DOUBLE) AS scoped_total,
+        CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN cost ELSE 0 END), 0) AS DOUBLE) AS combined_excluded_cost,
+        CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END), 0) AS DOUBLE) AS combined_excluded_rows,
+        CAST(COUNT(*) AS DOUBLE) AS total_rows${ruleAggSelects.length > 0 ? `,\n          ${ruleAggSelects}` : ''}
+      FROM ${source}
+      WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+    `.trim();
+
+    // === Query 2: daily breakdown (separate because GROUP BY) ===
+    const dailySql = `
+      SELECT
+        usage_date::VARCHAR AS date,
+        CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN 0 ELSE cost END), 0) AS DOUBLE) AS kept_cost,
+        CAST(COALESCE(SUM(CASE WHEN (${excludedPredicate}) THEN cost ELSE 0 END), 0) AS DOUBLE) AS excluded_cost
+      FROM ${source}
+      WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+      GROUP BY usage_date
+      ORDER BY usage_date
+    `.trim();
+
+    // === Query 3: top-|cost| sample rows (separate because ORDER BY LIMIT) ===
+    // CAST numerics to DOUBLE inside the CTE so DECIMAL-typed CUR columns
+    // come back as plain numbers — bare source.cost would return a
+    // DuckDBDecimalValue object and toNum would yield 0 for every row.
     const tagSelectSql = tagColumns.length > 0
       ? tagColumns.map(t => `COALESCE(${t.id}, '') AS ${t.id}`).join(',\n          ')
       : null;
-
-    let sampleRows: readonly CostScopeSampleRow[] = [];
-    let sampleTotalRowCount = 0;
-    try {
-      const countRows = await runQuery(`
-        SELECT CAST(COUNT(*) AS DOUBLE) AS n
-        FROM ${source}
-        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
-      `.trim());
-      sampleTotalRowCount = toNum(countRows[0]?.['n']);
-
-      // CAST numerics to DOUBLE so DECIMAL-typed CUR columns come back as
-      // plain numbers — bare references to source.cost would return a
-      // DuckDBDecimalValue object and toNum would yield 0 for every row,
-      // producing a table full of blank numbers. Columns are projected out
-      // of a CTE so the outer ORDER BY ABS(cost) unambiguously references
-      // the source's cost column (not a shadowed output alias).
-      const sampleSql = `
-        WITH scoped AS (
-          SELECT
-            usage_date,
-            account_id,
-            account_name,
-            region,
-            service,
-            service_family,
-            line_item_type,
-            operation,
-            usage_type,
-            description,
-            resource_id,
-            CAST(usage_amount AS DOUBLE) AS usage_amount,
-            CAST(cost AS DOUBLE) AS cost,
-            CAST(list_cost AS DOUBLE) AS list_cost,
-            CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END AS excluded${tagSelectSql === null ? '' : `,\n            ${tagSelectSql}`}
-          FROM ${source}
-          WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
-        )
+    const sampleSql = `
+      WITH scoped AS (
         SELECT
-          usage_date::VARCHAR AS usage_date,
+          usage_date,
           account_id, account_name, region, service, service_family,
           line_item_type, operation, usage_type, description, resource_id,
-          usage_amount, cost, list_cost, excluded${tagSelectSql === null ? '' : ',\n          ' + tagColumns.map(t => t.id).join(', ')}
-        FROM scoped
-        ORDER BY ABS(cost) DESC
-        LIMIT ${String(SAMPLE_ROW_LIMIT)}
-      `.trim();
-      const rows = await runQuery(sampleSql);
-      sampleRows = rows.map(r => {
+          CAST(usage_amount AS DOUBLE) AS usage_amount,
+          CAST(cost AS DOUBLE) AS cost,
+          CAST(list_cost AS DOUBLE) AS list_cost,
+          CASE WHEN (${excludedPredicate}) THEN 1 ELSE 0 END AS excluded${tagSelectSql === null ? '' : `,\n          ${tagSelectSql}`}
+        FROM ${source}
+        WHERE usage_date BETWEEN '${startStr}' AND '${endStr}'
+      )
+      SELECT
+        usage_date::VARCHAR AS usage_date,
+        account_id, account_name, region, service, service_family,
+        line_item_type, operation, usage_type, description, resource_id,
+        usage_amount, cost, list_cost, excluded${tagSelectSql === null ? '' : ',\n        ' + tagColumns.map(t => t.id).join(', ')}
+      FROM scoped
+      ORDER BY ABS(cost) DESC
+      LIMIT ${String(SAMPLE_ROW_LIMIT)}
+    `.trim();
+
+    // Run all three in parallel. The DuckDB worker pool (default size 4)
+    // lets independent queries execute concurrently. `allSettled` so one
+    // failing query doesn't drop the other two's results.
+    const [aggResult, dailyResult, sampleResult] = await Promise.allSettled([
+      runQuery(aggSql),
+      runQuery(dailySql),
+      runQuery(sampleSql),
+    ]);
+
+    // Agg → totals + per-rule + combined
+    let unscopedTotalCost = 0;
+    let scopedTotalCost = 0;
+    let sampleTotalRowCount = 0;
+    let combined = { excludedCost: 0, excludedRows: 0 };
+    const perRule: CostScopePreviewRow[] = ruleExprs.map(e => ({
+      ruleId: e.rule.id, excludedCost: 0, excludedRows: 0,
+    }));
+    if (aggResult.status === 'fulfilled') {
+      const row = aggResult.value[0];
+      unscopedTotalCost = toNum(row?.['unscoped_total']);
+      scopedTotalCost = toNum(row?.['scoped_total']);
+      sampleTotalRowCount = toNum(row?.['total_rows']);
+      combined = {
+        excludedCost: toNum(row?.['combined_excluded_cost']),
+        excludedRows: toNum(row?.['combined_excluded_rows']),
+      };
+      for (let i = 0; i < ruleExprs.length; i++) {
+        const entry = ruleExprs[i];
+        const prev = perRule[i];
+        if (entry === undefined || prev === undefined) continue;
+        perRule[i] = {
+          ruleId: entry.rule.id,
+          excludedCost: toNum(row?.[`rule_${String(i)}_cost`]),
+          excludedRows: toNum(row?.[`rule_${String(i)}_rows`]),
+        };
+      }
+    } else {
+      logger.warn(`cost-scope: agg query failed: ${aggResult.reason instanceof Error ? aggResult.reason.message : String(aggResult.reason)}`);
+    }
+
+    let dailyTotals: readonly CostScopeDailyRow[] = [];
+    if (dailyResult.status === 'fulfilled') {
+      dailyTotals = dailyResult.value.map(r => {
+        const raw = r['date'];
+        const date = typeof raw === 'string' ? raw : raw instanceof Date ? raw.toISOString().slice(0, 10) : '';
+        return { date, keptCost: toNum(r['kept_cost']), excludedCost: toNum(r['excluded_cost']) };
+      });
+    } else {
+      logger.warn(`cost-scope: daily query failed: ${dailyResult.reason instanceof Error ? dailyResult.reason.message : String(dailyResult.reason)}`);
+    }
+
+    let sampleRows: readonly CostScopeSampleRow[] = [];
+    if (sampleResult.status === 'fulfilled') {
+      sampleRows = sampleResult.value.map(r => {
         const tags: Record<string, string> = {};
         for (const t of tagColumns) {
           const v = r[t.id];
@@ -310,9 +287,8 @@ export function registerCostScopeHandlers(app: AppContext): void {
           tags,
         };
       });
-    } catch (err) {
-      logger.warn(`cost-scope: sample-rows query failed: ${err instanceof Error ? err.message : String(err)}`);
-      // Sample is a best-effort inspection; fall through with empty rows.
+    } else {
+      logger.warn(`cost-scope: sample query failed: ${sampleResult.reason instanceof Error ? sampleResult.reason.message : String(sampleResult.reason)}`);
     }
 
     return {

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -8,6 +8,7 @@ import {
   buildEntityDetailQuery,
   buildSource,
   buildAliasSqlCase,
+  buildRuleMatchExpr,
   computePeriodsInRange,
   listLocalMonths,
   logger,
@@ -341,10 +342,18 @@ export function registerQueryHandlers(app: AppContext): void {
     };
   });
 
-  ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, string>, dateRange?: { start: string; end: string }): Promise<{ value: string; label: string; count: number }[]> => {
+  ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, string>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
+    // Honour the cost-scope exclusions here too — a user who has
+    // excluded Tax / RI purchases doesn't want those values showing up
+    // in filter dropdowns either. The Cost Scope editor sets
+    // bypassCostScope=true so its rule-condition autocomplete still
+    // sees every available value when composing new rules.
+    const costScope = opts?.bypassCostScope === true
+      ? undefined
+      : await getCostScope().catch(() => undefined);
 
     const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
     const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);
@@ -386,6 +395,18 @@ export function registerQueryHandlers(app: AppContext): void {
 
     if (dateRange !== undefined) {
       whereClauses.push(`usage_date BETWEEN '${dateRange.start}' AND '${dateRange.end}'`);
+    }
+
+    if (costScope !== undefined) {
+      // NOT (rule_match) per enabled rule — same shape buildExclusionClauses
+      // emits for the main query builders. Apply the dim's reverse map
+      // (account collapse) when the condition targets account_id.
+      for (const rule of costScope.rules) {
+        if (!rule.enabled) continue;
+        const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+        if (matchExpr === null) continue;
+        whereClauses.push(`NOT (${matchExpr})`);
+      }
     }
 
     const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -52,7 +52,7 @@ import {
 } from './query-utils.js';
 
 export function registerQueryHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, runQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, getAvailableColumns, runQuery } = app;
 
   // Intersect the query's date range with the months actually on disk so
   // buildSource only globs directories that exist — DuckDB errors on empty
@@ -100,9 +100,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+    const availableColumns = await getAvailableColumns(tier);
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan, accountReverseMap, costScope);
+    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan, accountReverseMap, costScope, availableColumns);
     logger.info('query:costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -135,9 +136,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+    const availableColumns = await getAvailableColumns(tier);
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
+    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope, availableColumns);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -191,9 +193,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     const costScope = await getCostScope().catch(() => undefined);
+    const availableColumns = await getAvailableColumns('daily');
     const { available, plan, empty } = await planQuery('daily', params.dateRange);
     if (empty) return { increases: [], savings: [], totalIncrease: asDollars(0), totalSavings: asDollars(0) };
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
+    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope, availableColumns);
     logger.info('query:trends', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -214,6 +217,7 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
     const costScope = await getCostScope().catch(() => undefined);
+    const availableColumns = await getAvailableColumns('daily');
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
     const { available, plan, empty } = await planQuery('daily', params.dateRange);
@@ -228,8 +232,8 @@ export function registerQueryHandlers(app: AppContext): void {
         nonResourceRows: [],
       };
     }
-    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
-    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
+    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope, availableColumns);
+    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope, availableColumns);
     const [resourceRows, nonResourceRows] = await Promise.all([
       runQuery(resourceSql),
       runQuery(nonResourceSql),
@@ -315,6 +319,7 @@ export function registerQueryHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+    const availableColumns = await getAvailableColumns(tier);
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) {
       return {
@@ -328,7 +333,7 @@ export function registerQueryHandlers(app: AppContext): void {
         bySubEntity: [],
       };
     }
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
+    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope, availableColumns);
     logger.info('query:entity-detail', { entity: params.entity });
 
     const rows = await runQuery(sql);
@@ -413,7 +418,12 @@ export function registerQueryHandlers(app: AppContext): void {
 
     const orgPath = await getOrgAccountsPath();
     const periods = dateRange === undefined ? undefined : computePeriodsInRange(dateRange);
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods);
+    const availableColumns = await getAvailableColumns('daily');
+    // filter-values doesn't need a specific metric — just needs source
+    // with the fewest column constraints. Pass 'unblended' (always
+    // present) plus the probed column set so the source query doesn't
+    // reference missing columns.
+    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, undefined, 'unblended', availableColumns);
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
       FROM ${source}

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -51,7 +51,7 @@ import {
 } from './query-utils.js';
 
 export function registerQueryHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, runQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, runQuery } = app;
 
   // Intersect the query's date range with the months actually on disk so
   // buildSource only globs directories that exist — DuckDB errors on empty
@@ -97,10 +97,11 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
+    const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan, accountReverseMap);
+    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, plan, accountReverseMap, costScope);
     logger.info('query:costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -131,10 +132,11 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
+    const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
+    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -187,9 +189,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
+    const costScope = await getCostScope().catch(() => undefined);
     const { available, plan, empty } = await planQuery('daily', params.dateRange);
     if (empty) return { increases: [], savings: [], totalIncrease: asDollars(0), totalSavings: asDollars(0) };
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
+    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
     logger.info('query:trends', { groupBy: params.groupBy });
 
     const rows = await runQuery(sql);
@@ -209,6 +212,7 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
+    const costScope = await getCostScope().catch(() => undefined);
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
 
     const { available, plan, empty } = await planQuery('daily', params.dateRange);
@@ -223,8 +227,8 @@ export function registerQueryHandlers(app: AppContext): void {
         nonResourceRows: [],
       };
     }
-    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
-    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
+    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
+    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
     const [resourceRows, nonResourceRows] = await Promise.all([
       runQuery(resourceSql),
       runQuery(nonResourceSql),
@@ -308,6 +312,7 @@ export function registerQueryHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
     const orgPath = await getOrgAccountsPath();
+    const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const { available, plan, empty } = await planQuery(tier, params.dateRange);
     if (empty) {
@@ -322,7 +327,7 @@ export function registerQueryHandlers(app: AppContext): void {
         bySubEntity: [],
       };
     }
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap);
+    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, plan, accountReverseMap, costScope);
     logger.info('query:entity-detail', { entity: params.entity });
 
     const rows = await runQuery(sql);

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -10,6 +10,7 @@ import { registerUIHandlers } from './handlers/ui.js';
 import { registerOrgHandlers } from './handlers/org.js';
 import { registerAutoSyncHandlers } from './handlers/auto-sync.js';
 import { registerViewsHandlers } from './handlers/views.js';
+import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { enqueueStartupMigration } from './startup-migrate.js';
 
 export type { IpcContext };
@@ -26,6 +27,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   registerOrgHandlers(app);
   registerAutoSyncHandlers(app);
   registerViewsHandlers(app);
+  registerCostScopeHandlers(app);
 
   // Kick off background optimization for any raw files that aren't yet
   // sorted + sidecar'd. Idempotent — skips already-optimized files. Runs in

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -69,6 +69,7 @@ async function createWindow(db: DuckDBClient): Promise<void> {
     dimensionsPath: resolveConfigPath(configBase, 'dimensions'),
     orgTreePath: resolveConfigPath(configBase, 'org-tree'),
     viewsPath: resolveConfigPath(configBase, 'views'),
+    costScopePath: resolveConfigPath(configBase, 'cost-scope'),
     dataDir,
   });
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -68,8 +68,8 @@ const api: CostApi = {
   getOrgTree(): Promise<OrgNode[]> {
     return invoke<OrgNode[]>('config:org-tree');
   },
-  getFilterValues(dimensionId: string, filters: Record<string, string>, dateRange?: { start: string; end: string }): Promise<{ value: string; label: string; count: number }[]> {
-    return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange);
+  getFilterValues(dimensionId: string, filters: Record<string, string>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> {
+    return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange, opts);
   },
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult> {
     return invoke<DataInventoryResult>('data:inventory', tier);

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -29,6 +29,7 @@ import type {
   FileActivityEvent,
   OptimizeStatus,
   ViewsConfig,
+  CostScopeCapabilities,
   CostScopeConfig,
   CostScopePreviewResult,
 } from '@costgoblin/core';
@@ -199,6 +200,9 @@ const api: CostApi = {
   },
   previewCostScope(config: CostScopeConfig): Promise<CostScopePreviewResult> {
     return invoke<CostScopePreviewResult>('cost-scope:preview', config);
+  },
+  getCostScopeCapabilities(): Promise<CostScopeCapabilities> {
+    return invoke<CostScopeCapabilities>('cost-scope:get-capabilities');
   },
   revealCostScopeFolder(): Promise<void> {
     return invoke<undefined>('cost-scope:reveal-folder').then(() => undefined);

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -29,6 +29,8 @@ import type {
   FileActivityEvent,
   OptimizeStatus,
   ViewsConfig,
+  CostScopeConfig,
+  CostScopePreviewResult,
 } from '@costgoblin/core';
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
@@ -188,6 +190,18 @@ const api: CostApi = {
   },
   revealViewsFolder(): Promise<void> {
     return invoke<undefined>('views:reveal-folder').then(() => undefined);
+  },
+  getCostScope(): Promise<CostScopeConfig> {
+    return invoke<CostScopeConfig>('cost-scope:get-config');
+  },
+  saveCostScope(config: CostScopeConfig): Promise<void> {
+    return invoke<undefined>('cost-scope:save-config', config).then(() => undefined);
+  },
+  previewCostScope(config: CostScopeConfig): Promise<CostScopePreviewResult> {
+    return invoke<CostScopePreviewResult>('cost-scope:preview', config);
+  },
+  revealCostScopeFolder(): Promise<void> {
+    return invoke<undefined>('cost-scope:reveal-folder').then(() => undefined);
   },
 };
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostApiProvider, SetupWizard, ErrorBoundary, SyncActivityIndicator, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, CostApiProvider, SetupWizard, ErrorBoundary, SyncActivityIndicator, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 
 function getApi(): CostApi {
@@ -13,6 +13,7 @@ type View =
   | { page: 'missing-tags' }
   | { page: 'savings' }
   | { page: 'dimensions' }
+  | { page: 'cost-scope' }
   | { page: 'views-editor' }
   | { page: 'sync' }
   | { page: 'entity-detail'; entity: string; dimension: string };
@@ -24,6 +25,7 @@ const STATIC_LEFT_NAV: { id: string; label: string }[] = [
 ];
 
 const RIGHT_NAV: { id: string; label: string }[] = [
+  { id: 'cost-scope', label: 'Cost Scope' },
   { id: 'dimensions', label: 'Dimensions' },
   { id: 'views-editor', label: 'Views' },
   { id: 'sync', label: 'Sync' },
@@ -134,6 +136,7 @@ export function App(): React.JSX.Element {
       case 'trends': setView({ page: 'trends' }); break;
       case 'missing-tags': setView({ page: 'missing-tags' }); break;
       case 'savings': setView({ page: 'savings' }); break;
+      case 'cost-scope': setView({ page: 'cost-scope' }); break;
       case 'dimensions': setView({ page: 'dimensions' }); break;
       case 'views-editor': setView({ page: 'views-editor' }); break;
       case 'sync': setView({ page: 'sync' }); break;
@@ -184,6 +187,7 @@ export function App(): React.JSX.Element {
     if (view.page === 'trends') return 'trends';
     if (view.page === 'missing-tags') return 'missing-tags';
     if (view.page === 'savings') return 'savings';
+    if (view.page === 'cost-scope') return 'cost-scope';
     if (view.page === 'dimensions') return 'dimensions';
     if (view.page === 'views-editor') return 'views-editor';
     if (view.page === 'sync') return 'sync';
@@ -265,6 +269,7 @@ export function App(): React.JSX.Element {
         {view.page === 'trends' && <CostTrends onEntityClick={handleEntityClick} />}
         {view.page === 'missing-tags' && <MissingTags />}
         {view.page === 'savings' && <Savings />}
+        {view.page === 'cost-scope' && <CostScopeView />}
         {view.page === 'dimensions' && <DimensionsView />}
         {view.page === 'views-editor' && <ViewsEditor onConfigPersisted={setViewsConfig} />}
         <div className={view.page === 'sync' ? '' : 'hidden'}>

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -21,6 +21,7 @@ import type {
   CostGoblinConfig,
   DimensionsConfig,
   ViewsConfig,
+  CostScopeCapabilities,
   CostScopeConfig,
   CostScopePreviewResult,
 } from '@costgoblin/core/browser';
@@ -282,6 +283,9 @@ export class MockCostApi implements CostApi {
       sampleTotalRowCount: 0,
       tagColumns: [],
     });
+  }
+  getCostScopeCapabilities(): Promise<CostScopeCapabilities> {
+    return Promise.resolve({ hasEffectiveCostColumns: true, hasBlendedColumn: true });
   }
   revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -275,6 +275,9 @@ export class MockCostApi implements CostApi {
       endDate: '2026-04-18',
       perRule: [],
       combined: { excludedCost: 0, excludedRows: 0 },
+      unscopedTotalCost: 0,
+      scopedTotalCost: 0,
+      dailyTotals: [],
     });
   }
   revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -21,7 +21,10 @@ import type {
   CostGoblinConfig,
   DimensionsConfig,
   ViewsConfig,
+  CostScopeConfig,
+  CostScopePreviewResult,
 } from '@costgoblin/core/browser';
+import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
 
 const costResult: CostResult = {
   rows: [
@@ -263,6 +266,18 @@ export class MockCostApi implements CostApi {
   saveViewsConfig(): Promise<void> { return Promise.resolve(); }
   resetViewsConfig(): Promise<ViewsConfig> { return Promise.resolve(MOCK_VIEWS_CONFIG); }
   revealViewsFolder(): Promise<void> { return Promise.resolve(); }
+  getCostScope(): Promise<CostScopeConfig> { return Promise.resolve(DEFAULT_COST_SCOPE); }
+  saveCostScope(): Promise<void> { return Promise.resolve(); }
+  previewCostScope(): Promise<CostScopePreviewResult> {
+    return Promise.resolve({
+      windowDays: 30,
+      startDate: '2026-03-20',
+      endDate: '2026-04-18',
+      perRule: [],
+      combined: { excludedCost: 0, excludedRows: 0 },
+    });
+  }
+  revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }
 }
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -278,6 +278,9 @@ export class MockCostApi implements CostApi {
       unscopedTotalCost: 0,
       scopedTotalCost: 0,
       dailyTotals: [],
+      sampleRows: [],
+      sampleTotalRowCount: 0,
+      tagColumns: [],
     });
   }
   revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -285,7 +285,7 @@ export class MockCostApi implements CostApi {
     });
   }
   getCostScopeCapabilities(): Promise<CostScopeCapabilities> {
-    return Promise.resolve({ hasEffectiveCostColumns: true, hasBlendedColumn: true });
+    return Promise.resolve({ hasEffectiveCostColumns: true, hasBlendedColumn: true, hasNetColumns: true });
   }
   revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,6 +50,7 @@ export { Savings } from './views/savings.js';
 export { EntityDetail } from './views/entity-detail.js';
 export { DataManagement } from './views/data-management.js';
 export { DimensionsView } from './views/dimensions.js';
+export { CostScopeView } from './views/cost-scope.js';
 export { SetupWizard } from './views/setup-wizard.js';
 
 export { getDimensionId, isTagDimension, isEnvironmentDimension, isOwnerDimension, isProductDimension } from './lib/dimensions.js';

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -1,0 +1,487 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type {
+  CostMetric,
+  CostScopeConfig,
+  CostScopePreviewResult,
+  ExclusionCondition,
+  ExclusionRule,
+  Dimension,
+} from '@costgoblin/core/browser';
+import { COST_METRICS, DEFAULT_COST_SCOPE, asDimensionId } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { formatDollars } from '../components/format.js';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
+import { Button } from '../components/ui/button.js';
+
+const METRIC_LABELS: Record<CostMetric, { label: string; description: string }> = {
+  unblended: { label: 'Unblended', description: 'What you actually paid — the default for most analyses.' },
+  blended: { label: 'Blended', description: 'Org-averaged per-hour rate, smoothing RI/SP discounts across accounts.' },
+  list: { label: 'List price', description: 'On-demand list price before any discounts — useful for "what-if" comparisons.' },
+};
+
+function formatExcluded(cost: number, rows: number): string {
+  if (rows === 0 && cost === 0) return 'no data';
+  return `${formatDollars(cost)} excluded · ${String(rows)} rows`;
+}
+
+interface PreviewState {
+  result: CostScopePreviewResult | null;
+  loading: boolean;
+}
+
+function dimIdFor(d: Dimension): string {
+  return 'name' in d ? String(d.name) : `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+}
+
+interface ConditionRowProps {
+  condition: ExclusionCondition;
+  dimensions: Dimension[];
+  suggestions: readonly string[];
+  onUpdate: (next: ExclusionCondition) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+  invalid: boolean;
+}
+
+function ConditionRow({ condition, dimensions, suggestions, onUpdate, onRemove, canRemove, invalid }: ConditionRowProps) {
+  const [valuesInput, setValuesInput] = useState(condition.values.join(', '));
+
+  // Sync local input state when the condition prop changes externally (e.g.
+  // a sibling condition was removed and array-index keys make React hand this
+  // component a different condition at the same slot). Without this, the text
+  // field shows stale values and the next blur would overwrite the underlying
+  // condition with the wrong data.
+  useEffect(() => {
+    setValuesInput(condition.values.join(', '));
+  }, [condition.values]);
+
+  function handleDimChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const parsed = e.target.value.trim();
+    if (parsed.length === 0) return;
+    onUpdate({ dimensionId: asDimensionId(parsed), values: condition.values });
+  }
+
+  function commitValues() {
+    const values = valuesInput.split(',').map(v => v.trim()).filter(v => v.length > 0);
+    // Empty is valid local state (draft in-progress) — parent decides how to
+    // treat it (disables save, skips preview). We still push the empty array
+    // so the parent sees the latest user intent.
+    onUpdate({ dimensionId: condition.dimensionId, values });
+  }
+
+  const enabledDims = dimensions.filter(d => d.enabled !== false);
+  const currentDimId = String(condition.dimensionId);
+  const inputBorder = invalid ? 'border-negative' : 'border-border';
+
+  return (
+    <div className="flex items-start gap-2">
+      <select
+        className="rounded border border-border bg-bg-secondary text-text-primary text-sm px-2 py-1 min-w-36"
+        value={currentDimId}
+        onChange={handleDimChange}
+      >
+        {currentDimId.length === 0 && <option value="">— pick dimension —</option>}
+        {enabledDims.map(d => {
+          const id = dimIdFor(d);
+          return <option key={id} value={id}>{d.label}</option>;
+        })}
+      </select>
+      <div className="flex-1 flex flex-col gap-1">
+        <input
+          className={`rounded border ${inputBorder} bg-bg-secondary text-text-primary text-sm px-2 py-1 w-full`}
+          placeholder="Values (comma-separated)"
+          value={valuesInput}
+          onChange={e => { setValuesInput(e.target.value); }}
+          onBlur={commitValues}
+          list={`suggestions-${currentDimId}`}
+        />
+        {suggestions.length > 0 && (
+          <datalist id={`suggestions-${currentDimId}`}>
+            {suggestions.slice(0, 50).map(s => <option key={s} value={s} />)}
+          </datalist>
+        )}
+      </div>
+      {canRemove && (
+        <button
+          type="button"
+          className="text-text-muted hover:text-negative text-sm px-1 py-1 rounded shrink-0"
+          onClick={onRemove}
+          title="Remove condition"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface RuleCardProps {
+  rule: ExclusionRule;
+  preview: CostScopePreviewRow | undefined;
+  dimensions: Dimension[];
+  suggestionsByDim: ReadonlyMap<string, readonly string[]>;
+  onUpdate: (next: ExclusionRule) => void;
+  onDelete: () => void;
+}
+
+interface CostScopePreviewRow {
+  ruleId: string;
+  excludedCost: number;
+  excludedRows: number;
+}
+
+function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDelete }: RuleCardProps) {
+  function setEnabled(enabled: boolean) {
+    onUpdate({ ...rule, enabled });
+  }
+
+  function setName(name: string) {
+    onUpdate({ ...rule, name });
+  }
+
+  function updateCondition(index: number, next: ExclusionCondition) {
+    const conditions = rule.conditions.map((c, i) => i === index ? next : c);
+    onUpdate({ ...rule, conditions });
+  }
+
+  function removeCondition(index: number) {
+    const conditions = rule.conditions.filter((_, i) => i !== index);
+    if (conditions.length === 0) return;
+    onUpdate({ ...rule, conditions });
+  }
+
+  function addCondition() {
+    const firstDim = dimensions.find(d => d.enabled !== false);
+    const dimId = firstDim !== undefined ? dimIdFor(firstDim) : 'service';
+    onUpdate({
+      ...rule,
+      conditions: [...rule.conditions, { dimensionId: asDimensionId(dimId), values: [] }],
+    });
+  }
+
+  const previewText = preview !== undefined
+    ? formatExcluded(preview.excludedCost, preview.excludedRows)
+    : '—';
+
+  return (
+    <Card className={`transition-opacity ${rule.enabled ? '' : 'opacity-60'}`}>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={rule.enabled}
+            onClick={() => { setEnabled(!rule.enabled); }}
+            className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${rule.enabled ? 'bg-accent' : 'bg-bg-tertiary border border-border'}`}
+          >
+            <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${rule.enabled ? 'translate-x-4' : 'translate-x-0.5'}`} />
+          </button>
+          <input
+            className="flex-1 bg-transparent font-semibold text-text-primary text-sm focus:outline-none border-b border-transparent focus:border-border"
+            value={rule.name}
+            onChange={e => { setName(e.target.value); }}
+            placeholder="Rule name"
+          />
+          <span className="text-xs text-text-muted shrink-0">{previewText}</span>
+          {!rule.builtIn && (
+            <button
+              type="button"
+              className="text-text-muted hover:text-negative text-sm px-1 rounded shrink-0"
+              onClick={onDelete}
+              title="Delete rule"
+            >
+              Delete
+            </button>
+          )}
+          {rule.builtIn && (
+            <span className="text-xs text-text-muted shrink-0 px-1" title="Built-in rules can be disabled but not deleted">
+              built-in
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {rule.description !== undefined && rule.description.length > 0 && (
+          <p className="text-xs text-text-muted">{rule.description}</p>
+        )}
+        <div className="text-xs font-medium text-text-secondary mb-1">Conditions (AND)</div>
+        <div className="space-y-2">
+          {rule.conditions.map((cond, i) => (
+            <ConditionRow
+              key={i}
+              condition={cond}
+              dimensions={dimensions}
+              suggestions={suggestionsByDim.get(String(cond.dimensionId)) ?? []}
+              onUpdate={next => { updateCondition(i, next); }}
+              onRemove={() => { removeCondition(i); }}
+              canRemove={rule.conditions.length > 1}
+              invalid={rule.enabled && cond.values.length === 0}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          className="text-xs text-text-muted hover:text-text-primary mt-1"
+          onClick={addCondition}
+        >
+          + Add condition
+        </button>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** A draft is saveable iff every enabled rule has at least one condition and
+ *  every condition has at least one value. Disabled rules can hold empty
+ *  conditions without blocking saves — they're effectively draft scaffolding.
+ *  The validator on the main-process side enforces the same shape, so we
+ *  mirror it here to surface the check as UI affordance rather than a silent
+ *  IPC rejection. */
+function describeDraftError(draft: CostScopeConfig): string | null {
+  for (const rule of draft.rules) {
+    if (!rule.enabled) continue;
+    if (rule.conditions.length === 0) {
+      return `Rule '${rule.name}' has no conditions.`;
+    }
+    for (const cond of rule.conditions) {
+      if (cond.values.length === 0) {
+        return `Rule '${rule.name}' has a condition with no values — fill in the values field or disable the rule.`;
+      }
+    }
+  }
+  return null;
+}
+
+export function CostScopeView(): React.JSX.Element {
+  const api = useCostApi();
+  const [draft, setDraft] = useState(DEFAULT_COST_SCOPE);
+  const [saved, setSaved] = useState(DEFAULT_COST_SCOPE);
+  const [dimensions, setDimensions] = useState<Dimension[]>([]);
+  const [preview, setPreview] = useState<PreviewState>({ result: null, loading: false });
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [suggestionsByDim, setSuggestionsByDim] = useState(new Map<string, readonly string[]>());
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(saved);
+  const draftError = describeDraftError(draft);
+  const canSave = dirty && draftError === null && !saving;
+
+  useEffect(() => {
+    void api.getCostScope().then(cfg => {
+      setDraft(cfg);
+      setSaved(cfg);
+    });
+    void api.getDimensions().then(setDimensions);
+  }, [api]);
+
+  // Pre-fetch filter-value suggestions once per enabled dim so every
+  // ConditionRow's datalist shares a single IPC round-trip. Without this,
+  // every condition row fires its own identical fetch on mount.
+  useEffect(() => {
+    let cancelled = false;
+    async function run(): Promise<void> {
+      const enabled = dimensions.filter(d => d.enabled !== false);
+      const next = new Map<string, readonly string[]>();
+      await Promise.all(enabled.map(async d => {
+        const id = dimIdFor(d);
+        try {
+          const vals = await api.getFilterValues(id, {});
+          next.set(id, vals.map(v => v.value));
+        } catch {
+          next.set(id, []);
+        }
+      }));
+      if (!cancelled) setSuggestionsByDim(next);
+    }
+    if (dimensions.length > 0) void run();
+    return () => { cancelled = true; };
+  }, [api, dimensions]);
+
+  const refreshPreview = useCallback((config: CostScopeConfig) => {
+    setPreview(p => ({ ...p, loading: true }));
+    void api.previewCostScope(config)
+      .then(result => { setPreview({ result, loading: false }); })
+      .catch(() => { setPreview({ result: null, loading: false }); });
+  }, [api]);
+
+  useEffect(() => {
+    clearTimeout(debounceRef.current);
+    // Skip preview for drafts the main-process validator would reject — those
+    // IPC calls always fail and would blank the preview, making the user
+    // think the numbers dropped to zero while they were mid-edit.
+    if (describeDraftError(draft) !== null) {
+      setPreview({ result: null, loading: false });
+      return;
+    }
+    debounceRef.current = setTimeout(() => { refreshPreview(draft); }, 300);
+    return () => { clearTimeout(debounceRef.current); };
+  }, [draft, refreshPreview]);
+
+  function updateDraft(next: CostScopeConfig) {
+    setDraft(next);
+    setSaveError(null);
+  }
+
+  function handleMetricChange(metric: CostMetric) {
+    updateDraft({ ...draft, costMetric: metric });
+  }
+
+  function updateRule(index: number, next: ExclusionRule) {
+    const rules = draft.rules.map((r, i) => i === index ? next : r);
+    updateDraft({ ...draft, rules });
+  }
+
+  function deleteRule(index: number) {
+    const rules = draft.rules.filter((_, i) => i !== index);
+    updateDraft({ ...draft, rules });
+  }
+
+  function addRule() {
+    const firstDim = dimensions.find(d => d.enabled !== false);
+    const dimId = firstDim !== undefined ? dimIdFor(firstDim) : 'service';
+    // New rules start disabled: they have empty `values` by default, which
+    // fails validation — shipping them enabled by default would instantly
+    // block saves and blank the preview until the user fills the field in.
+    const newRule: ExclusionRule = {
+      id: `user:${crypto.randomUUID()}`,
+      name: 'New rule',
+      enabled: false,
+      builtIn: false,
+      conditions: [{ dimensionId: asDimensionId(dimId), values: [] }],
+    };
+    updateDraft({ ...draft, rules: [...draft.rules, newRule] });
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await api.saveCostScope(draft);
+      setSaved(draft);
+      refreshPreview(draft);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    setDraft(saved);
+    setSaveError(null);
+  }
+
+  const enabledRules = draft.rules.filter(r => r.enabled);
+  const combinedText = preview.result !== null
+    ? formatExcluded(preview.result.combined.excludedCost, preview.result.combined.excludedRows)
+    : preview.loading ? 'loading…' : 'no data';
+
+  function getPreviewRow(ruleId: string): CostScopePreviewRow | undefined {
+    return preview.result?.perRule.find(p => p.ruleId === ruleId);
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-text-primary">Cost Scope</h1>
+          <p className="text-sm text-text-muted mt-1">
+            Define what counts as cost: pick the cost metric and exclude polluting line items from all queries.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="text-xs text-text-muted hover:text-text-secondary"
+              onClick={() => { void api.revealCostScopeFolder(); }}
+            >
+              Reveal YAML
+            </button>
+            {dirty && (
+              <>
+                <Button variant="outline" size="sm" onClick={handleCancel} disabled={saving}>Cancel</Button>
+                <Button
+                  size="sm"
+                  onClick={() => { void handleSave(); }}
+                  disabled={!canSave}
+                  title={draftError ?? undefined}
+                >
+                  {saving ? 'Saving…' : 'Save'}
+                </Button>
+              </>
+            )}
+            {!dirty && <span className="text-xs text-text-muted">Saved</span>}
+          </div>
+          {(saveError !== null || draftError !== null) && (
+            <span className="text-xs text-negative max-w-sm text-right">
+              {saveError ?? draftError}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Cost metric */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Cost metric</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {COST_METRICS.map(metric => (
+            <label key={metric} className="flex items-start gap-3 cursor-pointer group">
+              <input
+                type="radio"
+                name="costMetric"
+                value={metric}
+                checked={draft.costMetric === metric}
+                onChange={() => { handleMetricChange(metric); }}
+                className="mt-0.5 accent-accent"
+              />
+              <div>
+                <span className="text-sm font-medium text-text-primary">{METRIC_LABELS[metric].label}</span>
+                <span className="ml-2 text-xs text-text-muted">{METRIC_LABELS[metric].description}</span>
+              </div>
+            </label>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Exclusion rules */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-text-primary">Exclusion rules</h2>
+            <p className="text-xs text-text-muted mt-0.5">Rows matching any enabled rule are excluded from every query.</p>
+          </div>
+          <Button variant="outline" size="sm" onClick={addRule}>Add rule</Button>
+        </div>
+
+        {draft.rules.length === 0 && (
+          <p className="text-sm text-text-muted py-4 text-center">No rules defined.</p>
+        )}
+
+        {draft.rules.map((rule, i) => (
+          <RuleCard
+            key={rule.id}
+            rule={rule}
+            preview={getPreviewRow(rule.id)}
+            dimensions={dimensions}
+            suggestionsByDim={suggestionsByDim}
+            onUpdate={next => { updateRule(i, next); }}
+            onDelete={() => { deleteRule(i); }}
+          />
+        ))}
+      </div>
+
+      {/* Combined preview */}
+      {enabledRules.length > 0 && (
+        <div className="rounded-lg border border-border bg-bg-secondary px-4 py-3 flex items-center justify-between">
+          <span className="text-sm text-text-secondary">Total excluded (last 30 days, union of all enabled rules)</span>
+          <span className="text-sm font-medium text-text-primary">{combinedText}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type {
   CostMetric,
   CostScopeConfig,
+  CostScopeDailyRow,
   CostScopePreviewResult,
   ExclusionCondition,
   ExclusionRule,
@@ -14,9 +15,18 @@ import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.
 import { Button } from '../components/ui/button.js';
 
 const METRIC_LABELS: Record<CostMetric, { label: string; description: string }> = {
-  unblended: { label: 'Unblended', description: 'What you actually paid — the default for most analyses.' },
-  blended: { label: 'Blended', description: 'Org-averaged per-hour rate, smoothing RI/SP discounts across accounts.' },
-  list: { label: 'List price', description: 'On-demand list price before any discounts — useful for "what-if" comparisons.' },
+  unblended: {
+    label: 'Unblended',
+    description: 'Cost as billed each day. Upfront RI/SP fees land as a lump on their purchase day; RI/SP-covered usage shows the discounted rate. Default.',
+  },
+  blended: {
+    label: 'Blended',
+    description: 'Consolidated-billing rate — each linked account is charged the org-wide weighted average for the same usage type. Accounting construct for per-account comparisons; not what you actually pay.',
+  },
+  amortized: {
+    label: 'Amortized',
+    description: 'Spreads RI/SP purchases over the commitment term and uses effective cost for covered usage. Smooths the bursts in Unblended; best for run-rate and forecasting.',
+  },
 };
 
 function formatExcluded(cost: number, rows: number): string {
@@ -228,6 +238,50 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
         </button>
       </CardContent>
     </Card>
+  );
+}
+
+interface PreviewHistogramProps {
+  readonly days: readonly CostScopeDailyRow[];
+  readonly height?: number;
+}
+
+/** Compact stacked bar chart for the Cost Scope preview. Each day shows
+ *  `kept` (solid accent) over `excluded` (muted). Purpose-built rather than
+ *  reusing the dashboard's StackedBarChart because that component is tied
+ *  to the Groups/Products/Services tab model. */
+function PreviewHistogram({ days, height = 120 }: PreviewHistogramProps) {
+  const maxTotal = days.reduce((m, d) => Math.max(m, d.keptCost + d.excludedCost), 0);
+  if (days.length === 0 || maxTotal === 0) {
+    return (
+      <div className="h-[120px] flex items-center justify-center text-xs text-text-muted">
+        No data in the last 30 days.
+      </div>
+    );
+  }
+  // Render as flex-bars so we don't have to measure container width — each
+  // day takes an equal share, heights are proportional to maxTotal.
+  return (
+    <div className="flex items-end gap-px" style={{ height }}>
+      {days.map(d => {
+        const total = d.keptCost + d.excludedCost;
+        const totalPct = (total / maxTotal) * 100;
+        const keptPct = total > 0 ? (d.keptCost / total) * 100 : 0;
+        return (
+          <div
+            key={d.date}
+            className="flex-1 flex flex-col justify-end min-w-0 group relative"
+            style={{ height: '100%' }}
+            title={`${d.date}\nkept: ${formatDollars(d.keptCost)}\nexcluded: ${formatDollars(d.excludedCost)}`}
+          >
+            <div className="flex flex-col" style={{ height: `${String(totalPct)}%` }}>
+              <div className="bg-negative/40 w-full" style={{ height: `${String(100 - keptPct)}%` }} />
+              <div className="bg-accent w-full" style={{ height: `${String(keptPct)}%` }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -475,13 +529,87 @@ export function CostScopeView(): React.JSX.Element {
         ))}
       </div>
 
-      {/* Combined preview */}
-      {enabledRules.length > 0 && (
-        <div className="rounded-lg border border-border bg-bg-secondary px-4 py-3 flex items-center justify-between">
-          <span className="text-sm text-text-secondary">Total excluded (last 30 days, union of all enabled rules)</span>
-          <span className="text-sm font-medium text-text-primary">{combinedText}</span>
+      {/* Preview */}
+      <PreviewPanel preview={preview} loading={preview.loading} combinedText={combinedText} metric={draft.costMetric} hasEnabledRules={enabledRules.length > 0} />
+    </div>
+  );
+}
+
+interface PreviewPanelProps {
+  readonly preview: PreviewState;
+  readonly loading: boolean;
+  readonly combinedText: string;
+  readonly metric: CostMetric;
+  readonly hasEnabledRules: boolean;
+}
+
+function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules }: PreviewPanelProps): React.JSX.Element {
+  const result = preview.result;
+  const metricLabel = METRIC_LABELS[metric].label;
+  const excludedPct = useMemo(() => {
+    if (result === null || result.unscopedTotalCost <= 0) return 0;
+    return ((result.unscopedTotalCost - result.scopedTotalCost) / result.unscopedTotalCost) * 100;
+  }, [result]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">Preview</CardTitle>
+          <span className="text-xs text-text-muted">Last 30 days · {metricLabel}</span>
         </div>
-      )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Summary row */}
+        <div className="grid grid-cols-3 gap-3">
+          <SummaryTile
+            label="Unscoped total"
+            value={result !== null ? formatDollars(result.unscopedTotalCost) : loading ? '…' : '—'}
+            hint={`Raw ${metricLabel.toLowerCase()} over the window`}
+          />
+          <SummaryTile
+            label="After scope"
+            value={result !== null ? formatDollars(result.scopedTotalCost) : loading ? '…' : '—'}
+            hint={hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled'}
+            emphasis
+          />
+          <SummaryTile
+            label="Excluded"
+            value={hasEnabledRules ? combinedText : '—'}
+            hint={hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule above'}
+          />
+        </div>
+
+        {/* Histogram */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-text-secondary">Daily cost</span>
+            <div className="flex items-center gap-3 text-xs text-text-muted">
+              <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-accent inline-block" /> kept</span>
+              {hasEnabledRules && (
+                <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-negative/40 inline-block" /> excluded</span>
+              )}
+            </div>
+          </div>
+          <PreviewHistogram days={result?.dailyTotals ?? []} />
+          {result !== null && result.dailyTotals.length > 0 && (
+            <div className="flex justify-between text-[10px] text-text-muted mt-1">
+              <span>{result.startDate}</span>
+              <span>{result.endDate}</span>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryTile({ label, value, hint, emphasis }: { label: string; value: string; hint: string; emphasis?: boolean }): React.JSX.Element {
+  return (
+    <div className={`rounded-md border border-border px-3 py-2 ${emphasis ? 'bg-bg-tertiary/40' : 'bg-bg-secondary/60'}`}>
+      <div className="text-[10px] uppercase tracking-wide text-text-muted">{label}</div>
+      <div className={`text-sm font-semibold tabular-nums ${emphasis ? 'text-text-primary' : 'text-text-secondary'}`}>{value}</div>
+      <div className="text-[10px] text-text-muted mt-0.5">{hint}</div>
     </div>
   );
 }

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -150,6 +150,16 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
     onUpdate({ ...rule, name });
   }
 
+  function setDescription(description: string) {
+    // Empty string collapses to undefined so the serializer omits the key
+    // entirely — a YAML with `description:` and no value is noisier than
+    // no key at all. Same treatment the validator gives it on load.
+    onUpdate({
+      ...rule,
+      ...(description.length > 0 ? { description } : { description: undefined }),
+    });
+  }
+
   function updateCondition(index: number, next: ExclusionCondition) {
     const conditions = rule.conditions.map((c, i) => i === index ? next : c);
     onUpdate({ ...rule, conditions });
@@ -183,9 +193,17 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
             role="switch"
             aria-checked={rule.enabled}
             onClick={() => { setEnabled(!rule.enabled); }}
-            className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${rule.enabled ? 'bg-accent' : 'bg-bg-tertiary border border-border'}`}
+            className={[
+              'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors',
+              rule.enabled ? 'bg-accent' : 'bg-bg-tertiary border border-border',
+            ].join(' ')}
           >
-            <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${rule.enabled ? 'translate-x-4' : 'translate-x-0.5'}`} />
+            <span
+              className={[
+                'inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform',
+                rule.enabled ? 'translate-x-[18px]' : 'translate-x-[3px]',
+              ].join(' ')}
+            />
           </button>
           <input
             className="flex-1 bg-transparent font-semibold text-text-primary text-sm focus:outline-none border-b border-transparent focus:border-border"
@@ -212,9 +230,13 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
         </div>
       </CardHeader>
       <CardContent className="space-y-2 pt-0">
-        {rule.description !== undefined && rule.description.length > 0 && (
-          <p className="text-xs text-text-muted">{rule.description}</p>
-        )}
+        <textarea
+          className="w-full rounded border border-border bg-bg-secondary text-text-muted text-xs px-2 py-1 resize-y min-h-[2rem] focus:outline-none focus:border-accent/50"
+          placeholder="Optional description — what this rule excludes and why."
+          value={rule.description ?? ''}
+          onChange={e => { setDescription(e.target.value); }}
+          rows={Math.max(2, Math.min(5, Math.ceil((rule.description ?? '').length / 80) + 1))}
+        />
         <div className="text-xs font-medium text-text-secondary mb-1">Conditions (AND)</div>
         <div className="space-y-2">
           {rule.conditions.map((cond, i) => (
@@ -244,6 +266,8 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
 
 interface PreviewHistogramProps {
   readonly days: readonly CostScopeDailyRow[];
+  readonly loading: boolean;
+  readonly hasResult: boolean;
   readonly height?: number;
 }
 
@@ -251,11 +275,27 @@ interface PreviewHistogramProps {
  *  `kept` (solid accent) over `excluded` (muted). Purpose-built rather than
  *  reusing the dashboard's StackedBarChart because that component is tied
  *  to the Groups/Products/Services tab model. */
-function PreviewHistogram({ days, height = 120 }: PreviewHistogramProps) {
+function PreviewHistogram({ days, loading, hasResult, height = 120 }: PreviewHistogramProps) {
+  if (loading && !hasResult) {
+    // Initial load — show an explicit label so tests / users can tell
+    // "loading" apart from "no data". Once a result arrives we keep
+    // rendering it even while the next debounce is in-flight (below).
+    return (
+      <div
+        data-testid="preview-histogram-loading"
+        className="h-[120px] flex items-center justify-center text-xs text-text-muted"
+      >
+        Loading preview…
+      </div>
+    );
+  }
   const maxTotal = days.reduce((m, d) => Math.max(m, d.keptCost + d.excludedCost), 0);
   if (days.length === 0 || maxTotal === 0) {
     return (
-      <div className="h-[120px] flex items-center justify-center text-xs text-text-muted">
+      <div
+        data-testid="preview-histogram-empty"
+        className="h-[120px] flex items-center justify-center text-xs text-text-muted"
+      >
         No data in the last 30 days.
       </div>
     );
@@ -291,6 +331,8 @@ interface SampleRowsTableProps {
   readonly tagColumns: readonly { readonly id: string; readonly label: string }[];
   readonly totalRowCount: number;
   readonly hasEnabledRules: boolean;
+  readonly loading: boolean;
+  readonly hasResult: boolean;
 }
 
 /** Signed-dollar formatter — keeps the sign so credits/refunds read as
@@ -305,10 +347,17 @@ function formatSignedDollars(n: number): string {
  *  sit at the top. Horizontal scroll + sticky header + vertical scroll;
  *  rendered as a plain table rather than TanStack because sort/pagination
  *  are server-side and there's no interaction beyond "look". */
-function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules }: SampleRowsTableProps): React.JSX.Element {
+function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loading, hasResult }: SampleRowsTableProps): React.JSX.Element {
+  if (loading && !hasResult) {
+    return (
+      <div data-testid="preview-table-loading" className="text-xs text-text-muted py-4 text-center">
+        Loading preview…
+      </div>
+    );
+  }
   if (rows.length === 0) {
     return (
-      <div className="text-xs text-text-muted py-4 text-center">
+      <div data-testid="preview-table-empty" className="text-xs text-text-muted py-4 text-center">
         No line items in the window — sync data to populate.
       </div>
     );
@@ -337,21 +386,27 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules }: S
       </div>
       <div className="border border-border rounded-md overflow-auto max-h-[480px]">
         <table className="text-[11px] w-full border-collapse">
+          {/* Column order prioritises what the user is scanning for:
+              Date → Cost → List (the two $$ fields sit together and stay on
+              screen without horizontal scroll) → Service & Account (the
+              two main "who/what" anchors) → Line type → then the long-tail
+              metadata (region, family, usage type, operation, usage,
+              tags, resource id, description) */}
           <thead className="sticky top-0 z-10 bg-bg-tertiary/95 backdrop-blur-sm">
             <tr className="text-left text-text-secondary">
               <Th>Date</Th>
-              <Th>Account</Th>
-              <Th>Region</Th>
-              <Th>Service</Th>
-              <Th>Family</Th>
-              <Th>Line type</Th>
-              <Th>Operation</Th>
-              <Th>Usage type</Th>
-              <Th>Resource</Th>
-              <Th align="right">Usage</Th>
               <Th align="right">Cost</Th>
               <Th align="right">List</Th>
+              <Th>Service</Th>
+              <Th>Account</Th>
+              <Th>Line type</Th>
+              <Th>Region</Th>
+              <Th>Family</Th>
+              <Th>Usage type</Th>
+              <Th>Operation</Th>
+              <Th align="right">Usage</Th>
               {tagColumns.map(t => <Th key={t.id}>{t.label}</Th>)}
+              <Th>Resource</Th>
               <Th>Description</Th>
             </tr>
           </thead>
@@ -362,18 +417,18 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules }: S
                 className={`border-t border-border/40 ${r.excluded ? 'bg-negative/5 text-text-muted' : 'hover:bg-bg-tertiary/30'}`}
               >
                 <Td mono>{r.date}</Td>
-                <Td title={r.accountId}>{r.accountName.length > 0 ? r.accountName : r.accountId}</Td>
-                <Td mono>{r.region}</Td>
-                <Td>{r.service}</Td>
-                <Td>{r.serviceFamily}</Td>
-                <Td>{r.lineItemType}</Td>
-                <Td>{r.operation}</Td>
-                <Td mono>{r.usageType}</Td>
-                <Td mono truncate title={r.resourceId}>{r.resourceId}</Td>
-                <Td align="right" mono>{r.usageAmount === 0 ? '' : r.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</Td>
                 <Td align="right" mono className={r.cost < 0 ? 'text-warning' : ''}>{formatSignedDollars(r.cost)}</Td>
                 <Td align="right" mono>{formatSignedDollars(r.listCost)}</Td>
+                <Td>{r.service}</Td>
+                <Td title={r.accountId}>{r.accountName.length > 0 ? r.accountName : r.accountId}</Td>
+                <Td>{r.lineItemType}</Td>
+                <Td mono>{r.region}</Td>
+                <Td>{r.serviceFamily}</Td>
+                <Td mono>{r.usageType}</Td>
+                <Td>{r.operation}</Td>
+                <Td align="right" mono>{r.usageAmount === 0 ? '' : r.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</Td>
                 {tagColumns.map(t => <Td key={t.id}>{r.tags[t.id] ?? ''}</Td>)}
+                <Td mono truncate title={r.resourceId}>{r.resourceId}</Td>
                 <Td truncate title={r.description}>{r.description}</Td>
               </tr>
             ))}
@@ -673,11 +728,19 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
   }, [result]);
 
   return (
-    <Card>
+    <Card data-testid="cost-scope-preview">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base">Preview</CardTitle>
-          <span className="text-xs text-text-muted">Last 30 days · {metricLabel}</span>
+          <span className="text-xs text-text-muted">
+            Last 30 days · {metricLabel}
+            {loading && (
+              <>
+                {' · '}
+                <span data-testid="preview-loading" className="text-accent">loading…</span>
+              </>
+            )}
+          </span>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -712,7 +775,11 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
               )}
             </div>
           </div>
-          <PreviewHistogram days={result?.dailyTotals ?? []} />
+          <PreviewHistogram
+            days={result?.dailyTotals ?? []}
+            loading={loading}
+            hasResult={result !== null}
+          />
           {result !== null && result.dailyTotals.length > 0 && (
             <div className="flex justify-between text-[10px] text-text-muted mt-1">
               <span>{result.startDate}</span>
@@ -731,6 +798,8 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
             tagColumns={result?.tagColumns ?? []}
             totalRowCount={result?.sampleTotalRowCount ?? 0}
             hasEnabledRules={hasEnabledRules}
+            loading={loading}
+            hasResult={result !== null}
           />
         </div>
       </CardContent>

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type {
   CostMetric,
+  CostScopeCapabilities,
   CostScopeConfig,
   CostScopeDailyRow,
   CostScopePreviewResult,
@@ -583,6 +584,7 @@ export function CostScopeView(): React.JSX.Element {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [suggestionsByDim, setSuggestionsByDim] = useState(new Map<string, readonly string[]>());
+  const [capabilities, setCapabilities] = useState<CostScopeCapabilities | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const dirty = JSON.stringify(draft) !== JSON.stringify(saved);
@@ -595,6 +597,11 @@ export function CostScopeView(): React.JSX.Element {
       setSaved(cfg);
     });
     void api.getDimensions().then(setDimensions);
+    void api.getCostScopeCapabilities().then(setCapabilities).catch(() => {
+      // capabilities are advisory — if the probe fails, assume
+      // everything is present (matches legacy behaviour).
+      setCapabilities({ hasEffectiveCostColumns: true, hasBlendedColumn: true });
+    });
   }, [api]);
 
   // Pre-fetch filter-value suggestions once per enabled dim so every
@@ -788,6 +795,22 @@ export function CostScopeView(): React.JSX.Element {
                   <div>
                     <span className="text-sm font-medium text-text-primary">{METRIC_LABELS[metric].label}</span>
                     <span className="ml-2 text-xs text-text-muted">{METRIC_LABELS[metric].description}</span>
+                    {metric === 'amortized' && capabilities !== null && !capabilities.hasEffectiveCostColumns && (
+                      <div className="mt-1 text-xs text-warning">
+                        Degraded → falls back to Unblended because your CUR export doesn't include
+                        <code className="mx-1 text-[11px]">reservation_effective_cost</code>
+                        /
+                        <code className="mx-1 text-[11px]">savings_plan_effective_cost</code>.
+                        Enable <em>Include Resource IDs</em> on your CUR report in AWS Billing to get
+                        an accurate amortized view (takes one billing cycle to land).
+                      </div>
+                    )}
+                    {metric === 'blended' && capabilities !== null && !capabilities.hasBlendedColumn && (
+                      <div className="mt-1 text-xs text-warning">
+                        Degraded → falls back to Unblended because your CUR export doesn't include
+                        <code className="mx-1 text-[11px]">line_item_blended_cost</code>.
+                      </div>
+                    )}
                   </div>
                 </label>
               ))}

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -395,7 +395,10 @@ function formatSignedDollars(n: number): string {
  *  rendered as a plain table rather than TanStack because sort/pagination
  *  are server-side and there's no interaction beyond "look". */
 function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loading, hasResult }: SampleRowsTableProps): React.JSX.Element {
-  const [hideExcluded, setHideExcluded] = useState(false);
+  // Default on: most of the time the user wants to inspect what made it
+  // *into* scope, not what was carved out. The handler returns up to N
+  // kept + N excluded so flipping this off still shows something useful.
+  const [hideExcluded, setHideExcluded] = useState(true);
 
   if (loading && !hasResult) {
     return (
@@ -411,28 +414,47 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loa
       </div>
     );
   }
+  const keptCount = rows.length - rows.filter(r => r.excluded).length;
+  // If the user has "Hide excluded" on but every sampled row is excluded,
+  // the table body would render empty with no hint why. Flip the toggle
+  // implicitly (on the display only) by falling back to showing
+  // excluded rows with a callout, so the table is never blank when we
+  // know there IS data.
+  const showEmptyKeptBanner = hideExcluded && keptCount === 0;
 
-  // When the user hides excluded rows, we drop them locally instead of
-  // re-querying — the top-500 sample already mixes kept + excluded, so
-  // filtering here is instant and stays honest about what the server
-  // returned. The counts below reflect the filtered count.
-  const visibleRows = hideExcluded ? rows.filter(r => !r.excluded) : rows;
+  // When hiding excluded, drop client-side — the handler returns top-N
+  // of each bucket (kept + excluded) so flipping shows rows instantly
+  // without a re-query. Fall back to excluded rows if kept is empty
+  // (showEmptyKeptBanner) so the table is never blank.
+  const visibleRows = hideExcluded && keptCount > 0
+    ? rows.filter(r => !r.excluded)
+    : rows;
+  const keptInSample = rows.length - rows.filter(r => r.excluded).length;
   const excludedInSample = rows.filter(r => r.excluded).length;
   const showing = visibleRows.length;
-  const capped = totalRowCount > rows.length;
 
   return (
     <div className="space-y-2">
+      {showEmptyKeptBanner && (
+        <div className="rounded-md border border-warning/40 bg-warning/5 text-xs text-text-secondary px-3 py-2">
+          Every row in the top-{String(rows.length)} sample is excluded by the
+          active rules — showing excluded rows so the table isn't blank.
+        </div>
+      )}
       <div className="flex items-center justify-between text-xs text-text-muted gap-4">
         <span className="min-w-0">
           Top <span className="text-text-secondary tabular-nums">{showing.toLocaleString()}</span>
-          {capped && !hideExcluded && (
-            <> of <span className="text-text-secondary tabular-nums">{totalRowCount.toLocaleString()}</span></>
-          )}
+          {' '}rows
           {hideExcluded && excludedInSample > 0 && (
-            <> (<span className="tabular-nums">{excludedInSample.toLocaleString()}</span> excluded rows hidden)</>
+            <> (<span className="tabular-nums">{excludedInSample.toLocaleString()}</span> excluded hidden)</>
           )}
-          {' '}rows, sorted by |cost| desc.
+          {!hideExcluded && excludedInSample > 0 && keptInSample > 0 && (
+            <> (<span className="tabular-nums">{keptInSample.toLocaleString()}</span> kept + <span className="tabular-nums">{excludedInSample.toLocaleString()}</span> excluded)</>
+          )}
+          {totalRowCount > rows.length && (
+            <> of <span className="text-text-secondary tabular-nums">{totalRowCount.toLocaleString()}</span> in window</>
+          )}
+          , sorted by |cost| desc.
         </span>
         <span className="flex items-center gap-3 shrink-0">
           {hasEnabledRules && excludedInSample > 0 && (
@@ -586,7 +608,12 @@ export function CostScopeView(): React.JSX.Element {
       await Promise.all(enabled.map(async d => {
         const id = dimIdFor(d);
         try {
-          const vals = await api.getFilterValues(id, {});
+          // bypassCostScope: users composing an exclusion rule need to
+          // see every value a dim can take, including ones the saved
+          // cost-scope rules already exclude. Otherwise once Tax is
+          // excluded globally, the autocomplete in a new rule can't
+          // suggest 'Tax' for them to add to a second rule.
+          const vals = await api.getFilterValues(id, {}, undefined, { bypassCostScope: true });
           next.set(id, vals.map(v => v.value));
         } catch {
           next.set(id, []);

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type {
   CostMetric,
+  CostPerspective,
   CostScopeCapabilities,
   CostScopeConfig,
   CostScopeDailyRow,
@@ -600,7 +601,7 @@ export function CostScopeView(): React.JSX.Element {
     void api.getCostScopeCapabilities().then(setCapabilities).catch(() => {
       // capabilities are advisory — if the probe fails, assume
       // everything is present (matches legacy behaviour).
-      setCapabilities({ hasEffectiveCostColumns: true, hasBlendedColumn: true });
+      setCapabilities({ hasEffectiveCostColumns: true, hasBlendedColumn: true, hasNetColumns: true });
     });
   }, [api]);
 
@@ -659,6 +660,19 @@ export function CostScopeView(): React.JSX.Element {
 
   function handleMetricChange(metric: CostMetric) {
     updateDraft({ ...draft, costMetric: metric });
+  }
+
+  function handlePerspectiveChange(perspective: CostPerspective) {
+    // Omit the field entirely when 'gross' so we serialise the default
+    // cleanly — exactOptionalPropertyTypes forbids writing `undefined`
+    // to an optional property, so destructure the old value out.
+    if (perspective === 'gross') {
+      const { costPerspective: _omit, ...rest } = draft;
+      void _omit;
+      updateDraft(rest);
+      return;
+    }
+    updateDraft({ ...draft, costPerspective: perspective });
   }
 
   function updateRule(index: number, next: ExclusionRule) {
@@ -814,6 +828,49 @@ export function CostScopeView(): React.JSX.Element {
                   </div>
                 </label>
               ))}
+
+              {/* Gross vs Net toggle — orthogonal to the metric axis.
+                  Disabled when the net columns aren't available, with a
+                  warning explaining the CUR-side fix. */}
+              <div className="pt-2 mt-2 border-t border-border">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-text-primary">Perspective</div>
+                    <div className="text-xs text-text-muted mt-0.5">
+                      Net applies credits, refunds, and promotional discounts on top of the chosen metric.
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5 shrink-0">
+                    {(['gross', 'net'] as const).map(perspective => {
+                      const disabled = perspective === 'net' && capabilities !== null && !capabilities.hasNetColumns;
+                      const active = (draft.costPerspective ?? 'gross') === perspective;
+                      return (
+                        <button
+                          key={perspective}
+                          type="button"
+                          disabled={disabled}
+                          onClick={() => { handlePerspectiveChange(perspective); }}
+                          className={[
+                            'px-3 py-1 text-xs rounded-md transition-colors capitalize',
+                            active ? 'bg-accent text-bg-primary' : 'text-text-secondary hover:text-text-primary',
+                            disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
+                          ].join(' ')}
+                          title={disabled ? 'Requires line_item_net_unblended_cost — enable "Include Net Columns" on the CUR report.' : undefined}
+                        >
+                          {perspective}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                {(draft.costPerspective ?? 'gross') === 'net' && capabilities !== null && !capabilities.hasNetColumns && (
+                  <div className="mt-2 text-xs text-warning">
+                    Degraded → falls back to Gross because your CUR export doesn't include
+                    <code className="mx-1 text-[11px]">line_item_net_unblended_cost</code>.
+                    Enable <em>Include Net Columns</em> on your CUR report in AWS Billing.
+                  </div>
+                )}
+              </div>
             </CardContent>
           </Card>
 

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -4,6 +4,7 @@ import type {
   CostScopeConfig,
   CostScopeDailyRow,
   CostScopePreviewResult,
+  CostScopeSampleRow,
   ExclusionCondition,
   ExclusionRule,
   Dimension,
@@ -283,6 +284,126 @@ function PreviewHistogram({ days, height = 120 }: PreviewHistogramProps) {
       })}
     </div>
   );
+}
+
+interface SampleRowsTableProps {
+  readonly rows: readonly CostScopeSampleRow[];
+  readonly tagColumns: readonly { readonly id: string; readonly label: string }[];
+  readonly totalRowCount: number;
+  readonly hasEnabledRules: boolean;
+}
+
+/** Signed-dollar formatter — keeps the sign so credits/refunds read as
+ *  clearly negative rather than showing as absolute dollars. */
+function formatSignedDollars(n: number): string {
+  if (n < 0) return `-${formatDollars(-n)}`;
+  return formatDollars(n);
+}
+
+/** Dense inspection table: raw line items in the preview window, sorted
+ *  by absolute cost so the largest charges and the largest credits/refunds
+ *  sit at the top. Horizontal scroll + sticky header + vertical scroll;
+ *  rendered as a plain table rather than TanStack because sort/pagination
+ *  are server-side and there's no interaction beyond "look". */
+function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules }: SampleRowsTableProps): React.JSX.Element {
+  if (rows.length === 0) {
+    return (
+      <div className="text-xs text-text-muted py-4 text-center">
+        No line items in the window — sync data to populate.
+      </div>
+    );
+  }
+  const showing = rows.length;
+  const capped = totalRowCount > showing;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-text-muted">
+        <span>
+          Top <span className="text-text-secondary tabular-nums">{showing.toLocaleString()}</span>
+          {capped && (
+            <> of <span className="text-text-secondary tabular-nums">{totalRowCount.toLocaleString()}</span></>
+          )}
+          {' '}rows, sorted by |cost| desc.
+        </span>
+        <span>
+          {hasEnabledRules && (
+            <>
+              <span className="inline-block w-2 h-2 rounded-sm bg-negative/40 mr-1 align-middle" />
+              highlighted rows are excluded
+            </>
+          )}
+        </span>
+      </div>
+      <div className="border border-border rounded-md overflow-auto max-h-[480px]">
+        <table className="text-[11px] w-full border-collapse">
+          <thead className="sticky top-0 z-10 bg-bg-tertiary/95 backdrop-blur-sm">
+            <tr className="text-left text-text-secondary">
+              <Th>Date</Th>
+              <Th>Account</Th>
+              <Th>Region</Th>
+              <Th>Service</Th>
+              <Th>Family</Th>
+              <Th>Line type</Th>
+              <Th>Operation</Th>
+              <Th>Usage type</Th>
+              <Th>Resource</Th>
+              <Th align="right">Usage</Th>
+              <Th align="right">Cost</Th>
+              <Th align="right">List</Th>
+              {tagColumns.map(t => <Th key={t.id}>{t.label}</Th>)}
+              <Th>Description</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr
+                key={`${String(i)}-${r.resourceId}`}
+                className={`border-t border-border/40 ${r.excluded ? 'bg-negative/5 text-text-muted' : 'hover:bg-bg-tertiary/30'}`}
+              >
+                <Td mono>{r.date}</Td>
+                <Td title={r.accountId}>{r.accountName.length > 0 ? r.accountName : r.accountId}</Td>
+                <Td mono>{r.region}</Td>
+                <Td>{r.service}</Td>
+                <Td>{r.serviceFamily}</Td>
+                <Td>{r.lineItemType}</Td>
+                <Td>{r.operation}</Td>
+                <Td mono>{r.usageType}</Td>
+                <Td mono truncate title={r.resourceId}>{r.resourceId}</Td>
+                <Td align="right" mono>{r.usageAmount === 0 ? '' : r.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</Td>
+                <Td align="right" mono className={r.cost < 0 ? 'text-warning' : ''}>{formatSignedDollars(r.cost)}</Td>
+                <Td align="right" mono>{formatSignedDollars(r.listCost)}</Td>
+                {tagColumns.map(t => <Td key={t.id}>{r.tags[t.id] ?? ''}</Td>)}
+                <Td truncate title={r.description}>{r.description}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Th({ children, align = 'left' }: { children: React.ReactNode; align?: 'left' | 'right' }): React.JSX.Element {
+  return <th className={`px-2 py-1.5 font-medium whitespace-nowrap ${align === 'right' ? 'text-right' : ''}`}>{children}</th>;
+}
+
+function Td({ children, align = 'left', mono, truncate, className, title }: {
+  children: React.ReactNode;
+  align?: 'left' | 'right';
+  mono?: boolean;
+  truncate?: boolean;
+  className?: string;
+  title?: string;
+}): React.JSX.Element {
+  const classes = [
+    'px-2 py-1 whitespace-nowrap',
+    align === 'right' ? 'text-right' : '',
+    mono === true ? 'tabular-nums font-mono' : '',
+    truncate === true ? 'max-w-[260px] overflow-hidden text-ellipsis' : '',
+    className ?? '',
+  ].filter(c => c.length > 0).join(' ');
+  return <td className={classes} title={title}>{children}</td>;
 }
 
 /** A draft is saveable iff every enabled rule has at least one condition and
@@ -598,6 +719,19 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
               <span>{result.endDate}</span>
             </div>
           )}
+        </div>
+
+        {/* Raw line items */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-text-secondary">Line items</span>
+          </div>
+          <SampleRowsTable
+            rows={result?.sampleRows ?? []}
+            tagColumns={result?.tagColumns ?? []}
+            totalRowCount={result?.sampleTotalRowCount ?? 0}
+            hasEnabledRules={hasEnabledRules}
+          />
         </div>
       </CardContent>
     </Card>

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -611,9 +611,20 @@ export function CostScopeView(): React.JSX.Element {
     return preview.result?.perRule.find(p => p.ruleId === ruleId);
   }
 
+  const preview_ = (
+    <PreviewPanel
+      preview={preview}
+      loading={preview.loading}
+      combinedText={combinedText}
+      metric={draft.costMetric}
+      hasEnabledRules={enabledRules.length > 0}
+    />
+  );
+
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
-      {/* Header */}
+    <div className="max-w-6xl mx-auto px-4 py-8 space-y-6">
+      {/* Header — full width above the two-column grid so Save/Cancel
+          stay easy to reach regardless of scroll position. */}
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-xl font-bold text-text-primary">Cost Scope</h1>
@@ -653,60 +664,80 @@ export function CostScopeView(): React.JSX.Element {
         </div>
       </div>
 
-      {/* Cost metric */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Cost metric</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {COST_METRICS.map(metric => (
-            <label key={metric} className="flex items-start gap-3 cursor-pointer group">
-              <input
-                type="radio"
-                name="costMetric"
-                value={metric}
-                checked={draft.costMetric === metric}
-                onChange={() => { handleMetricChange(metric); }}
-                className="mt-0.5 accent-accent"
-              />
-              <div>
-                <span className="text-sm font-medium text-text-primary">{METRIC_LABELS[metric].label}</span>
-                <span className="ml-2 text-xs text-text-muted">{METRIC_LABELS[metric].description}</span>
-              </div>
-            </label>
-          ))}
-        </CardContent>
-      </Card>
+      {/* Two-column grid on wide screens: config on the left (metric + rules),
+          sticky Preview floating on the right so the user always sees the
+          effect of a toggle without scrolling. On narrow screens the grid
+          collapses to a single column — `order` keeps the preview ABOVE
+          the rules there so it's still the first thing in the viewport,
+          without rendering the component twice in the DOM. */}
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_400px] gap-6 items-start">
+        <div className="space-y-6 min-w-0 order-2 lg:order-1">
+          {/* Cost metric */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Cost metric</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {COST_METRICS.map(metric => (
+                <label key={metric} className="flex items-start gap-3 cursor-pointer group">
+                  <input
+                    type="radio"
+                    name="costMetric"
+                    value={metric}
+                    checked={draft.costMetric === metric}
+                    onChange={() => { handleMetricChange(metric); }}
+                    className="mt-0.5 accent-accent"
+                  />
+                  <div>
+                    <span className="text-sm font-medium text-text-primary">{METRIC_LABELS[metric].label}</span>
+                    <span className="ml-2 text-xs text-text-muted">{METRIC_LABELS[metric].description}</span>
+                  </div>
+                </label>
+              ))}
+            </CardContent>
+          </Card>
 
-      {/* Exclusion rules */}
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-text-primary">Exclusion rules</h2>
-            <p className="text-xs text-text-muted mt-0.5">Rows matching any enabled rule are excluded from every query.</p>
+          {/* Exclusion rules */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-text-primary">Exclusion rules</h2>
+                <p className="text-xs text-text-muted mt-0.5">Rows matching any enabled rule are excluded from every query.</p>
+              </div>
+              <Button variant="outline" size="sm" onClick={addRule}>Add rule</Button>
+            </div>
+
+            {draft.rules.length === 0 && (
+              <p className="text-sm text-text-muted py-4 text-center">No rules defined.</p>
+            )}
+
+            {draft.rules.map((rule, i) => (
+              <RuleCard
+                key={rule.id}
+                rule={rule}
+                preview={getPreviewRow(rule.id)}
+                dimensions={dimensions}
+                suggestionsByDim={suggestionsByDim}
+                onUpdate={next => { updateRule(i, next); }}
+                onDelete={() => { deleteRule(i); }}
+              />
+            ))}
           </div>
-          <Button variant="outline" size="sm" onClick={addRule}>Add rule</Button>
         </div>
 
-        {draft.rules.length === 0 && (
-          <p className="text-sm text-text-muted py-4 text-center">No rules defined.</p>
-        )}
-
-        {draft.rules.map((rule, i) => (
-          <RuleCard
-            key={rule.id}
-            rule={rule}
-            preview={getPreviewRow(rule.id)}
-            dimensions={dimensions}
-            suggestionsByDim={suggestionsByDim}
-            onUpdate={next => { updateRule(i, next); }}
-            onDelete={() => { deleteRule(i); }}
-          />
-        ))}
+        {/* Sticky preview — on lg+ floats as a sidebar; on narrow screens
+            `order-1` puts it above the rules in the stacked layout. top-24
+            clears the app's sticky nav bar (h-10 title + ~34px button row +
+            pb-2 padding ≈ 82px); max-h bounds the panel. */}
+        <aside className="order-1 lg:order-2 lg:sticky lg:top-24 lg:self-start lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto">
+          {preview_}
+        </aside>
       </div>
 
-      {/* Preview */}
-      <PreviewPanel preview={preview} loading={preview.loading} combinedText={combinedText} metric={draft.costMetric} hasEnabledRules={enabledRules.length > 0} />
+      {/* Line items — full-width card below so the ~14-col table keeps its
+          horizontal budget. Separate card lets the sticky preview above
+          stay compact. */}
+      <LineItemsCard preview={preview} loading={preview.loading} hasEnabledRules={enabledRules.length > 0} />
     </div>
   );
 }
@@ -719,6 +750,11 @@ interface PreviewPanelProps {
   readonly hasEnabledRules: boolean;
 }
 
+/** Compact "always-visible" preview rendered in the sticky right column on
+ *  wide screens, and inline (full width) on narrow screens. Holds the
+ *  summary tiles + histogram — just enough to see the effect of rule
+ *  toggles while scrolling through a long rules list. The detailed line-
+ *  items table lives in its own full-width card below. */
 function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules }: PreviewPanelProps): React.JSX.Element {
   const result = preview.result;
   const metricLabel = METRIC_LABELS[metric].label;
@@ -728,9 +764,9 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
   }, [result]);
 
   return (
-    <Card data-testid="cost-scope-preview">
+    <Card data-testid="cost-scope-preview" className="shadow-lg @container">
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <CardTitle className="text-base">Preview</CardTitle>
           <span className="text-xs text-text-muted">
             Last 30 days · {metricLabel}
@@ -744,8 +780,9 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* Summary row */}
-        <div className="grid grid-cols-3 gap-3">
+        {/* Summary tiles — single column on narrow container (sticky right
+            panel is ~400px wide), expand to 3 cols when there's room. */}
+        <div className="grid grid-cols-1 @md:grid-cols-3 gap-2">
           <SummaryTile
             label="Unscoped total"
             value={result !== null ? formatDollars(result.unscopedTotalCost) : loading ? '…' : '—'}
@@ -760,7 +797,7 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
           <SummaryTile
             label="Excluded"
             value={hasEnabledRules ? combinedText : '—'}
-            hint={hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule above'}
+            hint={hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule'}
           />
         </div>
 
@@ -787,21 +824,36 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
             </div>
           )}
         </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-        {/* Raw line items */}
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-medium text-text-secondary">Line items</span>
-          </div>
-          <SampleRowsTable
-            rows={result?.sampleRows ?? []}
-            tagColumns={result?.tagColumns ?? []}
-            totalRowCount={result?.sampleTotalRowCount ?? 0}
-            hasEnabledRules={hasEnabledRules}
-            loading={loading}
-            hasResult={result !== null}
-          />
-        </div>
+interface LineItemsCardProps {
+  readonly preview: PreviewState;
+  readonly loading: boolean;
+  readonly hasEnabledRules: boolean;
+}
+
+/** Full-width card holding the raw line-items inspection table. Separated
+ *  from PreviewPanel so the sticky summary stays compact and this stays
+ *  wide enough to show the ~14-column table without horizontal scroll. */
+function LineItemsCard({ preview, loading, hasEnabledRules }: LineItemsCardProps): React.JSX.Element {
+  const result = preview.result;
+  return (
+    <Card data-testid="cost-scope-line-items">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Line items</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <SampleRowsTable
+          rows={result?.sampleRows ?? []}
+          tagColumns={result?.tagColumns ?? []}
+          totalRowCount={result?.sampleTotalRowCount ?? 0}
+          hasEnabledRules={hasEnabledRules}
+          loading={loading}
+          hasResult={result !== null}
+        />
       </CardContent>
     </Card>
   );

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -800,7 +800,7 @@ export function CostScopeView(): React.JSX.Element {
                         Degraded → falls back to Unblended because your CUR export doesn't include
                         <code className="mx-1 text-[11px]">reservation_effective_cost</code>
                         /
-                        <code className="mx-1 text-[11px]">savings_plan_effective_cost</code>.
+                        <code className="mx-1 text-[11px]">savings_plan_savings_plan_effective_cost</code>.
                         Enable <em>Include Resource IDs</em> on your CUR report in AWS Billing to get
                         an accurate amortized view (takes one billing cycle to land).
                       </div>

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -9,7 +9,7 @@ import type {
   ExclusionRule,
   Dimension,
 } from '@costgoblin/core/browser';
-import { COST_METRICS, DEFAULT_COST_SCOPE, asDimensionId } from '@costgoblin/core/browser';
+import { BUILTIN_EXCLUSION_RULES, COST_METRICS, DEFAULT_COST_SCOPE, asDimensionId } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { formatDollars } from '../components/format.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
@@ -141,7 +141,36 @@ interface CostScopePreviewRow {
   excludedRows: number;
 }
 
+/** For a built-in rule, returns the shipped seed version (name, description,
+ *  conditions) so the UI can offer a "Reset" affordance when the user has
+ *  drifted from it. Returns null for user rules. */
+function seedForBuiltIn(rule: ExclusionRule): ExclusionRule | null {
+  if (!rule.builtIn) return null;
+  return BUILTIN_EXCLUSION_RULES.find(s => s.id === rule.id) ?? null;
+}
+
+/** True if any editable field of a built-in rule differs from its seed.
+ *  `enabled` is deliberately excluded from the check — toggling a built-in
+ *  on/off is expected, not a "drift" we want to offer resetting. */
+function builtInDiverges(rule: ExclusionRule, seed: ExclusionRule): boolean {
+  if (rule.name !== seed.name) return true;
+  if ((rule.description ?? '') !== (seed.description ?? '')) return true;
+  // Conditions: compare as JSON — the arrays are small and order-sensitive
+  // by design (the UI preserves condition order on save).
+  if (JSON.stringify(rule.conditions) !== JSON.stringify(seed.conditions)) return true;
+  return false;
+}
+
 function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDelete }: RuleCardProps) {
+  const seed = seedForBuiltIn(rule);
+  const diverged = seed !== null && builtInDiverges(rule, seed);
+
+  function resetToSeed() {
+    if (seed === null) return;
+    // Preserve the user's enabled choice; everything else reverts.
+    onUpdate({ ...seed, enabled: rule.enabled });
+  }
+
   function setEnabled(enabled: boolean) {
     onUpdate({ ...rule, enabled });
   }
@@ -223,9 +252,21 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
             </button>
           )}
           {rule.builtIn && (
-            <span className="text-xs text-text-muted shrink-0 px-1" title="Built-in rules can be disabled but not deleted">
-              built-in
-            </span>
+            <div className="flex items-center gap-2 shrink-0">
+              {diverged && (
+                <button
+                  type="button"
+                  className="text-xs text-text-muted hover:text-text-primary underline decoration-dotted"
+                  onClick={resetToSeed}
+                  title="Restore this rule's name, description, and conditions to the shipped defaults. Your enable/disable choice is kept."
+                >
+                  Reset
+                </button>
+              )}
+              <span className="text-xs text-text-muted px-1" title="Built-in rules can be disabled but not deleted">
+                built-in
+              </span>
+            </div>
           )}
         </div>
       </CardHeader>
@@ -348,6 +389,8 @@ function formatSignedDollars(n: number): string {
  *  rendered as a plain table rather than TanStack because sort/pagination
  *  are server-side and there's no interaction beyond "look". */
 function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loading, hasResult }: SampleRowsTableProps): React.JSX.Element {
+  const [hideExcluded, setHideExcluded] = useState(false);
+
   if (loading && !hasResult) {
     return (
       <div data-testid="preview-table-loading" className="text-xs text-text-muted py-4 text-center">
@@ -362,25 +405,46 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loa
       </div>
     );
   }
-  const showing = rows.length;
-  const capped = totalRowCount > showing;
+
+  // When the user hides excluded rows, we drop them locally instead of
+  // re-querying — the top-500 sample already mixes kept + excluded, so
+  // filtering here is instant and stays honest about what the server
+  // returned. The counts below reflect the filtered count.
+  const visibleRows = hideExcluded ? rows.filter(r => !r.excluded) : rows;
+  const excludedInSample = rows.filter(r => r.excluded).length;
+  const showing = visibleRows.length;
+  const capped = totalRowCount > rows.length;
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs text-text-muted">
-        <span>
+      <div className="flex items-center justify-between text-xs text-text-muted gap-4">
+        <span className="min-w-0">
           Top <span className="text-text-secondary tabular-nums">{showing.toLocaleString()}</span>
-          {capped && (
+          {capped && !hideExcluded && (
             <> of <span className="text-text-secondary tabular-nums">{totalRowCount.toLocaleString()}</span></>
+          )}
+          {hideExcluded && excludedInSample > 0 && (
+            <> (<span className="tabular-nums">{excludedInSample.toLocaleString()}</span> excluded rows hidden)</>
           )}
           {' '}rows, sorted by |cost| desc.
         </span>
-        <span>
-          {hasEnabledRules && (
-            <>
+        <span className="flex items-center gap-3 shrink-0">
+          {hasEnabledRules && excludedInSample > 0 && (
+            <label className="flex items-center gap-1.5 cursor-pointer select-none hover:text-text-secondary">
+              <input
+                type="checkbox"
+                className="accent-accent"
+                checked={hideExcluded}
+                onChange={e => { setHideExcluded(e.target.checked); }}
+              />
+              Hide excluded
+            </label>
+          )}
+          {hasEnabledRules && !hideExcluded && (
+            <span>
               <span className="inline-block w-2 h-2 rounded-sm bg-negative/40 mr-1 align-middle" />
-              highlighted rows are excluded
-            </>
+              excluded
+            </span>
           )}
         </span>
       </div>
@@ -411,7 +475,7 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loa
             </tr>
           </thead>
           <tbody>
-            {rows.map((r, i) => (
+            {visibleRows.map((r, i) => (
               <tr
                 key={`${String(i)}-${r.resourceId}`}
                 className={`border-t border-border/40 ${r.excluded ? 'bg-negative/5 text-text-muted' : 'hover:bg-bg-tertiary/30'}`}

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -80,7 +80,12 @@ function ConditionRow({ condition, dimensions, suggestions, onUpdate, onRemove, 
     onUpdate({ dimensionId: condition.dimensionId, values });
   }
 
-  const enabledDims = dimensions.filter(d => d.enabled !== false);
+  // Show ALL dims in the rule picker, not just `enabled !== false` ones.
+  // `enabled=false` is a UX preference for hiding a dim from normal
+  // group-by / filter pickers; exclusion rules should still be able to
+  // target its column (critical for the built-ins that reference
+  // line_item_type even when the user has hidden that dim). Disabled dims
+  // get a "(hidden)" suffix so it's clear they're not in normal rotation.
   const currentDimId = String(condition.dimensionId);
   const inputBorder = invalid ? 'border-negative' : 'border-border';
 
@@ -92,9 +97,10 @@ function ConditionRow({ condition, dimensions, suggestions, onUpdate, onRemove, 
         onChange={handleDimChange}
       >
         {currentDimId.length === 0 && <option value="">— pick dimension —</option>}
-        {enabledDims.map(d => {
+        {dimensions.map(d => {
           const id = dimIdFor(d);
-          return <option key={id} value={id}>{d.label}</option>;
+          const hidden = d.enabled === false;
+          return <option key={id} value={id}>{hidden ? `${d.label} (hidden)` : d.label}</option>;
         })}
       </select>
       <div className="flex-1 flex flex-col gap-1">

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -6,6 +6,7 @@ import type {
   CostScopeConfig,
   CostScopeDailyRow,
   CostScopePreviewResult,
+  CostScopePreviewRow,
   CostScopeSampleRow,
   ExclusionCondition,
   ExclusionRule,
@@ -141,12 +142,6 @@ interface RuleCardProps {
   suggestionsByDim: ReadonlyMap<string, readonly string[]>;
   onUpdate: (next: ExclusionRule) => void;
   onDelete: () => void;
-}
-
-interface CostScopePreviewRow {
-  ruleId: string;
-  excludedCost: number;
-  excludedRows: number;
 }
 
 /** For a built-in rule, returns the shipped seed version (name, description,
@@ -663,16 +658,12 @@ export function CostScopeView(): React.JSX.Element {
   }
 
   function handlePerspectiveChange(perspective: CostPerspective) {
-    // Omit the field entirely when 'gross' so we serialise the default
-    // cleanly — exactOptionalPropertyTypes forbids writing `undefined`
-    // to an optional property, so destructure the old value out.
-    if (perspective === 'gross') {
-      const { costPerspective: _omit, ...rest } = draft;
-      void _omit;
-      updateDraft(rest);
-      return;
-    }
-    updateDraft({ ...draft, costPerspective: perspective });
+    // Rebuild the config without `costPerspective` when the user picks
+    // the default ('gross') so the serializer writes clean YAML.
+    // exactOptionalPropertyTypes forbids writing `undefined`, so we
+    // enumerate the retained fields instead of spreading + overwriting.
+    const base: CostScopeConfig = { costMetric: draft.costMetric, rules: draft.rules };
+    updateDraft(perspective === 'gross' ? base : { ...base, costPerspective: perspective });
   }
 
   function updateRule(index: number, next: ExclusionRule) {


### PR DESCRIPTION
## Summary

New top-level **Cost Scope** config view that answers "what counts as cost in this app?". Two orthogonal settings:

### Cost metric picker
Unblended / blended / list. Swaps the Parquet column threaded into every query builder instead of hardcoded `line_item_unblended_cost`. Amortized / net are deferred (CUR column presence detection).

### Exclusion rules
- Additive set of `(dim IN values)` AND-of-conditions. Rules are OR'd together into a `NOT (...)` clause injected into every query's WHERE.
- Two built-ins: **AWS Premium Support** and **RI/SP purchases**, both disabled by default.
- User rules are uuid'd, editable, deletable; built-ins can be toggled but not deleted.

### Live preview
Per-rule + combined `$X excluded · N rows` over 30 days, debounced 300ms.

## Architecture

```
core/
  types/cost-scope.ts              — CostScopeConfig, ExclusionRule, CostMetric
  config/cost-scope-{validator,serialize,seed}.ts
  query/cost-metric.ts             — metric → column map
  query/builder.ts                 — buildRuleMatchExpr + NOT clause injection
                                     (costScope threaded through all 5 builders)
desktop/
  main/handlers/cost-scope.ts      — get / save / preview / reveal-folder
  main/handlers/context.ts         — lazy-loaded, invalidated on save
  main/handlers/query.ts           — threads costScope into every query
ui/
  views/cost-scope.tsx             — editor + preview + shared suggestions cache
```

## Persistence

`cost-scope.yaml` alongside `views.yaml` / `dimensions.yaml`. Seeded on first access if missing. Parse / validation errors bubble to the UI rather than silently overwriting a hand-edit.

## Guards

- **Save-time**: rejects rules with unknown `dimensionId`s (would otherwise crash every query via a bogus column reference).
- **Runtime**: builder silently skips conditions whose dim no longer resolves, so legacy on-disk rules can't break queries after a dimension rename.
- **Preview type-safety**: `CAST(... AS DOUBLE)` in the aggregate SQL + `toNum` coercion so Decimal (CUR 2.0) / BigInt returns from `@duckdb/node-api` come back as plain numbers.
- **UI**: Save is disabled with a tooltip while any enabled rule has empty conditions; save errors surface inline; preview is skipped for invalid drafts instead of blanking.

## Tests

15 builder tests covering cost-column swap, single/multi condition exclusion, OR within values, SQL injection escaping, tag alias CASE resolution, stale/partial rule handling, and the default no-op case.

Full `npm run check`: 232 tests green, zero tsc / eslint errors.