### PR TITLE
Explorer view + unsaved-changes guard + sync polish

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -2,6 +2,15 @@ import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, Normalizatio
 import type { ViewsConfig } from './views.js';
 import type { CostScopeCapabilities, CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
 import type {
+  ExplorerFilterValue,
+  ExplorerFilterValuesParams,
+  ExplorerOverviewParams,
+  ExplorerOverviewResult,
+  ExplorerPreferences,
+  ExplorerRowsParams,
+  ExplorerRowsResult,
+} from './explorer.js';
+import type {
   CostQueryParams,
   CostResult,
   DailyCostsParams,
@@ -151,8 +160,26 @@ export interface CostApi {
    *  degraded Amortized when effective-cost columns are missing). */
   getCostScopeCapabilities(): Promise<CostScopeCapabilities>;
   revealCostScopeFolder(): Promise<void>;
+  /** Daily histogram + aggregate totals for the Explorer. Independent of
+   *  sort so the histogram doesn't re-fetch when the user reorders a
+   *  column. */
+  queryExplorerOverview(params: ExplorerOverviewParams): Promise<ExplorerOverviewResult>;
+  /** Top-|cost| sample rows under the explorer's filters + sort. Only
+   *  fires when sort / filters / range / scope changes — the overview
+   *  query handles the histogram independently. */
+  queryExplorerRows(params: ExplorerRowsParams): Promise<ExplorerRowsResult>;
+  /** Facet values for a single dim under the explorer's other filters.
+   *  Rolls the current dim out of the filter set so the dropdown shows
+   *  every value remaining under the other filters. */
+  getExplorerFilterValues(params: ExplorerFilterValuesParams): Promise<ExplorerFilterValue[]>;
+  getExplorerPreferences(): Promise<ExplorerPreferences>;
+  saveExplorerPreferences(prefs: ExplorerPreferences): Promise<void>;
   getAutoSyncEnabled(): Promise<boolean>;
   setAutoSyncEnabled(enabled: boolean): Promise<void>;
+  /** Minimum minutes between auto-sync runs. Default: 24 × 60 (one day).
+   *  Clamped server-side to [60, 7×24×60]. */
+  getAutoSyncIntervalMinutes(): Promise<number>;
+  setAutoSyncIntervalMinutes(minutes: number): Promise<void>;
   getAutoSyncStatus(): Promise<AutoSyncStatus>;
   syncOrgAccounts(profile: string): Promise<OrgSyncResult>;
   getOrgSyncResult(): Promise<OrgSyncResult | null>;

--- a/packages/core/src/types/explorer.ts
+++ b/packages/core/src/types/explorer.ts
@@ -1,0 +1,139 @@
+import type { CostMetric, CostPerspective } from './cost-scope.js';
+import type { DateRange, Granularity } from './query.js';
+
+/** Multi-value filter for the Explorer. Each key is a dimension id, each
+ *  array is the set of values the user has picked (OR within a dimension,
+ *  AND across dimensions). Empty arrays are no-ops. */
+export type ExplorerFilterMap = Readonly<Record<string, readonly string[]>>;
+
+export type ExplorerSortDirection = 'asc' | 'desc';
+
+/** Column id is either a built-in dimension column (e.g. `cost`, `service`,
+ *  `usage_date`) or a tag column (e.g. `tag_team`). The handler maps it to
+ *  the underlying SQL expression. */
+export interface ExplorerSort {
+  readonly column: string;
+  readonly direction: ExplorerSortDirection;
+}
+
+/** Shared across both overview + rows queries — the axes that both
+ *  respond to. Sort + rowLimit are rows-only. */
+export interface ExplorerBaseParams {
+  readonly filters: ExplorerFilterMap;
+  /** Inclusive day range the query covers. Defaults server-side to the
+   *  last 30 days ending yesterday when omitted. */
+  readonly dateRange?: DateRange;
+  /** Which tier to query. `hourly` reads the hourly Parquet directory and
+   *  exposes a `usage_hour` timestamp per row. Defaults to `daily` — the
+   *  hourly tier is opt-in and may not be synced. */
+  readonly granularity?: Granularity;
+  /** When true, apply the saved Cost Scope's exclusion rules as a WHERE
+   *  filter. Default false — the Explorer exists to inspect the raw
+   *  dataset, so hiding Tax / Credits / RI purchases by default defeats
+   *  the purpose. User opts in via a toggle to compare with other views. */
+  readonly applyCostScope?: boolean;
+  /** Which cost column backs the `cost` field. Defaults to `unblended`
+   *  (the as-billed amount, always present). The UI picks from the
+   *  probed column set so unsupported metrics never reach the server. */
+  readonly costMetric?: CostMetric;
+  /** Gross (as-billed) or Net (post-credit). Defaults to `gross`. Only
+   *  meaningful when the CUR includes `line_item_net_*` columns —
+   *  capabilities probe tells the UI whether to show the toggle. */
+  readonly costPerspective?: CostPerspective;
+}
+
+export type ExplorerOverviewParams = ExplorerBaseParams;
+
+export interface ExplorerRowsParams extends ExplorerBaseParams {
+  readonly sort?: ExplorerSort;
+  /** Cap on returned sample rows. Clamped server-side to avoid IPC blowup. */
+  readonly rowLimit: number;
+}
+
+export interface ExplorerDailyRow {
+  readonly date: string;
+  readonly cost: number;
+  readonly rows: number;
+}
+
+export interface ExplorerSampleRow {
+  readonly date: string;
+  /** ISO timestamp when the query ran against the hourly tier, else empty. */
+  readonly hour: string;
+  readonly accountId: string;
+  readonly accountName: string;
+  readonly region: string;
+  readonly service: string;
+  readonly serviceFamily: string;
+  readonly lineItemType: string;
+  readonly operation: string;
+  readonly usageType: string;
+  readonly description: string;
+  readonly resourceId: string;
+  readonly usageAmount: number;
+  readonly cost: number;
+  readonly listCost: number;
+  readonly tags: Readonly<Record<string, string>>;
+}
+
+export interface ExplorerTagColumn {
+  readonly id: string;
+  readonly label: string;
+}
+
+/** The "static" slice of the Explorer result — daily histogram + totals.
+ *  Driven only by filters/range/scope/metric/perspective, so it doesn't
+ *  refresh when the user changes the table sort. Paired with
+ *  ExplorerRowsResult which handles the sortable rows. */
+export interface ExplorerOverviewResult {
+  readonly windowDays: number;
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly dailyTotals: readonly ExplorerDailyRow[];
+  /** Underlying CUR line-item count matching the filters (before the
+   *  rows sample cap). The UI shows "N of M rows" honestly. */
+  readonly totalRows: number;
+  readonly totalCost: number;
+  /** Names of configured tag dimensions in the order the UI should render
+   *  them as columns. The same list is echoed on ExplorerRowsResult so a
+   *  consumer reading only one has what it needs. */
+  readonly tagColumns: readonly ExplorerTagColumn[];
+}
+
+export interface ExplorerRowsResult {
+  readonly sampleRows: readonly ExplorerSampleRow[];
+  readonly tagColumns: readonly ExplorerTagColumn[];
+}
+
+export interface ExplorerFilterValue {
+  readonly value: string;
+  readonly label: string;
+  readonly cost: number;
+  readonly rows: number;
+}
+
+/** Persisted user preferences for the Explorer view. Stored as a JSON file
+ *  in the userData dir (same pattern as SavingsPreferences). */
+export interface ExplorerPreferences {
+  /** Column keys the user has hidden. Stored as "hidden" not "visible" so
+   *  that columns added in future updates become visible automatically —
+   *  users don't have to re-enable them. */
+  readonly hiddenColumns: readonly string[];
+  /** User-chosen display order for the table columns. Keys that exist in
+   *  this list are rendered in the given order; columns not present
+   *  (e.g. a newly-added built-in, or a tag the user enabled after
+   *  reordering) are appended afterwards in their default order. */
+  readonly columnOrder: readonly string[];
+}
+
+export interface ExplorerFilterValuesParams {
+  readonly dimensionId: string;
+  readonly filters: ExplorerFilterMap;
+  readonly dateRange?: DateRange;
+  readonly granularity?: Granularity;
+  /** Same as `ExplorerQueryParams.applyCostScope` — lets the dropdown
+   *  counts reflect whatever scope the user is looking at. Default false. */
+  readonly applyCostScope?: boolean;
+  readonly costMetric?: CostMetric;
+  readonly costPerspective?: CostPerspective;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -89,3 +89,20 @@ export type {
   CostScopeSampleRow,
 } from './cost-scope.js';
 export { COST_METRICS, COST_PERSPECTIVES } from './cost-scope.js';
+
+export type {
+  ExplorerFilterMap,
+  ExplorerSort,
+  ExplorerSortDirection,
+  ExplorerBaseParams,
+  ExplorerOverviewParams,
+  ExplorerRowsParams,
+  ExplorerDailyRow,
+  ExplorerSampleRow,
+  ExplorerOverviewResult,
+  ExplorerRowsResult,
+  ExplorerTagColumn,
+  ExplorerFilterValue,
+  ExplorerFilterValuesParams,
+  ExplorerPreferences,
+} from './explorer.js';

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -11,6 +11,17 @@ export interface AutoSyncDeps {
 let status: AutoSyncStatus = { state: 'disabled' };
 let timer: ReturnType<typeof setTimeout> | null = null;
 let running = false;
+// Captured so `runOnce` can report the correct nextRun without needing
+// to know the scheduler's interval — `startAutoSync` refreshes this on
+// every (re)start.
+let currentIntervalMs = 24 * 60 * 60 * 1000;
+
+/** Minimum / maximum interval the UI can request. Anything sub-hour risks
+ *  hammering S3 for a typical multi-tier sync and anything beyond a week
+ *  stops feeling like "auto" to the user. */
+export const MIN_AUTO_SYNC_INTERVAL_MINUTES = 60;
+export const MAX_AUTO_SYNC_INTERVAL_MINUTES = 7 * 24 * 60;
+export const DEFAULT_AUTO_SYNC_INTERVAL_MINUTES = 24 * 60;
 
 export function getAutoSyncStatus(): AutoSyncStatus {
   return status;
@@ -39,6 +50,39 @@ export async function writeAutoSyncEnabled(prefsPath: string, enabled: boolean):
   } catch { /* */ }
   existing['autoSync'] = enabled;
   await fs.writeFile(prefsPath, JSON.stringify(existing, null, 2));
+}
+
+export async function readAutoSyncIntervalMinutes(prefsPath: string): Promise<number> {
+  const fs = await import('node:fs/promises');
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const value = parseJsonObject(raw)?.['autoSyncIntervalMinutes'];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return clampInterval(value);
+    }
+  } catch {
+    // file doesn't exist
+  }
+  return DEFAULT_AUTO_SYNC_INTERVAL_MINUTES;
+}
+
+export async function writeAutoSyncIntervalMinutes(prefsPath: string, minutes: number): Promise<void> {
+  const fs = await import('node:fs/promises');
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const parsed = parseJsonObject(raw);
+    if (parsed !== null) {
+      existing = { ...parsed };
+    }
+  } catch { /* */ }
+  existing['autoSyncIntervalMinutes'] = clampInterval(minutes);
+  await fs.writeFile(prefsPath, JSON.stringify(existing, null, 2));
+}
+
+function clampInterval(minutes: number): number {
+  if (!Number.isFinite(minutes)) return DEFAULT_AUTO_SYNC_INTERVAL_MINUTES;
+  return Math.max(MIN_AUTO_SYNC_INTERVAL_MINUTES, Math.min(MAX_AUTO_SYNC_INTERVAL_MINUTES, Math.round(minutes)));
 }
 
 function retentionCutoff(days: number): string {
@@ -112,8 +156,7 @@ async function runOnce(deps: AutoSyncDeps): Promise<void> {
     }
 
     const now = new Date().toISOString();
-    const intervalMs = (provider.sync.daily.retentionDays !== undefined ? 60 : 60) * 60 * 1000;
-    status = { state: 'idle', lastRun: now, nextRun: new Date(Date.now() + intervalMs).toISOString() };
+    status = { state: 'idle', lastRun: now, nextRun: new Date(Date.now() + currentIntervalMs).toISOString() };
   } catch (err: unknown) {
     status = { state: 'error', message: err instanceof Error ? err.message : String(err), lastRun: new Date().toISOString() };
   }
@@ -124,17 +167,18 @@ async function runOnce(deps: AutoSyncDeps): Promise<void> {
 export function startAutoSync(deps: AutoSyncDeps, intervalMinutes: number): void {
   stopAutoSync();
 
-  const intervalMs = intervalMinutes * 60 * 1000;
+  const clamped = clampInterval(intervalMinutes);
+  currentIntervalMs = clamped * 60 * 1000;
 
   // initial run after short delay (let the app finish loading)
   timer = setTimeout(() => {
     void runOnce(deps).then(() => {
       // schedule recurring
-      timer = setInterval(() => { void runOnce(deps); }, intervalMs);
+      timer = setInterval(() => { void runOnce(deps); }, currentIntervalMs);
     });
   }, 5000);
 
-  logger.info(`Auto-sync: scheduled every ${String(intervalMinutes)} minutes`);
+  logger.info(`Auto-sync: scheduled every ${String(clamped)} minutes`);
 }
 
 export function stopAutoSync(): void {

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -7,6 +7,8 @@ import {
   getAutoSyncStatus,
   readAutoSyncEnabled,
   writeAutoSyncEnabled,
+  readAutoSyncIntervalMinutes,
+  writeAutoSyncIntervalMinutes,
 } from '../auto-sync.js';
 import type { AppContext } from './context.js';
 
@@ -75,11 +77,30 @@ export function registerAutoSyncHandlers(app: AppContext): void {
   });
 
   ipcMain.handle('auto-sync:set-enabled', async (_event, enabled: boolean): Promise<void> => {
-    await writeAutoSyncEnabled(await autoSyncPrefsPath(), enabled);
+    const prefsPath = await autoSyncPrefsPath();
+    await writeAutoSyncEnabled(prefsPath, enabled);
     if (enabled) {
-      startAutoSync(buildAutoSyncDeps(), 60);
+      const minutes = await readAutoSyncIntervalMinutes(prefsPath);
+      startAutoSync(buildAutoSyncDeps(), minutes);
     } else {
       stopAutoSync();
+    }
+  });
+
+  ipcMain.handle('auto-sync:get-interval', async (): Promise<number> => {
+    return readAutoSyncIntervalMinutes(await autoSyncPrefsPath());
+  });
+
+  ipcMain.handle('auto-sync:set-interval', async (_event, minutes: number): Promise<void> => {
+    const prefsPath = await autoSyncPrefsPath();
+    await writeAutoSyncIntervalMinutes(prefsPath, minutes);
+    // Only restart the scheduler if auto-sync is actually on — otherwise
+    // saving the preference is enough; the new interval will be picked up
+    // next time the user flips the toggle.
+    const enabled = await readAutoSyncEnabled(prefsPath);
+    if (enabled) {
+      const stored = await readAutoSyncIntervalMinutes(prefsPath);
+      startAutoSync(buildAutoSyncDeps(), stored);
     }
   });
 
@@ -91,7 +112,8 @@ export function registerAutoSyncHandlers(app: AppContext): void {
   void autoSyncPrefsPath().then(async (prefsPath) => {
     const enabled = await readAutoSyncEnabled(prefsPath);
     if (enabled) {
-      startAutoSync(buildAutoSyncDeps(), 60);
+      const minutes = await readAutoSyncIntervalMinutes(prefsPath);
+      startAutoSync(buildAutoSyncDeps(), minutes);
     }
   }).catch(() => { /* auto-sync startup failure is non-fatal */ });
 }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -38,6 +38,12 @@ const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
   { name: asDimensionId('line_item_type'), label: 'Line Item Type', field: 'line_item_type', description: 'Usage vs Tax vs Credit vs Discount. Filter this to isolate real usage from billing adjustments.' },
   { name: asDimensionId('usage_type'), label: 'Usage Type', field: 'usage_type', description: 'Fine-grained usage string like USE2-BoxUsage:t3.medium. Use for instance/storage-tier breakdowns.', enabled: false },
   { name: asDimensionId('operation'), label: 'Operation', field: 'operation', description: 'API operation billed for (RunInstances, GetObject). Useful for API-level cost attribution.', enabled: false },
+  // Very high cardinality — disabled by default so the normal filter/nav
+  // pickers stay scannable. The Explorer references it directly so
+  // click-to-filter on a resource cell works whether or not this dim is
+  // enabled, and users who want a dedicated "per-resource" view can flip
+  // it on in Dimensions.
+  { name: asDimensionId('resource_id'), label: 'Resource', field: 'resource_id', description: 'AWS resource ID or ARN (i-0abc…, arn:aws:rds:…). High-cardinality — enable when investigating a specific resource.', enabled: false },
 ];
 
 /** Renames we want propagated to existing configs. Only overrides the stored

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -1,0 +1,489 @@
+import { ipcMain } from 'electron';
+import {
+  asDimensionId,
+  buildSource,
+  buildRuleMatchExpr,
+  buildAliasSqlCase,
+  computePeriodsInRange,
+  logger,
+  listLocalMonths,
+  parseJsonObject,
+} from '@costgoblin/core';
+import type {
+  CostMetric,
+  CostPerspective,
+  ExclusionRule,
+  ExplorerBaseParams,
+  ExplorerFilterMap,
+  ExplorerFilterValue,
+  ExplorerFilterValuesParams,
+  ExplorerOverviewParams,
+  ExplorerOverviewResult,
+  ExplorerPreferences,
+  ExplorerRowsParams,
+  ExplorerRowsResult,
+  ExplorerSampleRow,
+  ExplorerSort,
+  ExplorerDailyRow,
+  ExplorerTagColumn,
+  DimensionsConfig,
+  SidecarPlan,
+} from '@costgoblin/core';
+import { resolveSidecarPlan } from '../optimize.js';
+import type { AppContext } from './context.js';
+import { buildAccountReverseMap, toNum, toStr } from './query-utils.js';
+
+const DEFAULT_WINDOW_DAYS = 30;
+const MAX_ROW_LIMIT = 1000;
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDate(s: string | undefined): Date | null {
+  if (s === undefined || !ISO_DATE_RE.test(s)) return null;
+  const d = new Date(`${s}T00:00:00Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function resolveDateRange(raw: { start?: string; end?: string } | undefined): { startStr: string; endStr: string; windowDays: number } {
+  const start = parseDate(raw?.start);
+  const end = parseDate(raw?.end);
+  if (start !== null && end !== null && start.getTime() <= end.getTime()) {
+    const days = Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1;
+    return { startStr: toIsoDate(start), endStr: toIsoDate(end), windowDays: days };
+  }
+  const yesterday = new Date(Date.now() - 86_400_000);
+  const fallbackEnd = toIsoDate(yesterday);
+  const fallbackStart = toIsoDate(new Date(yesterday.getTime() - (DEFAULT_WINDOW_DAYS - 1) * 86_400_000));
+  return { startStr: fallbackStart, endStr: fallbackEnd, windowDays: DEFAULT_WINDOW_DAYS };
+}
+
+const SORTABLE_SCALAR_COLUMNS: ReadonlySet<string> = new Set([
+  'usage_date',
+  'usage_hour',
+  'account_id',
+  'account_name',
+  'region',
+  'service',
+  'service_family',
+  'line_item_type',
+  'operation',
+  'usage_type',
+  'description',
+  'resource_id',
+  'usage_amount',
+  'cost',
+  'list_cost',
+]);
+
+function clampRowLimit(n: number): number {
+  if (!Number.isFinite(n) || n <= 0) return 500;
+  return Math.min(Math.floor(n), MAX_ROW_LIMIT);
+}
+
+function pickMetric(metric: CostMetric | undefined, cols: ReadonlySet<string>): CostMetric {
+  if (metric === 'amortized' && cols.has('reservation_effective_cost') && cols.has('savings_plan_savings_plan_effective_cost')) return 'amortized';
+  if (metric === 'blended' && cols.has('line_item_blended_cost')) return 'blended';
+  return 'unblended';
+}
+
+function pickPerspective(p: CostPerspective | undefined, cols: ReadonlySet<string>): CostPerspective {
+  if (p === 'net' && cols.has('line_item_net_unblended_cost')) return 'net';
+  return 'gross';
+}
+
+function buildExplorerFilterPredicate(
+  filters: ExplorerFilterMap,
+  dimensions: DimensionsConfig,
+  accountReverseMap: ReadonlyMap<string, readonly string[]>,
+): string | null {
+  const conditions = Object.entries(filters)
+    .filter(([, values]) => values.length > 0)
+    .map(([dimId, values]) => ({
+      dimensionId: asDimensionId(dimId),
+      values,
+    }));
+  if (conditions.length === 0) return null;
+  const synthetic: ExclusionRule = {
+    id: '_explorer_filters',
+    name: '_explorer_filters',
+    enabled: true,
+    builtIn: false,
+    conditions,
+  };
+  return buildRuleMatchExpr(synthetic, dimensions, accountReverseMap);
+}
+
+function buildOrderBy(
+  sort: ExplorerSort | undefined,
+  tagColumnIds: ReadonlySet<string>,
+): string {
+  if (sort === undefined) return 'ABS(cost) DESC';
+  const dir = sort.direction === 'asc' ? 'ASC' : 'DESC';
+  if (SORTABLE_SCALAR_COLUMNS.has(sort.column) || tagColumnIds.has(sort.column)) {
+    return `${sort.column} ${dir}`;
+  }
+  return 'ABS(cost) DESC';
+}
+
+/** Everything the overview / rows / filter-values handlers compute up front.
+ *  `empty === true` when no matching months are on disk — caller returns a
+ *  zero-filled result without bothering DuckDB. */
+interface QueryContext {
+  readonly empty: boolean;
+  readonly source: string;
+  readonly whereStr: string;
+  readonly startStr: string;
+  readonly endStr: string;
+  readonly windowDays: number;
+  readonly tier: 'daily' | 'hourly';
+  readonly tagColumns: readonly ExplorerTagColumn[];
+  readonly tagIdSet: ReadonlySet<string>;
+  readonly dimensions: DimensionsConfig;
+  readonly accountMap: ReadonlyMap<string, string>;
+}
+
+async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams): Promise<QueryContext> {
+  const { ctx, getCostScope, getQueryDimensions, getOrgAccountsPath, getAvailableColumns, getAccountMap } = app;
+  const { startStr, endStr, windowDays } = resolveDateRange(params.dateRange);
+  const tier: 'daily' | 'hourly' = params.granularity === 'hourly' ? 'hourly' : 'daily';
+
+  const available = await listLocalMonths(ctx.dataDir, tier);
+  const required = computePeriodsInRange({ start: startStr, end: endStr });
+  const periods = required.filter(p => available.includes(p));
+
+  const dimensions = await getQueryDimensions();
+  const accountMap = await getAccountMap();
+
+  const tagColumns: readonly ExplorerTagColumn[] = dimensions.tags.map(t => ({
+    id: `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`,
+    label: t.label,
+  }));
+  const tagIdSet = new Set(tagColumns.map(t => t.id));
+
+  if (periods.length === 0) {
+    return {
+      empty: true,
+      source: '',
+      whereStr: '',
+      startStr,
+      endStr,
+      windowDays,
+      tier,
+      tagColumns,
+      tagIdSet,
+      dimensions,
+      accountMap,
+    };
+  }
+
+  const orgPath = await getOrgAccountsPath();
+  const availableColumns = await getAvailableColumns(tier);
+  const applyCostScope = params.applyCostScope === true;
+  const costScope = applyCostScope ? await getCostScope().catch(() => undefined) : undefined;
+  const accountReverseMap = buildAccountReverseMap(accountMap);
+  const metric = pickMetric(params.costMetric, availableColumns);
+  const perspective = pickPerspective(params.costPerspective, availableColumns);
+
+  let sidecarPlan: SidecarPlan | undefined;
+  try {
+    // Sidecars exist only for the daily tier today — hourly falls back to
+    // element_at() on the tag map. Skipping the resolve call avoids a
+    // noisy "no sidecar" log on every hourly query.
+    if (tier === 'daily') {
+      const resolved = await resolveSidecarPlan(ctx.dataDir, tier, periods, dimensions.tags);
+      sidecarPlan = resolved ?? undefined;
+    }
+  } catch {
+    sidecarPlan = undefined;
+  }
+
+  const source = buildSource(
+    ctx.dataDir,
+    tier,
+    dimensions,
+    orgPath,
+    periods,
+    sidecarPlan,
+    metric,
+    availableColumns,
+    perspective,
+  );
+
+  const filterPredicate = buildExplorerFilterPredicate(params.filters, dimensions, accountReverseMap);
+
+  const exclusionClauses: string[] = [];
+  if (costScope !== undefined) {
+    for (const rule of costScope.rules) {
+      if (!rule.enabled) continue;
+      const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+      if (matchExpr === null) continue;
+      exclusionClauses.push(`NOT (${matchExpr})`);
+    }
+  }
+
+  const whereClauses: string[] = [
+    `usage_date BETWEEN '${startStr}' AND '${endStr}'`,
+    ...(filterPredicate === null ? [] : [`(${filterPredicate})`]),
+    ...exclusionClauses,
+  ];
+  const whereStr = `WHERE ${whereClauses.join(' AND ')}`;
+
+  return {
+    empty: false,
+    source,
+    whereStr,
+    startStr,
+    endStr,
+    windowDays,
+    tier,
+    tagColumns,
+    tagIdSet,
+    dimensions,
+    accountMap,
+  };
+}
+
+export function registerExplorerHandlers(app: AppContext): void {
+  const { ctx, runQuery } = app;
+
+  async function explorerPrefsPath(): Promise<string> {
+    const path = await import('node:path');
+    return path.join(path.dirname(ctx.dataDir), 'explorer-preferences.json');
+  }
+
+  ipcMain.handle('explorer:get-preferences', async (): Promise<ExplorerPreferences> => {
+    const fs = await import('node:fs/promises');
+    try {
+      const raw = await fs.readFile(await explorerPrefsPath(), 'utf-8');
+      const obj = parseJsonObject(raw);
+      const rawHidden = obj?.['hiddenColumns'];
+      const rawOrder = obj?.['columnOrder'];
+      const hiddenColumns = Array.isArray(rawHidden) && rawHidden.every((v): v is string => typeof v === 'string')
+        ? rawHidden
+        : [];
+      const columnOrder = Array.isArray(rawOrder) && rawOrder.every((v): v is string => typeof v === 'string')
+        ? rawOrder
+        : [];
+      return { hiddenColumns, columnOrder };
+    } catch {
+      // file doesn't exist yet — first-run defaults
+    }
+    return { hiddenColumns: [], columnOrder: [] };
+  });
+
+  ipcMain.handle('explorer:save-preferences', async (_event, prefs: ExplorerPreferences): Promise<void> => {
+    const fs = await import('node:fs/promises');
+    await fs.writeFile(await explorerPrefsPath(), JSON.stringify(prefs, null, 2));
+  });
+
+  // Histogram + totals. Depends on filters/range/granularity/scope/metric/
+  // perspective — NOT on sort. Kept separate from the rows query so that
+  // clicking a column header doesn't wipe the histogram.
+  ipcMain.handle('explorer:query-overview', async (_event, payload: unknown): Promise<ExplorerOverviewResult> => {
+    const params = payload as ExplorerOverviewParams;
+    const qc = await prepareQueryContext(app, params);
+
+    const zero: ExplorerOverviewResult = {
+      windowDays: qc.windowDays,
+      startDate: qc.startStr,
+      endDate: qc.endStr,
+      dailyTotals: [],
+      totalRows: 0,
+      totalCost: 0,
+      tagColumns: qc.tagColumns,
+    };
+    if (qc.empty) return zero;
+
+    const totalsSql = `
+      SELECT
+        CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS total_cost,
+        CAST(COUNT(*) AS DOUBLE) AS total_rows
+      FROM ${qc.source}
+      ${qc.whereStr}
+    `.trim();
+
+    // Bucket width matches the queried tier — daily rows group per day,
+    // hourly rows group per hour. Without this the hourly-tier histogram
+    // would collapse back to daily bars and hide the whole point of
+    // switching granularity.
+    const bucketExpr = qc.tier === 'hourly' ? 'usage_hour' : 'usage_date';
+    const dailySql = `
+      SELECT
+        ${bucketExpr}::VARCHAR AS date,
+        CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS daily_cost,
+        CAST(COUNT(*) AS DOUBLE) AS daily_rows
+      FROM ${qc.source}
+      ${qc.whereStr}
+      GROUP BY ${bucketExpr}
+      ORDER BY ${bucketExpr}
+    `.trim();
+
+    const [totalsResult, dailyResult] = await Promise.allSettled([
+      runQuery(totalsSql),
+      runQuery(dailySql),
+    ]);
+
+    let totalCost = 0;
+    let totalRows = 0;
+    if (totalsResult.status === 'fulfilled') {
+      const row = totalsResult.value[0];
+      totalCost = toNum(row?.['total_cost']);
+      totalRows = toNum(row?.['total_rows']);
+    } else {
+      logger.warn(`explorer: totals query failed: ${totalsResult.reason instanceof Error ? totalsResult.reason.message : String(totalsResult.reason)}`);
+    }
+
+    let dailyTotals: readonly ExplorerDailyRow[] = [];
+    if (dailyResult.status === 'fulfilled') {
+      dailyTotals = dailyResult.value.map(r => {
+        const raw = r['date'];
+        const date = typeof raw === 'string' ? raw : raw instanceof Date ? raw.toISOString().slice(0, 10) : '';
+        return { date, cost: toNum(r['daily_cost']), rows: toNum(r['daily_rows']) };
+      });
+    } else {
+      logger.warn(`explorer: daily query failed: ${dailyResult.reason instanceof Error ? dailyResult.reason.message : String(dailyResult.reason)}`);
+    }
+
+    return {
+      windowDays: qc.windowDays,
+      startDate: qc.startStr,
+      endDate: qc.endStr,
+      dailyTotals,
+      totalRows,
+      totalCost,
+      tagColumns: qc.tagColumns,
+    };
+  });
+
+  // Sample rows. Depends on everything the overview does PLUS sort + rowLimit.
+  ipcMain.handle('explorer:query-rows', async (_event, payload: unknown): Promise<ExplorerRowsResult> => {
+    const params = payload as ExplorerRowsParams;
+    const qc = await prepareQueryContext(app, params);
+    const rowLimit = clampRowLimit(params.rowLimit);
+
+    if (qc.empty) return { sampleRows: [], tagColumns: qc.tagColumns };
+
+    const tagSelectSql = qc.tagColumns.length > 0
+      ? qc.tagColumns.map(t => `COALESCE(${t.id}, '') AS ${t.id}`).join(',\n          ')
+      : null;
+    const orderBy = buildOrderBy(params.sort, qc.tagIdSet);
+    // Hourly tier exposes `usage_hour` as a TIMESTAMP in the source — cast
+    // to VARCHAR so it survives IPC cleanly. Daily has no usage_hour
+    // column, so emit a literal empty string.
+    const hourSelect = qc.tier === 'hourly' ? `usage_hour::VARCHAR AS usage_hour` : `'' AS usage_hour`;
+    const sampleSql = `
+      SELECT
+        usage_date::VARCHAR AS usage_date,
+        ${hourSelect},
+        account_id, account_name, region, service, service_family,
+        line_item_type, operation, usage_type, description, resource_id,
+        CAST(usage_amount AS DOUBLE) AS usage_amount,
+        CAST(cost AS DOUBLE) AS cost,
+        CAST(list_cost AS DOUBLE) AS list_cost${tagSelectSql === null ? '' : `,\n        ${tagSelectSql}`}
+      FROM ${qc.source}
+      ${qc.whereStr}
+      ORDER BY ${orderBy}
+      LIMIT ${String(rowLimit)}
+    `.trim();
+
+    let sampleRows: readonly ExplorerSampleRow[] = [];
+    try {
+      const rows = await runQuery(sampleSql);
+      sampleRows = rows.map(r => {
+        const tags: Record<string, string> = {};
+        for (const t of qc.tagColumns) {
+          const v = r[t.id];
+          tags[t.id] = typeof v === 'string' ? v : '';
+        }
+        return {
+          date: toStr(r['usage_date']),
+          hour: toStr(r['usage_hour']),
+          accountId: toStr(r['account_id']),
+          accountName: toStr(r['account_name']),
+          region: toStr(r['region']),
+          service: toStr(r['service']),
+          serviceFamily: toStr(r['service_family']),
+          lineItemType: toStr(r['line_item_type']),
+          operation: toStr(r['operation']),
+          usageType: toStr(r['usage_type']),
+          description: toStr(r['description']),
+          resourceId: toStr(r['resource_id']),
+          usageAmount: toNum(r['usage_amount']),
+          cost: toNum(r['cost']),
+          listCost: toNum(r['list_cost']),
+          tags,
+        };
+      });
+    } catch (err) {
+      logger.warn(`explorer: sample query failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return { sampleRows, tagColumns: qc.tagColumns };
+  });
+
+  ipcMain.handle('explorer:filter-values', async (_event, payload: unknown): Promise<ExplorerFilterValue[]> => {
+    const params = payload as ExplorerFilterValuesParams;
+    const dimId = params.dimensionId;
+
+    // Exclude the current dim from the filter set — opening a dim's dropdown
+    // should show *all* values that remain under the other filters, not
+    // just the ones already picked. Standard facet-browsing behaviour.
+    const withoutSelf: ExplorerFilterMap = Object.fromEntries(
+      Object.entries(params.filters).filter(([k]) => k !== dimId),
+    );
+
+    const qc = await prepareQueryContext(app, { ...params, filters: withoutSelf });
+    if (qc.empty) return [];
+
+    const builtIn = qc.dimensions.builtIn.find(d => d.name === dimId);
+    const tag = qc.dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimId);
+    const field = builtIn === undefined ? dimId : builtIn.field;
+    let fieldExpr = field;
+    if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
+    else if (tag !== undefined) fieldExpr = buildAliasSqlCase(`tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`, tag);
+
+    const sql = `
+      SELECT ${fieldExpr} AS val,
+             CAST(COALESCE(SUM(cost), 0) AS DOUBLE) AS total_cost,
+             CAST(COUNT(*) AS DOUBLE) AS row_count
+      FROM ${qc.source}
+      ${qc.whereStr}
+      GROUP BY val
+      HAVING val IS NOT NULL AND val != ''
+      ORDER BY total_cost DESC
+      LIMIT 500
+    `.trim();
+
+    const rows = await runQuery(sql);
+    const isAccountDim = dimId === 'account' || dimId === 'account_id';
+    if (isAccountDim) {
+      const merged = new Map<string, { cost: number; rows: number }>();
+      for (const r of rows) {
+        const rawVal = toStr(r['val']);
+        const name = qc.accountMap.get(rawVal) ?? rawVal;
+        const existing = merged.get(name);
+        if (existing === undefined) merged.set(name, { cost: toNum(r['total_cost']), rows: toNum(r['row_count']) });
+        else {
+          existing.cost += toNum(r['total_cost']);
+          existing.rows += toNum(r['row_count']);
+        }
+      }
+      return [...merged.entries()]
+        .map(([name, d]) => ({ value: name, label: name, cost: d.cost, rows: d.rows }))
+        .sort((a, b) => b.cost - a.cost);
+    }
+    return rows.map(r => {
+      const rawVal = toStr(r['val']);
+      return {
+        value: rawVal,
+        label: rawVal,
+        cost: toNum(r['total_cost']),
+        rows: toNum(r['row_count']),
+      };
+    });
+  });
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { registerOrgHandlers } from './handlers/org.js';
 import { registerAutoSyncHandlers } from './handlers/auto-sync.js';
 import { registerViewsHandlers } from './handlers/views.js';
 import { registerCostScopeHandlers } from './handlers/cost-scope.js';
+import { registerExplorerHandlers } from './handlers/explorer.js';
 import { enqueueStartupMigration } from './startup-migrate.js';
 
 export type { IpcContext };
@@ -28,6 +29,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   registerAutoSyncHandlers(app);
   registerViewsHandlers(app);
   registerCostScopeHandlers(app);
+  registerExplorerHandlers(app);
 
   // Kick off background optimization for any raw files that aren't yet
   // sorted + sidecar'd. Idempotent — skips already-optimized files. Runs in

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -32,6 +32,13 @@ import type {
   CostScopeCapabilities,
   CostScopeConfig,
   CostScopePreviewResult,
+  ExplorerFilterValue,
+  ExplorerFilterValuesParams,
+  ExplorerOverviewParams,
+  ExplorerOverviewResult,
+  ExplorerPreferences,
+  ExplorerRowsParams,
+  ExplorerRowsResult,
 } from '@costgoblin/core';
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
@@ -177,6 +184,12 @@ const api: CostApi = {
   setAutoSyncEnabled(enabled: boolean): Promise<void> {
     return invoke<undefined>('auto-sync:set-enabled', enabled).then(() => undefined);
   },
+  getAutoSyncIntervalMinutes(): Promise<number> {
+    return invoke<number>('auto-sync:get-interval');
+  },
+  setAutoSyncIntervalMinutes(minutes: number): Promise<void> {
+    return invoke<undefined>('auto-sync:set-interval', minutes).then(() => undefined);
+  },
   getAutoSyncStatus(): Promise<AutoSyncStatus> {
     return invoke<AutoSyncStatus>('auto-sync:get-status');
   },
@@ -206,6 +219,21 @@ const api: CostApi = {
   },
   revealCostScopeFolder(): Promise<void> {
     return invoke<undefined>('cost-scope:reveal-folder').then(() => undefined);
+  },
+  queryExplorerOverview(params: ExplorerOverviewParams): Promise<ExplorerOverviewResult> {
+    return invoke<ExplorerOverviewResult>('explorer:query-overview', params);
+  },
+  queryExplorerRows(params: ExplorerRowsParams): Promise<ExplorerRowsResult> {
+    return invoke<ExplorerRowsResult>('explorer:query-rows', params);
+  },
+  getExplorerFilterValues(params: ExplorerFilterValuesParams): Promise<ExplorerFilterValue[]> {
+    return invoke<ExplorerFilterValue[]>('explorer:filter-values', params);
+  },
+  getExplorerPreferences(): Promise<ExplorerPreferences> {
+    return invoke<ExplorerPreferences>('explorer:get-preferences');
+  },
+  saveExplorerPreferences(prefs: ExplorerPreferences): Promise<void> {
+    return invoke<undefined>('explorer:save-preferences', prefs).then(() => undefined);
   },
 };
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, CostApiProvider, SetupWizard, ErrorBoundary, SyncActivityIndicator, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, SyncActivityIndicator, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 
 function getApi(): CostApi {
@@ -12,6 +12,7 @@ type View =
   | { page: 'trends' }
   | { page: 'missing-tags' }
   | { page: 'savings' }
+  | { page: 'explorer' }
   | { page: 'dimensions' }
   | { page: 'cost-scope' }
   | { page: 'views-editor' }
@@ -22,6 +23,7 @@ const STATIC_LEFT_NAV: { id: string; label: string }[] = [
   { id: 'trends', label: 'Trends' },
   { id: 'missing-tags', label: 'Missing Tags' },
   { id: 'savings', label: 'Savings' },
+  { id: 'explorer', label: 'Explorer' },
 ];
 
 const RIGHT_NAV: { id: string; label: string }[] = [
@@ -62,13 +64,34 @@ type SetupCheck =
 
 const FALLBACK_VIEWS: ViewsConfig = { views: [OVERVIEW_SEED_VIEW] };
 
+/** Top-level app shell — just establishes the context providers. All the
+ *  state + navigation lives in `AppShell` below so it can call
+ *  `useConfirmLeave()` from inside the UnsavedChangesProvider. */
 export function App(): React.JSX.Element {
   const api = getApi();
+  return (
+    <ErrorBoundary>
+      <CostApiProvider value={api}>
+        <UnsavedChangesProvider>
+          <AppShell />
+        </UnsavedChangesProvider>
+      </CostApiProvider>
+    </ErrorBoundary>
+  );
+}
+
+function AppShell(): React.JSX.Element {
+  const api = useCostApi();
+  const confirmLeave = useConfirmLeave();
   const [view, setView] = useState<View>({ page: 'custom', viewId: 'overview' });
   const [missingPeriods, setMissingPeriods] = useState(0);
   const [isDark, setIsDark] = useState(true);
   const [setupCheck, setSetupCheck] = useState<SetupCheck>({ status: 'checking' });
   const [viewsConfig, setViewsConfig] = useState(FALLBACK_VIEWS);
+  // Sync-health signal. Non-null whenever something AWS-side is broken —
+  // most commonly expired credentials. Surfaced as a red dot on the Sync
+  // nav button so the user notices without having to open the tab.
+  const [syncError, setSyncError] = useState<string | null>(null);
 
   useEffect(() => {
     void api.getSetupStatus().then(({ configured }) => {
@@ -126,34 +149,70 @@ export function App(): React.JSX.Element {
       const cutoffPeriod = `${String(cutoff.getFullYear())}-${String(cutoff.getMonth() + 1).padStart(2, '0')}`;
       const missing = inv.periods.filter(p => p.localStatus === 'missing' && p.period >= cutoffPeriod).length;
       setMissingPeriods(missing);
-    }).catch(() => {
-      // ignore — S3 may not be configured yet
+      setSyncError(null);
+    }).catch((err: unknown) => {
+      // Most common cause is expired AWS credentials — surface the
+      // message on the Sync nav indicator. Swallowed silently before,
+      // which left the user on a screen that looked fine while sync
+      // was completely broken.
+      const message = err instanceof Error ? err.message : String(err);
+      setSyncError(message);
     });
   }, [api, view, setupCheck]);
 
-  function handleNavClick(id: string) {
-    switch (id) {
-      case 'trends': setView({ page: 'trends' }); break;
-      case 'missing-tags': setView({ page: 'missing-tags' }); break;
-      case 'savings': setView({ page: 'savings' }); break;
-      case 'cost-scope': setView({ page: 'cost-scope' }); break;
-      case 'dimensions': setView({ page: 'dimensions' }); break;
-      case 'views-editor': setView({ page: 'views-editor' }); break;
-      case 'sync': setView({ page: 'sync' }); break;
-      default:
-        // Anything else is a custom view id (every nav left-nav entry that
-        // isn't one of the well-known static pages above).
-        setView({ page: 'custom', viewId: id });
+  // Independent auto-sync polling — catches background-sync failures
+  // even when the user isn't on the Sync tab. The inventory effect above
+  // only fires on navigation, so without this a silent auto-sync error
+  // wouldn't surface until the user happened to revisit Sync.
+  useEffect(() => {
+    if (setupCheck.status !== 'ready') return;
+    let cancelled = false;
+    async function tick(): Promise<void> {
+      try {
+        const status = await api.getAutoSyncStatus();
+        if (cancelled) return;
+        if (status.state === 'error') {
+          setSyncError(status.message);
+        } else {
+          // Only clear errors that came from auto-sync itself — don't
+          // stomp a credentials error raised by the inventory fetch.
+          setSyncError(prev => (prev !== null && prev.includes('AWS credentials') ? prev : null));
+        }
+      } catch { /* transient */ }
     }
+    void tick();
+    const timer = setInterval(() => { void tick(); }, 10_000);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [api, setupCheck]);
+
+  function handleNavClick(id: string) {
+    confirmLeave(() => {
+      switch (id) {
+        case 'trends': setView({ page: 'trends' }); break;
+        case 'missing-tags': setView({ page: 'missing-tags' }); break;
+        case 'savings': setView({ page: 'savings' }); break;
+        case 'explorer': setView({ page: 'explorer' }); break;
+        case 'cost-scope': setView({ page: 'cost-scope' }); break;
+        case 'dimensions': setView({ page: 'dimensions' }); break;
+        case 'views-editor': setView({ page: 'views-editor' }); break;
+        case 'sync': setView({ page: 'sync' }); break;
+        default:
+          // Anything else is a custom view id (every left-nav entry that
+          // isn't one of the well-known static pages above).
+          setView({ page: 'custom', viewId: id });
+      }
+    });
   }
 
   function handleEntityClick(entity: string, dimension: string) {
-    setView({ page: 'entity-detail', entity, dimension });
+    confirmLeave(() => { setView({ page: 'entity-detail', entity, dimension }); });
   }
 
   function handleBack() {
-    const firstId = viewsConfig.views[0]?.id ?? OVERVIEW_SEED_VIEW.id;
-    setView({ page: 'custom', viewId: firstId });
+    confirmLeave(() => {
+      const firstId = viewsConfig.views[0]?.id ?? OVERVIEW_SEED_VIEW.id;
+      setView({ page: 'custom', viewId: firstId });
+    });
   }
 
   function handleSetupComplete() {
@@ -162,19 +221,11 @@ export function App(): React.JSX.Element {
   }
 
   if (setupCheck.status === 'checking') {
-    return (
-      <CostApiProvider value={api}>
-        <div className="min-h-screen bg-bg-primary" />
-      </CostApiProvider>
-    );
+    return <div className="min-h-screen bg-bg-primary" />;
   }
 
   if (setupCheck.status === 'needs-setup') {
-    return (
-      <CostApiProvider value={api}>
-        <SetupWizard onComplete={handleSetupComplete} />
-      </CostApiProvider>
-    );
+    return <SetupWizard onComplete={handleSetupComplete} />;
   }
 
   // User-defined views populate the left nav before the static analytical
@@ -187,6 +238,7 @@ export function App(): React.JSX.Element {
     if (view.page === 'trends') return 'trends';
     if (view.page === 'missing-tags') return 'missing-tags';
     if (view.page === 'savings') return 'savings';
+    if (view.page === 'explorer') return 'explorer';
     if (view.page === 'cost-scope') return 'cost-scope';
     if (view.page === 'dimensions') return 'dimensions';
     if (view.page === 'views-editor') return 'views-editor';
@@ -200,43 +252,45 @@ export function App(): React.JSX.Element {
   }
 
   return (
-    <ErrorBoundary>
-    <CostApiProvider value={api}>
-      <div className="min-h-screen bg-bg-primary text-text-primary">
-        {/* Title bar + nav */}
-        <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border">
-          <div className="h-10 flex items-center justify-center gap-2 px-4 [-webkit-app-region:drag]">
-            <img src="goblin.png" alt="" className="h-7 w-7 object-contain" />
-            <span className="text-sm font-bold text-accent tracking-wider">CostGoblin</span>
-          </div>
-          <nav className="flex items-center justify-between px-4 pb-2">
-            <div className="flex items-center gap-1">
-              {leftNav.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => { handleNavClick(item.id); }}
-                  className={[
-                    'px-3 py-1.5 text-sm font-medium rounded-md transition-colors [-webkit-app-region:no-drag]',
-                    active === item.id
-                      ? 'bg-bg-tertiary text-text-primary'
-                      : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
-                  ].join(' ')}
-                >
-                  {item.label}
-                </button>
-              ))}
-            </div>
-            <div className="flex items-center gap-1 [-webkit-app-region:no-drag]">
+    <div className="min-h-screen bg-bg-primary text-text-primary">
+      {/* Title bar + nav */}
+      <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border">
+        <div className="h-10 flex items-center justify-center gap-2 px-4 [-webkit-app-region:drag]">
+          <img src="goblin.png" alt="" className="h-7 w-7 object-contain" />
+          <span className="text-sm font-bold text-accent tracking-wider">CostGoblin</span>
+        </div>
+        <nav className="flex items-center justify-between px-4 pb-2">
+          <div className="flex items-center gap-1">
+            {leftNav.map((item) => (
               <button
+                key={item.id}
                 type="button"
-                onClick={handleToggleTheme}
-                className="rounded-md p-1.5 text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
-                aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+                onClick={() => { handleNavClick(item.id); }}
+                className={[
+                  'px-3 py-1.5 text-sm font-medium rounded-md transition-colors [-webkit-app-region:no-drag]',
+                  active === item.id
+                    ? 'bg-bg-tertiary text-text-primary'
+                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
+                ].join(' ')}
               >
-                {isDark ? <SunIcon /> : <MoonIcon />}
+                {item.label}
               </button>
-              {RIGHT_NAV.map((item) => (
+            ))}
+          </div>
+          <div className="flex items-center gap-1 [-webkit-app-region:no-drag]">
+            <button
+              type="button"
+              onClick={handleToggleTheme}
+              className="rounded-md p-1.5 text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+              aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {isDark ? <SunIcon /> : <MoonIcon />}
+            </button>
+            {RIGHT_NAV.map((item) => {
+              const isSync = item.id === 'sync';
+              const showError = isSync && syncError !== null;
+              const showMissing = isSync && !showError && missingPeriods > 0 && view.page !== 'sync';
+              return (
                 <button
                   key={item.id}
                   type="button"
@@ -246,44 +300,54 @@ export function App(): React.JSX.Element {
                     active === item.id
                       ? 'bg-bg-tertiary text-text-primary'
                       : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
+                    showError ? 'ring-1 ring-negative/60' : '',
                   ].join(' ')}
+                  title={syncError !== null ? `Sync error — ${syncError}` : undefined}
                 >
+                  {showError && (
+                    <span className="inline-flex h-2 w-2 shrink-0 rounded-full bg-negative animate-pulse" aria-label="sync error" />
+                  )}
                   {item.label}
-                  {item.id === 'sync' && <SyncActivityIndicator />}
-                  {item.id === 'sync' && missingPeriods > 0 && view.page !== 'sync' && (
+                  {isSync && <SyncActivityIndicator />}
+                  {showError && (
+                    <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-negative px-1 text-[10px] font-bold text-white">
+                      !
+                    </span>
+                  )}
+                  {showMissing && (
                     <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-bold text-bg-primary">
                       {String(missingPeriods)}
                     </span>
                   )}
                 </button>
-              ))}
-            </div>
-          </nav>
-        </div>
-
-        {/* View content */}
-        {view.page === 'custom' && (() => {
-          const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
-          return <CustomView spec={spec} headerSubtitle="Cloud spending visibility" onEntityClick={handleEntityClick} />;
-        })()}
-        {view.page === 'trends' && <CostTrends onEntityClick={handleEntityClick} />}
-        {view.page === 'missing-tags' && <MissingTags />}
-        {view.page === 'savings' && <Savings />}
-        {view.page === 'cost-scope' && <CostScopeView />}
-        {view.page === 'dimensions' && <DimensionsView />}
-        {view.page === 'views-editor' && <ViewsEditor onConfigPersisted={setViewsConfig} />}
-        <div className={view.page === 'sync' ? '' : 'hidden'}>
-          <DataManagement />
-        </div>
-        {view.page === 'entity-detail' && (
-          <EntityDetail
-            entity={view.entity}
-            dimension={view.dimension}
-            onBack={handleBack}
-          />
-        )}
+              );
+            })}
+          </div>
+        </nav>
       </div>
-    </CostApiProvider>
-    </ErrorBoundary>
+
+      {/* View content */}
+      {view.page === 'custom' && (() => {
+        const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
+        return <CustomView spec={spec} headerSubtitle="Cloud spending visibility" onEntityClick={handleEntityClick} />;
+      })()}
+      {view.page === 'trends' && <CostTrends onEntityClick={handleEntityClick} />}
+      {view.page === 'missing-tags' && <MissingTags />}
+      {view.page === 'savings' && <Savings />}
+      {view.page === 'explorer' && <ExplorerView />}
+      {view.page === 'cost-scope' && <CostScopeView />}
+      {view.page === 'dimensions' && <DimensionsView />}
+      {view.page === 'views-editor' && <ViewsEditor onConfigPersisted={setViewsConfig} />}
+      <div className={view.page === 'sync' ? '' : 'hidden'}>
+        <DataManagement />
+      </div>
+      {view.page === 'entity-detail' && (
+        <EntityDetail
+          entity={view.entity}
+          dimension={view.dimension}
+          onBack={handleBack}
+        />
+      )}
+    </div>
   );
 }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -24,6 +24,9 @@ import type {
   CostScopeCapabilities,
   CostScopeConfig,
   CostScopePreviewResult,
+  ExplorerFilterValue,
+  ExplorerOverviewResult,
+  ExplorerRowsResult,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
 
@@ -262,6 +265,8 @@ export class MockCostApi implements CostApi {
   saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }
   setAutoSyncEnabled(): Promise<void> { return Promise.resolve(); }
+  getAutoSyncIntervalMinutes(): Promise<number> { return Promise.resolve(24 * 60); }
+  setAutoSyncIntervalMinutes(): Promise<void> { return Promise.resolve(); }
   getAutoSyncStatus(): Promise<{ state: 'disabled' }> { return Promise.resolve({ state: 'disabled' }); }
   getViewsConfig(): Promise<ViewsConfig> { return Promise.resolve(MOCK_VIEWS_CONFIG); }
   saveViewsConfig(): Promise<void> { return Promise.resolve(); }
@@ -288,6 +293,60 @@ export class MockCostApi implements CostApi {
     return Promise.resolve({ hasEffectiveCostColumns: true, hasBlendedColumn: true, hasNetColumns: true });
   }
   revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }
+  queryExplorerOverview(): Promise<ExplorerOverviewResult> {
+    const today = new Date();
+    const end = today.toISOString().slice(0, 10);
+    const start = new Date(today.getTime() - 29 * 86400_000).toISOString().slice(0, 10);
+    const dailyTotals = Array.from({ length: 30 }, (_, i) => {
+      const d = new Date(today.getTime() - (29 - i) * 86400_000);
+      return {
+        date: d.toISOString().slice(0, 10),
+        cost: 3_500 + Math.sin(i / 3) * 400 + Math.random() * 300,
+        rows: 1_800 + Math.floor(Math.random() * 400),
+      };
+    });
+    return Promise.resolve({
+      windowDays: 30,
+      startDate: start,
+      endDate: end,
+      dailyTotals,
+      totalRows: 54_012,
+      totalCost: dailyTotals.reduce((s, d) => s + d.cost, 0),
+      tagColumns: [
+        { id: 'tag_team', label: 'Team' },
+        { id: 'tag_env', label: 'Environment' },
+      ],
+    });
+  }
+  queryExplorerRows(): Promise<ExplorerRowsResult> {
+    const today = new Date();
+    const end = today.toISOString().slice(0, 10);
+    const start = new Date(today.getTime() - 29 * 86400_000).toISOString().slice(0, 10);
+    const mockRows = [
+      { date: end, hour: '', accountId: '111', accountName: 'prod-main', region: 'eu-central-1', service: 'Amazon EC2', serviceFamily: 'Compute', lineItemType: 'Usage', operation: 'RunInstances', usageType: 'EUC1-BoxUsage:t3.medium', description: '$0.0464 per On Demand Linux t3.medium Instance Hour', resourceId: 'i-0abc', usageAmount: 24, cost: 1_180.5, listCost: 1_200, tags: { tag_team: 'platform', tag_env: 'prod' } },
+      { date: end, hour: '', accountId: '222', accountName: 'staging', region: 'us-east-1', service: 'Amazon RDS', serviceFamily: 'Database', lineItemType: 'Usage', operation: 'CreateDBInstance', usageType: 'RDS:db.t4g.micro', description: 'Aurora MySQL db.t4g.micro', resourceId: 'arn:rds:...', usageAmount: 12, cost: 420, listCost: 500, tags: { tag_team: 'data', tag_env: 'staging' } },
+      { date: start, hour: '', accountId: '111', accountName: 'prod-main', region: 'eu-central-1', service: 'Amazon S3', serviceFamily: 'Storage', lineItemType: 'Usage', operation: 'PutObject', usageType: 'EUC1-Requests-Tier1', description: 'PUT requests', resourceId: 'arn:s3:::...', usageAmount: 12_000, cost: 3.6, listCost: 3.6, tags: { tag_team: 'platform', tag_env: 'prod' } },
+    ];
+    return Promise.resolve({
+      sampleRows: mockRows,
+      tagColumns: [
+        { id: 'tag_team', label: 'Team' },
+        { id: 'tag_env', label: 'Environment' },
+      ],
+    });
+  }
+  getExplorerFilterValues(): Promise<ExplorerFilterValue[]> {
+    return Promise.resolve([
+      { value: 'Amazon EC2', label: 'Amazon EC2', cost: 18_000, rows: 8_400 },
+      { value: 'Amazon RDS', label: 'Amazon RDS', cost: 9_500, rows: 3_200 },
+      { value: 'Amazon S3', label: 'Amazon S3', cost: 6_200, rows: 12_800 },
+      { value: 'AWS Lambda', label: 'AWS Lambda', cost: 4_100, rows: 1_200 },
+    ]);
+  }
+  getExplorerPreferences(): Promise<{ hiddenColumns: readonly string[]; columnOrder: readonly string[] }> {
+    return Promise.resolve({ hiddenColumns: [], columnOrder: [] });
+  }
+  saveExplorerPreferences(): Promise<void> { return Promise.resolve(); }
 }
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {

--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -11,15 +11,28 @@ interface Coin {
   scale: number;
 }
 
+const COIN_SIZE = 36;
+
+// Rotation (rotateY) oscillates between 25% (90°) and 75% (270°) of a full
+// turn. Each coin starts at one of the two endpoints at random and rotates
+// toward the other, then reverses. This keeps the coin hovering around
+// its back-face view (180°) — the previous "continuous 360°" rotation
+// would spend half its time with the coin fully side-on (invisibly thin).
+const ROTATION_MIN = 90;
+const ROTATION_MAX = 270;
+
 function createCoin(id: number, containerWidth: number, containerHeight: number): Coin {
+  const startAtMin = Math.random() < 0.5;
+  const speedMag = 0.5 + Math.random() * 1.5;
   return {
     id,
-    x: Math.random() * (containerWidth - 24),
-    y: -30 - Math.random() * containerHeight * 0.6,
-    vy: 0.5 + Math.random() * 1.5,
-    vx: (Math.random() - 0.5) * 0.3,
-    rotation: Math.random() * 360,
-    rotationSpeed: (Math.random() - 0.5) * 6,
+    x: Math.random() * Math.max(containerWidth - COIN_SIZE, 0),
+    y: -COIN_SIZE - Math.random() * containerHeight * 0.6,
+    vy: 0.37,
+    vx: (Math.random() - 0.5) * 0.1,
+    rotation: startAtMin ? ROTATION_MIN : ROTATION_MAX,
+    // Sign points the rotation toward the opposite limit.
+    rotationSpeed: startAtMin ? speedMag : -speedMag,
     scale: 0.7 + Math.random() * 0.5,
   };
 }
@@ -45,17 +58,19 @@ export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: 
     const tick = () => {
       setCoins(prev => prev.map(c => {
         let { x, y, vx, vy, rotation, rotationSpeed, scale } = c;
-        vy += 0.12;
-        vx += Math.sin(Date.now() / 800 + c.id * 2) * 0.04;
+        vy += 0.034;
+        vx += Math.sin(Date.now() / 800 + c.id * 2) * 0.013;
         vx *= 0.98;
         x += vx;
         y += vy;
         rotation += rotationSpeed;
+        if (rotation >= ROTATION_MAX) { rotation = ROTATION_MAX; rotationSpeed = -Math.abs(rotationSpeed); }
+        else if (rotation <= ROTATION_MIN) { rotation = ROTATION_MIN; rotationSpeed = Math.abs(rotationSpeed); }
 
         if (x < 0) { x = 0; vx = Math.abs(vx) * 0.5; }
-        if (x > w - 24 * scale) { x = w - 24 * scale; vx = -Math.abs(vx) * 0.5; }
+        if (x > w - COIN_SIZE * scale) { x = w - COIN_SIZE * scale; vx = -Math.abs(vx) * 0.5; }
 
-        if (y > height + 30) {
+        if (y > height + COIN_SIZE) {
           return createCoin(c.id, w, height);
         }
 
@@ -77,17 +92,27 @@ export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: 
       {coins.map(c => (
         <div
           key={c.id}
-          className="absolute pointer-events-none select-none"
+          className="absolute pointer-events-none select-none flex items-center justify-center rounded-full font-black"
           style={{
             left: c.x,
             top: c.y,
-            transform: `rotateZ(${String(c.rotation)}deg) scale(${String(c.scale)})`,
-            fontSize: 22,
+            width: 36,
+            height: 36,
+            // rotateY gives the 3D tumble effect — a plain Z-rotate on a
+            // symmetric circle is invisible. The Y axis flips the front/back
+            // face; the `$` glyph appears squashed at 90°/270° which reads as
+            // "spinning on its edge".
+            transform: `rotateY(${String(c.rotation)}deg) scale(${String(c.scale)})`,
+            background: 'radial-gradient(circle at 32% 28%, #FFF3B0 0%, #F4C430 35%, #D4A017 70%, #8B6914 100%)',
+            boxShadow: 'inset -2px -3px 0 rgba(0,0,0,0.22), inset 2px 2px 2px rgba(255,255,255,0.35), 0 3px 6px rgba(0,0,0,0.3)',
+            color: '#5A3D00',
+            fontSize: 20,
+            lineHeight: 1,
             willChange: 'transform',
             transition: 'transform 0.03s linear',
           }}
         >
-          🪙
+          $
         </div>
       ))}
     </div>

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -30,13 +30,17 @@ interface DateRangePickerProps {
   value: DateRange;
   granularity: Granularity;
   onChange: (range: DateRange, granularity: Granularity) => void;
+  /** Hide the "Hourly" preset row. Used by views that only query the
+   *  daily tier (Explorer), where offering hourly presets would lead to
+   *  empty result sets. */
+  hideHourly?: boolean;
 }
 
 export function getDefaultDateRange(): DateRange {
   return { start: daysAgo(31), end: daysAgo(1) };
 }
 
-export function DateRangePicker({ value, granularity, onChange }: DateRangePickerProps) {
+export function DateRangePicker({ value, granularity, onChange, hideHourly }: DateRangePickerProps) {
   const [showCustom, setShowCustom] = useState(false);
   const yesterday = daysAgo(1);
 
@@ -91,6 +95,7 @@ export function DateRangePicker({ value, granularity, onChange }: DateRangePicke
       </div>
 
       {/* Hourly row */}
+      {hideHourly !== true && (
       <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
         <span className="text-[10px] text-text-muted px-1.5">Hourly</span>
         {HOURLY_PRESETS.map(preset => (
@@ -109,6 +114,7 @@ export function DateRangePicker({ value, granularity, onChange }: DateRangePicke
           </button>
         ))}
       </div>
+      )}
 
       {/* Custom date inputs */}
       {showCustom && (

--- a/packages/ui/src/components/summary-card.tsx
+++ b/packages/ui/src/components/summary-card.tsx
@@ -1,14 +1,20 @@
 import { formatDollars, formatDate } from './format.js';
 
 interface SummaryCardProps {
-  totalCost: number;
-  previousCost?: number | undefined;
+  /** `null` means "not loaded yet" — the card renders placeholders so the
+   *  user doesn't briefly see "$0.00" before the real total lands. */
+  totalCost: number | null;
+  previousCost?: number | null | undefined;
   dateRange: { start: string; end: string };
 }
 
+const PLACEHOLDER = '—';
+
 export function SummaryCard({ totalCost, previousCost, dateRange }: Readonly<SummaryCardProps>) {
+  const hasTotal = totalCost !== null;
+  const hasPrevious = previousCost !== null && previousCost !== undefined;
   const delta =
-    previousCost !== undefined && previousCost > 0
+    hasTotal && hasPrevious && previousCost > 0
       ? ((totalCost - previousCost) / previousCost) * 100
       : null;
 
@@ -18,22 +24,24 @@ export function SummaryCard({ totalCost, previousCost, dateRange }: Readonly<Sum
   const rangeStart = new Date(dateRange.start).getTime();
   const rangeEnd = new Date(dateRange.end).getTime();
   const rangeDays = Math.max(1, Math.round((rangeEnd - rangeStart) / (24 * 60 * 60 * 1000)) + 1);
-  const dailyAvg = totalCost / rangeDays;
+  const dailyAvg = hasTotal ? totalCost / rangeDays : null;
 
   return (
     <div className="flex flex-col justify-between rounded-xl border border-border bg-bg-secondary px-6 py-5 h-full">
       <div>
         <p className="text-xs font-medium uppercase tracking-wider text-text-secondary">Total Cost</p>
         <span className="mt-2 block text-4xl font-bold tabular-nums text-text-primary">
-          {formatDollars(totalCost)}
+          {hasTotal ? formatDollars(totalCost) : PLACEHOLDER}
         </span>
       </div>
 
       <div className="flex flex-col gap-3 mt-4">
-        {delta !== null && (
+        {(delta !== null || (hasTotal && previousCost === null)) && (
           <div className="rounded-lg bg-bg-tertiary/30 px-4 py-3">
             <p className="text-xs uppercase tracking-wider text-text-muted">vs Previous Period</p>
-            {(() => {
+            {delta === null ? (
+              <p className="mt-1 text-2xl font-bold tabular-nums text-text-muted">{PLACEHOLDER}</p>
+            ) : (() => {
               const deltaColor = isIncrease ? 'text-negative' : isDecrease ? 'text-positive' : 'text-text-secondary';
               const deltaArrow = isDecrease ? '▼' : isIncrease ? '▲' : '';
               return (
@@ -43,7 +51,7 @@ export function SummaryCard({ totalCost, previousCost, dateRange }: Readonly<Sum
                 </p>
               );
             })()}
-            {previousCost !== undefined && (
+            {hasPrevious && (
               <p className="mt-0.5 text-xs text-text-muted">
                 Previous: {formatDollars(previousCost)}
               </p>
@@ -54,7 +62,7 @@ export function SummaryCard({ totalCost, previousCost, dateRange }: Readonly<Sum
         <div className="rounded-lg bg-bg-tertiary/30 px-4 py-3">
           <p className="text-xs uppercase tracking-wider text-text-muted">Daily Average</p>
           <p className="mt-1 text-lg font-semibold tabular-nums text-text-primary">
-            {formatDollars(dailyAvg)}
+            {dailyAvg === null ? PLACEHOLDER : formatDollars(dailyAvg)}
           </p>
         </div>
       </div>

--- a/packages/ui/src/hooks/use-unsaved-changes.tsx
+++ b/packages/ui/src/hooks/use-unsaved-changes.tsx
@@ -1,0 +1,126 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { ConfirmModal } from '../components/confirm-modal.js';
+
+/** Any view that edits something registers its dirty state via
+ *  `useUnsavedChanges(dirty, label)`. The provider keeps a registry of
+ *  currently-dirty keys; any call to `confirmLeave(onProceed)` with at
+ *  least one dirty entry pops a confirm modal before running the callback.
+ *
+ *  Scope is intentionally per-session (not persisted) — if a user reloads
+ *  the app mid-edit, their draft is gone anyway; the guard only protects
+ *  in-session navigation between views. */
+interface UnsavedChangesContextValue {
+  readonly hasUnsaved: boolean;
+  readonly label: string | null;
+  readonly setDirty: (key: string, dirty: boolean, label?: string) => void;
+  readonly confirmLeave: (onProceed: () => void) => void;
+}
+
+const UnsavedChangesContext = createContext<UnsavedChangesContextValue>({
+  hasUnsaved: false,
+  label: null,
+  setDirty: () => { /* no-op fallback when provider is missing (tests) */ },
+  confirmLeave: (fn) => { fn(); },
+});
+
+interface RegistryEntry {
+  readonly dirty: boolean;
+  readonly label: string | null;
+}
+
+export function UnsavedChangesProvider({ children }: Readonly<{ children: ReactNode }>): React.JSX.Element {
+  const [registry, setRegistry] = useState<ReadonlyMap<string, RegistryEntry>>(new Map());
+  const [pending, setPending] = useState<(() => void) | null>(null);
+
+  const setDirty = useCallback((key: string, dirty: boolean, label?: string) => {
+    setRegistry(prev => {
+      const existing = prev.get(key);
+      // Skip updates that would no-op the registry — keeps React from
+      // kicking off a re-render every keystroke when a dirty state stays
+      // dirty, which would otherwise re-fire every view's useEffect that
+      // depends on `setDirty`.
+      if (dirty && existing !== undefined && existing.dirty === dirty && existing.label === (label ?? null)) {
+        return prev;
+      }
+      if (!dirty && existing === undefined) return prev;
+      const next = new Map(prev);
+      if (dirty) next.set(key, { dirty, label: label ?? null });
+      else next.delete(key);
+      return next;
+    });
+  }, []);
+
+  const label = useMemo(() => {
+    for (const entry of registry.values()) {
+      if (entry.label !== null) return entry.label;
+    }
+    return null;
+  }, [registry]);
+  const hasUnsaved = registry.size > 0;
+
+  // Snapshot `hasUnsaved` at call time via a ref so `confirmLeave` is
+  // stable — otherwise the App.tsx navigation handler would change
+  // identity on every edit keystroke and its own useEffect deps would
+  // thrash.
+  const hasUnsavedRef = useRef(hasUnsaved);
+  hasUnsavedRef.current = hasUnsaved;
+
+  const confirmLeave = useCallback((onProceed: () => void) => {
+    if (!hasUnsavedRef.current) { onProceed(); return; }
+    setPending(() => onProceed);
+  }, []);
+
+  const value = useMemo<UnsavedChangesContextValue>(
+    () => ({ hasUnsaved, label, setDirty, confirmLeave }),
+    [hasUnsaved, label, setDirty, confirmLeave],
+  );
+
+  return (
+    <UnsavedChangesContext.Provider value={value}>
+      {children}
+      {pending !== null && (
+        <ConfirmModal
+          title={label === null ? 'Discard unsaved changes?' : `Discard changes in ${label}?`}
+          message="You have unsaved changes that haven't been saved yet. If you continue, they'll be lost."
+          confirmLabel="Discard"
+          cancelLabel="Stay"
+          destructive
+          onConfirm={() => {
+            const proceed = pending;
+            setPending(null);
+            proceed();
+          }}
+          onCancel={() => { setPending(null); }}
+        />
+      )}
+    </UnsavedChangesContext.Provider>
+  );
+}
+
+/** Register the current view's dirty state with the guard. Pass a stable
+ *  boolean (usually computed from draft-vs-saved) and an optional human
+ *  label ("Cost Scope", "Views") that'll appear in the confirm modal. */
+export function useUnsavedChanges(isDirty: boolean, label?: string): void {
+  const ctx = useContext(UnsavedChangesContext);
+  // Stable per-mount key so each mounted view registers independently.
+  // Using a ref keeps the key across renders — a new one would cause the
+  // cleanup/register pair to churn and leave stale entries behind.
+  const keyRef = useRef<string | undefined>(undefined);
+  if (keyRef.current === undefined) {
+    keyRef.current = `uc-${String(Math.random()).slice(2)}-${String(Date.now())}`;
+  }
+  const setDirty = ctx.setDirty;
+  useEffect(() => {
+    const key = keyRef.current;
+    if (key === undefined) return;
+    setDirty(key, isDirty, label);
+    return () => { setDirty(key, false); };
+  }, [isDirty, label, setDirty]);
+}
+
+/** Wrap a navigation (or any "leaving" action) — runs immediately if no
+ *  view is dirty, otherwise prompts before proceeding. */
+export function useConfirmLeave(): (onProceed: () => void) => void {
+  return useContext(UnsavedChangesContext).confirmLeave;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export { cn } from './lib/utils.js';
 
 export { useCostApi, CostApiProvider } from './hooks/use-cost-api.js';
 export { useQuery } from './hooks/use-query.js';
+export { UnsavedChangesProvider, useUnsavedChanges, useConfirmLeave } from './hooks/use-unsaved-changes.js';
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './components/ui/card.js';
 export { Button, buttonVariants } from './components/ui/button.js';
@@ -22,6 +23,7 @@ export { SyncStatusIndicator } from './components/sync-status.js';
 export { SyncActivityIndicator } from './components/sync-activity-indicator.js';
 export { formatDollars, formatPercent, formatDate } from './components/format.js';
 export { FilterBar } from './components/filter-bar.js';
+export { DateRangePicker, getDefaultDateRange } from './components/date-range-picker.js';
 export { EnvironmentBar } from './components/environment-bar.js';
 export { SummaryCard } from './components/summary-card.js';
 export { DimensionSelector } from './components/dimension-selector.js';
@@ -51,6 +53,7 @@ export { EntityDetail } from './views/entity-detail.js';
 export { DataManagement } from './views/data-management.js';
 export { DimensionsView } from './views/dimensions.js';
 export { CostScopeView } from './views/cost-scope.js';
+export { ExplorerView } from './views/explorer.js';
 export { SetupWizard } from './views/setup-wizard.js';
 
 export { getDimensionId, isTagDimension, isEnvironmentDimension, isOwnerDimension, isProductDimension } from './lib/dimensions.js';

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@costgoblin/core/browser';
 import { BUILTIN_EXCLUSION_RULES, COST_METRICS, DEFAULT_COST_SCOPE, asDimensionId } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { formatDollars } from '../components/format.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
 import { Button } from '../components/ui/button.js';
@@ -586,6 +587,7 @@ export function CostScopeView(): React.JSX.Element {
   const dirty = JSON.stringify(draft) !== JSON.stringify(saved);
   const draftError = describeDraftError(draft);
   const canSave = dirty && draftError === null && !saving;
+  useUnsavedChanges(dirty, 'Cost Scope');
 
   useEffect(() => {
     void api.getCostScope().then(cfg => {
@@ -931,6 +933,13 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
     return ((result.unscopedTotalCost - result.scopedTotalCost) / result.unscopedTotalCost) * 100;
   }, [result]);
 
+  // The handler returns a zero-filled result when there are no periods on
+  // disk — showing "$0.00 · 0.0% excluded" in that state looks like a
+  // real answer. Collapse both "no result yet" and "handler returned
+  // zeros" into a single "no data" rendering that matches the histogram.
+  const hasData = result !== null && result.dailyTotals.length > 0;
+  const placeholder = loading ? '…' : '—';
+
   return (
     <Card data-testid="cost-scope-preview" className="shadow-lg @container">
       <CardHeader className="pb-3">
@@ -953,19 +962,19 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
         <div className="grid grid-cols-1 @md:grid-cols-3 gap-2">
           <SummaryTile
             label="Unscoped total"
-            value={result !== null ? formatDollars(result.unscopedTotalCost) : loading ? '…' : '—'}
+            value={hasData ? formatDollars(result.unscopedTotalCost) : placeholder}
             hint={`Raw ${metricLabel.toLowerCase()} over the window`}
           />
           <SummaryTile
             label="After scope"
-            value={result !== null ? formatDollars(result.scopedTotalCost) : loading ? '…' : '—'}
-            hint={hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled'}
+            value={hasData ? formatDollars(result.scopedTotalCost) : placeholder}
+            hint={!hasData ? '' : hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled'}
             emphasis
           />
           <SummaryTile
             label="Excluded"
-            value={hasEnabledRules ? combinedText : '—'}
-            hint={hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule'}
+            value={hasData && hasEnabledRules ? combinedText : placeholder}
+            hint={!hasData ? '' : hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule'}
           />
         </div>
 

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -25,12 +25,19 @@ export function DataManagement() {
   const [hourlySyncState, setHourlySyncState] = useState<SyncState>({ status: 'idle' });
   const [costOptSyncState, setCostOptSyncState] = useState<SyncState>({ status: 'idle' });
   const autoSyncQuery = useQuery(() => api.getAutoSyncEnabled(), []);
+  const autoSyncIntervalQuery = useQuery(() => api.getAutoSyncIntervalMinutes(), []);
   const [autoSync, setAutoSync] = useState(false);
   const [autoSyncLoaded, setAutoSyncLoaded] = useState(false);
+  const [autoSyncInterval, setAutoSyncIntervalState] = useState(24 * 60);
+  const [autoSyncIntervalLoaded, setAutoSyncIntervalLoaded] = useState(false);
 
   if (!autoSyncLoaded && autoSyncQuery.status === 'success') {
     setAutoSyncLoaded(true);
     setAutoSync(autoSyncQuery.data);
+  }
+  if (!autoSyncIntervalLoaded && autoSyncIntervalQuery.status === 'success') {
+    setAutoSyncIntervalLoaded(true);
+    setAutoSyncIntervalState(autoSyncIntervalQuery.data);
   }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
@@ -368,6 +375,25 @@ export function DataManagement() {
             >
               <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
             </button>
+            <select
+              value={String(autoSyncInterval)}
+              disabled={!autoSync}
+              onChange={e => {
+                const next = Number(e.target.value);
+                setAutoSyncIntervalState(next);
+                void api.setAutoSyncIntervalMinutes(next);
+              }}
+              title="How often auto-sync runs. Keep this at least a day unless you're debugging — each run hits S3."
+              className="rounded-md border border-border bg-bg-tertiary/50 px-2 py-1 text-xs text-text-secondary disabled:opacity-40"
+            >
+              <option value="60">Every hour</option>
+              <option value="180">Every 3 hours</option>
+              <option value="360">Every 6 hours</option>
+              <option value="720">Every 12 hours</option>
+              <option value="1440">Once a day</option>
+              <option value="4320">Every 3 days</option>
+              <option value="10080">Once a week</option>
+            </select>
           </div>
           <button
             type="button"

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ChevronUp, ChevronDown, GripVertical } from 'lucide-react';
 import type { BuiltInDimension, DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { useQuery } from '../hooks/use-query.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
@@ -122,6 +123,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
   const initialRef = useRef(dim.editing);
   const [discardConfirm, setDiscardConfirm] = useState(false);
   const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
+  useUnsavedChanges(isDirty, 'Dimension editor');
   function requestCancel(): void {
     if (isDirty) setDiscardConfirm(true);
     else onCancel();
@@ -524,6 +526,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   const initialRef = useRef(tag);
   const [discardConfirm, setDiscardConfirm] = useState(false);
   const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
+  useUnsavedChanges(isDirty, 'Tag editor');
   function requestCancel(): void {
     if (isDirty) setDiscardConfirm(true);
     else onCancel();

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -1,0 +1,1334 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  CostMetric,
+  CostPerspective,
+  CostScopeCapabilities,
+  DateRange,
+  Dimension,
+  ExplorerFilterMap,
+  ExplorerFilterValue,
+  ExplorerOverviewResult,
+  ExplorerRowsResult,
+  ExplorerSort,
+  ExplorerSortDirection,
+  Granularity,
+} from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { formatDollars } from '../components/format.js';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
+import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
+import { CoinRainLoader } from '../components/coin-rain-loader.js';
+import { getDimensionId } from '../lib/dimensions.js';
+
+const DEBOUNCE_MS = 250;
+const ROW_LIMIT = 500;
+
+function formatSignedDollars(n: number): string {
+  if (n < 0) return `-${formatDollars(-n)}`;
+  return formatDollars(n);
+}
+
+interface OverviewState {
+  data: ExplorerOverviewResult | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface RowsState {
+  data: ExplorerRowsResult | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/** Columns the user can sort / filter on. Must line up with the server's
+ *  SORTABLE_SCALAR_COLUMNS set and with the dim ids the handler emits as
+ *  filter predicates. `dimId` is set when the column maps to a filter-able
+ *  dimension — clicking a cell's value then adds it to the filter. */
+interface ColumnSpec {
+  readonly key: string;
+  readonly label: string;
+  readonly dimId: string | null;
+  readonly align: 'left' | 'right';
+  readonly mono?: boolean;
+  readonly truncate?: boolean;
+}
+
+const BASE_COLUMNS: readonly ColumnSpec[] = [
+  { key: 'usage_date', label: 'Date', dimId: null, align: 'left', mono: true },
+  { key: 'usage_hour', label: 'Hour', dimId: null, align: 'left', mono: true },
+  { key: 'cost', label: 'Cost', dimId: null, align: 'right', mono: true },
+  { key: 'list_cost', label: 'List', dimId: null, align: 'right', mono: true },
+  { key: 'service', label: 'Service', dimId: 'service', align: 'left' },
+  { key: 'account_name', label: 'Account', dimId: 'account', align: 'left' },
+  { key: 'line_item_type', label: 'Line type', dimId: 'line_item_type', align: 'left' },
+  { key: 'region', label: 'Region', dimId: 'region', align: 'left', mono: true },
+  { key: 'service_family', label: 'Family', dimId: 'service_family', align: 'left' },
+  { key: 'usage_type', label: 'Usage type', dimId: 'usage_type', align: 'left', mono: true },
+  { key: 'operation', label: 'Operation', dimId: 'operation', align: 'left' },
+  { key: 'usage_amount', label: 'Usage', dimId: null, align: 'right', mono: true },
+];
+
+const TRAILING_COLUMNS: readonly ColumnSpec[] = [
+  { key: 'resource_id', label: 'Resource', dimId: 'resource_id', align: 'left', mono: true, truncate: true },
+  { key: 'description', label: 'Description', dimId: null, align: 'left', truncate: true },
+];
+
+export function ExplorerView(): React.JSX.Element {
+  const api = useCostApi();
+  const [filters, setFilters] = useState<ExplorerFilterMap>({});
+  const [sort, setSort] = useState<ExplorerSort | undefined>(undefined);
+  const [dimensions, setDimensions] = useState<Dimension[]>([]);
+  const [capabilities, setCapabilities] = useState<CostScopeCapabilities | null>(null);
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const [granularity, setGranularity] = useState<Granularity>('daily');
+  const [applyCostScope, setApplyCostScope] = useState(false);
+  const [costMetric, setCostMetric] = useState<CostMetric>('unblended');
+  const [costPerspective, setCostPerspective] = useState<CostPerspective>('gross');
+  const [overview, setOverview] = useState<OverviewState>({ data: null, loading: true, error: null });
+  const [rows, setRows] = useState<RowsState>({ data: null, loading: true, error: null });
+  const [hiddenColumns, setHiddenColumns] = useState<readonly string[]>([]);
+  const [columnOrder, setColumnOrder] = useState<readonly string[]>([]);
+  const overviewDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rowsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const overviewReqIdRef = useRef(0);
+  const rowsReqIdRef = useRef(0);
+
+  useEffect(() => {
+    // Store ALL dims (not just enabled). The filter bar normally hides
+    // disabled dims, but it needs to fall back to the full list to render
+    // chips for dims with active filters — e.g. the user clicks a Resource
+    // cell and that dim is disabled-by-default high-cardinality.
+    api.getDimensions().then(dims => { setDimensions(dims); }).catch(() => { setDimensions([]); });
+    api.getCostScopeCapabilities().then(setCapabilities).catch(() => { setCapabilities(null); });
+    api.getExplorerPreferences().then(prefs => {
+      setHiddenColumns(prefs.hiddenColumns);
+      setColumnOrder(prefs.columnOrder);
+    }).catch(() => {
+      setHiddenColumns([]);
+      setColumnOrder([]);
+    });
+  }, [api]);
+
+  // Persist column visibility / order on change. Fire-and-forget — the UI
+  // already reflects the new state locally, so a write failure just means
+  // the preference won't survive a reload (rare edge case, not worth
+  // surfacing). One helper keeps both fields in sync on every save.
+  function saveColumnPrefs(hidden: readonly string[], order: readonly string[]) {
+    void api.saveExplorerPreferences({ hiddenColumns: hidden, columnOrder: order });
+  }
+
+  function updateHiddenColumns(next: readonly string[]) {
+    setHiddenColumns(next);
+    saveColumnPrefs(next, columnOrder);
+  }
+
+  function updateColumnOrder(next: readonly string[]) {
+    setColumnOrder(next);
+    saveColumnPrefs(hiddenColumns, next);
+  }
+
+  // Back-off from a metric / perspective the CUR doesn't support. Happens
+  // when a user's CUR export drops the effective-cost or net-cost columns
+  // between sessions — we downgrade silently instead of returning bogus
+  // values from the server.
+  useEffect(() => {
+    if (capabilities === null) return;
+    if (costMetric === 'amortized' && !capabilities.hasEffectiveCostColumns) setCostMetric('unblended');
+    if (costMetric === 'blended' && !capabilities.hasBlendedColumn) setCostMetric('unblended');
+    if (costPerspective === 'net' && !capabilities.hasNetColumns) setCostPerspective('gross');
+  }, [capabilities, costMetric, costPerspective]);
+
+  const runOverview = useCallback((
+    f: ExplorerFilterMap,
+    range: DateRange,
+    gran: Granularity,
+    scope: boolean,
+    metric: CostMetric,
+    perspective: CostPerspective,
+  ) => {
+    const reqId = ++overviewReqIdRef.current;
+    setOverview(prev => ({ ...prev, loading: true, error: null }));
+    api.queryExplorerOverview({
+      filters: f,
+      dateRange: range,
+      granularity: gran,
+      applyCostScope: scope,
+      costMetric: metric,
+      costPerspective: perspective,
+    })
+      .then(data => {
+        if (reqId !== overviewReqIdRef.current) return;
+        setOverview({ data, loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (reqId !== overviewReqIdRef.current) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setOverview(prev => ({ data: prev.data, loading: false, error: message }));
+      });
+  }, [api]);
+
+  const runRows = useCallback((
+    f: ExplorerFilterMap,
+    s: ExplorerSort | undefined,
+    range: DateRange,
+    gran: Granularity,
+    scope: boolean,
+    metric: CostMetric,
+    perspective: CostPerspective,
+  ) => {
+    const reqId = ++rowsReqIdRef.current;
+    setRows(prev => ({ ...prev, loading: true, error: null }));
+    api.queryExplorerRows({
+      filters: f,
+      rowLimit: ROW_LIMIT,
+      dateRange: range,
+      granularity: gran,
+      applyCostScope: scope,
+      costMetric: metric,
+      costPerspective: perspective,
+      ...(s === undefined ? {} : { sort: s }),
+    })
+      .then(data => {
+        if (reqId !== rowsReqIdRef.current) return;
+        setRows({ data, loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (reqId !== rowsReqIdRef.current) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setRows(prev => ({ data: prev.data, loading: false, error: message }));
+      });
+  }, [api]);
+
+  // Overview (histogram + totals) — deliberately omits `sort` from deps so
+  // changing the table sort doesn't wipe the histogram.
+  useEffect(() => {
+    if (overviewDebounceRef.current !== null) clearTimeout(overviewDebounceRef.current);
+    overviewDebounceRef.current = setTimeout(() => {
+      runOverview(filters, dateRange, granularity, applyCostScope, costMetric, costPerspective);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (overviewDebounceRef.current !== null) clearTimeout(overviewDebounceRef.current);
+    };
+  }, [filters, dateRange, granularity, applyCostScope, costMetric, costPerspective, runOverview]);
+
+  // Sample rows — all overview deps PLUS sort. A sort-only change therefore
+  // only re-fires this fetch, leaving the histogram alone.
+  useEffect(() => {
+    if (rowsDebounceRef.current !== null) clearTimeout(rowsDebounceRef.current);
+    rowsDebounceRef.current = setTimeout(() => {
+      runRows(filters, sort, dateRange, granularity, applyCostScope, costMetric, costPerspective);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (rowsDebounceRef.current !== null) clearTimeout(rowsDebounceRef.current);
+    };
+  }, [filters, sort, dateRange, granularity, applyCostScope, costMetric, costPerspective, runRows]);
+
+  const tagColumns = overview.data?.tagColumns ?? rows.data?.tagColumns ?? [];
+  // Default column list (built-ins + tags + trailing), before the user's
+  // stored order is applied. Hour is daily-irrelevant so we drop it for
+  // daily queries rather than showing an always-empty column.
+  const defaultColumns = useMemo<readonly ColumnSpec[]>(() => [
+    ...BASE_COLUMNS.filter(c => c.key !== 'usage_hour' || granularity === 'hourly'),
+    ...tagColumns.map<ColumnSpec>(t => ({
+      key: t.id,
+      label: t.label,
+      dimId: t.id,
+      align: 'left',
+    })),
+    ...TRAILING_COLUMNS,
+  ], [tagColumns, granularity]);
+
+  // Apply the user's stored column order to the default list. Keys the
+  // user has never reordered (e.g. a tag dim they added later) keep their
+  // default relative position by getting appended at the end — cheaper
+  // than interleaving and the user can drag them to taste.
+  const availableColumns = useMemo<readonly ColumnSpec[]>(() => {
+    if (columnOrder.length === 0) return defaultColumns;
+    const byKey = new Map(defaultColumns.map(c => [c.key, c]));
+    const seen = new Set<string>();
+    const ordered: ColumnSpec[] = [];
+    for (const key of columnOrder) {
+      const col = byKey.get(key);
+      if (col !== undefined && !seen.has(key)) {
+        ordered.push(col);
+        seen.add(key);
+      }
+    }
+    for (const col of defaultColumns) {
+      if (!seen.has(col.key)) ordered.push(col);
+    }
+    return ordered;
+  }, [defaultColumns, columnOrder]);
+
+  const hiddenSet = useMemo(() => new Set(hiddenColumns), [hiddenColumns]);
+
+  // Columns auto-hidden because the user has pinned their dim to a single
+  // filter value — every cell would show that same value, so the column
+  // carries no information. Cleared automatically when the filter is
+  // widened. Kept separate from `hiddenColumns` so the user's explicit
+  // preference isn't overwritten.
+  const autoHiddenSet = useMemo(() => {
+    const keys = new Set<string>();
+    for (const [dimId, values] of Object.entries(filters)) {
+      if (values.length !== 1) continue;
+      for (const col of availableColumns) {
+        if (col.dimId === dimId) keys.add(col.key);
+      }
+    }
+    return keys;
+  }, [filters, availableColumns]);
+
+  const visibleColumns = useMemo(
+    () => availableColumns.filter(c => !hiddenSet.has(c.key) && !autoHiddenSet.has(c.key)),
+    [availableColumns, hiddenSet, autoHiddenSet],
+  );
+
+  function addFilterValue(dimId: string, value: string) {
+    setFilters(prev => {
+      const existing = prev[dimId] ?? [];
+      if (existing.includes(value)) return prev;
+      return { ...prev, [dimId]: [...existing, value] };
+    });
+  }
+
+  function setFilterValues(dimId: string, values: readonly string[]) {
+    setFilters(prev => {
+      if (values.length === 0) {
+        return Object.fromEntries(Object.entries(prev).filter(([k]) => k !== dimId));
+      }
+      return { ...prev, [dimId]: values };
+    });
+  }
+
+  function clearAll() {
+    setFilters({});
+  }
+
+  function handleSort(columnKey: string) {
+    setSort(prev => {
+      if (prev?.column === columnKey) {
+        const nextDir: ExplorerSortDirection = prev.direction === 'asc' ? 'desc' : 'asc';
+        return { column: columnKey, direction: nextDir };
+      }
+      // First click: desc for numeric, asc for text. The table is a
+      // raw-rows view so "biggest first" is the natural default for cost /
+      // usage, while alphabetical feels right for text.
+      const numericCols = new Set(['cost', 'list_cost', 'usage_amount', 'usage_date']);
+      const dir: ExplorerSortDirection = numericCols.has(columnKey) ? 'desc' : 'asc';
+      return { column: columnKey, direction: dir };
+    });
+  }
+
+  const activeFilterCount = Object.values(filters).reduce((n, vs) => n + vs.length, 0);
+  const overviewData = overview.data;
+
+  return (
+    <div className="p-6 max-w-[1800px] mx-auto space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">Explorer</h1>
+          <p className="text-sm text-text-secondary mt-1">
+            Inspect the raw CUR dataset. Filter on any dimension, sort any column, see daily totals over the selected range.
+          </p>
+          {overviewData !== null && (
+            <div className="mt-2 text-xs text-text-muted tabular-nums">
+              {formatDollars(overviewData.totalCost)} · {overviewData.totalRows.toLocaleString()} line items
+              {' · '}
+              {overviewData.startDate} → {overviewData.endDate}
+            </div>
+          )}
+        </div>
+        <DateRangePicker
+          value={dateRange}
+          granularity={granularity}
+          onChange={(range, g) => { setDateRange(range); setGranularity(g); }}
+        />
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Options</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ExplorerOptions
+            capabilities={capabilities}
+            applyCostScope={applyCostScope}
+            onApplyCostScopeChange={setApplyCostScope}
+            costMetric={costMetric}
+            onCostMetricChange={setCostMetric}
+            costPerspective={costPerspective}
+            onCostPerspectiveChange={setCostPerspective}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Daily total</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Histogram days={overviewData?.dailyTotals ?? []} loading={overview.loading} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3 flex flex-row items-center justify-between">
+          <CardTitle className="text-sm">Filters</CardTitle>
+          {activeFilterCount > 0 && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs text-text-secondary hover:text-text-primary underline-offset-2 hover:underline"
+            >
+              Clear all ({String(activeFilterCount)})
+            </button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <MultiFilterBar
+            dimensions={dimensions}
+            filters={filters}
+            onChange={setFilterValues}
+            fetchValues={(dimId) => api.getExplorerFilterValues({
+              dimensionId: dimId,
+              filters,
+              dateRange,
+              granularity,
+              applyCostScope,
+              costMetric,
+              costPerspective,
+            })}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-5">
+          <RowsTable
+            columns={visibleColumns}
+            allColumns={availableColumns}
+            hiddenColumns={hiddenColumns}
+            autoHiddenKeys={autoHiddenSet}
+            onHiddenColumnsChange={updateHiddenColumns}
+            onColumnOrderChange={updateColumnOrder}
+            rows={rows.data?.sampleRows ?? []}
+            totalRows={overviewData?.totalRows ?? 0}
+            sort={sort}
+            onSort={handleSort}
+            onFilterAdd={addFilterValue}
+            loading={rows.loading}
+            error={rows.error}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface ExplorerOptionsProps {
+  readonly capabilities: CostScopeCapabilities | null;
+  readonly applyCostScope: boolean;
+  readonly onApplyCostScopeChange: (v: boolean) => void;
+  readonly costMetric: CostMetric;
+  readonly onCostMetricChange: (m: CostMetric) => void;
+  readonly costPerspective: CostPerspective;
+  readonly onCostPerspectiveChange: (p: CostPerspective) => void;
+}
+
+function ExplorerOptions({
+  capabilities,
+  applyCostScope,
+  onApplyCostScopeChange,
+  costMetric,
+  onCostMetricChange,
+  costPerspective,
+  onCostPerspectiveChange,
+}: ExplorerOptionsProps): React.JSX.Element {
+  const metricOptions: { value: CostMetric; label: string; available: boolean }[] = [
+    { value: 'unblended', label: 'Unblended', available: true },
+    { value: 'blended', label: 'Blended', available: capabilities?.hasBlendedColumn !== false },
+    { value: 'amortized', label: 'Amortized', available: capabilities?.hasEffectiveCostColumns !== false },
+  ];
+  const netAvailable = capabilities?.hasNetColumns !== false;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+      <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+        <input
+          type="checkbox"
+          className="accent-accent"
+          checked={applyCostScope}
+          onChange={e => { onApplyCostScopeChange(e.target.checked); }}
+        />
+        <span className="text-text-secondary">Apply Cost Scope</span>
+        <span className="text-text-muted">(hide Tax, Credits, RI purchases, etc.)</span>
+      </label>
+
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-text-muted">Metric:</span>
+        <div className="flex items-center gap-3">
+          {metricOptions.map(opt => (
+            <label
+              key={opt.value}
+              className={[
+                'flex items-center gap-1 select-none',
+                opt.available ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
+              ].join(' ')}
+              title={opt.available ? undefined : 'Not available in your CUR export'}
+            >
+              <input
+                type="radio"
+                name="explorer-metric"
+                className="accent-accent"
+                checked={costMetric === opt.value}
+                disabled={!opt.available}
+                onChange={() => { onCostMetricChange(opt.value); }}
+              />
+              <span className="text-text-secondary">{opt.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-text-muted">Perspective:</span>
+        <div className="flex items-center gap-3">
+          {(['gross', 'net'] as const).map(p => {
+            const available = p === 'gross' || netAvailable;
+            return (
+              <label
+                key={p}
+                className={[
+                  'flex items-center gap-1 select-none',
+                  available ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
+                ].join(' ')}
+                title={available ? undefined : 'Net columns not present — enable "Include Net Columns" on the CUR'}
+              >
+                <input
+                  type="radio"
+                  name="explorer-perspective"
+                  className="accent-accent"
+                  checked={costPerspective === p}
+                  disabled={!available}
+                  onChange={() => { onCostPerspectiveChange(p); }}
+                />
+                <span className="text-text-secondary capitalize">{p}</span>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface HistogramProps {
+  readonly days: readonly { readonly date: string; readonly cost: number; readonly rows: number }[];
+  readonly loading: boolean;
+}
+
+const CHART_HEIGHT = 200;
+const Y_AXIS_WIDTH = 48;
+const Y_TICKS = [1, 0.75, 0.5, 0.25, 0] as const;
+
+/** Time-series histogram for the Explorer. Matches the visual style of the
+ *  main dashboard's StackedBarChart (Y-axis ticks, grid, hover tooltip)
+ *  but single-series — Explorer doesn't split the total, it's raw counts
+ *  over time. Bucket width follows whatever the handler emits (day or
+ *  hour), so the same component handles daily and hourly granularities. */
+function Histogram({ days, loading }: HistogramProps): React.JSX.Element {
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  if (loading) {
+    return <CoinRainLoader height={CHART_HEIGHT} count={6} />;
+  }
+  const max = days.reduce((m, d) => Math.max(m, d.cost), 0);
+  if (days.length === 0 || max <= 0) {
+    return (
+      <div className="flex items-center justify-center text-xs text-text-muted" style={{ height: CHART_HEIGHT }}>
+        No data in the selected range.
+      </div>
+    );
+  }
+
+  // Smart x-axis labels — show ~7 evenly spaced ticks, never more. For
+  // hourly views with 168+ bars this keeps the axis readable.
+  const labelStep = Math.max(1, Math.ceil(days.length / 7));
+
+  return (
+    <div className="space-y-1">
+      <div className="relative" style={{ height: CHART_HEIGHT }}>
+        {/* Y-axis tick labels */}
+        <div className="absolute left-0 top-0 h-full" style={{ width: Y_AXIS_WIDTH }}>
+          {Y_TICKS.map(pct => (
+            <div
+              key={pct}
+              className="absolute right-2 flex items-center"
+              style={{ top: `${String((1 - pct) * 100)}%`, transform: 'translateY(-50%)' }}
+            >
+              <span className="text-[10px] text-text-muted tabular-nums">{formatDollars(max * pct)}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Grid lines */}
+        <div className="absolute top-0 right-0 h-full" style={{ left: Y_AXIS_WIDTH }}>
+          {Y_TICKS.map(pct => (
+            <div
+              key={pct}
+              className="absolute left-0 right-0 border-b border-border-subtle/50"
+              style={{ top: `${String((1 - pct) * 100)}%` }}
+            />
+          ))}
+        </div>
+
+        {/* Bars */}
+        <div
+          className="absolute top-0 right-0 h-full flex items-end"
+          style={{ left: Y_AXIS_WIDTH, gap: 2 }}
+        >
+          {days.map(d => {
+            const pct = (d.cost / max) * 100;
+            const isHovered = hoveredKey === d.date;
+            return (
+              <div
+                key={d.date}
+                className="group relative flex-1 min-w-0 flex flex-col justify-end"
+                style={{ height: '100%' }}
+                onMouseEnter={() => { setHoveredKey(d.date); }}
+                onMouseLeave={() => { setHoveredKey(null); }}
+              >
+                <div
+                  className={[
+                    'w-full rounded-t-sm transition-colors',
+                    isHovered ? 'bg-accent' : 'bg-accent/80',
+                  ].join(' ')}
+                  style={{ height: `${String(Math.max(pct, 0.5))}%` }}
+                />
+                {isHovered && (
+                  <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20">
+                    <div className="rounded-lg border border-border bg-bg-secondary/95 px-3 py-2 text-[11px] text-text-primary whitespace-nowrap shadow-lg min-w-[160px]">
+                      <div className="font-semibold mb-1.5 text-xs">{d.date}</div>
+                      <div className="flex items-center justify-between gap-3 mb-0.5">
+                        <span className="text-text-secondary">Cost</span>
+                        <span className="tabular-nums font-medium">{formatDollars(d.cost)}</span>
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-text-secondary">Rows</span>
+                        <span className="tabular-nums text-text-secondary">{d.rows.toLocaleString()}</span>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* X-axis labels */}
+      <div className="flex" style={{ paddingLeft: Y_AXIS_WIDTH, gap: 2 }}>
+        {days.map((d, idx) => (
+          <div key={d.date} className="flex-1 min-w-0 text-center overflow-hidden">
+            {idx % labelStep === 0 && (
+              <span className="text-[10px] text-text-muted whitespace-nowrap">
+                {formatBucketLabel(d.date)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Compact axis label: "MM-DD" for daily buckets, "MM-DD HH:00" for
+ *  hourly. Inputs are the raw VARCHAR-casted timestamps from DuckDB. */
+function formatBucketLabel(bucket: string): string {
+  // Daily rows arrive as "YYYY-MM-DD"; hourly as "YYYY-MM-DD HH:MM:SS".
+  if (bucket.length === 10) return bucket.slice(5); // MM-DD
+  const parts = bucket.split(' ');
+  const datePart = parts[0] ?? bucket;
+  const timePart = parts[1] ?? '';
+  const hour = timePart.slice(0, 5); // HH:MM
+  return `${datePart.slice(5)} ${hour}`;
+}
+
+interface MultiFilterBarProps {
+  readonly dimensions: readonly Dimension[];
+  readonly filters: ExplorerFilterMap;
+  readonly onChange: (dimId: string, values: readonly string[]) => void;
+  readonly fetchValues: (dimId: string) => Promise<readonly ExplorerFilterValue[]>;
+}
+
+type DropdownState =
+  | { status: 'closed' }
+  | { status: 'loading'; dimId: string }
+  | { status: 'ready'; dimId: string; values: readonly ExplorerFilterValue[] }
+  | { status: 'error'; dimId: string; message: string };
+
+function MultiFilterBar({ dimensions, filters, onChange, fetchValues }: MultiFilterBarProps): React.JSX.Element {
+  const [dropdown, setDropdown] = useState<DropdownState>({ status: 'closed' });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Show every enabled dim PLUS any disabled dim that currently carries
+  // an active filter — so a user who clicked a cell for a disabled dim
+  // (resource_id is high-cardinality and default-off) can still see /
+  // edit / remove that filter rather than being stuck with "Clear all".
+  const visibleDims = useMemo(() => {
+    return dimensions.filter(d => {
+      const dimId = getDimensionId(d);
+      if (d.enabled !== false) return true;
+      const active = filters[dimId];
+      return active !== undefined && active.length > 0;
+    });
+  }, [dimensions, filters]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current !== null && !containerRef.current.contains(e.target as Node)) {
+        setDropdown({ status: 'closed' });
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => { document.removeEventListener('mousedown', handleClickOutside); };
+  }, []);
+
+  function openDim(dimId: string) {
+    if (dropdown.status !== 'closed' && 'dimId' in dropdown && dropdown.dimId === dimId) {
+      setDropdown({ status: 'closed' });
+      return;
+    }
+    setDropdown({ status: 'loading', dimId });
+    fetchValues(dimId).then(
+      values => {
+        setDropdown(prev => {
+          // Drop stale responses — the user may have opened a different dim
+          // while this query was in flight.
+          if (prev.status === 'closed') return prev;
+          if (!('dimId' in prev) || prev.dimId !== dimId) return prev;
+          return { status: 'ready', dimId, values };
+        });
+      },
+      (err: unknown) => {
+        setDropdown(prev => {
+          if (prev.status === 'closed') return prev;
+          if (!('dimId' in prev) || prev.dimId !== dimId) return prev;
+          return { status: 'error', dimId, message: err instanceof Error ? err.message : String(err) };
+        });
+      },
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="flex flex-wrap items-center gap-2">
+      {visibleDims.map(dim => {
+        const dimId = getDimensionId(dim);
+        const active = filters[dimId] ?? [];
+        const isOpen = dropdown.status !== 'closed' && 'dimId' in dropdown && dropdown.dimId === dimId;
+        const chipLabel = active.length === 0
+          ? dim.label
+          : active.length === 1
+            ? `${dim.label}: ${active[0] ?? ''}`
+            : `${dim.label} · ${String(active.length)}`;
+        return (
+          <div key={dimId} className="relative">
+            <button
+              type="button"
+              onClick={() => { openDim(dimId); }}
+              className={[
+                'flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                active.length === 0
+                  ? 'border-border bg-bg-tertiary/30 text-text-secondary hover:border-border hover:text-text-primary'
+                  : 'border-accent bg-accent-muted text-accent',
+              ].join(' ')}
+            >
+              {chipLabel}
+            </button>
+            {isOpen && (
+              <ValuesPicker
+                dropdown={dropdown}
+                selected={active}
+                onApply={(next) => { onChange(dimId, next); }}
+                onClose={() => { setDropdown({ status: 'closed' }); }}
+              />
+            )}
+          </div>
+        );
+      })}
+      {visibleDims.length === 0 && (
+        <span className="text-xs text-text-muted">No dimensions configured.</span>
+      )}
+    </div>
+  );
+}
+
+interface ValuesPickerProps {
+  readonly dropdown: DropdownState;
+  readonly selected: readonly string[];
+  readonly onApply: (next: readonly string[]) => void;
+  readonly onClose: () => void;
+}
+
+function ValuesPicker({ dropdown, selected, onApply, onClose }: ValuesPickerProps): React.JSX.Element {
+  const [search, setSearch] = useState('');
+  const [draft, setDraft] = useState(selected);
+
+  // Reset the draft when the dim changes — otherwise re-opening a
+  // previously-selected dim would show stale draft state.
+  useEffect(() => {
+    setDraft(selected);
+    setSearch('');
+  }, [selected]);
+
+  function toggle(value: string) {
+    setDraft(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
+  }
+
+  function apply() {
+    onApply(draft);
+    onClose();
+  }
+
+  function clear() {
+    setDraft([]);
+  }
+
+  const filteredValues = dropdown.status === 'ready'
+    ? dropdown.values.filter(v => search.length === 0 || v.label.toLowerCase().includes(search.toLowerCase()))
+    : [];
+
+  return (
+    <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-bg-secondary shadow-lg">
+      <div className="border-b border-border p-2">
+        <input
+          autoFocus
+          type="text"
+          value={search}
+          placeholder="Search values…"
+          onChange={(e) => { setSearch(e.target.value); }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') onClose();
+            if (e.key === 'Enter') apply();
+          }}
+          className="w-full rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
+        />
+      </div>
+      <div className="max-h-64 overflow-y-auto">
+        {dropdown.status === 'loading' && (
+          <div className="flex items-center justify-center gap-2 py-6 text-xs text-text-muted">
+            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-border border-t-accent" />
+            <span>Loading…</span>
+          </div>
+        )}
+        {dropdown.status === 'error' && (
+          <div className="px-3 py-4 text-xs text-negative">Failed to load: {dropdown.message}</div>
+        )}
+        {dropdown.status === 'ready' && filteredValues.length === 0 && (
+          <div className="px-3 py-4 text-xs text-text-muted">No matching values.</div>
+        )}
+        {dropdown.status === 'ready' && filteredValues.map(v => {
+          const checked = draft.includes(v.value);
+          return (
+            <label
+              key={v.value}
+              className={[
+                'flex items-center justify-between gap-2 px-3 py-1.5 text-xs cursor-pointer select-none',
+                checked ? 'bg-accent-muted/50 text-text-primary' : 'text-text-secondary hover:bg-bg-tertiary',
+              ].join(' ')}
+            >
+              <span className="flex items-center gap-2 min-w-0 flex-1">
+                <input
+                  type="checkbox"
+                  className="accent-accent shrink-0"
+                  checked={checked}
+                  onChange={() => { toggle(v.value); }}
+                />
+                <span className="truncate">{v.label}</span>
+              </span>
+              <span className="shrink-0 text-text-muted tabular-nums">{formatDollars(v.cost)}</span>
+            </label>
+          );
+        })}
+      </div>
+      <div className="flex items-center justify-between border-t border-border p-2 gap-2">
+        <button
+          type="button"
+          onClick={clear}
+          className="text-xs text-text-secondary hover:text-text-primary"
+          disabled={draft.length === 0}
+        >
+          Clear
+        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-xs text-text-secondary hover:bg-bg-tertiary"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={apply}
+            className="rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-bg-primary hover:bg-accent/90"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface RowsTableProps {
+  readonly columns: readonly ColumnSpec[];
+  readonly allColumns: readonly ColumnSpec[];
+  readonly hiddenColumns: readonly string[];
+  readonly autoHiddenKeys: ReadonlySet<string>;
+  readonly onHiddenColumnsChange: (next: readonly string[]) => void;
+  readonly onColumnOrderChange: (next: readonly string[]) => void;
+  readonly rows: readonly import('@costgoblin/core/browser').ExplorerSampleRow[];
+  readonly totalRows: number;
+  readonly sort: ExplorerSort | undefined;
+  readonly onSort: (columnKey: string) => void;
+  readonly onFilterAdd: (dimId: string, value: string) => void;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+function RowsTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, onHiddenColumnsChange, onColumnOrderChange, rows, totalRows, sort, onSort, onFilterAdd, loading, error }: RowsTableProps): React.JSX.Element {
+  // Header (row count / columns picker) is always rendered — keeps the
+  // Columns button reachable even when the table is empty or loading, so
+  // a user who accidentally hid every column isn't stranded.
+  const headerRow = (
+    <div className="flex items-center justify-between gap-3 text-xs text-text-muted">
+      <span>
+        {rows.length === 0
+          ? 'No rows'
+          : <>
+              Showing <span className="text-text-secondary tabular-nums">{rows.length.toLocaleString()}</span>
+              {totalRows > rows.length && (
+                <> of <span className="text-text-secondary tabular-nums">{totalRows.toLocaleString()}</span></>
+              )}
+              {' '}rows
+            </>}
+      </span>
+      <div className="flex items-center gap-3">
+        <span className="hidden md:inline text-text-muted">Click a cell to add that value to filters.</span>
+        <ColumnsPicker
+          allColumns={allColumns}
+          hiddenColumns={hiddenColumns}
+          autoHiddenKeys={autoHiddenKeys}
+          onChange={onHiddenColumnsChange}
+          onOrderChange={onColumnOrderChange}
+        />
+      </div>
+    </div>
+  );
+
+  if (error !== null) {
+    return (
+      <div className="space-y-2">
+        {headerRow}
+        <div className="rounded-md border border-negative/40 bg-negative/5 text-xs text-negative px-3 py-2">
+          {error}
+        </div>
+      </div>
+    );
+  }
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {headerRow}
+        <CoinRainLoader height={260} count={7} />
+      </div>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-2">
+        {headerRow}
+        <div className="text-xs text-text-muted py-4 text-center">No rows match the current filters.</div>
+      </div>
+    );
+  }
+  if (columns.length === 0) {
+    return (
+      <div className="space-y-2">
+        {headerRow}
+        <div className="text-xs text-text-muted py-4 text-center">
+          All columns are hidden — open <em>Columns</em> to show some again.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {headerRow}
+      <div className="border border-border rounded-md overflow-auto max-h-[560px]">
+        <table className="text-[11px] w-full border-collapse">
+          <thead className="sticky top-0 z-10 bg-bg-tertiary/95 backdrop-blur-sm">
+            <tr className="text-left text-text-secondary">
+              {columns.map(col => (
+                <ColumnHeader
+                  key={col.key}
+                  spec={col}
+                  sort={sort}
+                  onSort={() => { onSort(col.key); }}
+                />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr
+                key={`${String(i)}-${r.resourceId}-${r.date}`}
+                className="border-t border-border/40 hover:bg-bg-tertiary/30"
+              >
+                {columns.map(col => (
+                  <RowCell
+                    key={col.key}
+                    spec={col}
+                    row={r}
+                    onFilterAdd={onFilterAdd}
+                  />
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+interface ColumnsPickerProps {
+  readonly allColumns: readonly ColumnSpec[];
+  readonly hiddenColumns: readonly string[];
+  readonly autoHiddenKeys: ReadonlySet<string>;
+  readonly onChange: (next: readonly string[]) => void;
+  readonly onOrderChange: (next: readonly string[]) => void;
+}
+
+function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, onOrderChange }: ColumnsPickerProps): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  // The row currently being hovered during a drag — we use this to draw a
+  // blue top-border drop indicator. Separate from the dragged key because
+  // browsers don't give us dragover coords relative to the list.
+  const [dragOverKey, setDragOverKey] = useState<string | null>(null);
+  const [draggedKey, setDraggedKey] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hiddenSet = useMemo(() => new Set(hiddenColumns), [hiddenColumns]);
+  // Picker count reflects what the table ACTUALLY renders — subtracting
+  // both manual hides and auto-hides keeps it honest. Otherwise "5/10
+  // shown" while the table renders 3 columns would be confusing.
+  const visibleCount = allColumns.filter(c => !hiddenSet.has(c.key) && !autoHiddenKeys.has(c.key)).length;
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current !== null && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  function toggle(key: string) {
+    if (hiddenSet.has(key)) {
+      onChange(hiddenColumns.filter(k => k !== key));
+    } else {
+      onChange([...hiddenColumns, key]);
+    }
+  }
+
+  function showAll() {
+    onChange([]);
+  }
+
+  function hideAll() {
+    onChange(allColumns.map(c => c.key));
+  }
+
+  function resetOrder() {
+    onOrderChange([]);
+  }
+
+  function handleDrop(targetKey: string) {
+    if (draggedKey === null || draggedKey === targetKey) return;
+    const keys = allColumns.map(c => c.key);
+    const from = keys.indexOf(draggedKey);
+    const to = keys.indexOf(targetKey);
+    if (from === -1 || to === -1) return;
+    const next = [...keys];
+    next.splice(from, 1);
+    next.splice(to, 0, draggedKey);
+    onOrderChange(next);
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => { setOpen(prev => !prev); }}
+        className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border"
+        title="Choose and reorder columns"
+      >
+        <span>Columns</span>
+        <span className="tabular-nums text-text-muted">
+          {String(visibleCount)}/{String(allColumns.length)}
+        </span>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-80 rounded-lg border border-border bg-bg-secondary shadow-lg">
+          <div className="flex items-center justify-between border-b border-border px-3 py-2 text-[11px]">
+            <span className="text-text-muted">Drag to reorder</span>
+            <span className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={showAll}
+                className="text-text-secondary hover:text-text-primary"
+                disabled={hiddenColumns.length === 0}
+              >
+                Show all
+              </button>
+              <span className="text-text-muted">·</span>
+              <button
+                type="button"
+                onClick={hideAll}
+                className="text-text-secondary hover:text-text-primary"
+                disabled={hiddenColumns.length === allColumns.length}
+              >
+                Hide all
+              </button>
+              <span className="text-text-muted">·</span>
+              <button
+                type="button"
+                onClick={resetOrder}
+                className="text-text-secondary hover:text-text-primary"
+                title="Restore the default column order"
+              >
+                Reset order
+              </button>
+            </span>
+          </div>
+          <div className="max-h-96 overflow-y-auto py-1">
+            {allColumns.map(col => {
+              const checked = !hiddenSet.has(col.key);
+              const autoHidden = autoHiddenKeys.has(col.key);
+              const isDragging = draggedKey === col.key;
+              const isDropTarget = dragOverKey === col.key && draggedKey !== null && draggedKey !== col.key;
+              return (
+                <div
+                  key={col.key}
+                  draggable
+                  onDragStart={(e) => {
+                    setDraggedKey(col.key);
+                    e.dataTransfer.effectAllowed = 'move';
+                    // Firefox needs dataTransfer.setData or the drag never
+                    // starts. The payload itself is irrelevant — we drive
+                    // the logic off component state.
+                    e.dataTransfer.setData('text/plain', col.key);
+                  }}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = 'move';
+                    if (dragOverKey !== col.key) setDragOverKey(col.key);
+                  }}
+                  onDragLeave={() => {
+                    if (dragOverKey === col.key) setDragOverKey(null);
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    handleDrop(col.key);
+                    setDragOverKey(null);
+                    setDraggedKey(null);
+                  }}
+                  onDragEnd={() => {
+                    setDragOverKey(null);
+                    setDraggedKey(null);
+                  }}
+                  className={[
+                    'flex items-center gap-2 px-2 py-1.5 text-xs select-none',
+                    isDragging ? 'opacity-40' : '',
+                    isDropTarget ? 'border-t-2 border-t-accent' : 'border-t-2 border-t-transparent',
+                    'hover:bg-bg-tertiary',
+                  ].join(' ')}
+                >
+                  <span className="cursor-grab text-text-muted hover:text-text-secondary" title="Drag to reorder">⋮⋮</span>
+                  <input
+                    type="checkbox"
+                    className="accent-accent shrink-0"
+                    checked={checked}
+                    onChange={() => { toggle(col.key); }}
+                  />
+                  <span className={[
+                    'truncate flex-1',
+                    !checked || autoHidden ? 'text-text-muted' : 'text-text-primary',
+                  ].join(' ')}>
+                    {col.label}
+                  </span>
+                  {autoHidden && (
+                    <span
+                      className="text-[10px] text-text-muted uppercase tracking-wider shrink-0"
+                      title="Hidden because this column is pinned to a single filter value — clear or widen the filter to show it"
+                    >
+                      filtered
+                    </span>
+                  )}
+                  {!autoHidden && col.dimId !== null && col.dimId.startsWith('tag_') && (
+                    <span className="text-[10px] text-text-muted uppercase tracking-wider shrink-0">tag</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ColumnHeaderProps {
+  readonly spec: ColumnSpec;
+  readonly sort: ExplorerSort | undefined;
+  readonly onSort: () => void;
+}
+
+function ColumnHeader({ spec, sort, onSort }: ColumnHeaderProps): React.JSX.Element {
+  const isSorted = sort?.column === spec.key;
+  const indicator = isSorted ? (sort.direction === 'asc' ? '↑' : '↓') : '';
+  return (
+    <th className="p-0 font-medium whitespace-nowrap">
+      <button
+        type="button"
+        onClick={onSort}
+        className={[
+          'w-full px-2 py-1.5 inline-flex items-center gap-1 hover:text-text-primary hover:bg-bg-secondary/40 cursor-pointer',
+          spec.align === 'right' ? 'justify-end' : 'justify-start',
+          isSorted ? 'text-text-primary' : '',
+        ].join(' ')}
+      >
+        <span>{spec.label}</span>
+        <span className={`text-accent ${indicator.length > 0 ? '' : 'opacity-0'}`}>
+          {indicator.length > 0 ? indicator : '↕'}
+        </span>
+      </button>
+    </th>
+  );
+}
+
+interface RowCellProps {
+  readonly spec: ColumnSpec;
+  readonly row: import('@costgoblin/core/browser').ExplorerSampleRow;
+  readonly onFilterAdd: (dimId: string, value: string) => void;
+}
+
+function RowCell({ spec, row, onFilterAdd }: RowCellProps): React.JSX.Element {
+  const display = renderCell(spec, row);
+  const rawValue = filterValueFor(spec, row);
+  const titleText = spec.truncate === true ? stringValueFor(spec, row) : undefined;
+  const classes = [
+    'px-2 py-1 whitespace-nowrap',
+    spec.align === 'right' ? 'text-right' : '',
+    spec.mono === true ? 'tabular-nums font-mono' : '',
+    spec.truncate === true ? 'max-w-[260px] overflow-hidden text-ellipsis' : '',
+  ].filter(c => c.length > 0).join(' ');
+
+  if (spec.dimId !== null && rawValue !== null && rawValue.length > 0) {
+    const dimId = spec.dimId;
+    return (
+      <td className={classes} title={titleText}>
+        <button
+          type="button"
+          onClick={() => { onFilterAdd(dimId, rawValue); }}
+          className="hover:underline hover:text-accent text-left"
+          title={`Add "${rawValue}" to ${spec.label} filter`}
+        >
+          {display}
+        </button>
+      </td>
+    );
+  }
+  return (
+    <td className={classes} title={titleText}>
+      {display}
+    </td>
+  );
+}
+
+/** Plain-string value for the `title` (hover tooltip) on truncated cells.
+ *  Kept separate from renderCell because renderCell may return JSX (e.g. the
+ *  colored cost span) which can't be stringified usefully. */
+function stringValueFor(spec: ColumnSpec, row: import('@costgoblin/core/browser').ExplorerSampleRow): string {
+  switch (spec.key) {
+    case 'resource_id': return row.resourceId;
+    case 'description': return row.description;
+    default: {
+      const v = row.tags[spec.key];
+      return v ?? '';
+    }
+  }
+}
+
+/** Display-only rendering for a cell. Cost / list_cost / usage_amount get
+ *  numeric formatting; everything else is the raw string. Separate from
+ *  `filterValueFor` which returns the value the filter predicate wants. */
+function renderCell(spec: ColumnSpec, row: import('@costgoblin/core/browser').ExplorerSampleRow): React.ReactNode {
+  switch (spec.key) {
+    case 'usage_date': return row.date;
+    case 'usage_hour': {
+      // The handler sends the full TIMESTAMP (e.g. "2026-04-19 17:00:00").
+      // Trim to HH:MM:SS so the column stays narrow — the date is already
+      // in the Date column next to it.
+      if (row.hour.length === 0) return '';
+      const time = row.hour.includes(' ') ? row.hour.split(' ')[1] ?? row.hour : row.hour;
+      return time.slice(0, 8);
+    }
+    case 'cost': {
+      const cls = row.cost < 0 ? 'text-warning' : '';
+      return <span className={cls}>{formatSignedDollars(row.cost)}</span>;
+    }
+    case 'list_cost': return formatSignedDollars(row.listCost);
+    case 'service': return row.service;
+    case 'account_name': return row.accountName.length > 0 ? row.accountName : row.accountId;
+    case 'line_item_type': return row.lineItemType;
+    case 'region': return row.region;
+    case 'service_family': return row.serviceFamily;
+    case 'usage_type': return row.usageType;
+    case 'operation': return row.operation;
+    case 'usage_amount': return row.usageAmount === 0 ? '' : row.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 });
+    case 'resource_id': return row.resourceId;
+    case 'description': return row.description;
+    default: return row.tags[spec.key] ?? '';
+  }
+}
+
+function filterValueFor(spec: ColumnSpec, row: import('@costgoblin/core/browser').ExplorerSampleRow): string | null {
+  switch (spec.key) {
+    case 'service': return row.service;
+    case 'account_name': return row.accountName.length > 0 ? row.accountName : row.accountId;
+    case 'line_item_type': return row.lineItemType;
+    case 'region': return row.region;
+    case 'service_family': return row.serviceFamily;
+    case 'usage_type': return row.usageType;
+    case 'operation': return row.operation;
+    case 'resource_id': return row.resourceId.length > 0 ? row.resourceId : null;
+    default: {
+      if (spec.dimId !== null && spec.dimId.startsWith('tag_')) {
+        const v = row.tags[spec.key];
+        return v === undefined || v.length === 0 ? null : v;
+      }
+      return null;
+    }
+  }
+}

--- a/packages/ui/src/views/views-editor.tsx
+++ b/packages/ui/src/views/views-editor.tsx
@@ -7,6 +7,7 @@ import type {
   WidgetSpec,
 } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { useQuery } from '../hooks/use-query.js';
 import { CustomView } from './custom-view.js';
 import { WidgetInspector } from '../components/widget-inspector.js';
@@ -67,6 +68,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
     dirty: false,
   });
   const [saving, setSaving] = useState(false);
+  useUnsavedChanges(state.dirty, 'Views');
   const [error, setError] = useState<string | null>(null);
   const [modal, setModal] = useState<{ mode: 'export' | 'import' } | null>(null);
 

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -28,8 +28,10 @@ export function SummaryWidget({
     [groupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
 
-  const totalCost = cur.status === 'success' ? cur.data.totalCost : 0;
-  const previousCost = prev.status === 'success' ? prev.data.totalCost : undefined;
+  // `null` means "still loading / errored" — SummaryCard renders a dash
+  // placeholder rather than briefly showing $0.00.
+  const totalCost = cur.status === 'success' ? cur.data.totalCost : null;
+  const previousCost = prev.status === 'success' ? prev.data.totalCost : null;
 
   return (
     <SummaryCard totalCost={totalCost} previousCost={previousCost} dateRange={dateRange} />


### PR DESCRIPTION
## Summary

- **Explorer**: new raw-row CUR inspector — multi-value filters per dim, click-to-filter on any cell, sortable columns, drag-to-reorder + toggleable columns persisted per user, daily + hourly granularity with presets, opt-in Cost Scope toggle, single-series histogram matching the main-view style.
- **Unsaved-changes guard**: confirm modal before navigating away from Cost Scope / Views / Dimension editors with unsaved edits. Drop-in hook so future editable views register with one line.
- **Auto-sync interval**: configurable in the Sync view (default once a day, clamped to 1 hour – 7 days). Fixes the hardcoded nextRun calculation.
- **Sync nav indicator**: red badge on the Sync tab when AWS sync fails (expired credentials, auto-sync error) so it's noticed without opening the tab.
- **Loading polish**: SummaryCard + Cost Scope preview show a `—` placeholder instead of `$0.00` until data arrives.
- **CoinRainLoader**: bigger styled gold coin, slower fall, 25%↔75% rotation so the coin never flattens fully to its side.
- **Dimensions**: `resource_id` added as a built-in dimension (disabled by default — high-cardinality).