### PR TITLE
Fix SQL param validation, filter race condition, a11y gaps, date dedup

### DIFF
--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -20,6 +20,12 @@ export interface SidecarPlan {
   readonly sidecarFiles: readonly string[];
 }
 
+function assertFiniteNumber(value: number, name: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Query parameter "${name}" must be a non-negative finite number, got ${String(value)}`);
+  }
+}
+
 function tagColumnNameFromTag(t: TagDimension): string {
   return `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
 }
@@ -305,12 +311,6 @@ export function buildSource(
   // expose usage_hour as a standard TIMESTAMP — the source column is TIMESTAMP_NS
   // (nanoseconds) in CUR and the @duckdb/node-api row converter doesn't know
   // how to serialize that variant; casting to plain TIMESTAMP fixes it.
-  // usage_date is always DATE so date-range filters work consistently across
-  // tiers (BETWEEN against a TIMESTAMP truncates 'YYYY-MM-DD' to midnight and
-  // would silently drop ~23h of rows on the end day). For hourly we additionally
-  // expose usage_hour as a standard TIMESTAMP — the source column is TIMESTAMP_NS
-  // (nanoseconds) in CUR and the @duckdb/node-api row converter doesn't know
-  // how to serialize that variant; casting to plain TIMESTAMP fixes it.
   const dateExpr = tier === 'hourly'
     ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date::TIMESTAMP AS usage_hour'
     : 'line_item_usage_start_date::DATE AS usage_date';
@@ -389,6 +389,7 @@ export function buildCostQuery(
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
 ): string {
+  assertFiniteNumber(topN, 'topN');
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
@@ -464,6 +465,7 @@ export function buildTrendQuery(
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
 ): string {
+  assertFiniteNumber(Number(params.deltaThreshold), 'deltaThreshold');
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
@@ -524,7 +526,7 @@ export function buildTrendQuery(
       END AS percent_change
     FROM current_period c
     FULL OUTER JOIN previous_period p ON c.entity = p.entity
-    WHERE ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= ${String(params.deltaThreshold)}
+    WHERE ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= ${String(Number(params.deltaThreshold))}
     ORDER BY ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) DESC
   `.trim();
 }
@@ -558,6 +560,7 @@ export function buildMissingTagsQuery(
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
 ): string {
+  assertFiniteNumber(Number(params.minCost), 'minCost');
   const tagResolved = resolveField(params.tagDimension, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
   const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
@@ -612,7 +615,7 @@ export function buildMissingTagsQuery(
     FROM resources r
     JOIN category_coverage c USING (service, service_family)
     WHERE r.has_tag = 0
-      AND r.cost >= ${String(params.minCost)}
+      AND r.cost >= ${String(Number(params.minCost))}
     ORDER BY r.cost DESC
   `.trim();
 }

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -1,4 +1,5 @@
 import { isStringRecord } from '../utils/json.js';
+import { logger } from '../logger/logger.js';
 import type { ManifestFileEntry } from './manifest.js';
 
 export type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
@@ -105,8 +106,14 @@ export function groupByPeriod(files: readonly ManifestFileEntry[]): Map<string, 
  */
 export function parseEtagsJson(raw: string): Record<string, Record<string, string>> {
   let parsed: unknown;
-  try { parsed = JSON.parse(raw); } catch { return {}; }
-  if (!isStringRecord(parsed)) return {};
+  try { parsed = JSON.parse(raw); } catch {
+    logger.warn('Failed to parse sync-etags JSON — will re-download all files', { rawLength: raw.length });
+    return {};
+  }
+  if (!isStringRecord(parsed)) {
+    logger.warn('sync-etags JSON is not a valid object — will re-download all files');
+    return {};
+  }
 
   const result: Record<string, Record<string, string>> = {};
   for (const [period, periodEtags] of Object.entries(parsed)) {

--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -97,7 +97,7 @@ function BubbleChartInner({
 
   return (
     <div className="relative">
-      <svg width={width} height={height}>
+      <svg width={width} height={height} role="img" aria-label="Cost trend bubble chart: x-axis shows percent change, y-axis shows absolute delta, bubble size represents current cost">
         <Group left={MARGIN.left} top={MARGIN.top}>
           <GridRows
             scale={yScale}

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -29,6 +29,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
   const [search, setSearch] = useState('');
   const [labelMap, setLabelMap] = useState<Record<string, string>>({});
   const containerRef = useRef<HTMLDivElement>(null);
+  const requestIdRef = useRef(0);
 
   const hasActiveFilters = Object.keys(filters).length > 0;
 
@@ -68,15 +69,18 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     setDropdown({ status: 'loading' });
 
     const filtersWithoutThis = withoutFilter(dimId);
+    const thisRequestId = ++requestIdRef.current;
 
     getFilterValues(dimId, filtersWithoutThis).then(
       (values) => {
+        if (thisRequestId !== requestIdRef.current) return;
         setDropdown({
           status: 'ready',
           values: [...values].sort((a, b) => b.count - a.count),
         });
       },
       (err: unknown) => {
+        if (thisRequestId !== requestIdRef.current) return;
         setDropdown({
           status: 'error',
           error: err instanceof Error ? err : new Error(String(err)),

--- a/packages/ui/src/components/heatmap-chart.tsx
+++ b/packages/ui/src/components/heatmap-chart.tsx
@@ -61,7 +61,7 @@ function HeatmapInner({
   const cellH = yScale.bandwidth();
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} role="img" aria-label="Cost heatmap: rows are groups, columns are dates, color intensity represents cost">
       <Group left={MARGIN.left} top={MARGIN.top}>
         {cells.map((c) => {
           const x = xScale(c.date) ?? 0;

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -100,6 +100,7 @@ function PieChartInner({
           <select
             value={activeDimensionId ?? ''}
             onChange={(e) => { onDimensionChange(e.target.value); }}
+            aria-label={`Group by dimension (current: ${title})`}
             className="text-sm font-medium text-text-secondary bg-transparent border-none outline-none cursor-pointer hover:text-text-primary transition-colors appearance-none pr-4"
             style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'10\' height=\'6\' viewBox=\'0 0 10 6\' fill=\'none\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath d=\'M1 1l4 4 4-4\' stroke=\'%236b7280\' stroke-width=\'1.5\' stroke-linecap=\'round\'/%3E%3C/svg%3E")', backgroundRepeat: 'no-repeat', backgroundPosition: 'right center' }}
           >

--- a/packages/ui/src/components/summary-card.tsx
+++ b/packages/ui/src/components/summary-card.tsx
@@ -1,3 +1,4 @@
+import { daysBetween } from '../lib/dates.js';
 import { formatDollars, formatDate } from './format.js';
 
 interface SummaryCardProps {
@@ -21,9 +22,7 @@ export function SummaryCard({ totalCost, previousCost, dateRange }: Readonly<Sum
   const isDecrease = delta !== null && delta < 0;
   const isIncrease = delta !== null && delta > 0;
 
-  const rangeStart = new Date(dateRange.start).getTime();
-  const rangeEnd = new Date(dateRange.end).getTime();
-  const rangeDays = Math.max(1, Math.round((rangeEnd - rangeStart) / (24 * 60 * 60 * 1000)) + 1);
+  const rangeDays = Math.max(1, daysBetween(dateRange.start, dateRange.end));
   const dailyAvg = hasTotal ? totalCost / rangeDays : null;
 
   return (

--- a/packages/ui/src/components/top-n-bar-chart.tsx
+++ b/packages/ui/src/components/top-n-bar-chart.tsx
@@ -92,6 +92,7 @@ function TopNBarChartInner({
           <select
             value={activeDimensionId ?? ''}
             onChange={(e) => { onDimensionChange(e.target.value); }}
+            aria-label={`Group by dimension (current: ${title})`}
             className="text-sm font-medium text-text-secondary bg-transparent border-none outline-none cursor-pointer hover:text-text-primary transition-colors appearance-none pr-4"
             style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'10\' height=\'6\' viewBox=\'0 0 10 6\' fill=\'none\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath d=\'M1 1l4 4 4-4\' stroke=\'%236b7280\' stroke-width=\'1.5\' stroke-linecap=\'round\'/%3E%3C/svg%3E")', backgroundRepeat: 'no-repeat', backgroundPosition: 'right center' }}
           >

--- a/packages/ui/src/lib/dates.ts
+++ b/packages/ui/src/lib/dates.ts
@@ -1,0 +1,6 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Inclusive count of days between two ISO date strings. */
+export function daysBetween(start: string, end: string): number {
+  return Math.round((new Date(end).getTime() - new Date(start).getTime()) / DAY_MS) + 1;
+}

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { asDateString } from '@costgoblin/core/browser';
+import { daysBetween } from '../lib/dates.js';
 import type {
   Dimension,
   DimensionId,
@@ -45,9 +46,7 @@ function priorityFor(d: Dimension): number {
 }
 
 function previousRangeFor(dr: DateRange): DateRange {
-  const periodDays = Math.round(
-    (new Date(dr.end).getTime() - new Date(dr.start).getTime()) / (24 * 60 * 60 * 1000),
-  ) + 1;
+  const periodDays = daysBetween(dr.start, dr.end);
   const prevEnd = new Date(new Date(dr.start).getTime() - 24 * 60 * 60 * 1000);
   const prevStart = new Date(prevEnd.getTime() - (periodDays - 1) * 24 * 60 * 60 * 1000);
   return {

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { daysBetween } from '../lib/dates.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { StackedBarChart } from '../components/stacked-bar-chart.js';
@@ -65,9 +66,7 @@ export function StackedBarWidget({
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
-  const periodDays = Math.round(
-    (new Date(dateRange.end).getTime() - new Date(dateRange.start).getTime()) / (24 * 60 * 60 * 1000),
-  ) + 1;
+  const periodDays = daysBetween(dateRange.start, dateRange.end);
   const useWeekly = periodDays > 90;
   const barDays = useMemo(
     () => dailyToBarDays(query.status === 'success' ? query.data : null, useWeekly),


### PR DESCRIPTION
## Summary

Addresses issues found during a full-project code review:

- **SQL injection hardening**: validate numeric query parameters (`topN`, `deltaThreshold`, `minCost`) with `assertFiniteNumber()` before string interpolation into DuckDB queries
- **Filter bar race condition**: stale promises from rapid dimension-chip clicks no longer overwrite fresh dropdown results (request-counter guard)
- **ETag parse logging**: `parseEtagsJson()` now logs a warning when JSON is malformed instead of silently falling back to `{}` (which triggers a full re-download)
- **Accessibility**: add `aria-label` to dimension `<select>` pickers in pie/bar charts; add `role="img"` + `aria-label` to bubble chart and heatmap SVGs
- **Date util dedup**: extract `daysBetween()` into `ui/src/lib/dates.ts`, replacing identical inline calculations in `custom-view`, `stacked-bar-widget`, and `summary-card`
- **Cleanup**: remove duplicate comment block in `buildSource`