### PR TITLE
Simplify: remove unused normalization modes (lowercase-underscore, camelCase)

### DIFF
--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -43,7 +43,7 @@ export function assertNumber(value: unknown, context: string): asserts value is 
 }
 
 function isValidNormalizationRule(value: string): value is NormalizationRule {
-  return value === 'lowercase' || value === 'uppercase' || value === 'lowercase-kebab' || value === 'lowercase-underscore' || value === 'camelCase';
+  return value === 'lowercase' || value === 'uppercase' || value === 'lowercase-kebab';
 }
 
 function validateSyncTier(raw: unknown, context: string): SyncTierConfig {
@@ -139,7 +139,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     const normalize = dim['normalize'] !== undefined ? (() => {
       assertString(dim['normalize'], `${ctx}.normalize`);
       if (!isValidNormalizationRule(dim['normalize'])) {
-        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
+        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', or 'lowercase-kebab'`);
       }
       return dim['normalize'];
     })() : undefined;
@@ -188,7 +188,7 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
     const normalize = tag['normalize'] !== undefined ? (() => {
       assertString(tag['normalize'], `${ctx}.normalize`);
       if (!isValidNormalizationRule(tag['normalize'])) {
-        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
+        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', or 'lowercase-kebab'`);
       }
       return tag['normalize'];
     })() : undefined;

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -13,15 +13,6 @@ export function applyNormalizationRule(value: string, rule: NormalizationRule): 
         .replace(/([a-z])([A-Z])/g, '$1-$2')
         .replace(/[_\s]+/g, '-')
         .toLowerCase();
-    case 'lowercase-underscore':
-      return value
-        .replace(/([a-z])([A-Z])/g, '$1_$2')
-        .replace(/[-\s]+/g, '_')
-        .toLowerCase();
-    case 'camelCase':
-      return value
-        .replace(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase())
-        .replace(/^(.)/, (_, c: string) => c.toLowerCase());
   }
 }
 
@@ -148,13 +139,6 @@ export function buildAliasSqlCase(
         break;
       case 'lowercase-kebab':
         fieldExpr = `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${fieldExpr}, '([a-z])([A-Z])', '\\1-\\2'), '[_\\s]+', '-', 'g'))`;
-        break;
-      case 'lowercase-underscore':
-        fieldExpr = `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${fieldExpr}, '([a-z])([A-Z])', '\\1_\\2'), '[-\\s]+', '_', 'g'))`;
-        break;
-      case 'camelCase':
-        // SQL approximation for grouping — true camelCase applied in TypeScript
-        fieldExpr = `LOWER(REPLACE(REPLACE(REPLACE(${fieldExpr}, '-', ''), '_', ''), ' ', ''))`;
         break;
     }
   }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { BucketPath, DimensionId } from './branded.js';
 
-export type NormalizationRule = 'lowercase' | 'uppercase' | 'lowercase-kebab' | 'lowercase-underscore' | 'camelCase';
+export type NormalizationRule = 'lowercase' | 'uppercase' | 'lowercase-kebab';
 
 export type ConceptType = 'owner' | 'product' | 'environment';
 

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -70,8 +70,6 @@ const NORMALIZE_RULES: { value: NormalizationRule; label: string }[] = [
   { value: 'lowercase', label: 'lowercase' },
   { value: 'uppercase', label: 'UPPERCASE' },
   { value: 'lowercase-kebab', label: 'kebab-case (a-b-c)' },
-  { value: 'lowercase-underscore', label: 'snake_case (a_b_c)' },
-  { value: 'camelCase', label: 'camelCase' },
 ];
 
 interface EditingBuiltIn {
@@ -737,8 +735,6 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             case 'lowercase': return v.toLowerCase();
             case 'uppercase': return v.toUpperCase();
             case 'lowercase-kebab': return v.replace(/([a-z])([A-Z])/g, '$1-$2').replaceAll('_', '-').replaceAll(' ', '-').toLowerCase();
-            case 'lowercase-underscore': return v.replace(/([a-z])([A-Z])/g, '$1_$2').replaceAll('-', '_').replaceAll(' ', '_').toLowerCase();
-            case 'camelCase': return v.replaceAll(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, (_, c: string) => c.toLowerCase());
             default: return v;
           }
         };

--- a/specs/simplify-normalize-modes.md
+++ b/specs/simplify-normalize-modes.md
@@ -1,0 +1,92 @@
+# Simplification: Remove Unused Normalization Modes
+
+## Problem
+
+The tag normalization system supports 5 normalization modes: `lowercase`, `uppercase`, `lowercase-kebab`, `lowercase-underscore`, and `camelCase`. Analysis of all fixture configs, real configs, and test data shows that only 3 are actually used:
+
+| Mode | Usage |
+|------|-------|
+| `lowercase` | 4 dimensions across configs |
+| `lowercase-kebab` | 2 dimensions across configs |
+| `uppercase` | 2 dimensions across configs |
+| `lowercase-underscore` | **0 — never used** |
+| `camelCase` | **0 — never used** |
+
+The `camelCase` mode is additionally documented in the source as "approximate" — it just removes delimiters rather than implementing true camelCase conversion. This suggests it was speculatively added and never validated against real data.
+
+## Current Implementation
+
+In `packages/core/src/normalize/normalize.ts`, the `normalizeTagValue()` function (lines 14-32) switches on the normalization rule:
+
+```typescript
+export function normalizeTagValue(value: string, rule?: NormalizationRule): string {
+  if (rule === undefined) return value;
+  switch (rule) {
+    case 'lowercase': return value.toLowerCase();
+    case 'uppercase': return value.toUpperCase();
+    case 'lowercase-kebab':
+      return value
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .replace(/[_\s]+/g, '-')
+        .toLowerCase();
+    case 'lowercase-underscore':
+      return value
+        .replace(/([a-z])([A-Z])/g, '$1_$2')
+        .replace(/[-\s]+/g, '_')
+        .toLowerCase();
+    case 'camelCase':
+      return value.replace(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase());
+  }
+}
+```
+
+The corresponding SQL generation in `buildNormalizeSql()` (lines 54-75) produces increasingly complex REGEXP_REPLACE expressions for each mode. For `lowercase-kebab`:
+
+```sql
+LOWER(REGEXP_REPLACE(REGEXP_REPLACE(tag_team, '([a-z])([A-Z])', '\1-\2'), '[_\s]+', '-', 'g'))
+```
+
+When combined with aliases, each normalization function is repeated N+1 times in the generated CASE expression (once per alias bucket plus the ELSE clause).
+
+The `NormalizationRule` type is defined in `packages/core/src/types/config.ts`:
+
+```typescript
+export type NormalizationRule = 'lowercase' | 'uppercase' | 'lowercase-kebab' | 'lowercase-underscore' | 'camelCase';
+```
+
+## Proposed Change
+
+Remove the `lowercase-underscore` and `camelCase` modes from the codebase.
+
+### What to change
+
+1. **`types/config.ts`**: Remove `'lowercase-underscore' | 'camelCase'` from the `NormalizationRule` union type
+
+2. **`normalize/normalize.ts`**: Remove the two switch cases from both `normalizeTagValue()` and `buildNormalizeSql()`
+
+3. **`config/validator.ts`**: Update validation to reject the removed modes (if they appear in a user's YAML, the validator should produce a clear error message suggesting the supported alternatives)
+
+4. **Tests**: Remove test cases for the deleted modes
+
+### What stays
+
+- `lowercase`, `uppercase`, `lowercase-kebab` — all actively used
+- Alias resolution — orthogonal, unaffected
+- The overall normalization architecture — still needed for the 3 remaining modes
+
+## Migration
+
+- If a user has `normalize: lowercase-underscore` or `normalize: camelCase` in their dimensions.yaml, config validation will reject it on next load with a clear error message listing the supported modes.
+- `lowercase-underscore` users should switch to `lowercase-kebab` (same concept, different delimiter).
+- `camelCase` users should remove the normalize rule and rely on aliases for the specific values they want to canonicalize.
+
+## Risks
+
+- **Breaking config**: Any user who has configured one of the removed modes will get a validation error. Given zero usage in fixtures and real configs, this risk is near-zero. The error message makes the fix obvious.
+
+## Estimated Impact
+
+- **~40 lines deleted** across 3 files
+- **Type narrowed** from 5 variants to 3
+- **Generated SQL slightly simpler** (fewer code paths to reason about)
+- **Minor** — this is a small cleanup, not a major simplification. Included because it removes dead code that adds maintenance burden and testing surface.


### PR DESCRIPTION
## Summary

Remove two unused tag normalization modes — `lowercase-underscore` and `camelCase` — that have zero usage across all configs and fixtures.

Narrows the `NormalizationRule` type from 5 variants to 3, removing dead code paths in both TypeScript normalization and generated SQL.

**Impact: 24 lines deleted across 4 files.**

### Changes

- `types/config.ts` — narrowed `NormalizationRule` union
- `normalize/normalize.ts` — removed 2 switch cases from both `applyNormalizationRule()` and `buildAliasSqlCase()`
- `config/validator.ts` — updated validation to only accept the 3 remaining modes
- `ui/views/dimensions.tsx` — removed dropdown options and preview logic

See `specs/simplify-normalize-modes.md` for the full analysis.