### PR TITLE
Fix tag dimension filter + remove pie drilldown

### DIFF
--- a/packages/core/src/__fixtures__/generate.ts
+++ b/packages/core/src/__fixtures__/generate.ts
@@ -100,7 +100,7 @@ async function profile(): Promise<void> {
   const tagDefs = await loadTagDefs();
   const tagResults: Record<string, { values: string[]; missingPercent: number }> = {};
   for (const tag of tagDefs) {
-    const curKey = `user_${tag.tagName}`;
+    const curKey = tag.tagName.startsWith('user_') ? tag.tagName : `user_${tag.tagName}`;
     const concept = tag.concept ?? tag.tagName;
     const valRows = await queryAll(conn, `SELECT DISTINCT element_at(resource_tags, '${curKey}')[1] as v FROM ${src} WHERE element_at(resource_tags, '${curKey}') IS NOT NULL LIMIT 30`);
     const values = valRows.map(r => String(r['v'])).filter(v => v !== '' && v !== 'null');

--- a/packages/core/src/__tests__/views-validator.test.ts
+++ b/packages/core/src/__tests__/views-validator.test.ts
@@ -16,7 +16,7 @@ describe('validateViews', () => {
               widgets: [
                 { id: 'w1', type: 'summary', size: 'small', metric: 'total' },
                 { id: 'w2', type: 'pie', size: 'medium', groupBy: 'account' },
-                { id: 'w3', type: 'pie', size: 'medium', groupBy: 'service', drillable: true },
+                { id: 'w3', type: 'pie', size: 'medium', groupBy: 'service' },
               ],
             },
             {

--- a/packages/core/src/config/views-serialize.ts
+++ b/packages/core/src/config/views-serialize.ts
@@ -18,7 +18,6 @@ export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
       return base;
     case 'pie':
       base['groupBy'] = w.groupBy;
-      if (w.drillable === true) base['drillable'] = true;
       return base;
     case 'stackedBar':
     case 'bubble':

--- a/packages/core/src/config/views-validator.ts
+++ b/packages/core/src/config/views-validator.ts
@@ -102,13 +102,7 @@ function validateWidget(raw: unknown, ctx: string): WidgetSpec {
     }
     case 'pie': {
       assertString(raw['groupBy'], `${ctx}.groupBy`);
-      const drillable = raw['drillable'] === true || undefined;
-      return {
-        type,
-        ...base,
-        groupBy: asDimensionId(raw['groupBy']),
-        ...(drillable !== undefined ? { drillable } : {}),
-      };
+      return { type, ...base, groupBy: asDimensionId(raw['groupBy']) };
     }
     case 'stackedBar':
     case 'bubble':

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -205,7 +205,7 @@ export function buildSource(
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
 
   const tagSelects = dimensions.tags.map(t => {
-    const curKey = `user_${t.tagName}`;
+    const curKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
     const colName = `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
     const tablePrefix = needsOrgJoin ? 'cur.' : '';
     const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;

--- a/packages/core/src/types/seed-views.ts
+++ b/packages/core/src/types/seed-views.ts
@@ -20,7 +20,7 @@ export const OVERVIEW_SEED_VIEW: ViewSpec = {
       widgets: [
         { id: 'overview-pie-account', type: 'pie', size: 'medium', groupBy: asDimensionId('account') },
         { id: 'overview-pie-region', type: 'pie', size: 'medium', groupBy: asDimensionId('region') },
-        { id: 'overview-pie-service', type: 'pie', size: 'medium', groupBy: asDimensionId('service'), drillable: true },
+        { id: 'overview-pie-service', type: 'pie', size: 'medium', groupBy: asDimensionId('service') },
       ],
     },
     {

--- a/packages/core/src/types/views.ts
+++ b/packages/core/src/types/views.ts
@@ -34,7 +34,6 @@ export type WidgetSpec =
   | (WidgetBase & {
       readonly type: 'pie';
       readonly groupBy: DimensionId;
-      readonly drillable?: boolean | undefined;
     })
   | (WidgetBase & {
       readonly type: 'stackedBar';

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -333,7 +333,7 @@ builtIn:
     field: service_family
 
 # Map your CUR resource tags below.
-# tagName: the tag key in your CUR (without the "user_" prefix)
+# tagName: the tag key in your CUR (with or without the "user_" prefix)
 # concept: owner | product | environment (enables special UI features)
 tags: []
   # Example:

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -361,7 +361,7 @@ const MOCK_VIEWS_CONFIG: ViewsConfig = {
           widgets: [
             { id: 'm-pie-account', type: 'pie', size: 'medium', groupBy: asDimensionId('account') },
             { id: 'm-pie-region', type: 'pie', size: 'medium', groupBy: asDimensionId('region') },
-            { id: 'm-pie-service', type: 'pie', size: 'medium', groupBy: asDimensionId('service'), drillable: true },
+            { id: 'm-pie-service', type: 'pie', size: 'medium', groupBy: asDimensionId('service') },
           ],
         },
       ],

--- a/packages/ui/src/components/filter-active-banner.tsx
+++ b/packages/ui/src/components/filter-active-banner.tsx
@@ -4,35 +4,16 @@ export function FilterActiveBanner() {
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
 
-  const hasEnvironment = focus.environment !== null;
-  const hasDrill = focus.serviceDrill.depth !== 'none';
-
-  if (!hasEnvironment && !hasDrill) return null;
+  if (focus.environment === null) return null;
 
   return (
     <div className="flex items-center justify-between rounded-lg border border-accent/30 bg-accent/5 px-4 py-3">
       <div className="flex flex-col gap-0.5 text-sm">
         <span className="font-medium text-text-primary">Filter active</span>
-        <div className="flex flex-col gap-0.5 text-text-secondary">
-          {hasDrill && (
-            <span>
-              {'Showing costs for '}
-              <strong className="text-accent">{focus.serviceDrill.service}</strong>
-              {focus.serviceDrill.depth === 'serviceFamily' && (
-                <>
-                  {' → '}
-                  <strong className="text-accent">{focus.serviceDrill.family}</strong>
-                </>
-              )}
-            </span>
-          )}
-          {hasEnvironment && (
-            <span>
-              {'Environment: '}
-              <strong className="text-accent">{focus.environment}</strong>
-            </span>
-          )}
-        </div>
+        <span className="text-text-secondary">
+          {'Environment: '}
+          <strong className="text-accent">{focus.environment}</strong>
+        </span>
       </div>
       <button
         type="button"

--- a/packages/ui/src/components/widget-inspector.tsx
+++ b/packages/ui/src/components/widget-inspector.tsx
@@ -29,7 +29,7 @@ function stripTitle(w: WidgetSpec): WidgetSpec {
     case 'summary':
       return { ...common, type: w.type, ...(w.metric !== undefined ? { metric: w.metric } : {}) };
     case 'pie':
-      return { ...common, type: w.type, groupBy: w.groupBy, ...(w.drillable !== undefined ? { drillable: w.drillable } : {}) };
+      return { ...common, type: w.type, groupBy: w.groupBy };
     case 'stackedBar':
     case 'bubble':
       return { ...common, type: w.type, groupBy: w.groupBy };

--- a/packages/ui/src/hooks/use-cost-focus.ts
+++ b/packages/ui/src/hooks/use-cost-focus.ts
@@ -1,15 +1,9 @@
 import { createContext, useContext, useReducer, type Dispatch } from 'react';
 
-export type ServiceDrillState =
-  | { readonly depth: 'none' }
-  | { readonly depth: 'service'; readonly service: string }
-  | { readonly depth: 'serviceFamily'; readonly service: string; readonly family: string };
-
 export type ExpandedPie = 'accounts' | 'products' | 'services' | null;
 
 export interface CostFocusState {
   readonly environment: string | null;
-  readonly serviceDrill: ServiceDrillState;
   readonly hoveredEntity: string | null;
   readonly hoveredDimension: string | null;
   readonly expandedPie: ExpandedPie;
@@ -17,17 +11,12 @@ export interface CostFocusState {
 
 export type CostFocusAction =
   | { type: 'SET_ENVIRONMENT'; env: string | null }
-  | { type: 'DRILL_SERVICE'; service: string }
-  | { type: 'DRILL_SERVICE_FAMILY'; family: string }
-  | { type: 'DRILL_UNWIND' }
-  | { type: 'CLEAR_DRILL' }
   | { type: 'HOVER'; entity: string | null; dimension: string | null }
   | { type: 'TOGGLE_EXPAND'; pie: ExpandedPie }
   | { type: 'CLEAR_ALL' };
 
 export const initialFocusState: CostFocusState = {
   environment: null,
-  serviceDrill: { depth: 'none' },
   hoveredEntity: null,
   hoveredDimension: null,
   expandedPie: null,
@@ -37,22 +26,6 @@ export function costFocusReducer(state: CostFocusState, action: CostFocusAction)
   switch (action.type) {
     case 'SET_ENVIRONMENT':
       return { ...state, environment: action.env };
-
-    case 'DRILL_SERVICE':
-      return { ...state, serviceDrill: { depth: 'service', service: action.service } };
-
-    case 'DRILL_SERVICE_FAMILY':
-      if (state.serviceDrill.depth !== 'service') return state;
-      return { ...state, serviceDrill: { depth: 'serviceFamily', service: state.serviceDrill.service, family: action.family } };
-
-    case 'DRILL_UNWIND':
-      if (state.serviceDrill.depth === 'serviceFamily') {
-        return { ...state, serviceDrill: { depth: 'service', service: state.serviceDrill.service } };
-      }
-      return { ...state, serviceDrill: { depth: 'none' } };
-
-    case 'CLEAR_DRILL':
-      return { ...state, serviceDrill: { depth: 'none' } };
 
     case 'HOVER':
       return { ...state, hoveredEntity: action.entity, hoveredDimension: action.dimension };

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -4,8 +4,8 @@ import { useQuery } from '../hooks/use-query.js';
 import { PieChart } from '../components/pie-chart.js';
 import type { PieSlice } from '../components/pie-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
-import { asDimensionId, asTagValue } from '@costgoblin/core/browser';
-import type { CostResult, DimensionId } from '@costgoblin/core/browser';
+import { asTagValue } from '@costgoblin/core/browser';
+import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
 
@@ -32,25 +32,14 @@ export function PieWidget({
   const dispatch = useCostFocusDispatch();
   if (spec.type !== 'pie') return null;
   const specGroupBy = spec.groupBy;
-  const specDrillable = spec.drillable === true;
   const specTitle = spec.title;
 
-  const serviceDimId = asDimensionId('service');
-  const isServiceDrillable = specDrillable && specGroupBy === serviceDimId;
-
-  const groupBy: DimensionId = isServiceDrillable && focus.serviceDrill.depth === 'service'
-    ? asDimensionId('service_family')
-    : specGroupBy;
-
   const baseFilters = mergeFilters(globalFilters, spec.filters);
-  const effectiveFilters = isServiceDrillable && focus.serviceDrill.depth === 'service'
-    ? { ...baseFilters, [serviceDimId]: asTagValue(focus.serviceDrill.service) }
-    : baseFilters;
 
-  const fk = filtersKey(effectiveFilters);
+  const fk = filtersKey(baseFilters);
   const query = useQuery(
-    () => api.queryCosts({ groupBy, dateRange, filters: effectiveFilters, granularity }),
-    [groupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    () => api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity }),
+    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
   const slices = useMemo(
     () => rowsToSlices(query.status === 'success' ? query.data : null),
@@ -59,43 +48,12 @@ export function PieWidget({
 
   const label = dimensionLabelFor(dimensions, specGroupBy);
 
-  function getTitle(): string {
-    if (specTitle !== undefined) return specTitle;
-    if (!isServiceDrillable) return label;
-    if (focus.serviceDrill.depth === 'none') return label;
-    if (focus.serviceDrill.depth === 'service') return focus.serviceDrill.service;
-    return `${focus.serviceDrill.service} → ${focus.serviceDrill.family}`;
-  }
-
-  function getSubtitle(): string {
-    if (!isServiceDrillable) return 'Click to filter';
-    if (focus.serviceDrill.depth === 'none') return 'Click to drill down';
-    if (focus.serviceDrill.depth === 'service') return 'Click to drill deeper';
-    return 'Click to go back';
-  }
-
-  function handleClick(name: string) {
-    if (isServiceDrillable) {
-      if (focus.serviceDrill.depth === 'none') {
-        dispatch({ type: 'DRILL_SERVICE', service: name });
-        return;
-      }
-      if (focus.serviceDrill.depth === 'service') {
-        dispatch({ type: 'DRILL_SERVICE_FAMILY', family: name });
-        return;
-      }
-      dispatch({ type: 'DRILL_UNWIND' });
-      return;
-    }
-    onSetFilter(specGroupBy, asTagValue(name));
-  }
-
   return (
     <PieChart
       data={slices}
-      title={getTitle()}
-      subtitle={getSubtitle()}
-      onSliceClick={handleClick}
+      title={specTitle ?? label}
+      subtitle="Click to filter"
+      onSliceClick={(name) => { onSetFilter(specGroupBy, asTagValue(name)); }}
       onSliceHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: specGroupBy }); }}
       externalHoveredName={focus.hoveredDimension === specGroupBy ? focus.hoveredEntity : null}
     />


### PR DESCRIPTION
## Summary

- **Fix empty tag filters**: `buildSource` always prepended `user_` to `tagName`, but the dimension UI stores full CUR keys (already prefixed with `user_`). This caused a double prefix (`user_user_sb_system`) that matched nothing in the data — filter dropdowns returned "No values found".
- **Remove pie drill-down**: All pie charts now uniformly add a filter pill on click. Removes the service-specific drill-down mechanism (`serviceDrill` state, `DRILL_*` actions, drill banner, `drillable` widget prop) — ~100 lines of dead code.