### PR TITLE
Cancel stale queries on navigation + scale DuckDB pool to CPU count

### DIFF
--- a/e2e/perf.test.ts
+++ b/e2e/perf.test.ts
@@ -1,0 +1,670 @@
+import { test, expect, _electron, type ElectronApplication, type Page } from '@playwright/test';
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+
+const ROOT = join(import.meta.dirname, '..');
+const DESKTOP_DIR = join(ROOT, 'packages', 'desktop');
+const REPORT_DIR = join(tmpdir(), 'costgoblin-perf');
+mkdirSync(REPORT_DIR, { recursive: true });
+
+const LOAD_TIMEOUT = 30_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface IpcTiming {
+  channel: string;
+  durationMs: number;
+  timestamp: string;
+}
+
+interface RenderTiming {
+  id: string;
+  phase: string;
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+}
+
+interface PerfResult {
+  name: string;
+  wallClockMs: number;
+  ipcCalls: number;
+  ipcTotalMs: number;
+  ipcTimings: IpcTiming[];
+  reactRenders: number;
+  reactTotalMs: number;
+  reactTimings: RenderTiming[];
+  heapBeforeMB: number;
+  heapAfterMB: number;
+  heapDeltaMB: number;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const results: PerfResult[] = [];
+const cpuProfiles: { label: string; path: string }[] = [];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function launchApp(): Promise<ElectronApplication> {
+  return _electron.launch({
+    args: [join(DESKTOP_DIR, 'out', 'main', 'main.js')],
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      COSTGOBLIN_PERF_MODE: '1',
+      COSTGOBLIN_DATA_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'data'),
+      COSTGOBLIN_CONFIG_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'config'),
+    },
+  });
+}
+
+async function waitForQuerySettle(page: Page): Promise<void> {
+  try {
+    await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: LOAD_TIMEOUT });
+  } catch {
+    // Loading text might never have appeared
+  }
+  await page.waitForTimeout(300);
+}
+
+async function waitForCostScopePreview(page: Page): Promise<void> {
+  await page.waitForTimeout(400);
+  const marker = page.getByTestId('preview-loading');
+  try {
+    await expect(marker).toBeHidden({ timeout: LOAD_TIMEOUT });
+  } catch { /* may have finished */ }
+  await page.waitForTimeout(200);
+}
+
+function heapMB(bytes: number): number {
+  return Math.round(bytes / 1024 / 1024 * 10) / 10;
+}
+
+async function getHeap(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const perf = performance as any;
+    return perf.memory ? perf.memory.usedJSHeapSize : 0;
+  });
+}
+
+async function measure(
+  page: Page,
+  name: string,
+  action: () => Promise<void>,
+): Promise<void> {
+  // Clear accumulators
+  await page.evaluate(() => {
+    if (window.costgoblinPerf) window.costgoblinPerf.clearIpcTimings();
+    if (window.__PERF_REACT__) window.__PERF_REACT__.length = 0;
+  });
+
+  const heapBefore = await getHeap(page);
+  const start = Date.now();
+
+  await action();
+
+  const wallClockMs = Date.now() - start;
+  const heapAfter = await getHeap(page);
+
+  const ipcTimings: IpcTiming[] = await page.evaluate(() =>
+    window.costgoblinPerf ? window.costgoblinPerf.getIpcTimings() : [],
+  );
+  const reactTimings: RenderTiming[] = await page.evaluate(() =>
+    window.__PERF_REACT__ ? [...window.__PERF_REACT__] : [],
+  );
+
+  results.push({
+    name,
+    wallClockMs,
+    ipcCalls: ipcTimings.length,
+    ipcTotalMs: Math.round(ipcTimings.reduce((s, t) => s + t.durationMs, 0) * 100) / 100,
+    ipcTimings,
+    reactRenders: reactTimings.length,
+    reactTotalMs: Math.round(reactTimings.reduce((s, t) => s + t.actualDuration, 0) * 100) / 100,
+    reactTimings,
+    heapBeforeMB: heapMB(heapBefore),
+    heapAfterMB: heapMB(heapAfter),
+    heapDeltaMB: heapMB(heapAfter - heapBefore),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+function writeReport(): void {
+  // JSON (full detail)
+  writeFileSync(join(REPORT_DIR, 'results.json'), JSON.stringify({ results, cpuProfiles }, null, 2));
+
+  // Markdown summary
+  const lines: string[] = [];
+  lines.push('# CostGoblin Performance Report');
+  lines.push('');
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push('| Scenario | TTI (ms) | IPC calls | IPC total (ms) | Renders | Render (ms) | Heap Δ (MB) |');
+  lines.push('|----------|----------|-----------|----------------|---------|-------------|-------------|');
+  for (const r of results) {
+    lines.push(
+      `| ${r.name} | ${String(r.wallClockMs)} | ${String(r.ipcCalls)} | ${String(r.ipcTotalMs)} | ${String(r.reactRenders)} | ${String(r.reactTotalMs)} | ${r.heapDeltaMB >= 0 ? '+' : ''}${String(r.heapDeltaMB)} |`,
+    );
+  }
+  lines.push('');
+
+  // IPC breakdown per scenario (top 5 slowest channels)
+  lines.push('## IPC Breakdown (top 5 slowest per scenario)');
+  lines.push('');
+  for (const r of results) {
+    if (r.ipcTimings.length === 0) continue;
+    lines.push(`### ${r.name}`);
+    lines.push('');
+    lines.push('| Channel | Duration (ms) |');
+    lines.push('|---------|---------------|');
+    const sorted = [...r.ipcTimings].sort((a, b) => b.durationMs - a.durationMs);
+    for (const t of sorted.slice(0, 5)) {
+      lines.push(`| ${t.channel} | ${String(t.durationMs)} |`);
+    }
+    lines.push('');
+  }
+
+  // CPU profiles
+  if (cpuProfiles.length > 0) {
+    lines.push('## CPU Profiles');
+    lines.push('');
+    lines.push('Load these `.cpuprofile` files in Chrome DevTools → Performance tab:');
+    lines.push('');
+    for (const p of cpuProfiles) {
+      lines.push(`- **${p.label}**: \`${p.path}\``);
+    }
+    lines.push('');
+  }
+
+  const md = lines.join('\n');
+  writeFileSync(join(REPORT_DIR, 'report.md'), md);
+
+  // Print summary to stdout
+  process.stdout.write('\n');
+  process.stdout.write(md);
+  process.stdout.write('\n');
+  process.stdout.write(`\nFull report: ${REPORT_DIR}/report.md\n`);
+  process.stdout.write(`Raw data:    ${REPORT_DIR}/results.json\n\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Performance Benchmarks', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    app = await launchApp();
+    page = await app.firstWindow();
+    await expect(page).toHaveTitle('CostGoblin');
+    await waitForQuerySettle(page);
+  });
+
+  test.afterAll(async () => {
+    writeReport();
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Cost Overview
+  // -------------------------------------------------------------------------
+  test.describe('Cost Overview', () => {
+    test.beforeAll(async () => {
+      await page.evaluate(() => window.costgoblinPerf?.startCpuProfile());
+    });
+
+    test.afterAll(async () => {
+      const result: any = await page.evaluate(() =>
+        window.costgoblinPerf?.stopCpuProfile('cost-overview'),
+      );
+      if (result?.path) cpuProfiles.push({ label: 'Cost Overview', path: result.path });
+    });
+
+    test('baseline', async () => {
+      await measure(page, 'Cost Overview → baseline', async () => {
+        await page.getByRole('button', { name: 'Cost Overview', exact: true }).click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('switch to 90 days', async () => {
+      await measure(page, 'Cost Overview → 90 days', async () => {
+        await page.getByRole('button', { name: '90 days' }).first().click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('switch to 365 days', async () => {
+      await measure(page, 'Cost Overview → 365 days', async () => {
+        await page.getByRole('button', { name: '365 days' }).first().click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('apply filter', async () => {
+      await measure(page, 'Cost Overview → apply filter', async () => {
+        const chip = page.getByRole('button', { name: 'Account', exact: true });
+        if (!await chip.isVisible().catch(() => false)) return;
+        await chip.click();
+        const dropdown = page.locator('.absolute.left-0.top-full');
+        await expect(dropdown).toBeVisible({ timeout: 5000 });
+        try {
+          await expect(page.getByText('Loading…')).toBeHidden({ timeout: 10_000 });
+        } catch { /* */ }
+        const items = dropdown.locator('button');
+        if (await items.count() > 0) {
+          await items.first().click();
+          await waitForQuerySettle(page);
+        }
+      });
+    });
+
+    test('clear filter', async () => {
+      const clearAll = page.getByRole('button', { name: 'Clear all' });
+      if (!await clearAll.isVisible().catch(() => false)) return;
+      await measure(page, 'Cost Overview → clear filter', async () => {
+        await clearAll.click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('switch histogram tab', async () => {
+      await measure(page, 'Cost Overview → histogram Products', async () => {
+        await page.getByRole('button', { name: 'Products' }).click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('restore 30 days', async () => {
+      await page.getByRole('button', { name: 'Groups' }).click();
+      await page.getByRole('button', { name: '30 days' }).first().click();
+      await waitForQuerySettle(page);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cost Trends
+  // -------------------------------------------------------------------------
+  test.describe('Cost Trends', () => {
+    test.beforeAll(async () => {
+      await page.evaluate(() => window.costgoblinPerf?.startCpuProfile());
+    });
+
+    test.afterAll(async () => {
+      const result: any = await page.evaluate(() =>
+        window.costgoblinPerf?.stopCpuProfile('trends'),
+      );
+      if (result?.path) cpuProfiles.push({ label: 'Trends', path: result.path });
+    });
+
+    test('baseline', async () => {
+      await measure(page, 'Trends → baseline', async () => {
+        await page.getByRole('button', { name: 'Trends' }).click();
+        await expect(page.getByRole('heading', { name: 'Cost Trends' })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('switch dimension', async () => {
+      const dimBtns = page.locator('.rounded-lg.border.bg-bg-tertiary\\/30 button');
+      const count = await dimBtns.count();
+      if (count <= 1) return;
+      await measure(page, 'Trends → switch dimension', async () => {
+        await dimBtns.nth(1).click();
+        await waitForQuerySettle(page);
+      });
+      // restore
+      await dimBtns.first().click();
+      await waitForQuerySettle(page);
+    });
+
+    test('toggle to savings', async () => {
+      const toggleContainer = page.locator('.flex.items-center.gap-1.rounded-lg.border').nth(1);
+      const savingsBtn = toggleContainer.getByRole('button', { name: 'savings' });
+      if (!await savingsBtn.isVisible().catch(() => false)) return;
+      await measure(page, 'Trends → toggle savings', async () => {
+        await savingsBtn.click();
+        await waitForQuerySettle(page);
+      });
+      // restore
+      const increasesBtn = toggleContainer.getByRole('button', { name: 'increases' });
+      await increasesBtn.click();
+      await waitForQuerySettle(page);
+    });
+
+    test('change thresholds', async () => {
+      const inputs = page.locator('input[type="number"]');
+      if (await inputs.count() < 2) return;
+      await measure(page, 'Trends → high thresholds', async () => {
+        await inputs.first().fill('1000');
+        await inputs.nth(1).fill('50');
+        await waitForQuerySettle(page);
+      });
+      // restore
+      await inputs.first().fill('10');
+      await inputs.nth(1).fill('1');
+      await waitForQuerySettle(page);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing Tags
+  // -------------------------------------------------------------------------
+  test.describe('Missing Tags', () => {
+    test.beforeAll(async () => {
+      await page.evaluate(() => window.costgoblinPerf?.startCpuProfile());
+    });
+
+    test.afterAll(async () => {
+      const result: any = await page.evaluate(() =>
+        window.costgoblinPerf?.stopCpuProfile('missing-tags'),
+      );
+      if (result?.path) cpuProfiles.push({ label: 'Missing Tags', path: result.path });
+    });
+
+    test('baseline', async () => {
+      await measure(page, 'Missing Tags → baseline', async () => {
+        await page.getByRole('button', { name: 'Missing Tags' }).click();
+        await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('switch tag tab', async () => {
+      const tabContainer = page.locator('.rounded-lg.border.bg-bg-tertiary\\/30');
+      const tabs = tabContainer.first().locator('button');
+      if (await tabs.count() <= 1) return;
+      await measure(page, 'Missing Tags → switch tab', async () => {
+        await tabs.nth(1).click();
+        await waitForQuerySettle(page);
+      });
+      await tabs.first().click();
+      await waitForQuerySettle(page);
+    });
+
+    test('change min cost', async () => {
+      const input = page.locator('input[type="number"]');
+      if (!await input.isVisible().catch(() => false)) return;
+      await measure(page, 'Missing Tags → min cost 0', async () => {
+        await input.fill('0');
+        await waitForQuerySettle(page);
+      });
+      await input.fill('50');
+      await waitForQuerySettle(page);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Savings
+  // -------------------------------------------------------------------------
+  test.describe('Savings', () => {
+    test('baseline', async () => {
+      await measure(page, 'Savings → baseline', async () => {
+        await page.getByRole('button', { name: 'Savings' }).click();
+        await expect(page.getByRole('heading', { name: 'Savings Opportunities' })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('filter by action type', async () => {
+      const pills = page.locator('button.rounded-full');
+      if (await pills.count() <= 1) return;
+      await measure(page, 'Savings → filter action type', async () => {
+        await pills.nth(1).click();
+      });
+      await pills.first().click();
+    });
+
+    test('sort by column', async () => {
+      const th = page.locator('th').filter({ hasText: 'Savings/mo' }).first();
+      if (!await th.isVisible().catch(() => false)) return;
+      await measure(page, 'Savings → sort column', async () => {
+        await th.click();
+        await page.waitForTimeout(200);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Explorer
+  // -------------------------------------------------------------------------
+  test.describe('Explorer', () => {
+    test.beforeAll(async () => {
+      await page.evaluate(() => window.costgoblinPerf?.startCpuProfile());
+    });
+
+    test.afterAll(async () => {
+      const result: any = await page.evaluate(() =>
+        window.costgoblinPerf?.stopCpuProfile('explorer'),
+      );
+      if (result?.path) cpuProfiles.push({ label: 'Explorer', path: result.path });
+    });
+
+    test('baseline', async () => {
+      await measure(page, 'Explorer → baseline', async () => {
+        await page.getByRole('button', { name: 'Explorer' }).click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('apply filter', async () => {
+      const chip = page.getByRole('button', { name: 'Account', exact: true });
+      if (!await chip.isVisible().catch(() => false)) return;
+      await measure(page, 'Explorer → apply filter', async () => {
+        await chip.click();
+        const dropdown = page.locator('.absolute.left-0.top-full');
+        await expect(dropdown).toBeVisible({ timeout: 5000 });
+        try {
+          await expect(page.getByText('Loading…')).toBeHidden({ timeout: 10_000 });
+        } catch { /* */ }
+        // Skip disabled buttons (e.g. "Clear") — only click enabled value buttons
+        const items = dropdown.locator('button:not([disabled])');
+        if (await items.count() > 0) {
+          await items.first().click();
+          await waitForQuerySettle(page);
+        }
+      });
+    });
+
+    test('clear filter', async () => {
+      // Explorer uses "Clear all" or individual clear buttons
+      const clearAll = page.getByRole('button', { name: /Clear all/ });
+      if (!await clearAll.isVisible().catch(() => false)) return;
+      await measure(page, 'Explorer → clear filter', async () => {
+        await clearAll.click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('sort column', async () => {
+      const th = page.locator('th').filter({ hasText: 'Cost' }).first();
+      if (!await th.isVisible().catch(() => false)) return;
+      await measure(page, 'Explorer → sort column', async () => {
+        await th.click();
+        await waitForQuerySettle(page);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Entity Detail (via Trends)
+  // -------------------------------------------------------------------------
+  test.describe('Entity Detail', () => {
+    let reached = false;
+
+    test('navigate via trends', async () => {
+      await page.getByRole('button', { name: 'Trends' }).click();
+      await expect(page.getByRole('heading', { name: 'Cost Trends' })).toBeVisible();
+      await waitForQuerySettle(page);
+
+      const entityLink = page.locator('table button.text-accent').first();
+      if (!await entityLink.isVisible().catch(() => false)) return;
+
+      await measure(page, 'Entity Detail → navigate', async () => {
+        await entityLink.click();
+        await expect(page.getByRole('button', { name: '← Back' })).toBeVisible({ timeout: 5000 });
+        await waitForQuerySettle(page);
+      });
+      reached = true;
+    });
+
+    test('switch histogram dimension', async () => {
+      if (!reached) return;
+      const accountTab = page.getByRole('button', { name: 'account' });
+      if (!await accountTab.isVisible().catch(() => false)) return;
+      await measure(page, 'Entity Detail → histogram account', async () => {
+        await accountTab.click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('change date range', async () => {
+      if (!reached) return;
+      await measure(page, 'Entity Detail → 90 days', async () => {
+        await page.getByRole('button', { name: '90 days' }).first().click();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('back to overview', async () => {
+      if (!reached) return;
+      await page.getByRole('button', { name: '← Back' }).click();
+      await waitForQuerySettle(page);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cost Scope
+  // -------------------------------------------------------------------------
+  test.describe('Cost Scope', () => {
+    test.beforeAll(async () => {
+      await page.evaluate(() => window.costgoblinPerf?.startCpuProfile());
+    });
+
+    test.afterAll(async () => {
+      const result: any = await page.evaluate(() =>
+        window.costgoblinPerf?.stopCpuProfile('cost-scope'),
+      );
+      if (result?.path) cpuProfiles.push({ label: 'Cost Scope', path: result.path });
+    });
+
+    test('baseline', async () => {
+      await measure(page, 'Cost Scope → baseline', async () => {
+        await page.getByRole('button', { name: 'Cost Scope' }).click();
+        await expect(page.getByRole('heading', { name: 'Cost Scope' })).toBeVisible();
+        await waitForCostScopePreview(page);
+      });
+    });
+
+    test('toggle rule', async () => {
+      const toggle = page.getByRole('switch').first();
+      if (!await toggle.isVisible().catch(() => false)) return;
+      await measure(page, 'Cost Scope → toggle rule', async () => {
+        await toggle.click();
+        await waitForCostScopePreview(page);
+      });
+      // revert: toggle back and cancel if the button is visible
+      await toggle.click();
+      const cancelBtn = page.getByRole('button', { name: 'Cancel' });
+      if (await cancelBtn.isVisible().catch(() => false)) {
+        await cancelBtn.click();
+      }
+      await waitForCostScopePreview(page);
+    });
+
+    test('switch metric', async () => {
+      const amortizedRadio = page.locator('input[type="radio"][value="amortized"]');
+      if (!await amortizedRadio.isVisible().catch(() => false)) return;
+      await measure(page, 'Cost Scope → switch to amortized', async () => {
+        await amortizedRadio.click();
+        await waitForCostScopePreview(page);
+      });
+      // revert
+      const unblendedRadio = page.locator('input[type="radio"][value="unblended"]');
+      await unblendedRadio.click();
+      const cancelBtn2 = page.getByRole('button', { name: 'Cancel' });
+      if (await cancelBtn2.isVisible().catch(() => false)) {
+        await cancelBtn2.click();
+      }
+      await waitForCostScopePreview(page);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dimensions
+  // -------------------------------------------------------------------------
+  test.describe('Dimensions', () => {
+    test('baseline', async () => {
+      await measure(page, 'Dimensions → baseline', async () => {
+        await page.getByRole('button', { name: 'Dimensions' }).click();
+        await expect(page.getByRole('heading', { name: 'Dimensions', exact: true })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('open editor', async () => {
+      const editBtn = page.locator('button').filter({ hasText: 'Edit →' }).first();
+      if (!await editBtn.isVisible().catch(() => false)) return;
+      await measure(page, 'Dimensions → open editor', async () => {
+        await editBtn.click();
+        await expect(page.getByText('Concept')).toBeVisible();
+      });
+      await page.getByRole('button', { name: 'Cancel' }).click();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Views Editor
+  // -------------------------------------------------------------------------
+  test.describe('Views Editor', () => {
+    test('baseline', async () => {
+      await measure(page, 'Views Editor → baseline', async () => {
+        await page.getByRole('button', { name: 'Views' }).click();
+        await expect(page.getByRole('heading', { name: 'Views', exact: true })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Data Management (Sync)
+  // -------------------------------------------------------------------------
+  test.describe('Data Management', () => {
+    test('baseline', async () => {
+      await measure(page, 'Data Management → baseline', async () => {
+        await page.getByRole('button', { name: 'Sync' }).click();
+        await expect(page.getByRole('heading', { name: 'Data Management' })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rapid navigation stress test
+  // -------------------------------------------------------------------------
+  test.describe('Navigation stress', () => {
+    test('rapid switching', async () => {
+      await measure(page, 'Rapid navigation (9 switches)', async () => {
+        const views = ['Cost Overview', 'Trends', 'Missing Tags', 'Savings', 'Explorer', 'Cost Scope', 'Dimensions', 'Sync', 'Cost Overview'];
+        for (const v of views) {
+          await page.getByRole('button', { name: v, exact: true }).first().click();
+        }
+        await waitForQuerySettle(page);
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "repartition": "npx tsx scripts/repartition.ts",
     "build": "npm run build --workspaces",
     "e2e": "npm run build --workspace=packages/desktop && npx playwright test && npx tsx e2e/collect-coverage.ts",
+    "perf": "npm run build --workspace=packages/desktop && npx playwright test e2e/perf.test.ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -179,6 +179,10 @@ export interface CostApi {
   /** Swap the AWS profile used to talk to AWS, leaving bucket paths and
    *  every other config field untouched. */
   updateAwsProfile(profile: string): Promise<void>;
+  /** Cancel all queued (not yet running) DuckDB queries. Call on view
+   *  navigation so stale queries from the previous view don't hold pool
+   *  connections and slow down the new view's queries. */
+  cancelPendingQueries(): Promise<void>;
 }
 
 export interface AccountMappingEntry {

--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -5,6 +5,7 @@ export type RawRow = Readonly<Record<string, unknown>>;
 
 export interface DuckDBClient {
   runQuery(sql: string): Promise<RawRow[]>;
+  cancelPendingQueries(): void;
   terminate(): Promise<void>;
 }
 
@@ -113,6 +114,9 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
         });
         worker.postMessage({ kind: 'query', id, sql });
       });
+    },
+    cancelPendingQueries(): void {
+      worker.postMessage({ kind: 'cancel-pending' });
     },
     async terminate(): Promise<void> {
       await worker.terminate();

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,4 +1,5 @@
 import { parentPort } from 'node:worker_threads';
+import { cpus } from 'node:os';
 import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
 import { createResourcePool } from './connection-pool.js';
 import type { ResourcePool } from './connection-pool.js';
@@ -17,9 +18,6 @@ if (parentPort === null) {
 }
 const port = parentPort;
 
-type WorkerRequest =
-  | { kind: 'query'; id: number; sql: string };
-
 type WorkerResponse =
   | { kind: 'ready' }
   | { kind: 'rows'; id: number; rows: Readonly<Record<string, unknown>>[] }
@@ -31,7 +29,23 @@ function isQueryRequest(msg: unknown): msg is { kind: 'query'; id: number; sql: 
   return m['kind'] === 'query' && typeof m['id'] === 'number' && typeof m['sql'] === 'string';
 }
 
-async function fetchAllRows(conn: DuckDBConnection, sql: string): Promise<Readonly<Record<string, unknown>>[]> {
+function isCancelRequest(msg: unknown): msg is { kind: 'cancel-pending' } {
+  if (typeof msg !== 'object' || msg === null) return false;
+  return (msg as Record<string, unknown>)['kind'] === 'cancel-pending';
+}
+
+// ---------------------------------------------------------------------------
+// Query cancellation state
+// ---------------------------------------------------------------------------
+const cancelledIds = new Set<number>();
+const queuedIds = new Set<number>();  // waiting for pool.acquire()
+const runningIds = new Set<number>(); // executing in DuckDB
+
+async function fetchAllRows(
+  conn: DuckDBConnection,
+  sql: string,
+  isCancelled: () => boolean,
+): Promise<Readonly<Record<string, unknown>>[]> {
   const result = await conn.run(sql);
   const cols = result.columnCount;
   const names: string[] = [];
@@ -40,6 +54,7 @@ async function fetchAllRows(conn: DuckDBConnection, sql: string): Promise<Readon
   const rows: Record<string, unknown>[] = [];
   let chunk = await result.fetchChunk();
   while (chunk !== null && chunk.rowCount > 0) {
+    if (isCancelled()) return [];
     for (let r = 0; r < chunk.rowCount; r++) {
       const row: Record<string, unknown> = {};
       for (let c = 0; c < cols; c++) {
@@ -59,14 +74,16 @@ async function fetchAllRows(conn: DuckDBConnection, sql: string): Promise<Readon
  * execute in parallel (bound by DuckDB's own thread scheduling). Queries
  * arriving while all connections are busy queue FIFO via ResourcePool.
  *
- * Size defaults to 4 (matches typical cost-overview fan-out and laptop
- * core counts). Override with COSTGOBLIN_DUCKDB_POOL_SIZE.
+ * Size defaults to the number of logical CPUs (min 4, max 16). Override
+ * with COSTGOBLIN_DUCKDB_POOL_SIZE.
  */
 function parsePoolSize(): number {
   const raw = process.env['COSTGOBLIN_DUCKDB_POOL_SIZE'];
-  if (raw === undefined) return 4;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n >= 1 && n <= 32 ? n : 4;
+  if (raw !== undefined) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n >= 1 && n <= 32) return n;
+  }
+  return Math.min(Math.max(4, cpus().length), 16);
 }
 
 let poolPromise: Promise<ResourcePool<DuckDBConnection>> | null = null;
@@ -86,27 +103,59 @@ void getPool().then(() => {
   send({ kind: 'ready' });
 }).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);
-  // Surface init failure as an error response with id -1; the client treats
-  // any error before `ready` as fatal and rejects all in-flight + future queries.
   send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
 });
 
-async function handleRequest(req: WorkerRequest): Promise<void> {
+async function handleRequest(req: { kind: 'query'; id: number; sql: string }): Promise<void> {
+  // Check before acquiring a pool connection
+  if (cancelledIds.has(req.id)) {
+    cancelledIds.delete(req.id);
+    send({ kind: 'rows', id: req.id, rows: [] });
+    return;
+  }
+
+  queuedIds.add(req.id);
   const pool = await getPool();
   const conn = await pool.acquire();
+  queuedIds.delete(req.id);
+
   try {
-    const rows = await fetchAllRows(conn, req.sql);
-    send({ kind: 'rows', id: req.id, rows });
+    // Check after acquiring — cancel may have arrived while queued
+    if (cancelledIds.has(req.id)) {
+      cancelledIds.delete(req.id);
+      send({ kind: 'rows', id: req.id, rows: [] });
+      return;
+    }
+
+    runningIds.add(req.id);
+    const rows = await fetchAllRows(conn, req.sql, () => cancelledIds.has(req.id));
+
+    // Skip serialization if cancelled during execution
+    if (cancelledIds.has(req.id)) {
+      cancelledIds.delete(req.id);
+      send({ kind: 'rows', id: req.id, rows: [] });
+    } else {
+      send({ kind: 'rows', id: req.id, rows });
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     send({ kind: 'error', id: req.id, message });
   } finally {
+    runningIds.delete(req.id);
     pool.release(conn);
+  }
+}
+
+function handleCancelPending(): void {
+  for (const id of queuedIds) {
+    cancelledIds.add(id);
   }
 }
 
 port.on('message', (msg: unknown) => {
   if (isQueryRequest(msg)) {
     void handleRequest(msg);
+  } else if (isCancelRequest(msg)) {
+    handleCancelPending();
   }
 });

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -52,6 +52,10 @@ import {
 export function registerQueryHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, getAvailableColumns, runQuery } = app;
 
+  ipcMain.handle('query:cancel-pending', () => {
+    ctx.db.cancelPendingQueries();
+  });
+
   async function resolveAvailablePeriods(
     tier: 'daily' | 'hourly',
     dateRange: { readonly start: string; readonly end: string },

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -1,4 +1,7 @@
-import { app, BrowserWindow, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { Session } from 'node:inspector';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { logger } from '@costgoblin/core';
 import type { LogEntry } from '@costgoblin/core';
@@ -51,6 +54,44 @@ function formatEntry(entry: LogEntry): string {
 logger.addHandler((entry: LogEntry) => {
   process.stdout.write(formatEntry(entry));
 });
+
+// ---------------------------------------------------------------------------
+// CPU profiling — active only when COSTGOBLIN_PERF_MODE=1
+// ---------------------------------------------------------------------------
+const perfMode = process.env['COSTGOBLIN_PERF_MODE'] === '1';
+
+if (perfMode) {
+  const session = new Session();
+  session.connect();
+
+  ipcMain.handle('perf:start-cpu-profile', () => {
+    return new Promise<void>((resolve, reject) => {
+      session.post('Profiler.enable', (err) => {
+        if (err !== null) { reject(err); return; }
+        session.post('Profiler.start', (err2) => {
+          if (err2 !== null) { reject(err2); return; }
+          resolve();
+        });
+      });
+    });
+  });
+
+  ipcMain.handle('perf:stop-cpu-profile', (_event: unknown, label: string) => {
+    return new Promise<{ path: string }>((resolve, reject) => {
+      session.post('Profiler.stop', (err, result) => {
+        if (err !== null) { reject(err); return; }
+        session.post('Profiler.disable');
+        const dir = join(tmpdir(), 'costgoblin-perf');
+        mkdirSync(dir, { recursive: true });
+        const outPath = join(dir, `cpu-${label}.cpuprofile`);
+        writeFileSync(outPath, JSON.stringify(result.profile));
+        resolve({ path: outPath });
+      });
+    });
+  });
+
+  logger.info('Perf mode enabled — CPU profiling handlers registered');
+}
 
 function resolveConfigPath(base: string, name: string): string {
   const envKey = `COSTGOBLIN_${name.toUpperCase()}_PATH`;

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -39,8 +39,30 @@ import type {
   ExplorerRowsResult,
 } from '@costgoblin/core';
 
+// ---------------------------------------------------------------------------
+// Performance instrumentation — active only when COSTGOBLIN_PERF_MODE=1
+// ---------------------------------------------------------------------------
+const perfMode = process.env['COSTGOBLIN_PERF_MODE'] === '1';
+
+interface IpcTiming {
+  readonly channel: string;
+  readonly durationMs: number;
+  readonly timestamp: string;
+}
+
+const ipcTimings: IpcTiming[] = [];
+
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
-  return ipcRenderer.invoke(channel, ...args) as Promise<T>;
+  const start = perfMode ? performance.now() : 0;
+  const result = ipcRenderer.invoke(channel, ...args) as Promise<T>;
+  if (!perfMode) return result;
+  return result.finally(() => {
+    ipcTimings.push({
+      channel,
+      durationMs: Math.round((performance.now() - start) * 100) / 100,
+      timestamp: new Date().toISOString(),
+    });
+  });
 }
 
 const api: CostApi = {
@@ -218,6 +240,20 @@ const api: CostApi = {
   saveExplorerPreferences(prefs: ExplorerPreferences): Promise<void> {
     return invoke<undefined>('explorer:save-preferences', prefs).then(() => undefined);
   },
+  cancelPendingQueries(): Promise<void> {
+    return invoke<undefined>('query:cancel-pending').then(() => undefined);
+  },
 };
 
 contextBridge.exposeInMainWorld('costgoblin', api);
+
+if (perfMode) {
+  contextBridge.exposeInMainWorld('costgoblinPerf', {
+    getIpcTimings(): IpcTiming[] { return [...ipcTimings]; },
+    clearIpcTimings(): void { ipcTimings.length = 0; },
+    startCpuProfile(): Promise<undefined> { return invoke<undefined>('perf:start-cpu-profile'); },
+    stopCpuProfile(label: string): Promise<{ path: string }> {
+      return invoke<{ path: string }>('perf:stop-cpu-profile', label);
+    },
+  });
+}

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,6 +1,29 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Profiler } from 'react';
 import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
+
+// ---------------------------------------------------------------------------
+// React Profiler — collects render timings when perf mode is active
+// ---------------------------------------------------------------------------
+const perfEnabled = globalThis.costgoblinPerf !== undefined;
+const renderTimings: RenderTiming[] = [];
+
+if (perfEnabled) {
+  globalThis.__PERF_REACT__ = renderTimings;
+}
+
+function onPerfRender(
+  id: string,
+  phase: 'mount' | 'update' | 'nested-update',
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+): void {
+  if (perfEnabled) {
+    renderTimings.push({ id, phase, actualDuration, baseDuration, startTime, commitTime });
+  }
+}
 
 function getApi(): CostApi {
   return globalThis.costgoblin;
@@ -187,6 +210,7 @@ function AppShell(): React.JSX.Element {
 
   function handleNavClick(id: string) {
     confirmLeave(() => {
+      void api.cancelPendingQueries();
       switch (id) {
         case 'trends': setView({ page: 'trends' }); break;
         case 'missing-tags': setView({ page: 'missing-tags' }); break;
@@ -205,11 +229,15 @@ function AppShell(): React.JSX.Element {
   }
 
   function handleEntityClick(entity: string, dimension: string) {
-    confirmLeave(() => { setView({ page: 'entity-detail', entity, dimension }); });
+    confirmLeave(() => {
+      void api.cancelPendingQueries();
+      setView({ page: 'entity-detail', entity, dimension });
+    });
   }
 
   function handleBack() {
     confirmLeave(() => {
+      void api.cancelPendingQueries();
       const firstId = viewsConfig.views[0]?.id ?? OVERVIEW_SEED_VIEW.id;
       setView({ page: 'custom', viewId: firstId });
     });
@@ -328,24 +356,60 @@ function AppShell(): React.JSX.Element {
       {/* View content */}
       {view.page === 'custom' && (() => {
         const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
-        return <CustomView spec={spec} headerSubtitle="Cloud spending visibility" onEntityClick={handleEntityClick} />;
+        return (
+          <Profiler id={`custom:${view.viewId}`} onRender={onPerfRender}>
+            <CustomView spec={spec} headerSubtitle="Cloud spending visibility" onEntityClick={handleEntityClick} />
+          </Profiler>
+        );
       })()}
-      {view.page === 'trends' && <CostTrends onEntityClick={handleEntityClick} />}
-      {view.page === 'missing-tags' && <MissingTags />}
-      {view.page === 'savings' && <Savings />}
-      {view.page === 'explorer' && <ExplorerView />}
-      {view.page === 'cost-scope' && <CostScopeView />}
-      {view.page === 'dimensions' && <DimensionsView />}
-      {view.page === 'views-editor' && <ViewsEditor onConfigPersisted={setViewsConfig} />}
+      {view.page === 'trends' && (
+        <Profiler id="trends" onRender={onPerfRender}>
+          <CostTrends onEntityClick={handleEntityClick} />
+        </Profiler>
+      )}
+      {view.page === 'missing-tags' && (
+        <Profiler id="missing-tags" onRender={onPerfRender}>
+          <MissingTags />
+        </Profiler>
+      )}
+      {view.page === 'savings' && (
+        <Profiler id="savings" onRender={onPerfRender}>
+          <Savings />
+        </Profiler>
+      )}
+      {view.page === 'explorer' && (
+        <Profiler id="explorer" onRender={onPerfRender}>
+          <ExplorerView />
+        </Profiler>
+      )}
+      {view.page === 'cost-scope' && (
+        <Profiler id="cost-scope" onRender={onPerfRender}>
+          <CostScopeView />
+        </Profiler>
+      )}
+      {view.page === 'dimensions' && (
+        <Profiler id="dimensions" onRender={onPerfRender}>
+          <DimensionsView />
+        </Profiler>
+      )}
+      {view.page === 'views-editor' && (
+        <Profiler id="views-editor" onRender={onPerfRender}>
+          <ViewsEditor onConfigPersisted={setViewsConfig} />
+        </Profiler>
+      )}
       <div className={view.page === 'sync' ? '' : 'hidden'}>
-        <DataManagement />
+        <Profiler id="sync" onRender={onPerfRender}>
+          <DataManagement />
+        </Profiler>
       </div>
       {view.page === 'entity-detail' && (
-        <EntityDetail
-          entity={view.entity}
-          dimension={view.dimension}
-          onBack={handleBack}
-        />
+        <Profiler id="entity-detail" onRender={onPerfRender}>
+          <EntityDetail
+            entity={view.entity}
+            dimension={view.dimension}
+            onBack={handleBack}
+          />
+        </Profiler>
       )}
     </div>
   );

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -1,8 +1,34 @@
 import type { CostApi } from '@costgoblin/core/browser';
 
 declare global {
+  interface IpcTiming {
+    readonly channel: string;
+    readonly durationMs: number;
+    readonly timestamp: string;
+  }
+
+  interface PerfApi {
+    getIpcTimings(): IpcTiming[];
+    clearIpcTimings(): void;
+    startCpuProfile(): Promise<undefined>;
+    stopCpuProfile(label: string): Promise<{ path: string }>;
+  }
+
+  interface RenderTiming {
+    readonly id: string;
+    readonly phase: string;
+    readonly actualDuration: number;
+    readonly baseDuration: number;
+    readonly startTime: number;
+    readonly commitTime: number;
+  }
+
   interface Window {
     costgoblin: CostApi;
+    costgoblinPerf?: PerfApi;
+    __PERF_REACT__?: RenderTiming[];
   }
   var costgoblin: CostApi;
+  var costgoblinPerf: PerfApi | undefined;
+  var __PERF_REACT__: RenderTiming[] | undefined;
 }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -342,6 +342,7 @@ export class MockCostApi implements CostApi {
     return Promise.resolve({ hiddenColumns: [], columnOrder: [] });
   }
   saveExplorerPreferences(): Promise<void> { return Promise.resolve(); }
+  cancelPendingQueries(): Promise<void> { return Promise.resolve(); }
 }
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {


### PR DESCRIPTION
## Summary

- **Cancel stale DuckDB queries on view navigation** — queued queries from the previous view are marked as cancelled in the worker, skipping execution and releasing pool connections immediately. Running queries finish but skip row serialization.
- **Scale DuckDB pool to CPU count** — default pool size changed from hardcoded 4 to `min(max(4, cpus().length), 16)`, eliminating FIFO queuing for typical widget fan-out.
- **Add perf benchmark suite** — `npm run perf` runs 33 Playwright scenarios across all views, collecting IPC timing, React render metrics, heap deltas, and CPU profiles.

## Before / After

| Scenario | Before | After | Change |
|---|---|---|---|
| Cost Overview → apply filter | 10,041 ms | 1,900 ms | **-81%** |
| Cost Overview → 90 days | 339 ms | 329 ms | -3% |
| Trends → switch dimension | 1,182 ms | 1,187 ms | ~same |

The filter scenario is the big win: 12 widget queries were queueing 3 rounds through 4 pool slots. Now all 12 run in parallel.

Trends/Cost Scope baselines are unchanged because their bottleneck is `data:inventory` (S3 calls on every view change) and the preview queries themselves — addressed separately.