### PR TITLE
Add sync engine test coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,16 @@ export default [
     },
   },
   {
+    files: ['packages/*/src/__tests__/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+    },
+  },
+  {
     ignores: ['**/dist/**', '**/node_modules/**', '**/*.config.*', '**/__fixtures__/generate.ts'],
   },
 ];

--- a/packages/core/src/__tests__/data-inventory.test.ts
+++ b/packages/core/src/__tests__/data-inventory.test.ts
@@ -1,0 +1,1070 @@
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getDataInventory } from '../sync/data-inventory.js';
+import type { S3Handle } from '../sync/s3-client.js';
+import type { ManifestFileEntry } from '../sync/manifest.js';
+
+function createMockS3Handle(files: ManifestFileEntry[]): S3Handle {
+  return {
+    listFiles(): Promise<ManifestFileEntry[]> {
+      return Promise.resolve(files);
+    },
+    downloadFile(): Promise<void> {
+      return Promise.reject(new Error('downloadFile not implemented in mock'));
+    },
+  };
+}
+
+function file(key: string, hash = 'etag-hash', size = 1000): ManifestFileEntry {
+  return { key, contentHash: hash, size };
+}
+
+describe('getDataInventory with mocked S3', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `costgoblin-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  it('returns empty inventory when S3 has no files', async () => {
+    const mock = createMockS3Handle([]);
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.periods).toEqual([]);
+    expect(inventory.totalRemoteSize).toBe(0);
+    expect(inventory.totalRemotePeriods).toBe(0);
+    expect(inventory.totalLocalPeriods).toBe(0);
+    expect(inventory.local.periods).toEqual([]);
+    expect(inventory.local.diskBytes).toBe(0);
+    expect(inventory.local.oldestPeriod).toBeNull();
+    expect(inventory.local.newestPeriod).toBeNull();
+  });
+
+  it('lists remote periods with all missing local status', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+      file('cur/data/BILLING_PERIOD=2026-02/file3.parquet', 'hash3', 7000),
+    ]);
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.totalRemotePeriods).toBe(2);
+    expect(inventory.totalRemoteSize).toBe(15000);
+    expect(inventory.totalLocalPeriods).toBe(0);
+
+    expect(inventory.periods).toHaveLength(2);
+    const periods = inventory.periods.map(p => p.period).sort();
+    expect(periods).toEqual(['2026-01', '2026-02']);
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    expect(jan?.files).toHaveLength(2);
+    expect(jan?.totalSize).toBe(8000);
+    expect(jan?.localStatus).toBe('missing');
+
+    const feb = inventory.periods.find(p => p.period === '2026-02');
+    expect(feb?.files).toHaveLength(1);
+    expect(feb?.totalSize).toBe(7000);
+    expect(feb?.localStatus).toBe('missing');
+  });
+
+  it('detects repartitioned status when local period exists and hashes match', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+    ]);
+
+    // Create local raw period directory
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'dummy data');
+
+    // Create etag file with matching hashes
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-01': {
+        'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1',
+        'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'hash2',
+      },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.totalLocalPeriods).toBe(1);
+    expect(inventory.local.periods).toEqual(['2026-01']);
+    expect(inventory.local.diskBytes).toBeGreaterThan(0);
+    expect(inventory.local.oldestPeriod).toBe('2026-01');
+    expect(inventory.local.newestPeriod).toBe('2026-01');
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    expect(jan?.localStatus).toBe('repartitioned');
+  });
+
+  it('detects stale status when local period exists but hash differs', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'new-hash', 5000),
+    ]);
+
+    // Create local raw period directory
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'old data');
+
+    // Create etag file with old hash
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-01': {
+        'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'old-hash',
+      },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    expect(jan?.localStatus).toBe('stale');
+  });
+
+  it('handles mixed period statuses correctly', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      file('cur/data/BILLING_PERIOD=2026-02/file2.parquet', 'new-hash2', 3000),
+      file('cur/data/BILLING_PERIOD=2026-03/file3.parquet', 'hash3', 7000),
+    ]);
+
+    // Create local periods for 2026-01 and 2026-02
+    const rawDir = join(tempDir, 'aws', 'raw');
+    await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+    await mkdir(join(rawDir, 'daily-2026-02'), { recursive: true });
+    await writeFile(join(rawDir, 'daily-2026-01', 'data.parquet'), 'data1');
+    await writeFile(join(rawDir, 'daily-2026-02', 'data.parquet'), 'data2');
+
+    // 2026-01: matching hash (repartitioned)
+    // 2026-02: different hash (stale)
+    // 2026-03: no local (missing)
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-01': { 'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1' },
+      '2026-02': { 'cur/data/BILLING_PERIOD=2026-02/file2.parquet': 'old-hash2' },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.totalRemotePeriods).toBe(3);
+    expect(inventory.totalLocalPeriods).toBe(2);
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    const feb = inventory.periods.find(p => p.period === '2026-02');
+    const mar = inventory.periods.find(p => p.period === '2026-03');
+
+    expect(jan?.localStatus).toBe('repartitioned');
+    expect(feb?.localStatus).toBe('stale');
+    expect(mar?.localStatus).toBe('missing');
+  });
+
+  it('extracts periods from date= format (cost-optimization)', async () => {
+    const mock = createMockS3Handle([
+      file('cost-opt/date=2026-03-15/file1.parquet', 'hash1', 2000),
+      file('cost-opt/date=2026-03-20/file2.parquet', 'hash2', 3000),
+      file('cost-opt/date=2026-04-01/file3.parquet', 'hash3', 1000),
+    ]);
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cost-opt/',
+      'default',
+      tempDir,
+      'cost-optimization',
+      mock,
+    );
+
+    expect(inventory.totalRemotePeriods).toBe(2);
+    const periods = inventory.periods.map(p => p.period).sort();
+    expect(periods).toEqual(['2026-03', '2026-04']);
+
+    const mar = inventory.periods.find(p => p.period === '2026-03');
+    expect(mar?.files).toHaveLength(2);
+    expect(mar?.totalSize).toBe(5000);
+  });
+
+  it('sorts periods in descending order (newest first)', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 1000),
+      file('cur/data/BILLING_PERIOD=2026-03/file2.parquet', 'hash2', 1000),
+      file('cur/data/BILLING_PERIOD=2026-02/file3.parquet', 'hash3', 1000),
+    ]);
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    const periods = inventory.periods.map(p => p.period);
+    expect(periods).toEqual(['2026-03', '2026-02', '2026-01']);
+  });
+
+  it('handles hourly tier with correct etag file', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'hourly-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'hourly data');
+
+    const etagFile = join(tempDir, 'sync-etags-hourly.json');
+    const etags = {
+      '2026-01': { 'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1' },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'hourly',
+      mock,
+    );
+
+    expect(inventory.totalLocalPeriods).toBe(1);
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    expect(jan?.localStatus).toBe('repartitioned');
+  });
+
+  it('handles cost-optimization tier with correct etag file and directory prefix', async () => {
+    const mock = createMockS3Handle([
+      file('cost-opt/date=2026-03-15/file1.parquet', 'hash1', 5000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'cost-opt-2026-03');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'cost-opt data');
+
+    const etagFile = join(tempDir, 'sync-etags-cost-optimization.json');
+    const etags = {
+      '2026-03': { 'cost-opt/date=2026-03-15/file1.parquet': 'hash1' },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cost-opt/',
+      'default',
+      tempDir,
+      'cost-optimization',
+      mock,
+    );
+
+    expect(inventory.totalLocalPeriods).toBe(1);
+    expect(inventory.local.periods).toEqual(['2026-03']);
+    const mar = inventory.periods.find(p => p.period === '2026-03');
+    expect(mar?.localStatus).toBe('repartitioned');
+  });
+
+  it('handles missing etag file gracefully', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+    // No etag file created
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.totalLocalPeriods).toBe(1);
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    // Without etag file, we can't verify staleness, so it's considered repartitioned
+    expect(jan?.localStatus).toBe('repartitioned');
+  });
+
+  it('detects repartitioned when etag file exists but has no entry for period', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+    // Create etag file but without entry for 2026-01
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-02': { 'cur/data/BILLING_PERIOD=2026-02/file1.parquet': 'hash2' },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    // Etag file exists but has no entry for this period → repartitioned
+    expect(jan?.localStatus).toBe('repartitioned');
+  });
+
+  it('detects repartitioned when etag file has partial file coverage with all matching', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+      file('cur/data/BILLING_PERIOD=2026-01/file3.parquet', 'hash3', 2000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+    // Etag file only has entries for file1 and file2, not file3
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-01': {
+        'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1',
+        'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'hash2',
+        // file3 not in etags
+      },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    // All files that have etags match, missing etags are ignored → repartitioned
+    expect(jan?.localStatus).toBe('repartitioned');
+  });
+
+  it('detects stale when one file hash differs among multiple files', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'new-hash1', 5000),
+      file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+      file('cur/data/BILLING_PERIOD=2026-01/file3.parquet', 'hash3', 2000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+    // file1 has changed hash, file2 and file3 match
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-01': {
+        'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'old-hash1',
+        'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'hash2',
+        'cur/data/BILLING_PERIOD=2026-01/file3.parquet': 'hash3',
+      },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    // One file has different hash → stale
+    expect(jan?.localStatus).toBe('stale');
+  });
+
+  it('detects stale when only one file is tracked and it differs', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'new-hash', 5000),
+      file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+    ]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    await mkdir(periodDir, { recursive: true });
+    await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+    // Only file1 is in etags and it differs, file2 is not tracked
+    const etagFile = join(tempDir, 'sync-etags.json');
+    const etags = {
+      '2026-01': {
+        'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'old-hash',
+      },
+    };
+    await writeFile(etagFile, JSON.stringify(etags));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    const jan = inventory.periods.find(p => p.period === '2026-01');
+    // The one tracked file differs → stale
+    expect(jan?.localStatus).toBe('stale');
+  });
+
+  it('handles local period without corresponding remote files', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-02/file1.parquet', 'hash1', 5000),
+    ]);
+
+    // Create local period for 2026-01 that doesn't exist remotely
+    const rawDir = join(tempDir, 'aws', 'raw');
+    await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+    await mkdir(join(rawDir, 'daily-2026-02'), { recursive: true });
+    await writeFile(join(rawDir, 'daily-2026-01', 'data.parquet'), 'old data');
+    await writeFile(join(rawDir, 'daily-2026-02', 'data.parquet'), 'current data');
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    // totalLocalPeriods includes both 2026-01 and 2026-02
+    expect(inventory.totalLocalPeriods).toBe(2);
+    expect(inventory.local.periods).toEqual(['2026-01', '2026-02']);
+
+    // But inventory.periods only includes remote periods (2026-02)
+    expect(inventory.totalRemotePeriods).toBe(1);
+    expect(inventory.periods).toHaveLength(1);
+    expect(inventory.periods[0]?.period).toBe('2026-02');
+  });
+
+  it('skips files without recognizable period markers', async () => {
+    const mock = createMockS3Handle([
+      file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      file('cur/data/random-path/file2.parquet', 'hash2', 3000),
+      file('cur/metadata.parquet', 'hash3', 1000),
+    ]);
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    // Only the file with BILLING_PERIOD should be included in periods
+    expect(inventory.totalRemotePeriods).toBe(1);
+    expect(inventory.periods).toHaveLength(1);
+    expect(inventory.periods[0]?.period).toBe('2026-01');
+    // totalRemoteSize includes all files, even those without recognized periods
+    expect(inventory.totalRemoteSize).toBe(9000);
+  });
+
+  it('calculates local disk bytes correctly across multiple periods', async () => {
+    const mock = createMockS3Handle([]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+    await mkdir(join(rawDir, 'daily-2026-02'), { recursive: true });
+
+    // Write files with known sizes
+    await writeFile(join(rawDir, 'daily-2026-01', 'file1.parquet'), 'a'.repeat(1000));
+    await writeFile(join(rawDir, 'daily-2026-01', 'file2.parquet'), 'b'.repeat(2000));
+    await writeFile(join(rawDir, 'daily-2026-02', 'file3.parquet'), 'c'.repeat(3000));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.local.diskBytes).toBe(6000);
+  });
+
+  it('handles nested directory structures when calculating disk bytes', async () => {
+    const mock = createMockS3Handle([]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    const periodDir = join(rawDir, 'daily-2026-01');
+    const subDir = join(periodDir, 'subfolder');
+    await mkdir(subDir, { recursive: true });
+
+    await writeFile(join(periodDir, 'file1.parquet'), 'a'.repeat(1000));
+    await writeFile(join(subDir, 'file2.parquet'), 'b'.repeat(2000));
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.local.diskBytes).toBe(3000);
+  });
+
+  it('sets oldest and newest period correctly', async () => {
+    const mock = createMockS3Handle([]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+    await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+    await mkdir(join(rawDir, 'daily-2026-02'), { recursive: true });
+    await mkdir(join(rawDir, 'daily-2026-03'), { recursive: true });
+    await writeFile(join(rawDir, 'daily-2026-01', 'data.parquet'), 'data');
+    await writeFile(join(rawDir, 'daily-2026-02', 'data.parquet'), 'data');
+    await writeFile(join(rawDir, 'daily-2026-03', 'data.parquet'), 'data');
+
+    const inventory = await getDataInventory(
+      's3://test-bucket/cur/',
+      'default',
+      tempDir,
+      'daily',
+      mock,
+    );
+
+    expect(inventory.local.oldestPeriod).toBe('2026-01');
+    expect(inventory.local.newestPeriod).toBe('2026-03');
+  });
+
+  it('handles tier-specific directory prefixes correctly', async () => {
+    const mock = createMockS3Handle([]);
+
+    const rawDir = join(tempDir, 'aws', 'raw');
+
+    // Create directories for different tiers to ensure we only count the right ones
+    await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+    await mkdir(join(rawDir, 'hourly-2026-01'), { recursive: true });
+    await mkdir(join(rawDir, 'cost-opt-2026-01'), { recursive: true });
+
+    await writeFile(join(rawDir, 'daily-2026-01', 'data.parquet'), 'daily');
+    await writeFile(join(rawDir, 'hourly-2026-01', 'data.parquet'), 'hourly');
+    await writeFile(join(rawDir, 'cost-opt-2026-01', 'data.parquet'), 'cost-opt');
+
+    const expected = [
+      { tier: 'daily' as const, periods: ['2026-01'], bytes: 5 },
+      { tier: 'hourly' as const, periods: ['2026-01'], bytes: 6 },
+      { tier: 'cost-optimization' as const, periods: ['2026-01'], bytes: 8 },
+    ];
+
+    for (const { tier, periods, bytes } of expected) {
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        tier,
+        mock,
+      );
+
+      expect(inventory.local.periods).toEqual(periods);
+      expect(inventory.local.diskBytes).toBe(bytes);
+    }
+  });
+
+  describe('incremental sync validation', () => {
+    it('marks period as repartitioned when all tracked files have matching etags (skip sync)', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'etag-abc', 5000),
+        file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'etag-def', 3000),
+        file('cur/data/BILLING_PERIOD=2026-01/file3.parquet', 'etag-ghi', 2000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'local data');
+
+      // All three files have matching etags
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const etags = {
+        '2026-01': {
+          'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'etag-abc',
+          'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'etag-def',
+          'cur/data/BILLING_PERIOD=2026-01/file3.parquet': 'etag-ghi',
+        },
+      };
+      await writeFile(etagFile, JSON.stringify(etags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      // All etags match → repartitioned → sync can safely skip this period
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('marks period as stale when any tracked file has mismatched etag (must re-sync entire period)', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'etag-abc', 5000),
+        file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'etag-xyz-NEW', 3000),
+        file('cur/data/BILLING_PERIOD=2026-01/file3.parquet', 'etag-ghi', 2000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'local data');
+
+      // file2 has changed etag (was etag-def, now etag-xyz-NEW)
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const etags = {
+        '2026-01': {
+          'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'etag-abc',
+          'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'etag-def',
+          'cur/data/BILLING_PERIOD=2026-01/file3.parquet': 'etag-ghi',
+        },
+      };
+      await writeFile(etagFile, JSON.stringify(etags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      // One etag differs → stale → entire period must be re-synced
+      expect(jan?.localStatus).toBe('stale');
+    });
+
+    it('allows incremental sync: new remote files not in etag cache do not trigger stale status', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'etag-abc', 5000),
+        file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'etag-def', 3000),
+        file('cur/data/BILLING_PERIOD=2026-01/file3-NEW.parquet', 'etag-new', 1000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'local data');
+
+      // Etag cache only has file1 and file2, file3-NEW is a new remote file
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const etags = {
+        '2026-01': {
+          'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'etag-abc',
+          'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'etag-def',
+          // file3-NEW not in cache
+        },
+      };
+      await writeFile(etagFile, JSON.stringify(etags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      // Tracked files (file1, file2) match → repartitioned
+      // New file (file3-NEW) is not tracked, so doesn't cause stale status
+      // Sync orchestrator will download new file incrementally
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('validates multi-period incremental sync: unchanged period stays repartitioned', async () => {
+      const mock = createMockS3Handle([
+        // Period 2026-01: unchanged (etags match)
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+        file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+        // Period 2026-02: missing locally
+        file('cur/data/BILLING_PERIOD=2026-02/file3.parquet', 'hash3', 7000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const jan2026Dir = join(rawDir, 'daily-2026-01');
+      await mkdir(jan2026Dir, { recursive: true });
+      await writeFile(join(jan2026Dir, 'data.parquet'), 'jan data');
+
+      // Etag cache shows 2026-01 was previously synced with matching hashes
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const etags = {
+        '2026-01': {
+          'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1',
+          'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'hash2',
+        },
+      };
+      await writeFile(etagFile, JSON.stringify(etags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      const feb = inventory.periods.find(p => p.period === '2026-02');
+
+      // 2026-01: unchanged → repartitioned → skip
+      expect(jan?.localStatus).toBe('repartitioned');
+      // 2026-02: new period → missing → download
+      expect(feb?.localStatus).toBe('missing');
+
+      // Incremental sync would skip 2026-01 and only download 2026-02
+      expect(inventory.totalRemotePeriods).toBe(2);
+      expect(inventory.totalLocalPeriods).toBe(1);
+    });
+
+    it('validates etag-based skip decision across all three status values', async () => {
+      const mock = createMockS3Handle([
+        // Period 1: repartitioned (skip)
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 1000),
+        // Period 2: stale (re-download)
+        file('cur/data/BILLING_PERIOD=2026-02/file2.parquet', 'new-hash2', 2000),
+        // Period 3: missing (download)
+        file('cur/data/BILLING_PERIOD=2026-03/file3.parquet', 'hash3', 3000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+      await mkdir(join(rawDir, 'daily-2026-02'), { recursive: true });
+      await writeFile(join(rawDir, 'daily-2026-01', 'data.parquet'), 'data1');
+      await writeFile(join(rawDir, 'daily-2026-02', 'data.parquet'), 'data2');
+
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const etags = {
+        '2026-01': { 'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1' },
+        '2026-02': { 'cur/data/BILLING_PERIOD=2026-02/file2.parquet': 'old-hash2' },
+      };
+      await writeFile(etagFile, JSON.stringify(etags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const initial: Record<string, string> = {};
+      const periods = inventory.periods.reduce((acc, p) => {
+        acc[p.period] = p.localStatus;
+        return acc;
+      }, initial);
+
+      // Incremental sync decision matrix:
+      expect(periods['2026-01']).toBe('repartitioned'); // SKIP: local matches remote
+      expect(periods['2026-02']).toBe('stale');         // RE-DOWNLOAD: local outdated
+      expect(periods['2026-03']).toBe('missing');       // DOWNLOAD: not synced yet
+    });
+
+    it('validates empty etag cache does not prevent initial sync', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      // Etag file exists but is empty (first sync after etag feature deployed)
+      const etagFile = join(tempDir, 'sync-etags.json');
+      await writeFile(etagFile, JSON.stringify({}));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      // No etag tracking for this period → assume repartitioned
+      // (conservative: treat as synced, sync orchestrator can handle validation)
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+  });
+
+  describe('corrupted manifest JSON handling', () => {
+    it('handles invalid JSON syntax gracefully', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      // Write invalid JSON to etag file
+      const etagFile = join(tempDir, 'sync-etags.json');
+      await writeFile(etagFile, 'not valid json {{{');
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      // Should not throw, should treat as if no etag file exists
+      expect(inventory.totalLocalPeriods).toBe(1);
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('handles JSON array instead of object', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      // Write JSON array instead of object
+      const etagFile = join(tempDir, 'sync-etags.json');
+      await writeFile(etagFile, JSON.stringify(['not', 'an', 'object']));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      // Should treat as empty etag cache
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('handles JSON null instead of object', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      const etagFile = join(tempDir, 'sync-etags.json');
+      await writeFile(etagFile, 'null');
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('handles JSON string instead of object', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      const etagFile = join(tempDir, 'sync-etags.json');
+      await writeFile(etagFile, JSON.stringify('string value'));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('skips period entries that are not objects', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'new-hash1', 5000),
+        file('cur/data/BILLING_PERIOD=2026-02/file2.parquet', 'new-hash2', 3000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      await mkdir(join(rawDir, 'daily-2026-01'), { recursive: true });
+      await mkdir(join(rawDir, 'daily-2026-02'), { recursive: true });
+      await writeFile(join(rawDir, 'daily-2026-01', 'data.parquet'), 'data1');
+      await writeFile(join(rawDir, 'daily-2026-02', 'data.parquet'), 'data2');
+
+      // 2026-01 is a string instead of object, 2026-02 is valid
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const corruptedEtags = {
+        '2026-01': 'not-an-object',
+        '2026-02': { 'cur/data/BILLING_PERIOD=2026-02/file2.parquet': 'new-hash2' },
+      };
+      await writeFile(etagFile, JSON.stringify(corruptedEtags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      const feb = inventory.periods.find(p => p.period === '2026-02');
+
+      // 2026-01: corrupted period entry is skipped → treated as repartitioned
+      expect(jan?.localStatus).toBe('repartitioned');
+      // 2026-02: valid entry with matching hash → repartitioned
+      expect(feb?.localStatus).toBe('repartitioned');
+    });
+
+    it('drops non-string hash values within a period', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
+        file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+        file('cur/data/BILLING_PERIOD=2026-01/file3.parquet', 'hash3', 2000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      // Mix of valid and invalid hash types
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const corruptedEtags = {
+        '2026-01': {
+          'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1',
+          'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 42, // number
+          'cur/data/BILLING_PERIOD=2026-01/file3.parquet': null, // null
+        },
+      };
+      await writeFile(etagFile, JSON.stringify(corruptedEtags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      // Only file1 has valid etag and it matches → repartitioned
+      // file2 and file3 have invalid etags (dropped) → not compared
+      expect(jan?.localStatus).toBe('repartitioned');
+    });
+
+    it('detects stale when valid hash differs despite other corrupted entries', async () => {
+      const mock = createMockS3Handle([
+        file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'new-hash1', 5000),
+        file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
+      ]);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'daily-2026-01');
+      await mkdir(periodDir, { recursive: true });
+      await writeFile(join(periodDir, 'data.parquet'), 'data');
+
+      // file1 has valid but stale hash, file2 has corrupted hash value
+      const etagFile = join(tempDir, 'sync-etags.json');
+      const corruptedEtags = {
+        '2026-01': {
+          'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'old-hash1',
+          'cur/data/BILLING_PERIOD=2026-01/file2.parquet': false, // boolean
+        },
+      };
+      await writeFile(etagFile, JSON.stringify(corruptedEtags));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/cur/',
+        'default',
+        tempDir,
+        'daily',
+        mock,
+      );
+
+      const jan = inventory.periods.find(p => p.period === '2026-01');
+      // file1's valid etag differs → stale (file2's invalid etag is ignored)
+      expect(jan?.localStatus).toBe('stale');
+    });
+  });
+});

--- a/packages/core/src/__tests__/s3-client-mock.test.ts
+++ b/packages/core/src/__tests__/s3-client-mock.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createS3Handle } from '../sync/s3-client.js';
+import type { S3Handle } from '../sync/s3-client.js';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn(() => ({ send: mockSend })),
+  ListObjectsV2Command: vi.fn((params) => ({ name: 'ListObjectsV2Command', params })),
+  GetObjectCommand: vi.fn((params) => ({ name: 'GetObjectCommand', params })),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+describe('S3 client (mocked) - listFiles', () => {
+  let s3: S3Handle;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    s3 = await createS3Handle('default', 'us-east-1');
+  });
+
+  it('returns parquet files from single page response', async () => {
+    mockSend.mockResolvedValueOnce({
+      Contents: [
+        { Key: 'data/2026-01/file1.parquet', Size: 1000, ETag: '"abc123"' },
+        { Key: 'data/2026-01/file2.parquet', Size: 2000, ETag: '"def456"' },
+      ],
+      IsTruncated: false,
+    });
+
+    const files = await s3.listFiles('test-bucket', 'data/2026-01/');
+
+    expect(files).toHaveLength(2);
+    expect(files[0]).toEqual({ key: 'data/2026-01/file1.parquet', size: 1000, contentHash: '"abc123"' });
+    expect(files[1]).toEqual({ key: 'data/2026-01/file2.parquet', size: 2000, contentHash: '"def456"' });
+  });
+
+  it('handles pagination with continuation token', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'data/file1.parquet', Size: 1000, ETag: '"hash1"' }],
+        IsTruncated: true,
+        NextContinuationToken: 'token-page-2',
+      })
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'data/file2.parquet', Size: 2000, ETag: '"hash2"' }],
+        IsTruncated: true,
+        NextContinuationToken: 'token-page-3',
+      })
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'data/file3.parquet', Size: 3000, ETag: '"hash3"' }],
+        IsTruncated: false,
+      });
+
+    const files = await s3.listFiles('test-bucket', 'data/');
+
+    expect(files).toHaveLength(3);
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+
+  it('filters out non-parquet files', async () => {
+    mockSend.mockResolvedValueOnce({
+      Contents: [
+        { Key: 'data/file1.parquet', Size: 1000, ETag: '"hash1"' },
+        { Key: 'data/manifest.json', Size: 100, ETag: '"hash2"' },
+        { Key: 'data/readme.txt', Size: 50, ETag: '"hash3"' },
+        { Key: 'data/file2.parquet', Size: 2000, ETag: '"hash4"' },
+      ],
+      IsTruncated: false,
+    });
+
+    const files = await s3.listFiles('test-bucket', 'data/');
+
+    expect(files).toHaveLength(2);
+    expect(files.every(f => f.key.endsWith('.parquet'))).toBe(true);
+  });
+
+  it('skips objects with missing Key or Size', async () => {
+    mockSend.mockResolvedValueOnce({
+      Contents: [
+        { Key: 'data/valid.parquet', Size: 1000, ETag: '"hash1"' },
+        { Key: undefined, Size: 1000, ETag: '"hash2"' },
+        { Key: 'data/no-size.parquet', Size: undefined, ETag: '"hash3"' },
+        { Key: 'data/valid2.parquet', Size: 2000, ETag: '"hash4"' },
+      ],
+      IsTruncated: false,
+    });
+
+    const files = await s3.listFiles('test-bucket', 'data/');
+
+    expect(files).toHaveLength(2);
+    expect(files[0]?.key).toBe('data/valid.parquet');
+    expect(files[1]?.key).toBe('data/valid2.parquet');
+  });
+
+  it('handles empty or undefined ETag', async () => {
+    mockSend.mockResolvedValueOnce({
+      Contents: [
+        { Key: 'data/file1.parquet', Size: 1000, ETag: undefined },
+        { Key: 'data/file2.parquet', Size: 2000, ETag: '' },
+      ],
+      IsTruncated: false,
+    });
+
+    const files = await s3.listFiles('test-bucket', 'data/');
+
+    expect(files).toHaveLength(2);
+    expect(files[0]?.contentHash).toBe('');
+    expect(files[1]?.contentHash).toBe('');
+  });
+
+  it('returns empty array when Contents is empty or undefined', async () => {
+    mockSend.mockResolvedValueOnce({ Contents: [], IsTruncated: false });
+    expect(await s3.listFiles('test-bucket', 'data/')).toHaveLength(0);
+
+    mockSend.mockResolvedValueOnce({ Contents: undefined, IsTruncated: false });
+    expect(await s3.listFiles('test-bucket', 'data/')).toHaveLength(0);
+  });
+
+  it('passes correct parameters to ListObjectsV2Command', async () => {
+    const { ListObjectsV2Command } = await import('@aws-sdk/client-s3');
+    mockSend.mockResolvedValueOnce({ Contents: [], IsTruncated: false });
+
+    await s3.listFiles('my-bucket', 'my-prefix/');
+
+    expect(ListObjectsV2Command).toHaveBeenCalledWith({
+      Bucket: 'my-bucket',
+      Prefix: 'my-prefix/',
+      ContinuationToken: undefined,
+    });
+  });
+
+  it('passes continuation token on subsequent pages', async () => {
+    const { ListObjectsV2Command } = await import('@aws-sdk/client-s3');
+    mockSend
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'data/file1.parquet', Size: 1000, ETag: '"hash1"' }],
+        IsTruncated: true,
+        NextContinuationToken: 'my-token',
+      })
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'data/file2.parquet', Size: 2000, ETag: '"hash2"' }],
+        IsTruncated: false,
+      });
+
+    await s3.listFiles('my-bucket', 'data/');
+
+    expect(ListObjectsV2Command).toHaveBeenNthCalledWith(2, {
+      Bucket: 'my-bucket',
+      Prefix: 'data/',
+      ContinuationToken: 'my-token',
+    });
+  });
+
+  it('uses custom endpoint options when provided', async () => {
+    const { S3Client } = await import('@aws-sdk/client-s3');
+
+    await createS3Handle('default', 'us-west-2', {
+      endpoint: 'http://localhost:9000',
+      forcePathStyle: true,
+      credentials: { accessKeyId: 'test', secretAccessKey: 'secret' },
+    });
+
+    expect(S3Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'us-west-2',
+        endpoint: 'http://localhost:9000',
+        forcePathStyle: true,
+      })
+    );
+  });
+
+  it('uses profile when not default', async () => {
+    const { S3Client } = await import('@aws-sdk/client-s3');
+    await createS3Handle('my-profile', 'eu-west-1');
+
+    expect(S3Client).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'eu-west-1', profile: 'my-profile' })
+    );
+  });
+
+  it.each([
+    ['ECONNREFUSED', 'NetworkingError'],
+    ['TimeoutError', 'TimeoutError'],
+    ['Service Unavailable', 'ServiceUnavailable'],
+    ['Access Denied', 'AccessDenied'],
+    ['NoSuchBucket', 'NoSuchBucket'],
+  ])('throws on %s error', async (message, name) => {
+    const error = new Error(message);
+    error.name = name;
+    mockSend.mockRejectedValueOnce(error);
+
+    await expect(s3.listFiles('test-bucket', 'data/')).rejects.toThrow(message);
+  });
+});
+
+describe('S3 client (mocked) - downloadFile', () => {
+  let s3: S3Handle;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    vi.mocked(mkdir).mockResolvedValue(undefined);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+    s3 = await createS3Handle('default', 'us-east-1');
+  });
+
+  function createMockBody(chunks: Uint8Array[]): AsyncIterable<Uint8Array> {
+    return {
+      async *[Symbol.asyncIterator]() {
+        await Promise.resolve();
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+      },
+    };
+  }
+
+  it('downloads file and writes to disk', async () => {
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    const chunk1 = new Uint8Array([1, 2, 3, 4]);
+    const chunk2 = new Uint8Array([5, 6, 7, 8]);
+
+    mockSend.mockResolvedValueOnce({ Body: createMockBody([chunk1, chunk2]) });
+
+    await s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/local.parquet');
+
+    expect(vi.mocked(mkdir)).toHaveBeenCalledWith('/tmp', { recursive: true });
+    expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+      '/tmp/local.parquet',
+      Buffer.concat([Buffer.from(chunk1), Buffer.from(chunk2)])
+    );
+  });
+
+  it('passes correct parameters to GetObjectCommand', async () => {
+    const { GetObjectCommand } = await import('@aws-sdk/client-s3');
+    mockSend.mockResolvedValueOnce({ Body: createMockBody([new Uint8Array([1])]) });
+
+    await s3.downloadFile('my-bucket', 'my-key/file.parquet', '/tmp/file.parquet');
+
+    expect(GetObjectCommand).toHaveBeenCalledWith({ Bucket: 'my-bucket', Key: 'my-key/file.parquet' });
+  });
+
+  it('throws when response body is undefined', async () => {
+    mockSend.mockResolvedValueOnce({ Body: undefined });
+
+    await expect(
+      s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet')
+    ).rejects.toThrow('Empty response body for s3://test-bucket/data/file.parquet');
+  });
+
+  it('cancels when abort signal is already aborted', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    mockSend.mockResolvedValueOnce({ Body: createMockBody([new Uint8Array([1, 2, 3])]) });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet', { signal: controller.signal })
+    ).rejects.toThrow('Download cancelled');
+
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+  });
+
+  it('aborts mid-stream and does not write partial file', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const controller = new AbortController();
+    let chunkCount = 0;
+
+    const mockBody = {
+      async *[Symbol.asyncIterator]() {
+        await Promise.resolve();
+        yield new Uint8Array([1, 2, 3]);
+        chunkCount++;
+        yield new Uint8Array([4, 5, 6]);
+        chunkCount++;
+        controller.abort();
+        yield new Uint8Array([7, 8, 9]);
+        chunkCount++;
+      },
+    };
+
+    mockSend.mockResolvedValueOnce({ Body: mockBody });
+
+    await expect(
+      s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet', { signal: controller.signal })
+    ).rejects.toThrow('Download cancelled');
+
+    expect(chunkCount).toBe(2);
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+  });
+
+  it('calls onBytes callback with accumulated byte count', async () => {
+    const chunks = [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6]), new Uint8Array([7, 8, 9])];
+    mockSend.mockResolvedValueOnce({ Body: createMockBody(chunks) });
+
+    const onBytes = vi.fn();
+    await s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet', { onBytes });
+
+    expect(onBytes).toHaveBeenCalledTimes(3);
+    expect(onBytes).toHaveBeenNthCalledWith(1, 4);
+    expect(onBytes).toHaveBeenNthCalledWith(2, 6);
+    expect(onBytes).toHaveBeenNthCalledWith(3, 9);
+  });
+
+  it('does not write partial file on mid-stream network error', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const mockBody = {
+      async *[Symbol.asyncIterator]() {
+        await Promise.resolve();
+        yield new Uint8Array([1, 2, 3]);
+        throw new Error('Connection lost');
+      },
+    };
+
+    mockSend.mockResolvedValueOnce({ Body: mockBody });
+
+    await expect(
+      s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet')
+    ).rejects.toThrow('Connection lost');
+
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['Connection reset by peer', 'NetworkingError'],
+    ['Request timeout', 'TimeoutError'],
+    ['NoSuchKey', 'NoSuchKey'],
+    ['Access Denied', 'AccessDenied'],
+    ['Forbidden', 'Forbidden'],
+  ])('throws on %s error', async (message, name) => {
+    const error = new Error(message);
+    error.name = name;
+    mockSend.mockRejectedValueOnce(error);
+
+    await expect(
+      s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet')
+    ).rejects.toThrow(message);
+  });
+
+  it('throws on disk full during write', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    mockSend.mockResolvedValueOnce({ Body: createMockBody([new Uint8Array([1, 2, 3])]) });
+
+    vi.mocked(writeFile).mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
+
+    await expect(
+      s3.downloadFile('test-bucket', 'data/file.parquet', '/tmp/file.parquet')
+    ).rejects.toThrow('ENOSPC: no space left on device');
+  });
+});

--- a/packages/core/src/__tests__/selective-sync.test.ts
+++ b/packages/core/src/__tests__/selective-sync.test.ts
@@ -1,0 +1,858 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { join } from 'node:path';
+import type { ManifestFileEntry } from '../sync/manifest.js';
+import { syncSelectedFiles } from '../sync/selective-sync.js';
+import type { SyncProgress } from '../sync/s3-client.js';
+
+vi.mock('node:child_process');
+vi.mock('node:fs/promises');
+vi.mock('../logger/logger.js');
+
+const file = (key: string, hash = 'h', size = 1): ManifestFileEntry => ({ key, contentHash: hash, size });
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+
+  kill(): boolean {
+    this.killed = true;
+    this.emit('close', null, 'SIGTERM');
+    return true;
+  }
+}
+
+describe('syncSelectedFiles', () => {
+  let mockSpawn: ReturnType<typeof vi.fn>;
+  let mockMkdir: ReturnType<typeof vi.fn>;
+  let mockReadFile: ReturnType<typeof vi.fn>;
+  let mockWriteFile: ReturnType<typeof vi.fn>;
+  let mockReaddir: ReturnType<typeof vi.fn>;
+  let mockCopyFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const childProcess = await import('node:child_process');
+    const fsPromises = await import('node:fs/promises');
+
+    mockSpawn = vi.fn();
+    childProcess.spawn = mockSpawn;
+
+    mockMkdir = vi.fn().mockResolvedValue(undefined);
+    mockReadFile = vi.fn().mockRejectedValue(new Error('ENOENT'));
+    mockWriteFile = vi.fn().mockResolvedValue(undefined);
+    mockReaddir = vi.fn().mockResolvedValue([]);
+    mockCopyFile = vi.fn().mockResolvedValue(undefined);
+
+    fsPromises.mkdir = mockMkdir;
+    fsPromises.readFile = mockReadFile;
+    fsPromises.writeFile = mockWriteFile;
+    fsPromises.readdir = mockReaddir;
+    fsPromises.copyFile = mockCopyFile;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createSuccessfulSpawn(): MockChildProcess {
+    const proc = new MockChildProcess();
+    setTimeout(() => { proc.emit('close', 0, null); }, 10);
+    return proc;
+  }
+
+  function createFailedSpawn(exitCode: number, stderrMessage: string): MockChildProcess {
+    const proc = new MockChildProcess();
+    setTimeout(() => {
+      proc.stderr.emit('data', Buffer.from(stderrMessage));
+      proc.emit('close', exitCode, null);
+    }, 10);
+    return proc;
+  }
+
+  it('successfully syncs daily CUR files', async () => {
+    const proc = createSuccessfulSpawn();
+    mockSpawn.mockReturnValue(proc);
+
+    const files = [
+      file('cur/data/BILLING_PERIOD=2026-03/file1.parquet', 'hash1'),
+      file('cur/data/BILLING_PERIOD=2026-03/file2.parquet', 'hash2'),
+    ];
+
+    const dataDir = join('/tmp', 'test');
+    const expectedDest = join(dataDir, 'aws', 'raw', 'daily-2026-03');
+
+    const result = await syncSelectedFiles({
+      bucketPath: 's3://test-bucket/cur/data/',
+      profile: 'test-profile',
+      dataDir,
+      expectedDataType: 'daily',
+      files,
+    });
+
+    expect(result.filesDownloaded).toBe(2);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'aws',
+      ['s3', 'sync', 's3://test-bucket/cur/data/BILLING_PERIOD=2026-03/', expectedDest, '--profile', 'test-profile'],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+  });
+
+  it('successfully syncs hourly CUR files', async () => {
+    const proc = createSuccessfulSpawn();
+    mockSpawn.mockReturnValue(proc);
+
+    const files = [file('cur/hourly/BILLING_PERIOD=2026-03/file.parquet', 'hash1')];
+    const dataDir = '/data';
+
+    const result = await syncSelectedFiles({
+      bucketPath: 's3://test-bucket/cur/hourly/',
+      profile: 'prod',
+      dataDir,
+      expectedDataType: 'hourly',
+      files,
+    });
+
+    expect(result.filesDownloaded).toBe(1);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'aws',
+      ['s3', 'sync', 's3://test-bucket/cur/hourly/BILLING_PERIOD=2026-03/', join(dataDir, 'aws', 'raw', 'hourly-2026-03'), '--profile', 'prod'],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+  });
+
+  it('successfully syncs cost-optimization files', async () => {
+    mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+    mockReaddir.mockResolvedValue(['data.parquet']);
+
+    const files = [
+      file('cost-opt/date=2026-03-15/file.parquet', 'hash1'),
+      file('cost-opt/date=2026-03-16/file.parquet', 'hash2'),
+    ];
+
+    const result = await syncSelectedFiles({
+      bucketPath: 's3://test-bucket/cost-opt/',
+      profile: 'test-profile',
+      dataDir: '/tmp/test',
+      expectedDataType: 'cost-optimization',
+      files,
+    });
+
+    expect(result.filesDownloaded).toBe(2);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockCopyFile).toHaveBeenCalled();
+  });
+
+  it('handles multiple periods in sorted order', async () => {
+    mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+
+    const files = [
+      file('cur/BILLING_PERIOD=2026-01/a.parquet', 'h1'),
+      file('cur/BILLING_PERIOD=2026-03/b.parquet', 'h2'),
+      file('cur/BILLING_PERIOD=2026-02/c.parquet', 'h3'),
+    ];
+
+    await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir: '/data',
+      files,
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+    const calls = mockSpawn.mock.calls;
+    expect(calls[0]?.[1]).toEqual(expect.arrayContaining([expect.stringContaining('2026-01')]));
+    expect(calls[1]?.[1]).toEqual(expect.arrayContaining([expect.stringContaining('2026-02')]));
+    expect(calls[2]?.[1]).toEqual(expect.arrayContaining([expect.stringContaining('2026-03')]));
+  });
+
+  it('calls progress callback during download', async () => {
+    const proc = createSuccessfulSpawn();
+    mockSpawn.mockReturnValue(proc);
+
+    setTimeout(() => {
+      proc.stdout.emit('data', Buffer.from('download: s3://bucket/file1.parquet to /tmp/file1.parquet\n'));
+      proc.stdout.emit('data', Buffer.from('Completed 1.5 MB/2.0 MB\n'));
+    }, 5);
+
+    const files = [file('cur/BILLING_PERIOD=2026-03/file1.parquet')];
+    const progressEvents: SyncProgress[] = [];
+
+    await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir: '/tmp',
+      files,
+      onProgress: (progress) => { progressEvents.push(progress); },
+    });
+
+    expect(progressEvents.some((p) => p.phase === 'downloading')).toBe(true);
+    expect(progressEvents.some((p) => p.phase === 'done')).toBe(true);
+    expect(progressEvents.some((p) => p.message?.includes('Completed'))).toBe(true);
+  });
+
+  it('calls onFileDownloaded callback when file downloads', async () => {
+    const proc = createSuccessfulSpawn();
+    mockSpawn.mockReturnValue(proc);
+
+    setTimeout(() => {
+      proc.stdout.emit('data', Buffer.from('download: s3://bucket/file.parquet to /tmp/local/file.parquet\n'));
+    }, 5);
+
+    const files = [file('cur/BILLING_PERIOD=2026-03/file.parquet')];
+    const downloadedPaths: string[] = [];
+
+    await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir: '/tmp',
+      files,
+      onFileDownloaded: (localPath) => { downloadedPaths.push(localPath); },
+    });
+
+    expect(downloadedPaths).toContain('/tmp/local/file.parquet');
+  });
+
+  it('rejects when AWS CLI is not found', async () => {
+    const proc = new MockChildProcess();
+    setTimeout(() => { proc.emit('error', new Error('spawn aws ENOENT')); }, 10);
+    mockSpawn.mockReturnValue(proc);
+
+    await expect(
+      syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+      })
+    ).rejects.toThrow('AWS CLI not found');
+  });
+
+  it.each([
+    [1, 'Access Denied', 'Access Denied'],
+    [1, 'Could not connect to the endpoint URL', 'Could not connect to the endpoint URL'],
+    [1, 'Read timeout on endpoint URL', 'Read timeout on endpoint URL'],
+    [1, 'SSL validation failed', 'SSL validation failed'],
+    [255, 'Name or service not known', 'Name or service not known'],
+    [1, 'SlowDown: Please reduce your request rate', 'SlowDown: Please reduce your request rate'],
+    [1, 'An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied', 'AccessDenied'],
+    [1, 'fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden', 'Forbidden'],
+  ])('rejects on CLI exit %i with "%s"', async (exitCode, stderr, expectedMessage) => {
+    const proc = createFailedSpawn(exitCode, stderr);
+    mockSpawn.mockReturnValue(proc);
+
+    await expect(
+      syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+      })
+    ).rejects.toThrow(expectedMessage);
+  });
+
+  it('cancels sync when signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir: '/tmp',
+      files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+      signal: controller.signal,
+    });
+
+    expect(result.filesDownloaded).toBe(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('kills process when aborted during download', async () => {
+    const controller = new AbortController();
+    const proc = new MockChildProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    setTimeout(() => { controller.abort(); }, 5);
+
+    await expect(
+      syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+        signal: controller.signal,
+      })
+    ).rejects.toThrow('Download cancelled');
+
+    expect(proc.killed).toBe(true);
+  });
+
+  it('stops processing additional periods when cancelled', async () => {
+    const controller = new AbortController();
+    let spawnCount = 0;
+
+    mockSpawn.mockImplementation(() => {
+      spawnCount++;
+      const proc = new MockChildProcess();
+      setTimeout(() => {
+        if (spawnCount === 1) {
+          proc.stdout.emit('data', Buffer.from('download: file.parquet\n'));
+        }
+        proc.emit('close', 0, null);
+      }, 10);
+      return proc;
+    });
+
+    await expect(
+      syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [
+          file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+          file('cur/BILLING_PERIOD=2026-02/b.parquet'),
+          file('cur/BILLING_PERIOD=2026-03/c.parquet'),
+        ],
+        signal: controller.signal,
+        onProgress: (progress) => {
+          if (progress.phase === 'downloading') controller.abort();
+        },
+      })
+    ).rejects.toThrow('Download cancelled');
+
+    expect(spawnCount).toBe(1);
+  });
+
+  it('saves and merges ETags correctly', async () => {
+    const proc = createSuccessfulSpawn();
+    mockSpawn.mockReturnValue(proc);
+
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ '2026-01': { 'old-file.parquet': 'old-hash' } })
+    );
+
+    const files = [file('cur/BILLING_PERIOD=2026-02/new-file.parquet', 'new-hash')];
+    const dataDir = '/tmp';
+    const expectedEtagFile = join(dataDir, 'sync-etags.json');
+
+    await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir,
+      files,
+    });
+
+    expect(mockWriteFile).toHaveBeenCalledWith(expectedEtagFile, expect.stringContaining('2026-01'));
+    expect(mockWriteFile).toHaveBeenCalledWith(expectedEtagFile, expect.stringContaining('2026-02'));
+    expect(mockWriteFile).toHaveBeenCalledWith(expectedEtagFile, expect.stringContaining('new-hash'));
+  });
+
+  it('handles empty file list', async () => {
+    const result = await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir: '/tmp',
+      files: [],
+    });
+
+    expect(result.filesDownloaded).toBe(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('creates necessary directories', async () => {
+    const proc = createSuccessfulSpawn();
+    mockSpawn.mockReturnValue(proc);
+
+    const dataDir = join('/tmp', 'data');
+
+    await syncSelectedFiles({
+      bucketPath: 's3://bucket/cur/',
+      profile: 'test',
+      dataDir,
+      files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+    });
+
+    expect(mockMkdir).toHaveBeenCalledWith(
+      join(dataDir, 'aws', 'raw', 'daily-2026-03'),
+      { recursive: true }
+    );
+  });
+
+  it('fails when network error occurs during multi-period sync', async () => {
+    let spawnCount = 0;
+    mockSpawn.mockImplementation(() => {
+      spawnCount++;
+      if (spawnCount === 2) return createFailedSpawn(1, 'Connection timed out');
+      return createSuccessfulSpawn();
+    });
+
+    await expect(
+      syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [
+          file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+          file('cur/BILLING_PERIOD=2026-02/b.parquet'),
+          file('cur/BILLING_PERIOD=2026-03/c.parquet'),
+        ],
+      })
+    ).rejects.toThrow('Connection timed out');
+
+    expect(spawnCount).toBe(2);
+  });
+
+  describe('per-period orchestration', () => {
+    /** Helper: sets up mock fs to track etag writes as raw strings */
+    function setupEtagTracking(etagFileName = 'sync-etags.json'): { getLastWritten: () => string } {
+      let lastWritten = '{}';
+
+      mockReadFile.mockImplementation((path: unknown) => {
+        if (String(path).includes(etagFileName)) return Promise.resolve(lastWritten);
+        return Promise.reject(new Error('ENOENT'));
+      });
+
+      mockWriteFile.mockImplementation((path: unknown, content: unknown) => {
+        if (String(path).includes(etagFileName)) {
+          lastWritten = String(content);
+        }
+        return Promise.resolve();
+      });
+
+      return { getLastWritten: () => lastWritten };
+    }
+
+    it('saves ETags after each period completes', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      const { getLastWritten } = setupEtagTracking();
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [
+          file('cur/BILLING_PERIOD=2026-01/a.parquet', 'hash-jan'),
+          file('cur/BILLING_PERIOD=2026-02/b.parquet', 'hash-feb'),
+          file('cur/BILLING_PERIOD=2026-03/c.parquet', 'hash-mar'),
+        ],
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledTimes(3);
+
+      const saved = JSON.parse(getLastWritten());
+      expect(saved['2026-01']?.['cur/BILLING_PERIOD=2026-01/a.parquet']).toBe('hash-jan');
+      expect(saved['2026-02']?.['cur/BILLING_PERIOD=2026-02/b.parquet']).toBe('hash-feb');
+      expect(saved['2026-03']?.['cur/BILLING_PERIOD=2026-03/c.parquet']).toBe('hash-mar');
+    });
+
+    it('processes periods sequentially', async () => {
+      const spawnOrder: string[] = [];
+
+      mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
+        const period = args.find((arg) => arg.includes('BILLING_PERIOD='))?.match(/2026-\d{2}/)?.[0];
+        if (period !== undefined) spawnOrder.push(period);
+
+        const proc = new MockChildProcess();
+        setTimeout(() => { proc.emit('close', 0, null); }, 10);
+        return proc;
+      });
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [
+          file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+          file('cur/BILLING_PERIOD=2026-02/b.parquet'),
+          file('cur/BILLING_PERIOD=2026-03/c.parquet'),
+        ],
+      });
+
+      expect(spawnOrder).toEqual(['2026-01', '2026-02', '2026-03']);
+    });
+
+    it('stops processing subsequent periods when one fails', async () => {
+      let spawnCount = 0;
+      mockSpawn.mockImplementation(() => {
+        spawnCount++;
+        if (spawnCount === 2) return createFailedSpawn(1, 'Access Denied for period 2');
+        return createSuccessfulSpawn();
+      });
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://bucket/cur/',
+          profile: 'test',
+          dataDir: '/tmp',
+          files: [
+            file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+            file('cur/BILLING_PERIOD=2026-02/b.parquet'),
+            file('cur/BILLING_PERIOD=2026-03/c.parquet'),
+          ],
+        })
+      ).rejects.toThrow('Access Denied for period 2');
+
+      expect(spawnCount).toBe(2);
+      expect(mockWriteFile).toHaveBeenCalledTimes(1);
+      const written = String(mockWriteFile.mock.calls[0]?.[1]);
+      expect(written).toContain('2026-01');
+      expect(written).not.toContain('2026-02');
+    });
+
+    it('tracks progress correctly across multiple periods', async () => {
+      const progressEvents: SyncProgress[] = [];
+
+      mockSpawn.mockImplementation(() => {
+        const proc = new MockChildProcess();
+        setTimeout(() => {
+          proc.stdout.emit('data', Buffer.from('download: file1.parquet\n'));
+          proc.stdout.emit('data', Buffer.from('download: file2.parquet\n'));
+          proc.emit('close', 0, null);
+        }, 5);
+        return proc;
+      });
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [
+          file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+          file('cur/BILLING_PERIOD=2026-01/b.parquet'),
+          file('cur/BILLING_PERIOD=2026-02/c.parquet'),
+          file('cur/BILLING_PERIOD=2026-02/d.parquet'),
+        ],
+        onProgress: (progress) => { progressEvents.push(progress); },
+      });
+
+      const downloadEvents = progressEvents.filter((p) => p.phase === 'downloading');
+      expect(downloadEvents.every((p) => p.filesTotal === 4)).toBe(true);
+      expect(Math.max(...downloadEvents.map((p) => p.filesDone))).toBe(4);
+
+      const doneEvent = progressEvents.find((p) => p.phase === 'done');
+      expect(doneEvent?.filesTotal).toBe(4);
+      expect(doneEvent?.filesDone).toBe(4);
+    });
+
+    it('preserves ETags from previous sync sessions', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+
+      const { getLastWritten } = setupEtagTracking();
+      // Seed with pre-existing etag data
+      mockReadFile.mockImplementation((path: unknown) => {
+        if (String(path).includes('sync-etags.json')) {
+          return Promise.resolve(JSON.stringify({ '2025-12': { 'old-file.parquet': 'old-hash' } }));
+        }
+        return Promise.reject(new Error('ENOENT'));
+      });
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [file('cur/BILLING_PERIOD=2026-01/new-file.parquet', 'new-hash-1')],
+      });
+
+      const saved = JSON.parse(getLastWritten());
+      expect(saved['2025-12']?.['old-file.parquet']).toBe('old-hash');
+      expect(saved['2026-01']?.['cur/BILLING_PERIOD=2026-01/new-file.parquet']).toBe('new-hash-1');
+    });
+
+    it('handles abort between periods — saves completed period ETags only', async () => {
+      const controller = new AbortController();
+      let spawnCount = 0;
+
+      const { getLastWritten } = setupEtagTracking();
+
+      mockWriteFile.mockImplementation((path: unknown, content: unknown) => {
+        if (String(path).includes('sync-etags.json')) {
+          if (spawnCount === 1) controller.abort();
+          mockReadFile.mockImplementation((p: unknown) => {
+            if (String(p).includes('sync-etags.json')) return Promise.resolve(String(content));
+            return Promise.reject(new Error('ENOENT'));
+          });
+        }
+        return Promise.resolve();
+      });
+
+      mockSpawn.mockImplementation(() => {
+        spawnCount++;
+        const proc = new MockChildProcess();
+        setTimeout(() => { proc.emit('close', 0, null); }, 10);
+        return proc;
+      });
+
+      const result = await syncSelectedFiles({
+        bucketPath: 's3://bucket/cur/',
+        profile: 'test',
+        dataDir: '/tmp',
+        files: [
+          file('cur/BILLING_PERIOD=2026-01/a.parquet'),
+          file('cur/BILLING_PERIOD=2026-02/b.parquet'),
+          file('cur/BILLING_PERIOD=2026-03/c.parquet'),
+        ],
+        signal: controller.signal,
+      });
+
+      expect(result.filesDownloaded).toBe(1);
+      expect(spawnCount).toBe(1);
+      void getLastWritten(); // Suppress unused warning
+    });
+  });
+
+  describe('cost-optimization sync', () => {
+    it('groups files by date and syncs each', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['file1.parquet', 'file2.parquet']);
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cost-opt/',
+        profile: 'test',
+        dataDir: '/data',
+        expectedDataType: 'cost-optimization',
+        files: [
+          file('cost-opt/date=2026-03-15/file1.parquet', 'h1'),
+          file('cost-opt/date=2026-03-15/file2.parquet', 'h2'),
+          file('cost-opt/date=2026-03-16/file3.parquet', 'h3'),
+        ],
+      });
+
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+      expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('usage_date=2026-03-15'), { recursive: true });
+      expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('usage_date=2026-03-16'), { recursive: true });
+    });
+
+    it('emits repartitioning progress', async () => {
+      const proc = createSuccessfulSpawn();
+      mockSpawn.mockReturnValue(proc);
+      mockReaddir.mockResolvedValue(['data.parquet']);
+
+      const progressEvents: SyncProgress[] = [];
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cost-opt/',
+        profile: 'test',
+        dataDir: '/tmp',
+        expectedDataType: 'cost-optimization',
+        files: [file('cost-opt/date=2026-03-15/file.parquet')],
+        onProgress: (progress) => { progressEvents.push(progress); },
+      });
+
+      expect(progressEvents.some((p) => p.phase === 'repartitioning')).toBe(true);
+    });
+
+    it('only copies parquet files from staging', async () => {
+      const proc = createSuccessfulSpawn();
+      mockSpawn.mockReturnValue(proc);
+      mockReaddir.mockResolvedValue(['data.parquet', 'metadata.json', 'other.txt']);
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cost-opt/',
+        profile: 'test',
+        dataDir: '/tmp',
+        expectedDataType: 'cost-optimization',
+        files: [file('cost-opt/date=2026-03-15/file.parquet')],
+      });
+
+      expect(mockCopyFile).toHaveBeenCalledTimes(1);
+      expect(mockCopyFile).toHaveBeenCalledWith(expect.stringContaining('data.parquet'), expect.anything());
+    });
+
+    it('invokes AWS CLI with correct S3 paths', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['data.parquet']);
+
+      await syncSelectedFiles({
+        bucketPath: 's3://test-bucket/cost-opt/',
+        profile: 'prod-profile',
+        dataDir: '/tmp/test',
+        expectedDataType: 'cost-optimization',
+        files: [file('cost-opt/date=2026-03-15/file.parquet', 'h1')],
+      });
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'aws',
+        ['s3', 'sync', 's3://test-bucket/cost-opt/date=2026-03-15/', expect.stringContaining('cost-opt-2026-03-15'), '--profile', 'prod-profile'],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+    });
+
+    it('creates correct output directory structure', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['data.parquet']);
+
+      const dataDir = '/data/test';
+
+      await syncSelectedFiles({
+        bucketPath: 's3://bucket/cost-opt/',
+        profile: 'test',
+        dataDir,
+        expectedDataType: 'cost-optimization',
+        files: [
+          file('cost-opt/date=2026-03-15/file1.parquet', 'h1'),
+          file('cost-opt/date=2026-04-20/file2.parquet', 'h2'),
+        ],
+      });
+
+      expect(mockMkdir).toHaveBeenCalledWith(join(dataDir, 'aws', 'cost-optimization', 'usage_date=2026-03-15'), { recursive: true });
+      expect(mockMkdir).toHaveBeenCalledWith(join(dataDir, 'aws', 'cost-optimization', 'usage_date=2026-04-20'), { recursive: true });
+    });
+
+    it('skips files without valid date', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['data.parquet']);
+
+      const result = await syncSelectedFiles({
+        bucketPath: 's3://bucket/cost-opt/',
+        profile: 'test',
+        dataDir: '/tmp',
+        expectedDataType: 'cost-optimization',
+        files: [
+          file('cost-opt/invalid-path/file.parquet', 'h1'),
+          file('cost-opt/date=2026-03-15/valid.parquet', 'h2'),
+        ],
+      });
+
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      expect(result.filesDownloaded).toBe(1);
+    });
+
+    it('stops when aborted between dates', async () => {
+      const controller = new AbortController();
+      let syncCount = 0;
+
+      mockSpawn.mockImplementation(() => {
+        syncCount++;
+        const proc = new MockChildProcess();
+        setTimeout(() => {
+          proc.emit('close', 0, null);
+          if (syncCount === 1) controller.abort();
+        }, 10);
+        return proc;
+      });
+
+      mockReaddir.mockResolvedValue(['data.parquet']);
+
+      const result = await syncSelectedFiles({
+        bucketPath: 's3://bucket/cost-opt/',
+        profile: 'test',
+        dataDir: '/tmp',
+        expectedDataType: 'cost-optimization',
+        files: [
+          file('cost-opt/date=2026-03-15/file1.parquet'),
+          file('cost-opt/date=2026-03-16/file2.parquet'),
+          file('cost-opt/date=2026-03-17/file3.parquet'),
+        ],
+        signal: controller.signal,
+      });
+
+      expect(result.filesDownloaded).toBe(1);
+      expect(syncCount).toBe(1);
+    });
+
+    it('rejects on permission denied', async () => {
+      const proc = createFailedSpawn(1, 'An error occurred (403) when calling the GetObject operation: Forbidden');
+      mockSpawn.mockReturnValue(proc);
+      mockReaddir.mockResolvedValue(['data.parquet']);
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://bucket/cost-opt/',
+          profile: 'test',
+          dataDir: '/tmp',
+          expectedDataType: 'cost-optimization',
+          files: [file('cost-opt/date=2026-03-15/file.parquet')],
+        })
+      ).rejects.toThrow('Forbidden');
+    });
+  });
+
+  describe('disk full errors', () => {
+    it('rejects when disk full during download', async () => {
+      const proc = new MockChildProcess();
+      mockSpawn.mockReturnValue(proc);
+
+      setTimeout(() => {
+        proc.stderr.emit('data', Buffer.from('fatal error: An error occurred (ENOSPC) when calling the GetObject operation: No space left on device\n'));
+        proc.emit('close', 1, null);
+      }, 10);
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://bucket/cur/',
+          profile: 'test',
+          dataDir: '/tmp',
+          files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+        })
+      ).rejects.toThrow('ENOSPC');
+    });
+
+    it('rejects when staging directory creation fails', async () => {
+      mockMkdir.mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://bucket/cur/',
+          profile: 'test',
+          dataDir: '/tmp',
+          files: [file('cur/BILLING_PERIOD=2026-03/file.parquet')],
+        })
+      ).rejects.toThrow('ENOSPC: no space left on device');
+    });
+
+    it('rejects when cost-optimization copy fails', async () => {
+      mockSpawn.mockReturnValue(createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['data.parquet']);
+      mockCopyFile.mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://bucket/cost-opt/',
+          profile: 'test',
+          dataDir: '/tmp',
+          expectedDataType: 'cost-optimization',
+          files: [file('cost-opt/date=2026-03-15/file.parquet')],
+        })
+      ).rejects.toThrow('ENOSPC: no space left on device');
+    });
+
+    it('saves ETags for completed periods before failure', async () => {
+      let savedRaw = '{}';
+
+      mockReadFile.mockImplementation((path: unknown) => {
+        if (String(path).includes('sync-etags.json')) return Promise.resolve(savedRaw);
+        return Promise.reject(new Error('ENOENT'));
+      });
+
+      mockWriteFile.mockImplementation((path: unknown, content: unknown) => {
+        if (String(path).includes('sync-etags.json')) savedRaw = String(content);
+        return Promise.resolve();
+      });
+
+      let spawnCount = 0;
+      mockSpawn.mockImplementation(() => {
+        spawnCount++;
+        if (spawnCount === 2) return createFailedSpawn(1, 'ENOSPC: no space left on device');
+        return createSuccessfulSpawn();
+      });
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://bucket/cur/',
+          profile: 'test',
+          dataDir: '/tmp',
+          files: [
+            file('cur/BILLING_PERIOD=2026-01/a.parquet', 'hash-jan'),
+            file('cur/BILLING_PERIOD=2026-02/b.parquet', 'hash-feb'),
+          ],
+        })
+      ).rejects.toThrow('ENOSPC');
+
+      const saved = JSON.parse(savedRaw);
+      expect(saved['2026-01']?.['cur/BILLING_PERIOD=2026-01/a.parquet']).toBe('hash-jan');
+      expect(saved['2026-02']).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `data-inventory.test.ts` — 33 tests against real `getDataInventory` with injected mock S3Handle and real filesystem (temp dirs). Covers period detection, etag-based staleness, tier variants, corrupted manifest handling.
- Add `s3-client-mock.test.ts` — 28 tests for `createS3Handle` wrapper. Covers pagination, filtering, streaming, abort signals, error propagation (`it.each`).
- Add `selective-sync.test.ts` — 40 tests for `syncSelectedFiles`. Covers daily/hourly/cost-optimization sync, multi-period orchestration, etag persistence, abort handling, CLI error propagation (`it.each`).
- Add targeted ESLint override for test files: relaxes `no-unsafe-*` rules (required for `vi.mock`/`vi.fn` patterns), keeps all other strict rules active.