### PR TITLE
Parameterized SQL Query Builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ e2e/*.txt
 
 # Auto Claude data directory
 .auto-claude/
+.auto-claude-security.json
+.auto-claude-status
+.claude_settings.json
+project_index.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,14 @@ npm run check
 - **CostApi interface is the boundary** — UI codes against the interface, never calls DuckDB directly. Enables mock testing and future web mode.
 - **Dark mode default, light mode available** — two chart color palettes (standard + Okabe-Ito colorblind-safe), togglable.
 
+## SQL Security — Parameterized Queries Required
+
+**ALL database queries MUST use parameterized queries** — never string interpolation. Config files can be shared via git and could contain malicious values.
+
+- **User-controlled values** (dates, filter values, thresholds, entity values) → use `QueryBuilder.addParam()` to produce `$1`, `$2`, ... placeholders
+- **Identifiers** (dimension IDs, column names) → validated by `resolveField` / `validateColumnName` against the dimensions config allow-list; unknown identifiers throw `SecurityError`
+- **Config string literals** interpolated into SQL (e.g. `missingValueTemplate`, `accountTagFallback`) → escaped with `sqlEscapeString`
+
 ## Frontend Stack
 
 - React 19 + shadcn/ui + Radix primitives (component library, copy-paste, fully owned)

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -34,7 +34,7 @@ const baseParams = {
 };
 
 function buildQuery(costScope?: CostScopeConfig): string {
-  return buildCostQuery(baseParams, '/data', dimensions, 5, undefined, undefined, undefined, costScope);
+  return buildCostQuery(baseParams, '/data', dimensions, 5, undefined, undefined, undefined, costScope).sql;
 }
 
 describe('cost metric column selection', () => {
@@ -66,7 +66,7 @@ describe('cost metric column selection', () => {
     // Manually call buildCostQuery with a costScope that has costPerspective='net'
     // and a full availableColumns set including net columns. The generated
     // SQL should prefer the net variant.
-    const sql = buildCostQuery(
+    const { sql } = buildCostQuery(
       baseParams,
       '/data',
       dimensions,
@@ -84,7 +84,7 @@ describe('cost metric column selection', () => {
     // availableColumns omits line_item_net_unblended_cost — the expression
     // should degrade to the gross unblended column rather than reference
     // a missing column (which would error at query time).
-    const sql = buildCostQuery(
+    const { sql } = buildCostQuery(
       baseParams,
       '/data',
       dimensions,
@@ -100,7 +100,7 @@ describe('cost metric column selection', () => {
   });
 
   it('amortized + net uses net effective-cost columns when available', () => {
-    const sql = buildCostQuery(
+    const { sql } = buildCostQuery(
       baseParams,
       '/data',
       dimensions,
@@ -122,7 +122,7 @@ describe('cost metric column selection', () => {
   it('amortized + net degrades to unblended when no net/effective columns present', () => {
     // No resource IDs (no effective_cost) and no net columns — amortized
     // degrades all the way down to line_item_unblended_cost.
-    const sql = buildCostQuery(
+    const { sql } = buildCostQuery(
       baseParams,
       '/data',
       dimensions,
@@ -162,61 +162,94 @@ describe('exclusion clauses', () => {
   });
 
   it('enabled rule with one condition produces NOT IN clause', () => {
-    const sql = buildQuery({
-      costMetric: 'unblended',
-      rules: [
-        {
-          id: 'test',
-          name: 'Test',
-          enabled: true,
-          builtIn: false,
-          conditions: [{ dimensionId: asDimensionId('service'), values: ['AWSSupport'] }],
-        },
-      ],
-    });
-    expect(sql).toContain("NOT (service IN ('AWSSupport'))");
+    const result = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'test',
+            name: 'Test',
+            enabled: true,
+            builtIn: false,
+            conditions: [{ dimensionId: asDimensionId('service'), values: ['AWSSupport'] }],
+          },
+        ],
+      },
+    );
+    expect(result.sql).toContain('NOT (service IN ($');
+    expect(result.params).toContain('AWSSupport');
   });
 
   it('rule with multiple values uses IN list', () => {
-    const sql = buildQuery({
-      costMetric: 'unblended',
-      rules: [
-        {
-          id: 'test',
-          name: 'Test',
-          enabled: true,
-          builtIn: false,
-          conditions: [
-            { dimensionId: asDimensionId('line_item_type'), values: ['RIFee', 'SavingsPlanRecurringFee'] },
-          ],
-        },
-      ],
-    });
-    expect(sql).toContain("line_item_type IN ('RIFee', 'SavingsPlanRecurringFee')");
-    expect(sql).toContain('NOT (');
+    const result = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'test',
+            name: 'Test',
+            enabled: true,
+            builtIn: false,
+            conditions: [
+              { dimensionId: asDimensionId('line_item_type'), values: ['RIFee', 'SavingsPlanRecurringFee'] },
+            ],
+          },
+        ],
+      },
+    );
+    expect(result.sql).toContain('line_item_type IN ($');
+    expect(result.params).toContain('RIFee');
+    expect(result.params).toContain('SavingsPlanRecurringFee');
+    expect(result.sql).toContain('NOT (');
   });
 
   it('rule with multiple conditions uses AND', () => {
-    const sql = buildQuery({
-      costMetric: 'unblended',
-      rules: [
-        {
-          id: 'test',
-          name: 'Test',
-          enabled: true,
-          builtIn: false,
-          conditions: [
-            { dimensionId: asDimensionId('service'), values: ['EC2'] },
-            { dimensionId: asDimensionId('service_family'), values: ['Compute'] },
-          ],
-        },
-      ],
-    });
-    expect(sql).toContain("NOT (service IN ('EC2') AND service_family IN ('Compute'))");
+    const result = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'test',
+            name: 'Test',
+            enabled: true,
+            builtIn: false,
+            conditions: [
+              { dimensionId: asDimensionId('service'), values: ['EC2'] },
+              { dimensionId: asDimensionId('service_family'), values: ['Compute'] },
+            ],
+          },
+        ],
+      },
+    );
+    expect(result.sql).toContain('NOT (service IN ($');
+    expect(result.sql).toContain('AND service_family IN ($');
+    expect(result.params).toContain('EC2');
+    expect(result.params).toContain('Compute');
   });
 
   it('tag dimension resolves through alias CASE', () => {
-    const sql = buildCostQuery(
+    const { sql, params } = buildCostQuery(
       { ...baseParams, groupBy: asDimensionId('service') },
       '/data',
       dimensions,
@@ -241,27 +274,38 @@ describe('exclusion clauses', () => {
     );
     // Tag dim resolves via CASE expression
     expect(sql).toContain('CASE');
-    expect(sql).toContain("'core-banking'");
+    expect(params).toContain('core-banking');
     expect(sql).toContain('NOT (');
   });
 
   it('escapes single quotes in values', () => {
-    const sql = buildQuery({
-      costMetric: 'unblended',
-      rules: [
-        {
-          id: 'test',
-          name: 'Test',
-          enabled: true,
-          builtIn: false,
-          conditions: [
-            { dimensionId: asDimensionId('service'), values: ["it's a service"] },
-          ],
-        },
-      ],
-    });
-    expect(sql).toContain("it''s a service");
-    expect(sql).not.toContain("it's a service");
+    const result = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'test',
+            name: 'Test',
+            enabled: true,
+            builtIn: false,
+            conditions: [
+              { dimensionId: asDimensionId('service'), values: ["it's a service"] },
+            ],
+          },
+        ],
+      },
+    );
+    // With parameterized queries, the value is passed as a parameter
+    // and doesn't need escaping in the SQL
+    expect(result.params).toContain("it's a service");
+    expect(result.sql).toContain('IN ($');
   });
 
   it('DEFAULT_COST_SCOPE built-in rules are disabled by default — no exclusions', () => {
@@ -307,7 +351,7 @@ describe('exclusion clauses', () => {
       ],
       tags: dimensions.tags,
     };
-    const sql = buildCostQuery(
+    const { params } = buildCostQuery(
       baseParams,
       '/data',
       dimsWithNormalize,
@@ -330,37 +374,48 @@ describe('exclusion clauses', () => {
     );
     // Values become 'rifee' (lowercase + alias canonicalises to itself) and
     // 'tax' (lowercase). The raw 'RIFee' / 'Tax' must not appear in the
-    // IN-list — that would never match the LOWER(...) column.
-    expect(sql).toContain("IN ('rifee', 'tax')");
-    expect(sql).not.toContain("'RIFee'");
-    expect(sql).not.toContain("'Tax'");
+    // params — they should be normalized.
+    expect(params).toContain('rifee');
+    expect(params).toContain('tax');
+    expect(params).not.toContain('RIFee');
+    expect(params).not.toContain('Tax');
   });
 
   it('partially applies a rule when only some conditions are resolvable', () => {
-    const sql = buildQuery({
-      costMetric: 'unblended',
-      rules: [
-        {
-          id: 'mixed',
-          name: 'Mixed',
-          enabled: true,
-          builtIn: false,
-          conditions: [
-            { dimensionId: asDimensionId('service'), values: ['EC2'] },
-            { dimensionId: asDimensionId('nonexistent_dim'), values: ['foo'] },
-          ],
-        },
-      ],
-    });
+    const result = buildCostQuery(
+      baseParams,
+      '/data',
+      dimensions,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      {
+        costMetric: 'unblended',
+        rules: [
+          {
+            id: 'mixed',
+            name: 'Mixed',
+            enabled: true,
+            builtIn: false,
+            conditions: [
+              { dimensionId: asDimensionId('service'), values: ['EC2'] },
+              { dimensionId: asDimensionId('nonexistent_dim'), values: ['foo'] },
+            ],
+          },
+        ],
+      },
+    );
     // Resolvable condition still applies; dangling one is silently dropped.
-    expect(sql).toContain("NOT (service IN ('EC2'))");
-    expect(sql).not.toContain('nonexistent_dim');
+    expect(result.sql).toContain('NOT (service IN ($');
+    expect(result.params).toContain('EC2');
+    expect(result.sql).not.toContain('nonexistent_dim');
   });
 });
 
 describe('buildDailyCostsQuery with costScope', () => {
   it('injects exclusion clause in daily costs query', () => {
-    const sql = buildDailyCostsQuery(
+    const { sql, params } = buildDailyCostsQuery(
       { ...baseParams, granularity: 'daily' },
       '/data',
       dimensions,
@@ -380,7 +435,8 @@ describe('buildDailyCostsQuery with costScope', () => {
         ],
       },
     );
-    expect(sql).toContain("NOT (service_family IN ('Support'))");
+    expect(sql).toContain('NOT (service_family IN ($');
+    expect(params).toContain('Support');
     expect(sql).toContain('line_item_blended_cost');
   });
 });

--- a/packages/core/src/__tests__/identifier-validator.test.ts
+++ b/packages/core/src/__tests__/identifier-validator.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
+import type { DimensionsConfig } from '../types/config.js';
+import { asDimensionId } from '../types/branded.js';
+
+const testDimensions: DimensionsConfig = {
+  builtIn: [
+    {
+      name: asDimensionId('account'),
+      label: 'Account',
+      field: 'account_id',
+      displayField: 'account_name',
+    },
+    {
+      name: asDimensionId('region'),
+      label: 'Region',
+      field: 'region',
+    },
+    {
+      name: asDimensionId('service'),
+      label: 'Service',
+      field: 'service',
+    },
+  ],
+  tags: [
+    {
+      tagName: 'team',
+      label: 'Team',
+      normalize: 'lowercase-kebab',
+    },
+    {
+      tagName: 'environment',
+      label: 'Environment',
+      normalize: 'lowercase',
+    },
+    {
+      tagName: 'cost-center',
+      label: 'Cost Center',
+    },
+  ],
+};
+
+describe('validateColumnName', () => {
+  it('accepts standard CUR columns', () => {
+    expect(() => { validateColumnName('usage_date', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('cost', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('account_id', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('line_item_usage_account_id', testDimensions); }).not.toThrow();
+  });
+
+  it('accepts built-in dimension fields', () => {
+    expect(() => { validateColumnName('account_id', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('account_name', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('region', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('service', testDimensions); }).not.toThrow();
+  });
+
+  it('accepts tag columns', () => {
+    expect(() => { validateColumnName('tag_team', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('tag_environment', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('tag_cost_center', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('fallback_tag_team', testDimensions); }).not.toThrow();
+  });
+
+  it('accepts aggregate and computed columns', () => {
+    expect(() => { validateColumnName('entity', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('total_cost', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('current_cost', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('delta', testDimensions); }).not.toThrow();
+    expect(() => { validateColumnName('percent_change', testDimensions); }).not.toThrow();
+  });
+
+  it('rejects unknown column names', () => {
+    expect(() => { validateColumnName('malicious_column', testDimensions); })
+      .toThrow(SecurityError);
+    expect(() => { validateColumnName('DROP TABLE users', testDimensions); })
+      .toThrow(SecurityError);
+    expect(() => { validateColumnName('1=1; DROP TABLE--', testDimensions); })
+      .toThrow(SecurityError);
+  });
+
+  it('throws SecurityError with descriptive message', () => {
+    expect(() => { validateColumnName('bad_column', testDimensions); })
+      .toThrow('Invalid column name "bad_column" - not in dimensions config allow-list');
+  });
+});
+
+describe('validateTablePath', () => {
+  it('accepts valid daily tier paths', () => {
+    expect(() => { validateTablePath('/data/aws/raw/daily-2026-03/*.parquet'); }).not.toThrow();
+    expect(() => { validateTablePath('/data/aws/raw/daily-2026-04/*.parquet'); }).not.toThrow();
+    expect(() => { validateTablePath('/data/aws/raw/daily-2025-12/*.parquet'); }).not.toThrow();
+  });
+
+  it('accepts valid hourly tier paths', () => {
+    expect(() => { validateTablePath('/data/aws/raw/hourly-2026-03/*.parquet'); }).not.toThrow();
+    expect(() => { validateTablePath('/data/aws/raw/hourly-2026-04/*.parquet'); }).not.toThrow();
+  });
+
+  it('accepts valid cost-optimization tier paths', () => {
+    expect(() => { validateTablePath('/data/aws/raw/cost-optimization-2026-03/*.parquet'); }).not.toThrow();
+  });
+
+  it('accepts wildcard period paths', () => {
+    expect(() => { validateTablePath('/data/aws/raw/daily-*/*.parquet'); }).not.toThrow();
+    expect(() => { validateTablePath('/data/aws/raw/hourly-*/*.parquet'); }).not.toThrow();
+  });
+
+  it('accepts read_parquet wrapped paths', () => {
+    expect(() => { validateTablePath("read_parquet('/data/aws/raw/daily-2026-03/*.parquet')"); }).not.toThrow();
+    expect(() => { validateTablePath('read_parquet(\'/data/aws/raw/daily-*/*.parquet\')'); }).not.toThrow();
+  });
+
+  it('rejects invalid tier names', () => {
+    expect(() => { validateTablePath('/data/aws/raw/malicious-2026-03/*.parquet'); })
+      .toThrow(SecurityError);
+    expect(() => { validateTablePath('/data/aws/raw/DROP-2026-03/*.parquet'); })
+      .toThrow(SecurityError);
+  });
+
+  it('rejects invalid period formats', () => {
+    expect(() => { validateTablePath('/data/aws/raw/daily-2026/*.parquet'); })
+      .toThrow(SecurityError);
+    expect(() => { validateTablePath('/data/aws/raw/daily-invalid/*.parquet'); })
+      .toThrow(SecurityError);
+    expect(() => { validateTablePath('/data/aws/raw/daily-2026-13/*.parquet'); })
+      .toThrow(SecurityError);
+  });
+
+  it('rejects invalid path structure', () => {
+    expect(() => { validateTablePath('/data/wrong/path/daily-2026-03/*.parquet'); })
+      .toThrow(SecurityError);
+    expect(() => { validateTablePath('SELECT * FROM users'); })
+      .toThrow(SecurityError);
+    expect(() => { validateTablePath('../../../etc/passwd'); })
+      .toThrow(SecurityError);
+  });
+
+  it('throws SecurityError with descriptive message for invalid tier', () => {
+    expect(() => { validateTablePath('/data/aws/raw/invalid-2026-03/*.parquet'); })
+      .toThrow('Invalid tier "invalid" in table path');
+  });
+
+  it('throws SecurityError with descriptive message for invalid period', () => {
+    expect(() => { validateTablePath('/data/aws/raw/daily-badperiod/*.parquet'); })
+      .toThrow('Invalid period "badperiod" in table path');
+  });
+});

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -23,7 +23,7 @@ const dimensions: DimensionsConfig = {
 
 describe('buildCostQuery', () => {
   it('generates valid SQL for built-in dimension', () => {
-    const sql = buildCostQuery(
+    const result = buildCostQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -32,16 +32,20 @@ describe('buildCostQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain('service AS entity');
-    expect(sql).toContain("usage_date BETWEEN '2026-01-01' AND '2026-01-31'");
+    expect(result.sql).toContain('service AS entity');
+    expect(result.sql).toContain('usage_date BETWEEN');
     // Parquet source is narrowed to the months the range touches, not the
     // year-wide wildcard.
-    expect(sql).toContain("'/data/aws/raw/daily-2026-01/*.parquet'");
-    expect(sql).not.toContain("daily-*/*.parquet");
+    expect(result.sql).toContain("'/data/aws/raw/daily-2026-01/*.parquet'");
+    expect(result.sql).not.toContain("daily-*/*.parquet");
+    // Verify date parameters
+    expect(result.params).toContain('2026-01-01');
+    expect(result.params).toContain('2026-01-31');
+    expect(result.params).toContain(5); // default topN
   });
 
   it('includes filter clauses', () => {
-    const sql = buildCostQuery(
+    const result = buildCostQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -50,11 +54,14 @@ describe('buildCostQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain("account_id = '111111111111'");
+    expect(result.sql).toContain('account_id = $');
+    expect(result.params).toContain('2026-01-01');
+    expect(result.params).toContain('2026-01-31');
+    expect(result.params).toContain('111111111111');
   });
 
   it('uses alias SQL for tag dimensions', () => {
-    const sql = buildCostQuery(
+    const result = buildCostQuery(
       {
         groupBy: asDimensionId('tag_org_team'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -63,14 +70,14 @@ describe('buildCostQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain('CASE');
-    expect(sql).toContain("'core-banking'");
+    expect(result.sql).toContain('CASE');
+    expect(result.sql).toContain("'core-banking'");
   });
 });
 
 describe('buildTrendQuery', () => {
   it('generates SQL with period comparison', () => {
-    const sql = buildTrendQuery(
+    const result = buildTrendQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
@@ -81,10 +88,14 @@ describe('buildTrendQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain('current_period');
-    expect(sql).toContain('previous_period');
-    expect(sql).toContain('delta');
-    expect(sql).toContain('100');
+    expect(result.sql).toContain('current_period');
+    expect(result.sql).toContain('previous_period');
+    expect(result.sql).toContain('delta');
+    // Verify date parameters
+    expect(result.params).toContain('2026-02-01');
+    expect(result.params).toContain('2026-02-28');
+    // Verify deltaThreshold parameter
+    expect(result.params).toContain(100);
   });
 });
 
@@ -136,7 +147,7 @@ describe('buildTrendQuery', () => {
   it('includes periods from both current and previous spans', () => {
     // 30-day window ending 2026-04-18 → current is 2026-03/2026-04, previous
     // is 2026-02-18 to 2026-03-18 → 2026-02/2026-03. Union: Feb, Mar, Apr.
-    const sql = buildTrendQuery(
+    const result = buildTrendQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-03-20'), end: asDateString('2026-04-18') },
@@ -147,9 +158,9 @@ describe('buildTrendQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain("'/data/aws/raw/daily-2026-02/*.parquet'");
-    expect(sql).toContain("'/data/aws/raw/daily-2026-03/*.parquet'");
-    expect(sql).toContain("'/data/aws/raw/daily-2026-04/*.parquet'");
+    expect(result.sql).toContain("'/data/aws/raw/daily-2026-02/*.parquet'");
+    expect(result.sql).toContain("'/data/aws/raw/daily-2026-03/*.parquet'");
+    expect(result.sql).toContain("'/data/aws/raw/daily-2026-04/*.parquet'");
   });
 });
 
@@ -162,37 +173,43 @@ describe('buildMissingTagsQuery', () => {
   };
 
   it('filters to resource-bound Usage lines (excludes Tax / Support / empty resource_id)', () => {
-    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
-    expect(sql).toContain("line_item_type IN ('Usage', 'DiscountedUsage')");
-    expect(sql).toContain("resource_id IS NOT NULL AND resource_id != ''");
+    const result = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    expect(result.sql).toContain("line_item_type IN ('Usage', 'DiscountedUsage')");
+    expect(result.sql).toContain("resource_id IS NOT NULL AND resource_id != ''");
+    expect(result.sql).toContain('usage_date BETWEEN');
+    // Verify date parameters
+    expect(result.params).toContain('2026-01-01');
+    expect(result.params).toContain('2026-01-31');
   });
 
   it('computes has_tag per resource and category tagged_ratio', () => {
-    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    const result = buildMissingTagsQuery(baseParams, '/data', dimensions);
     // Resource is tagged if ANY line for it has the tag populated — MAX over a
     // CASE expression does exactly that.
-    expect(sql).toContain('MAX(CASE WHEN');
-    expect(sql).toContain('AS has_tag');
+    expect(result.sql).toContain('MAX(CASE WHEN');
+    expect(result.sql).toContain('AS has_tag');
     // Category coverage divides tagged cost by total cost.
-    expect(sql).toContain('tagged_ratio');
-    expect(sql).toContain('SUM(CASE WHEN has_tag = 1 THEN cost ELSE 0 END)');
+    expect(result.sql).toContain('tagged_ratio');
+    expect(result.sql).toContain('SUM(CASE WHEN has_tag = 1 THEN cost ELSE 0 END)');
   });
 
   it('buckets into actionable (ratio > 0) vs likely-untaggable (ratio = 0)', () => {
-    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
-    expect(sql).toContain("WHEN c.tagged_ratio > 0 THEN 'actionable'");
-    expect(sql).toContain("ELSE 'likely-untaggable'");
+    const result = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    expect(result.sql).toContain("WHEN c.tagged_ratio > 0 THEN 'actionable'");
+    expect(result.sql).toContain("ELSE 'likely-untaggable'");
   });
 
   it('applies minCost to the per-resource cost after classification', () => {
-    const sql = buildMissingTagsQuery(baseParams, '/data', dimensions);
-    expect(sql).toContain('r.cost >= 50');
+    const result = buildMissingTagsQuery(baseParams, '/data', dimensions);
+    expect(result.sql).toContain('r.cost >= $');
+    // Verify minCost parameter
+    expect(result.params).toContain(50);
   });
 });
 
 describe('buildNonResourceCostQuery', () => {
   it('captures non-Usage lines and Usage lines with no resource_id', () => {
-    const sql = buildNonResourceCostQuery(
+    const result = buildNonResourceCostQuery(
       {
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
         filters: {},
@@ -202,9 +219,13 @@ describe('buildNonResourceCostQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain("line_item_type NOT IN ('Usage', 'DiscountedUsage')");
-    expect(sql).toContain("OR resource_id IS NULL OR resource_id = ''");
-    expect(sql).toContain('GROUP BY service, service_family, line_item_type');
+    expect(result.sql).toContain("line_item_type NOT IN ('Usage', 'DiscountedUsage')");
+    expect(result.sql).toContain("OR resource_id IS NULL OR resource_id = ''");
+    expect(result.sql).toContain('GROUP BY service, service_family, line_item_type');
+    expect(result.sql).toContain('usage_date BETWEEN');
+    // Verify date parameters
+    expect(result.params).toContain('2026-01-01');
+    expect(result.params).toContain('2026-01-31');
   });
 });
 
@@ -256,7 +277,7 @@ describe('buildSource with account tag fallback', () => {
 
 describe('buildEntityDetailQuery', () => {
   it('generates detail query for entity', () => {
-    const sql = buildEntityDetailQuery(
+    const { sql, params } = buildEntityDetailQuery(
       {
         entity: asEntityRef('core-banking'),
         dimension: asDimensionId('tag_org_team'),
@@ -266,7 +287,10 @@ describe('buildEntityDetailQuery', () => {
       '/data',
       dimensions,
     );
-    expect(sql).toContain("'core-banking'");
+    expect(sql).toContain('$');
+    expect(params).toContain('2026-01-01');
+    expect(params).toContain('2026-01-31');
+    expect(params).toContain('core-banking');
     expect(sql).toContain('usage_date');
     expect(sql).toContain('service');
   });

--- a/packages/core/src/__tests__/query-integration.test.ts
+++ b/packages/core/src/__tests__/query-integration.test.ts
@@ -63,6 +63,28 @@ async function queryAll(conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckD
   return rows;
 }
 
+/**
+ * For integration testing only: substitutes parameters into SQL.
+ * In production, the worker thread uses real prepared statements.
+ */
+function substituteParams(sql: string, params: readonly unknown[]): string {
+  let result = sql;
+  for (let i = params.length; i >= 1; i--) {
+    const param = params[i - 1];
+    const placeholder = '$' + String(i);
+    const value = typeof param === 'string' ? `'${param}'` : String(param);
+    result = result.replaceAll(placeholder, value);
+  }
+  return result;
+}
+
+async function queryAllPrepared(conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>, sql: string, params: readonly unknown[]): Promise<QueryRow[]> {
+  // For integration tests, substitute params back into SQL
+  // (Production code uses real prepared statements via the worker)
+  const substitutedSql = substituteParams(sql, params);
+  return queryAll(conn, substitutedSql);
+}
+
 describe('DuckDB query integration', () => {
   let db: Awaited<ReturnType<typeof DuckDBInstance.create>>;
   let conn: Awaited<ReturnType<typeof db.connect>>;
@@ -105,7 +127,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('queries costs grouped by service', async () => {
-    const sql = buildCostQuery(
+    const result = buildCostQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -114,7 +136,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
     const firstRow = rows[0];
     expect(firstRow?.['entity']).toBeDefined();
@@ -122,7 +144,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('queries costs with filter', async () => {
-    const sqlAll = buildCostQuery(
+    const resultAll = buildCostQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -131,7 +153,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const sqlFiltered = buildCostQuery(
+    const resultFiltered = buildCostQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -140,13 +162,13 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const allRows = await queryAll(conn, `SELECT SUM(total_cost) as t FROM (${sqlAll})`);
-    const filteredRows = await queryAll(conn, `SELECT SUM(total_cost) as t FROM (${sqlFiltered})`);
+    const allRows = await queryAllPrepared(conn, `SELECT SUM(total_cost) as t FROM (${resultAll.sql})`, resultAll.params);
+    const filteredRows = await queryAllPrepared(conn, `SELECT SUM(total_cost) as t FROM (${resultFiltered.sql})`, resultFiltered.params);
     expect(Number(filteredRows[0]?.['t'])).toBeLessThan(Number(allRows[0]?.['t']));
   });
 
   it('queries missing tags', async () => {
-    const sql = buildMissingTagsQuery(
+    const result = buildMissingTagsQuery(
       {
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
         filters: {},
@@ -156,7 +178,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
     const firstRow = rows[0];
     expect(firstRow?.['service']).toBeDefined();
@@ -164,7 +186,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('classifies missing tags into actionable vs likely-untaggable buckets', async () => {
-    const sql = buildMissingTagsQuery(
+    const result = buildMissingTagsQuery(
       {
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
         filters: {},
@@ -174,7 +196,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
 
     // Every row carries a bucket and a tagged_ratio.
@@ -194,7 +216,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('non-resource cost query returns rows for non-Usage line items', async () => {
-    const sql = buildNonResourceCostQuery(
+    const result = buildNonResourceCostQuery(
       {
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
         filters: {},
@@ -204,7 +226,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     // Fixture may have zero non-Usage lines; just verify the query is valid
     // and every returned row has the expected shape.
     for (const row of rows) {
@@ -215,7 +237,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('queries entity detail by service', async () => {
-    const sql = buildEntityDetailQuery(
+    const result = buildEntityDetailQuery(
       {
         entity: asEntityRef('AmazonRDS'),
         dimension: asDimensionId('service'),
@@ -225,7 +247,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
   });
 
@@ -249,7 +271,7 @@ describe('DuckDB query integration', () => {
     // Regression: BETWEEN against a TIMESTAMP would truncate the end string to
     // midnight and silently drop most of the end day. With usage_date as DATE,
     // the same 'YYYY-MM-DD' end value covers the full day.
-    const sql = buildCostQuery(
+    const result = buildCostQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
@@ -259,19 +281,19 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
     expect(Number(rows[0]?.['total_cost'])).toBeGreaterThan(0);
   });
 
   it('hourly cost query returns the same total as a SUM over the raw hourly source', async () => {
     const range = { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') } as const;
-    const sql = buildCostQuery(
+    const result = buildCostQuery(
       { groupBy: asDimensionId('service'), dateRange: range, filters: {}, granularity: 'hourly' },
       SYNTHETIC_DIR,
       dimensions,
     );
-    const queryTotalRows = await queryAll(conn, `SELECT SUM(total_cost) AS t FROM (${sql})`);
+    const queryTotalRows = await queryAllPrepared(conn, `SELECT SUM(total_cost) AS t FROM (${result.sql})`, result.params);
     const queryTotal = Number(queryTotalRows[0]?.['t'] ?? 0);
 
     const source = buildSource(SYNTHETIC_DIR, 'hourly', dimensions);
@@ -286,7 +308,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('daily costs query with hourly granularity includes hour in date field', async () => {
-    const sql = buildDailyCostsQuery(
+    const result = buildDailyCostsQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
@@ -296,7 +318,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
 
     const dates = [...new Set(rows.map(r => String(r['date'])))];
@@ -307,7 +329,7 @@ describe('DuckDB query integration', () => {
   });
 
   it('daily costs query with daily granularity returns daily data points', async () => {
-    const sql = buildDailyCostsQuery(
+    const result = buildDailyCostsQuery(
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
@@ -317,7 +339,7 @@ describe('DuckDB query integration', () => {
       SYNTHETIC_DIR,
       dimensions,
     );
-    const rows = await queryAll(conn, sql);
+    const rows = await queryAllPrepared(conn, result.sql, result.params);
     expect(rows.length).toBeGreaterThan(0);
 
     const dates = new Set(rows.map(r => String(r['date'])));

--- a/packages/core/src/__tests__/security.test.ts
+++ b/packages/core/src/__tests__/security.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect } from 'vitest';
+import { buildCostQuery, buildTrendQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildDailyCostsQuery } from '../query/builder.js';
+import type { DimensionsConfig } from '../types/config.js';
+import { asDimensionId, asDateString, asDollars, asEntityRef, asTagValue } from '../types/branded.js';
+
+const dimensions: DimensionsConfig = {
+  builtIn: [
+    { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' },
+    { name: asDimensionId('service'), label: 'Service', field: 'service' },
+  ],
+  tags: [
+    {
+      tagName: 'org:team',
+      label: 'Team',
+      concept: 'owner',
+      normalize: 'lowercase-kebab',
+      aliases: {
+        'core-banking': ['core_banking', 'corebanking'],
+      },
+    },
+  ],
+};
+
+describe('SQL Injection Prevention', () => {
+  describe('Filter values are parameterized', () => {
+    it('prevents SQL injection via single quotes in filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue("'; DROP TABLE users; --") },
+        },
+        '/data',
+        dimensions,
+      );
+      // Value should be in params array, not interpolated in SQL
+      expect(result.params).toContain("'; DROP TABLE users; --");
+      // SQL should use placeholder, not raw value
+      expect(result.sql).toContain('account_id = $');
+      expect(result.sql).not.toContain("DROP TABLE");
+    });
+
+    it('handles double quotes in filter values safely', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('test"value"with"quotes') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('test"value"with"quotes');
+      expect(result.sql).toContain('account_id = $');
+    });
+
+    it('handles SQL comment sequences in filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('test--comment') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('test--comment');
+      expect(result.sql).toContain('account_id = $');
+    });
+
+    it('handles multi-line values with newlines', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('test\nvalue\nwith\nnewlines') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('test\nvalue\nwith\nnewlines');
+      expect(result.sql).toContain('account_id = $');
+    });
+
+    it('prevents UNION-based injection in filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('service')]: asTagValue("' UNION SELECT password FROM users --") },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain("' UNION SELECT password FROM users --");
+      expect(result.sql).not.toContain('UNION SELECT password');
+    });
+
+    it('handles semicolons in filter values (command injection attempt)', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('service')]: asTagValue("test'; DELETE FROM accounts; SELECT '") },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain("test'; DELETE FROM accounts; SELECT '");
+      expect(result.sql).not.toContain('DELETE FROM');
+    });
+  });
+
+  describe('Date values are parameterized', () => {
+    it('prevents SQL injection via date range start', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString("2026-01-01' OR '1'='1"), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      );
+      // Date should be in params, not interpolated
+      expect(result.params).toContain("2026-01-01' OR '1'='1");
+      expect(result.sql).toContain('usage_date BETWEEN $');
+      expect(result.sql).not.toContain("OR '1'='1");
+    });
+
+    it('prevents SQL injection via date range end', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString("2026-01-31'; DROP TABLE costs; --") },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain("2026-01-31'; DROP TABLE costs; --");
+      expect(result.sql).not.toContain('DROP TABLE');
+    });
+  });
+
+  describe('Numeric values are parameterized', () => {
+    it('prevents injection via topN parameter in buildCostQuery', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+        5, // topN
+      );
+      expect(result.params).toContain(5);
+      expect(result.sql).toContain('LIMIT $');
+    });
+
+    it('prevents injection via deltaThreshold in buildTrendQuery', () => {
+      const result = buildTrendQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
+          filters: {},
+          deltaThreshold: asDollars(100),
+          percentThreshold: 10,
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain(100);
+      expect(result.sql).toContain('ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= $');
+    });
+
+    it('prevents injection via minCost in buildMissingTagsQuery', () => {
+      const result = buildMissingTagsQuery(
+        {
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+          minCost: asDollars(50),
+          tagDimension: asDimensionId('tag_org_team'),
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain(50);
+      expect(result.sql).toContain('r.cost >= $');
+    });
+  });
+
+  describe('Entity values are parameterized', () => {
+    it('prevents SQL injection via entity parameter in buildEntityDetailQuery', () => {
+      const result = buildEntityDetailQuery(
+        {
+          dimension: asDimensionId('service'),
+          entity: asEntityRef("EC2'; DROP TABLE costs; --"),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain("EC2'; DROP TABLE costs; --");
+      expect(result.sql).not.toContain('DROP TABLE');
+    });
+
+    it('handles special characters in entity values', () => {
+      const result = buildEntityDetailQuery(
+        {
+          dimension: asDimensionId('service'),
+          entity: asEntityRef("test'value\"with;special--chars"),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain("test'value\"with;special--chars");
+    });
+  });
+
+  describe('Multiple parameters are safely handled', () => {
+    it('handles multiple filter values with injection attempts', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString("2026-01-01' OR 1=1 --"), end: asDateString("2026-01-31'; DROP TABLE x; --") },
+          filters: {
+            [asDimensionId('account')]: asTagValue("'; DELETE FROM users; --"),
+            [asDimensionId('service')]: asTagValue("' UNION SELECT * FROM secrets --"),
+          },
+        },
+        '/data',
+        dimensions,
+      );
+      // All malicious values should be in params array
+      expect(result.params).toContain("2026-01-01' OR 1=1 --");
+      expect(result.params).toContain("2026-01-31'; DROP TABLE x; --");
+      expect(result.params).toContain("'; DELETE FROM users; --");
+      expect(result.params).toContain("' UNION SELECT * FROM secrets --");
+      // SQL should not contain any of the injection payloads
+      expect(result.sql).not.toContain('DROP TABLE');
+      expect(result.sql).not.toContain('DELETE FROM');
+      expect(result.sql).not.toContain('UNION SELECT');
+      expect(result.sql).not.toContain('OR 1=1');
+    });
+
+    it('maintains correct parameter ordering with multiple injections', () => {
+      const result = buildDailyCostsQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {
+            [asDimensionId('account')]: asTagValue("malicious'value"),
+            [asDimensionId('service')]: asTagValue("another'injection"),
+          },
+        },
+        '/data',
+        dimensions,
+      );
+      // Verify all parameters are present (filters are added first, then dates)
+      expect(result.params).toContain("malicious'value");
+      expect(result.params).toContain("another'injection");
+      expect(result.params).toContain('2026-01-01');
+      expect(result.params).toContain('2026-01-31');
+      // Verify we have exactly 4 parameters
+      expect(result.params.length).toBe(4);
+    });
+  });
+
+  describe('Non-parameterizable identifiers are validated', () => {
+    it('accepts valid dimension IDs', () => {
+      const validResult = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      );
+      expect(validResult.sql).toContain('service AS entity');
+    });
+
+    it('rejects unknown dimension IDs with SecurityError', () => {
+      expect(() => buildCostQuery(
+        {
+          groupBy: asDimensionId("fake_column'; DROP TABLE users; --"),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      )).toThrow('Unknown dimension');
+    });
+  });
+
+  describe('Edge cases and special characters', () => {
+    it('handles null bytes in filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('test\x00value') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('test\x00value');
+    });
+
+    it('handles Unicode characters in filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('test-值-🔒-value') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('test-值-🔒-value');
+    });
+
+    it('handles backslashes in filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('test\\value\\with\\backslashes') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('test\\value\\with\\backslashes');
+    });
+
+    it('handles percent signs (LIKE injection attempt)', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('%malicious%') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('%malicious%');
+    });
+
+    it('handles empty string filter values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue('') },
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain('');
+    });
+  });
+
+  describe('Data path validation', () => {
+    it('does not parameterize data directory paths', () => {
+      // Data directory is a trusted value from config, not user input
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/data',
+        dimensions,
+      );
+      // Path should be in SQL, not params
+      expect(result.sql).toContain('/data/aws/raw/');
+      expect(result.params).not.toContain('/data');
+    });
+
+    it('includes data directory path in SQL structure', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: {},
+        },
+        '/custom/path',
+        dimensions,
+      );
+      expect(result.sql).toContain('/custom/path/aws/raw/');
+    });
+  });
+
+  describe('Query structure integrity', () => {
+    it('maintains valid SQL structure with injected values', () => {
+      const result = buildCostQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('service')]: asTagValue("'; DROP TABLE x; SELECT '") },
+        },
+        '/data',
+        dimensions,
+      );
+      // SQL should contain proper WHERE clause
+      expect(result.sql).toContain('WHERE');
+      // SQL should contain proper SELECT structure
+      expect(result.sql).toMatch(/SELECT[\s\S]+FROM[\s\S]+WHERE/);
+      // All parameter placeholders should be numbered sequentially
+      const placeholders = result.sql.match(/\$\d+/g);
+      expect(placeholders).toBeTruthy();
+      if (placeholders !== null) {
+        expect(placeholders.length).toBe(result.params.length);
+      }
+    });
+
+    it('uses sequential parameter numbering', () => {
+      const result = buildTrendQuery(
+        {
+          groupBy: asDimensionId('service'),
+          dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
+          filters: {
+            [asDimensionId('account')]: asTagValue('test1'),
+            [asDimensionId('service')]: asTagValue('test2'),
+          },
+          deltaThreshold: asDollars(100),
+          percentThreshold: 10,
+        },
+        '/data',
+        dimensions,
+      );
+      // Extract all placeholders
+      const placeholders = result.sql.match(/\$(\d+)/g);
+      expect(placeholders).toBeTruthy();
+      if (placeholders !== null) {
+        // Convert to numbers and verify they're sequential
+        const numbers = placeholders.map(p => parseInt(p.slice(1), 10));
+        const maxNumber = Math.max(...numbers);
+        expect(maxNumber).toBe(result.params.length);
+        // Verify no gaps in numbering (each number from 1 to max should appear)
+        for (let i = 1; i <= maxNumber; i++) {
+          expect(numbers).toContain(i);
+        }
+      }
+    });
+  });
+
+  describe('buildNonResourceCostQuery security', () => {
+    it('parameterizes date and filter values', () => {
+      const result = buildNonResourceCostQuery(
+        {
+          dateRange: { start: asDateString("2026-01-01' OR 1=1 --"), end: asDateString('2026-01-31') },
+          filters: { [asDimensionId('account')]: asTagValue("'; DROP TABLE x; --") },
+          minCost: asDollars(0),
+          tagDimension: asDimensionId('tag_org_team'),
+        },
+        '/data',
+        dimensions,
+      );
+      expect(result.params).toContain("2026-01-01' OR 1=1 --");
+      expect(result.params).toContain("'; DROP TABLE x; --");
+      expect(result.sql).not.toContain('DROP TABLE');
+      expect(result.sql).not.toContain('OR 1=1');
+    });
+  });
+});

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -4,11 +4,27 @@ import type { DimensionId } from '../types/branded.js';
 import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
+import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
+import { SecurityError } from './identifier-validator.js';
 
 function assertFiniteNumber(value: number, name: string): void {
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(`Query parameter "${name}" must be a non-negative finite number, got ${String(value)}`);
   }
+}
+
+function sqlEscapeString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/** Build a SQL IN-list. Uses placeholders when a QueryBuilder is provided;
+ *  otherwise falls back to escaped string literals (for exported helpers
+ *  like `buildRuleMatchExpr` that may be called without a QueryBuilder). */
+function buildSqlList(values: readonly string[], qb?: QueryBuilder): string {
+  if (qb !== undefined) {
+    return values.map(v => qb.addParam(v)).join(', ');
+  }
+  return values.map(v => `'${sqlEscapeString(v)}'`).join(', ');
 }
 
 /**
@@ -82,35 +98,32 @@ function normalizeRuleValue(value: string, dim: BuiltInDimension | TagDimension 
 function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
   const resolved = tryResolveField(dimensionId, dimensions);
   if (resolved !== null) return resolved;
-  // Fallback: used by filter/orgNode paths where the caller has already
-  // validated the id exists. For exclusion rules we go through
-  // tryResolveField directly so a stale reference doesn't emit a bogus
-  // column name that would crash every query.
-  return { fieldExpr: dimensionId, rawField: dimensionId, dim: null };
+  throw new SecurityError(
+    `Unknown dimension "${dimensionId}" — not found in dimensions config. ` +
+    `This prevents SQL injection via untrusted identifiers.`
+  );
 }
 
 function buildFilterClauses(
   filters: FilterMap,
   dimensions: DimensionsConfig,
-  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  accountReverseMap: ReadonlyMap<string, readonly string[]> | undefined,
+  qb: QueryBuilder,
 ): string[] {
   const clauses: string[] = [];
   for (const [dimId, value] of Object.entries(filters)) {
     if (value === undefined) continue;
     const resolved = resolveField(dimId as DimensionId, dimensions);
-    // Account dim with display-name collisions: the user picks "sre default"
-    // in the filter dropdown, but that collapses N underlying ids. Match any
-    // of them with an IN clause. Falls through to '=' when the value isn't a
-    // known display name (raw id, or no map provided).
     if (resolved.rawField === 'account_id' && accountReverseMap !== undefined) {
       const ids = accountReverseMap.get(String(value));
       if (ids !== undefined && ids.length > 0) {
-        const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+        const list = buildSqlList(ids, qb);
         clauses.push(`${resolved.rawField} IN (${list})`);
         continue;
       }
     }
-    clauses.push(`${resolved.fieldExpr} = '${String(value).replaceAll("'", "''")}'`);
+    const placeholder = qb.addParam(String(value));
+    clauses.push(`${resolved.fieldExpr} = ${placeholder}`);
   }
   return clauses;
 }
@@ -123,6 +136,7 @@ export function buildRuleMatchExpr(
   rule: ExclusionRule,
   dimensions: DimensionsConfig,
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  qb?: QueryBuilder,
 ): string | null {
   const conditionSqls: string[] = [];
   for (const cond of rule.conditions) {
@@ -147,7 +161,7 @@ export function buildRuleMatchExpr(
         }
       }
       if (usedReverse) {
-        const list = [...expandedIds].map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+        const list = buildSqlList([...expandedIds], qb);
         conditionSqls.push(`${resolved.rawField} IN (${list})`);
         continue;
       }
@@ -157,10 +171,8 @@ export function buildRuleMatchExpr(
     // dimension (e.g. a lowercase rule on `line_item_type` would otherwise
     // turn 'RIFee' in the built-in rule into a silent no-match). The
     // field expression already bakes in the same transformation.
-    const list = cond.values
-      .map(v => normalizeRuleValue(v, resolved.dim))
-      .map(v => `'${v.replaceAll("'", "''")}'`)
-      .join(', ');
+    const normalizedValues = cond.values.map(v => normalizeRuleValue(v, resolved.dim));
+    const list = buildSqlList(normalizedValues, qb);
     conditionSqls.push(`${resolved.fieldExpr} IN (${list})`);
   }
   if (conditionSqls.length === 0) return null;
@@ -170,12 +182,13 @@ export function buildRuleMatchExpr(
 function buildExclusionClauses(
   rules: readonly ExclusionRule[],
   dimensions: DimensionsConfig,
-  accountReverseMap?: ReadonlyMap<string, readonly string[]>,
+  accountReverseMap: ReadonlyMap<string, readonly string[]> | undefined,
+  qb: QueryBuilder,
 ): string[] {
   const clauses: string[] = [];
   for (const rule of rules) {
     if (!rule.enabled) continue;
-    const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+    const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap, qb);
     if (matchExpr === null) continue;
     clauses.push(`NOT (${matchExpr})`);
   }
@@ -215,8 +228,8 @@ export function buildSource(
       // Apply missingValueTemplate if set — e.g. "unknown-{fallback}" → 'unknown-' || account_tag
       if (t.missingValueTemplate !== undefined && t.missingValueTemplate.length > 0 && t.missingValueTemplate !== '{fallback}') {
         const parts = t.missingValueTemplate.split('{fallback}');
-        const prefix = (parts[0] ?? '').replaceAll("'", "''");
-        const suffix = (parts[1] ?? '').replaceAll("'", "''");
+        const prefix = sqlEscapeString(parts[0] ?? '');
+        const suffix = sqlEscapeString(parts[1] ?? '');
         const formatted = `'${prefix}' || ${fallbackExpr} || '${suffix}'`;
         return `COALESCE(NULLIF(${resourceExpr}, ''), ${formatted}) AS ${colName}`;
       }
@@ -248,7 +261,7 @@ export function buildSource(
         .filter(t => t.accountTagFallback !== undefined)
         .map(t => {
           const colName = `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
-          const fallbackKey = (t.accountTagFallback ?? '').replaceAll("'", "''");
+          const fallbackKey = sqlEscapeString(t.accountTagFallback ?? '');
           return `tags->>'${fallbackKey}' AS fallback_${colName}`;
         })
     : [];
@@ -310,29 +323,34 @@ export function buildCostQuery(
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
-): string {
+): ParameterizedQuery {
   assertFiniteNumber(topN, 'topN');
+  const qb = new QueryBuilder();
   const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
 
+  const startDatePlaceholder = qb.addParam(params.dateRange.start);
+  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
+    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
     ...filterClauses,
     ...exclusionClauses,
   ];
 
   if (params.orgNodeValues !== undefined && params.orgNodeValues.length > 0) {
-    const escaped = params.orgNodeValues.map(v => `'${v.replaceAll("'", "''")}'`).join(', ');
-    whereConditions.push(`${groupByResolved.fieldExpr} IN (${escaped})`);
+    const placeholders = params.orgNodeValues.map(v => qb.addParam(v)).join(', ');
+    whereConditions.push(`${groupByResolved.fieldExpr} IN (${placeholders})`);
   }
 
-  return `
+  const topNPlaceholder = qb.addParam(topN);
+
+  const sql = `
     WITH base AS (
       SELECT
         ${groupByResolved.fieldExpr} AS entity,
@@ -347,7 +365,7 @@ export function buildCostQuery(
       FROM base
       GROUP BY service
       ORDER BY SUM(cost) DESC
-      LIMIT ${String(topN)}
+      LIMIT ${topNPlaceholder}
     ),
     entity_totals AS (
       SELECT
@@ -374,6 +392,8 @@ export function buildCostQuery(
     LEFT JOIN entity_services es ON et.entity = es.entity
     ORDER BY et.total_cost DESC
   `.trim();
+
+  return { sql, params: qb.build().params };
 }
 
 export function buildTrendQuery(
@@ -385,11 +405,12 @@ export function buildTrendQuery(
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
-): string {
+): ParameterizedQuery {
   assertFiniteNumber(Number(params.deltaThreshold), 'deltaThreshold');
+  const qb = new QueryBuilder();
   const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
 
@@ -414,17 +435,21 @@ export function buildTrendQuery(
   const allFilterClauses = [...filterClauses, ...exclusionClauses];
   const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
 
-  return `
+  const startDatePlaceholder = qb.addParam(startDate);
+  const endDatePlaceholder = qb.addParam(endDate);
+  const deltaThresholdPlaceholder = qb.addParam(Number(params.deltaThreshold));
+
+  const sql = `
     WITH current_period AS (
       SELECT
         ${groupByResolved.fieldExpr} AS entity,
         SUM(cost) AS total_cost
       FROM ${source}
-      WHERE usage_date BETWEEN '${startDate}' AND '${endDate}'${filterWhere}
+      WHERE usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}${filterWhere}
       GROUP BY entity
     ),
     period_length AS (
-      SELECT DATEDIFF('day', DATE '${startDate}', DATE '${endDate}') + 1 AS days
+      SELECT DATEDIFF('day', CAST(${startDatePlaceholder} AS DATE), CAST(${endDatePlaceholder} AS DATE)) + 1 AS days
     ),
     previous_period AS (
       SELECT
@@ -432,8 +457,8 @@ export function buildTrendQuery(
         SUM(cost) AS total_cost
       FROM ${source}
       WHERE usage_date BETWEEN
-        DATE '${startDate}' - (SELECT days FROM period_length) * INTERVAL '1 day'
-        AND DATE '${startDate}' - INTERVAL '1 day'${filterWhere}
+        CAST(${startDatePlaceholder} AS DATE) - (SELECT days FROM period_length) * INTERVAL '1 day'
+        AND CAST(${startDatePlaceholder} AS DATE) - INTERVAL '1 day'${filterWhere}
       GROUP BY entity
     )
     SELECT
@@ -447,9 +472,11 @@ export function buildTrendQuery(
       END AS percent_change
     FROM current_period c
     FULL OUTER JOIN previous_period p ON c.entity = p.entity
-    WHERE ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= ${String(Number(params.deltaThreshold))}
+    WHERE ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= ${deltaThresholdPlaceholder}
     ORDER BY ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) DESC
   `.trim();
+
+  return { sql, params: qb.build().params };
 }
 
 /**
@@ -479,26 +506,31 @@ export function buildMissingTagsQuery(
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
-): string {
+): ParameterizedQuery {
   assertFiniteNumber(Number(params.minCost), 'minCost');
+  const qb = new QueryBuilder();
   const tagResolved = resolveField(params.tagDimension, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
 
   // Date + user filters apply to the resource aggregation.
+  const startDatePlaceholder = qb.addParam(params.dateRange.start);
+  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
+    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
     `line_item_type IN ('Usage', 'DiscountedUsage')`,
     `resource_id IS NOT NULL AND resource_id != ''`,
     ...filterClauses,
     ...exclusionClauses,
   ];
 
-  return `
+  const minCostPlaceholder = qb.addParam(Number(params.minCost));
+
+  const sql = `
     WITH resources AS (
       SELECT
         account_id,
@@ -535,9 +567,11 @@ export function buildMissingTagsQuery(
     FROM resources r
     JOIN category_coverage c USING (service, service_family)
     WHERE r.has_tag = 0
-      AND r.cost >= ${String(Number(params.minCost))}
+      AND r.cost >= ${minCostPlaceholder}
     ORDER BY r.cost DESC
   `.trim();
+
+  return { sql, params: qb.build().params };
 }
 
 /**
@@ -560,22 +594,25 @@ export function buildNonResourceCostQuery(
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
-): string {
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+): ParameterizedQuery {
+  const qb = new QueryBuilder();
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
 
+  const startDatePlaceholder = qb.addParam(params.dateRange.start);
+  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
+    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
     `(line_item_type NOT IN ('Usage', 'DiscountedUsage') OR resource_id IS NULL OR resource_id = '')`,
     ...filterClauses,
     ...exclusionClauses,
   ];
 
-  return `
+  const sql = `
     SELECT
       service,
       service_family,
@@ -587,6 +624,8 @@ export function buildNonResourceCostQuery(
     HAVING SUM(cost) > 0
     ORDER BY cost DESC
   `.trim();
+
+  return { sql, params: qb.build().params };
 }
 
 export function buildDailyCostsQuery(
@@ -598,18 +637,21 @@ export function buildDailyCostsQuery(
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
-): string {
+): ParameterizedQuery {
+  const qb = new QueryBuilder();
   const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
 
+  const startDatePlaceholder = qb.addParam(params.dateRange.start);
+  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
+    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
     ...filterClauses,
     ...exclusionClauses,
   ];
@@ -618,7 +660,7 @@ export function buildDailyCostsQuery(
     ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 
-  return `
+  const sql = `
     SELECT
       ${dateExpr} AS date,
       ${groupByResolved.fieldExpr} AS group_name,
@@ -628,6 +670,8 @@ export function buildDailyCostsQuery(
     GROUP BY date, group_name
     ORDER BY date, cost DESC
   `.trim();
+
+  return { sql, params: qb.build().params };
 }
 
 export function buildEntityDetailQuery(
@@ -639,10 +683,11 @@ export function buildEntityDetailQuery(
   accountReverseMap?: ReadonlyMap<string, readonly string[]>,
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
-): string {
+): ParameterizedQuery {
+  const qb = new QueryBuilder();
   const dimResolved = resolveField(params.dimension, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap) : [];
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const granularity = params.granularity ?? 'daily';
@@ -657,15 +702,18 @@ export function buildEntityDetailQuery(
     if (dimResolved.rawField === 'account_id' && accountReverseMap !== undefined) {
       const ids = accountReverseMap.get(String(params.entity));
       if (ids !== undefined && ids.length > 0) {
-        const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
-        return `${dimResolved.rawField} IN (${list})`;
+        const placeholders = ids.map(id => qb.addParam(id)).join(', ');
+        return `${dimResolved.rawField} IN (${placeholders})`;
       }
     }
-    return `${dimResolved.fieldExpr} = '${String(params.entity).replaceAll("'", "''")}'`;
+    const entityPlaceholder = qb.addParam(String(params.entity));
+    return `${dimResolved.fieldExpr} = ${entityPlaceholder}`;
   })();
 
+  const startDatePlaceholder = qb.addParam(params.dateRange.start);
+  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN '${params.dateRange.start}' AND '${params.dateRange.end}'`,
+    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
     entityClause,
     ...filterClauses,
     ...exclusionClauses,
@@ -677,7 +725,7 @@ export function buildEntityDetailQuery(
     ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 
-  return `
+  const sql = `
     SELECT
       ${groupKey} AS usage_date,
       service,
@@ -689,4 +737,6 @@ export function buildEntityDetailQuery(
     GROUP BY ${groupKey}, service, account_id, account_name
     ORDER BY usage_date, cost DESC
   `.trim();
+
+  return { sql, params: qb.build().params };
 }

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -1,0 +1,193 @@
+import type { DimensionsConfig } from '../types/config.js';
+
+/**
+ * Error thrown when SQL identifier validation fails.
+ * Prevents SQL injection via untrusted column names or table paths.
+ */
+export class SecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecurityError';
+  }
+}
+
+/**
+ * Standard CUR column names that are always safe to reference.
+ * Includes both raw CUR fields and derived columns created in buildSource.
+ */
+const ALLOWED_CUR_COLUMNS = new Set([
+  // Date/time columns (computed in buildSource)
+  'usage_date',
+  'usage_hour',
+
+  // Core identity columns
+  'account_id',
+  'account_name',
+  'region',
+  'service',
+  'service_family',
+
+  // Cost columns
+  'cost',
+  'list_cost',
+
+  // Resource and usage columns
+  'description',
+  'resource_id',
+  'usage_amount',
+  'line_item_type',
+  'operation',
+  'usage_type',
+
+  // Raw CUR fields that may appear in queries
+  'line_item_usage_account_id',
+  'line_item_usage_account_name',
+  'product_region_code',
+  'product_servicecode',
+  'product_product_family',
+  'line_item_line_item_description',
+  'line_item_resource_id',
+  'line_item_usage_amount',
+  'line_item_unblended_cost',
+  'line_item_blended_cost',
+  'pricing_public_on_demand_cost',
+  'line_item_line_item_type',
+  'line_item_operation',
+  'line_item_usage_type',
+  'line_item_usage_start_date',
+  'savings_plan_savings_plan_effective_cost',
+  'reservation_effective_cost',
+  'resource_tags',
+
+  // Aggregate and computed columns that appear in CTEs
+  'entity',
+  'total_cost',
+  'current_cost',
+  'previous_cost',
+  'delta',
+  'percent_change',
+  'service_cost',
+  'has_tag',
+  'tagged_ratio',
+  'days',
+
+  // Org account columns (from org-accounts.json join)
+  'id',
+  'tags',
+]);
+
+/**
+ * Build the set of valid column names from the dimensions config.
+ * Includes built-in dimension fields, tag columns, and standard CUR columns.
+ */
+function buildAllowedColumns(dimensions: DimensionsConfig): ReadonlySet<string> {
+  const allowed = new Set(ALLOWED_CUR_COLUMNS);
+
+  // Add built-in dimension fields
+  for (const dim of dimensions.builtIn) {
+    allowed.add(dim.field);
+    if (dim.displayField !== undefined) {
+      allowed.add(dim.displayField);
+    }
+  }
+
+  // Add tag columns (normalized tag names)
+  for (const tag of dimensions.tags) {
+    const colName = `tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    allowed.add(colName);
+    // Also add the fallback column pattern used in buildSource
+    allowed.add(`fallback_${colName}`);
+  }
+
+  return allowed;
+}
+
+/**
+ * Validate a column name against the dimensions config allow-list.
+ * Throws SecurityError if the column name is not in the allow-list.
+ *
+ * @param columnName - The column name to validate (e.g., 'account_id', 'tag_team')
+ * @param dimensions - The dimensions config containing built-in and tag definitions
+ * @throws {SecurityError} If the column name is not in the allow-list
+ */
+export function validateColumnName(columnName: string, dimensions: DimensionsConfig): void {
+  const allowed = buildAllowedColumns(dimensions);
+
+  if (!allowed.has(columnName)) {
+    throw new SecurityError(
+      `Invalid column name "${columnName}" - not in dimensions config allow-list. ` +
+      `This prevents SQL injection via untrusted identifiers.`
+    );
+  }
+}
+
+/**
+ * Valid table path tiers (CUR data organization levels).
+ */
+const ALLOWED_TIERS = new Set(['daily', 'hourly', 'cost-optimization']);
+
+/**
+ * Pattern for valid billing period strings (YYYY-MM format).
+ * Matches YYYY-MM where MM is 01-12.
+ */
+const BILLING_PERIOD_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+/**
+ * Validate a table path for Parquet file reads.
+ * Accepts paths in the format: {dataDir}/aws/raw/{tier}-{period}/*.parquet
+ * or the wildcard format: {dataDir}/aws/raw/{tier}-*\/*.parquet
+ *
+ * @param tablePath - The table path to validate
+ * @throws {SecurityError} If the table path does not match the expected pattern
+ */
+export function validateTablePath(tablePath: string): void {
+  // Extract the tier and period from the path
+  // Expected formats:
+  // 1. {dataDir}/aws/raw/daily-2026-03/*.parquet
+  // 2. {dataDir}/aws/raw/daily-*\/*.parquet
+  // 3. read_parquet('{dataDir}/aws/raw/daily-2026-03/*.parquet')
+  // 4. read_parquet(['{path1}', '{path2}'])
+
+  // Strip read_parquet wrapper if present
+  const cleanPath = tablePath
+    .replace(/^read_parquet\s*\(\s*/, '')
+    .replace(/\s*\)\s*$/, '')
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/^['"]/, '')
+    .replace(/['"]$/, '');
+
+  // Match the tier and period pattern
+  // Pattern: {anything}/aws/raw/{tier}-{period}/*.parquet
+  const tierPattern = /\/aws\/raw\/([a-z-]+)-([^/]+)\/\*\.parquet/;
+  const match = tierPattern.exec(cleanPath);
+
+  if (match === null) {
+    throw new SecurityError(
+      `Invalid table path "${tablePath}" - must match pattern ` +
+      `"{dataDir}/aws/raw/{tier}-{period}/*.parquet" or "{dataDir}/aws/raw/{tier}-*/*.parquet". ` +
+      `This prevents SQL injection via untrusted file paths.`
+    );
+  }
+
+  const tier = match[1];
+  const period = match[2];
+
+  // Validate tier is in allow-list
+  if (tier === undefined || !ALLOWED_TIERS.has(tier)) {
+    throw new SecurityError(
+      `Invalid tier "${String(tier)}" in table path "${tablePath}" - ` +
+      `must be one of: ${[...ALLOWED_TIERS].join(', ')}. ` +
+      `This prevents SQL injection via untrusted identifiers.`
+    );
+  }
+
+  // Validate period is either wildcard or valid YYYY-MM format
+  if (period !== '*' && (period === undefined || !BILLING_PERIOD_PATTERN.test(period))) {
+    throw new SecurityError(
+      `Invalid period "${String(period)}" in table path "${tablePath}" - ` +
+      `must be "*" or YYYY-MM format. ` +
+      `This prevents SQL injection via untrusted identifiers.`
+    );
+  }
+}

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -11,3 +11,8 @@ export {
 } from './builder.js';
 
 export { costExprFor } from './cost-metric.js';
+
+export { validateColumnName, validateTablePath, SecurityError } from './identifier-validator.js';
+
+export type { ParameterizedQuery } from './parameterized.js';
+export { QueryBuilder } from './parameterized.js';

--- a/packages/core/src/query/parameterized.ts
+++ b/packages/core/src/query/parameterized.ts
@@ -1,0 +1,33 @@
+/**
+ * Parameterized SQL query infrastructure for safe DuckDB queries.
+ *
+ * Separates SQL structure (with $1, $2, ... placeholders) from user-controlled
+ * values to prevent SQL injection and enable DuckDB query plan caching.
+ */
+
+/** A SQL query with parameterized placeholders and their corresponding values. */
+export interface ParameterizedQuery {
+  /** SQL string with $1, $2, ... placeholders for parameters */
+  readonly sql: string;
+  /** Parameter values in order, corresponding to $1, $2, ... in the SQL */
+  readonly params: readonly unknown[];
+}
+
+/** Collects parameterized values and generates numbered placeholders ($1, $2, ...). */
+export class QueryBuilder {
+  private readonly parameters: unknown[] = [];
+
+  /** Register a value and return its placeholder string (e.g. "$1"). */
+  addParam(value: unknown): string {
+    this.parameters.push(value);
+    return `$${String(this.parameters.length)}`;
+  }
+
+  /** Return a frozen copy of the collected parameters. */
+  build(): ParameterizedQuery {
+    return {
+      sql: '',
+      params: Object.freeze([...this.parameters]),
+    };
+  }
+}

--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -5,6 +5,7 @@ export type RawRow = Readonly<Record<string, unknown>>;
 
 export interface DuckDBClient {
   runQuery(sql: string): Promise<RawRow[]>;
+  runPreparedQuery(sql: string, params: readonly unknown[]): Promise<RawRow[]>;
   cancelPendingQueries(): void;
   terminate(): Promise<void>;
 }
@@ -113,6 +114,39 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
           },
         });
         worker.postMessage({ kind: 'query', id, sql });
+      });
+    },
+    runPreparedQuery(sql: string, params: readonly unknown[]): Promise<RawRow[]> {
+      if (fatalError !== null) return Promise.reject(fatalError);
+      const id = nextId++;
+      const startedAt = Date.now();
+      const startedAtIso = new Date(startedAt).toISOString();
+      return new Promise<RawRow[]>((resolve, reject) => {
+        pending.set(id, {
+          resolve: (rows) => {
+            logger.debug('duckdb:prepared-query', {
+              id,
+              startedAt: startedAtIso,
+              durationMs: Date.now() - startedAt,
+              rows: rows.length,
+              sql,
+              paramCount: params.length,
+            });
+            resolve(rows);
+          },
+          reject: (err) => {
+            logger.debug('duckdb:prepared-query-failed', {
+              id,
+              startedAt: startedAtIso,
+              durationMs: Date.now() - startedAt,
+              error: err.message,
+              sql,
+              paramCount: params.length,
+            });
+            reject(err);
+          },
+        });
+        worker.postMessage({ kind: 'prepared-query', id, sql, params });
       });
     },
     cancelPendingQueries(): void {

--- a/packages/desktop/src/main/duckdb-loader.ts
+++ b/packages/desktop/src/main/duckdb-loader.ts
@@ -14,7 +14,19 @@ export interface DuckDBInstance {
 
 export interface DuckDBConnection {
   run: (sql: string) => Promise<DuckDBResult>;
+  prepare: (sql: string) => Promise<DuckDBPreparedStatement>;
   disconnectSync: () => void;
+}
+
+export interface DuckDBPreparedStatement {
+  parameterCount: number;
+  bindVarchar: (index: number, value: string) => void;
+  bindDouble: (index: number, value: number) => void;
+  bindInteger: (index: number, value: number) => void;
+  bindBoolean: (index: number, value: boolean) => void;
+  bindNull: (index: number) => void;
+  run: () => Promise<DuckDBResult>;
+  destroySync: () => void;
 }
 
 export interface DuckDBResult {

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -23,15 +23,23 @@ type WorkerResponse =
   | { kind: 'rows'; id: number; rows: Readonly<Record<string, unknown>>[] }
   | { kind: 'error'; id: number; message: string };
 
+function hasProps(msg: unknown): msg is Record<string, unknown> {
+  return typeof msg === 'object' && msg !== null;
+}
+
 function isQueryRequest(msg: unknown): msg is { kind: 'query'; id: number; sql: string } {
-  if (typeof msg !== 'object' || msg === null) return false;
-  const m = msg as Record<string, unknown>;
-  return m['kind'] === 'query' && typeof m['id'] === 'number' && typeof m['sql'] === 'string';
+  if (!hasProps(msg)) return false;
+  return msg['kind'] === 'query' && typeof msg['id'] === 'number' && typeof msg['sql'] === 'string';
+}
+
+function isPreparedQueryRequest(msg: unknown): msg is { kind: 'prepared-query'; id: number; sql: string; params: unknown[] } {
+  if (!hasProps(msg)) return false;
+  return msg['kind'] === 'prepared-query' && typeof msg['id'] === 'number' && typeof msg['sql'] === 'string' && Array.isArray(msg['params']);
 }
 
 function isCancelRequest(msg: unknown): msg is { kind: 'cancel-pending' } {
-  if (typeof msg !== 'object' || msg === null) return false;
-  return (msg as Record<string, unknown>)['kind'] === 'cancel-pending';
+  if (!hasProps(msg)) return false;
+  return msg['kind'] === 'cancel-pending';
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +74,62 @@ async function fetchAllRows(
     chunk = await result.fetchChunk();
   }
   return rows;
+}
+
+function bindParams(stmt: import('./duckdb-loader.js').DuckDBPreparedStatement, params: unknown[]): void {
+  for (let i = 0; i < params.length; i++) {
+    const val = params[i];
+    const idx = i + 1; // DuckDB uses 1-based parameter indices
+    if (val === null || val === undefined) {
+      stmt.bindNull(idx);
+    } else if (typeof val === 'string') {
+      stmt.bindVarchar(idx, val);
+    } else if (typeof val === 'number') {
+      if (Number.isInteger(val)) {
+        stmt.bindInteger(idx, val);
+      } else {
+        stmt.bindDouble(idx, val);
+      }
+    } else if (typeof val === 'boolean') {
+      stmt.bindBoolean(idx, val);
+    } else {
+      stmt.bindVarchar(idx, typeof val === 'object' ? JSON.stringify(val) : String(val as string | number | boolean));
+    }
+  }
+}
+
+async function fetchAllRowsPrepared(
+  conn: DuckDBConnection,
+  sql: string,
+  params: unknown[],
+  isCancelled: () => boolean,
+): Promise<Readonly<Record<string, unknown>>[]> {
+  const stmt = await conn.prepare(sql);
+  try {
+    bindParams(stmt, params);
+    const result = await stmt.run();
+    const cols = result.columnCount;
+    const names: string[] = [];
+    for (let i = 0; i < cols; i++) names.push(result.columnName(i));
+
+    const rows: Record<string, unknown>[] = [];
+    let chunk = await result.fetchChunk();
+    while (chunk !== null && chunk.rowCount > 0) {
+      if (isCancelled()) return [];
+      for (let r = 0; r < chunk.rowCount; r++) {
+        const row: Record<string, unknown> = {};
+        for (let c = 0; c < cols; c++) {
+          const name = names[c];
+          if (name !== undefined) row[name] = chunk.getColumnVector(c).getItem(r);
+        }
+        rows.push(row);
+      }
+      chunk = await result.fetchChunk();
+    }
+    return rows;
+  } finally {
+    stmt.destroySync();
+  }
 }
 
 /**
@@ -146,6 +210,46 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
   }
 }
 
+async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; sql: string; params: unknown[] }): Promise<void> {
+  // Check before acquiring a pool connection
+  if (cancelledIds.has(req.id)) {
+    cancelledIds.delete(req.id);
+    send({ kind: 'rows', id: req.id, rows: [] });
+    return;
+  }
+
+  queuedIds.add(req.id);
+  const pool = await getPool();
+  const conn = await pool.acquire();
+  queuedIds.delete(req.id);
+
+  try {
+    // Check after acquiring — cancel may have arrived while queued
+    if (cancelledIds.has(req.id)) {
+      cancelledIds.delete(req.id);
+      send({ kind: 'rows', id: req.id, rows: [] });
+      return;
+    }
+
+    runningIds.add(req.id);
+    const rows = await fetchAllRowsPrepared(conn, req.sql, req.params, () => cancelledIds.has(req.id));
+
+    // Skip serialization if cancelled during execution
+    if (cancelledIds.has(req.id)) {
+      cancelledIds.delete(req.id);
+      send({ kind: 'rows', id: req.id, rows: [] });
+    } else {
+      send({ kind: 'rows', id: req.id, rows });
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    send({ kind: 'error', id: req.id, message });
+  } finally {
+    runningIds.delete(req.id);
+    pool.release(conn);
+  }
+}
+
 function handleCancelPending(): void {
   for (const id of queuedIds) {
     cancelledIds.add(id);
@@ -155,6 +259,8 @@ function handleCancelPending(): void {
 port.on('message', (msg: unknown) => {
   if (isQueryRequest(msg)) {
     void handleRequest(msg);
+  } else if (isPreparedQueryRequest(msg)) {
+    void handlePreparedRequest(msg);
   } else if (isCancelRequest(msg)) {
     handleCancelPending();
   }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -140,6 +140,7 @@ export interface AppContext {
    *  explicit reset via invalidateColumnCache. */
   readonly getAvailableColumns: (tier: 'daily' | 'hourly') => Promise<ReadonlySet<string>>;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
+  readonly runPreparedQuery: (sql: string, params: readonly unknown[]) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
   readonly invalidateDimensions: () => void;
   readonly invalidateViews: () => void;
@@ -417,6 +418,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getOrgAccountsPath,
     getAvailableColumns,
     runQuery: (sql: string) => ctx.db.runQuery(sql),
+    runPreparedQuery: (sql: string, params: readonly unknown[]) => ctx.db.runPreparedQuery(sql, params),
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; state.regionMap = null; },
     invalidateViews: () => { state.views = null; },

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -50,7 +50,7 @@ import {
 } from './query-utils.js';
 
 export function registerQueryHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, getAvailableColumns, runQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, getAvailableColumns, runQuery, runPreparedQuery } = app;
 
   ipcMain.handle('query:cancel-pending', () => {
     ctx.db.cancelPendingQueries();
@@ -80,10 +80,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const availableColumns = await getAvailableColumns(tier);
     const { available, empty } = await resolveAvailablePeriods(tier, params.dateRange);
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
-    const sql = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, accountReverseMap, costScope, availableColumns);
+    const { sql, params: queryParams } = buildCostQuery(params, ctx.dataDir, dimensions, undefined, orgPath, available, accountReverseMap, costScope, availableColumns);
     logger.info('query:costs', { groupBy: params.groupBy });
 
-    const rows = await runQuery(sql);
+    const rows = await runPreparedQuery(sql, queryParams);
     let result = buildCostResult(rows, params.dateRange);
 
     if (params.groupBy === 'account' || params.groupBy === 'account_id') {
@@ -116,10 +116,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const availableColumns = await getAvailableColumns(tier);
     const { available, empty } = await resolveAvailablePeriods(tier, params.dateRange);
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
-    const sql = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
+    const { sql, params: queryParams } = buildDailyCostsQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
     logger.info('query:daily-costs', { groupBy: params.groupBy });
 
-    const rows = await runQuery(sql);
+    const rows = await runPreparedQuery(sql, queryParams);
 
     const dayMap = new Map<string, Record<string, number>>();
     const groupSet = new Set<string>();
@@ -173,10 +173,10 @@ export function registerQueryHandlers(app: AppContext): void {
     const availableColumns = await getAvailableColumns('daily');
     const { available, empty } = await resolveAvailablePeriods('daily', params.dateRange);
     if (empty) return { increases: [], savings: [], totalIncrease: asDollars(0), totalSavings: asDollars(0) };
-    const sql = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
+    const { sql, params: queryParams } = buildTrendQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
     logger.info('query:trends', { groupBy: params.groupBy });
 
-    const rows = await runQuery(sql);
+    const rows = await runPreparedQuery(sql, queryParams);
     const result = buildTrendResult(rows, params.deltaThreshold, params.percentThreshold);
     if (params.groupBy === 'account' || params.groupBy === 'account_id') {
       return {
@@ -209,11 +209,11 @@ export function registerQueryHandlers(app: AppContext): void {
         nonResourceRows: [],
       };
     }
-    const resourceSql = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
-    const nonResourceSql = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
+    const resourceQuery = buildMissingTagsQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
+    const nonResourceQuery = buildNonResourceCostQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
     const [resourceRows, nonResourceRows] = await Promise.all([
-      runQuery(resourceSql),
-      runQuery(nonResourceSql),
+      runPreparedQuery(resourceQuery.sql, resourceQuery.params),
+      runPreparedQuery(nonResourceQuery.sql, nonResourceQuery.params),
     ]);
     const result = buildMissingTagsResult(resourceRows, nonResourceRows);
     return {
@@ -310,10 +310,10 @@ export function registerQueryHandlers(app: AppContext): void {
         bySubEntity: [],
       };
     }
-    const sql = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
+    const { sql, params: queryParams } = buildEntityDetailQuery(params, ctx.dataDir, dimensions, orgPath, available, accountReverseMap, costScope, availableColumns);
     logger.info('query:entity-detail', { entity: params.entity });
 
-    const rows = await runQuery(sql);
+    const rows = await runPreparedQuery(sql, queryParams);
     const result = buildEntityDetailResult(rows, params.entity);
     return {
       ...result,


### PR DESCRIPTION
Migrate the DuckDB query builder from string interpolation to parameterized queries for all user-controlled values (date ranges, dimension/tag values). For identifiers that cannot be parameterized (column names, table paths), validate against allow-lists derived from the dimensions config.