### PR TITLE
Worker Thread Migration for DuckDB and S3 Sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Lint
         run: npx eslint packages/*/src/
 
+      - name: Build workers
+        run: npm run build:worker --workspace=packages/desktop
+
       - name: Test with coverage
         run: npx vitest run --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -144,11 +144,9 @@ interface CostApi {
 
 The interface is exported from `@costgoblin/core/browser`. The renderer accesses it through a React context (`useCostApi()`) — never through globals — so component tests can swap in `MockCostApi`.
 
-### Worker Thread Architecture (v1)
+### Worker Thread Architecture
 
-> **Status: v1.** Today, DuckDB and S3 sync run on the Electron main process. Heavy queries can stall IPC responsiveness. Migration to worker threads is a v1 commitment.
-
-Target architecture:
+DuckDB and S3 sync run in dedicated worker threads so the main process stays responsive.
 
 ```
 Main Process
@@ -157,11 +155,9 @@ Main Process
   └── Window (Renderer)       # React UI
 ```
 
-Constraints:
-- Workers communicate via structured-clone messages typed with the same `CostApi`-adjacent types.
-- DuckDB instance is owned exclusively by its worker. The main process never touches DuckDB directly.
-- Sync worker streams progress events back to main, which forwards to the renderer.
-- Cancellation (`AbortSignal`-style) must work from the renderer down through main into the worker.
+- **DuckDB worker** owns the database exclusively. Queries arrive via structured-clone messages; results are serialized back to main. Connection pooling and prepared statement cache are internal to the worker.
+- **Sync worker** runs S3 downloads and DuckDB repartitioning. Progress events stream back to main for UI updates. Cancellation propagates via `AbortController` signaling.
+- Workers communicate via typed messages (`{ kind, id, ... }` discriminated unions). No `any` types cross the worker boundary.
 
 ### Electron Security
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,6 @@ export default [
     },
   },
   {
-    ignores: ['**/dist/**', '**/node_modules/**', '**/*.config.*', '**/__fixtures__/generate.ts'],
+    ignores: ['**/dist/**', '**/node_modules/**', '**/out/**', '**/*.config.*', '**/__fixtures__/generate.ts'],
   },
 ];

--- a/packages/core/src/__fixtures__/config/cost-scope.yaml
+++ b/packages/core/src/__fixtures__/config/cost-scope.yaml
@@ -1,0 +1,77 @@
+costMetric: unblended
+rules:
+  - id: builtin:aws-premium-support
+    name: AWS Premium Support
+    description: AWS Enterprise / Business / Developer support subscription fees.
+      Flat-rate monthly billing outside per-resource usage.
+    enabled: false
+    builtIn: true
+    conditions:
+      - dimensionId: service
+        values:
+          - AWSSupportEnterprise
+          - AWSSupportBusiness
+          - AWSSupportDeveloper
+  - id: builtin:ri-sp-purchases
+    name: RI & Savings Plan purchases
+    description: Upfront/recurring fees for Reserved Instances and Savings Plans,
+      plus SP negation adjustments. RI/SP-covered usage still appears under
+      DiscountedUsage / SavingsPlanCoveredUsage and is not affected by this
+      rule.
+    enabled: false
+    builtIn: true
+    conditions:
+      - dimensionId: line_item_type
+        values:
+          - RIFee
+          - SavingsPlanRecurringFee
+          - SavingsPlanUpfrontFee
+          - SavingsPlanNegation
+  - id: builtin:tax
+    name: Tax
+    description: VAT / GST / sales-tax line items. Toggle on to compare pre-tax
+      run-rate across regions or exclude tax from forecasts; leave off to see
+      the all-in bill.
+    enabled: false
+    builtIn: true
+    conditions:
+      - dimensionId: line_item_type
+        values:
+          - Tax
+  - id: builtin:edp-discount
+    name: EDP discount
+    description: Negative line items from the AWS Enterprise Discount Program
+      (contractual volume discount). Toggle on to view gross / pre-negotiation
+      cost; leave off to see the effective bill after the EDP credit.
+    enabled: false
+    builtIn: true
+    conditions:
+      - dimensionId: line_item_type
+        values:
+          - EdpDiscount
+  - id: builtin:bundled-discount
+    name: Bundled discount
+    description: Negative discount line items applied automatically by AWS bundle
+      pricing rules (e.g. support-tier bundle credits). Like EDP, standalone —
+      not paired with a specific usage row. Toggle on to see pre-bundle cost.
+    enabled: false
+    builtIn: true
+    conditions:
+      - dimensionId: line_item_type
+        values:
+          - BundledDiscount
+  - id: builtin:commitment-covered-usage
+    name: RI & SP covered usage
+    description: Usage already covered by a Reserved Instance (DiscountedUsage) or
+      Savings Plan (SavingsPlanCoveredUsage paired with SavingsPlanNegation).
+      Toggle on to isolate on-demand spend — the workloads NOT yet covered by a
+      commitment. SP negation is bundled so its discount does not leak when the
+      usage it offsets is removed.
+    enabled: false
+    builtIn: true
+    conditions:
+      - dimensionId: line_item_type
+        values:
+          - DiscountedUsage
+          - SavingsPlanCoveredUsage
+          - SavingsPlanNegation

--- a/packages/core/src/__fixtures__/config/views.yaml
+++ b/packages/core/src/__fixtures__/config/views.yaml
@@ -1,0 +1,38 @@
+views:
+  - id: overview
+    name: Cost Overview
+    builtIn: true
+    rows:
+      - widgets:
+          - id: overview-summary
+            type: summary
+            size: small
+            metric: total
+          - id: overview-histogram
+            type: stackedBar
+            size: large
+            groupBy: service
+      - widgets:
+          - id: overview-pie-account
+            type: pie
+            size: medium
+            groupBy: account
+          - id: overview-pie-region
+            type: pie
+            size: medium
+            groupBy: region
+          - id: overview-pie-service
+            type: pie
+            size: medium
+            groupBy: service
+      - widgets:
+          - id: overview-breakdown
+            type: table
+            size: full
+            groupBy: account
+            topN: 20
+            columns:
+              - entity
+              - service
+              - cost
+              - percentage

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -5,7 +5,7 @@
   "main": "out/main/main.js",
   "scripts": {
     "build": "electron-vite build --sourcemap && npm run build:worker",
-    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron",
+    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron && esbuild src/main/sync-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/sync-worker.cjs --external:@duckdb/node-api --external:@aws-sdk/client-s3 --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",
     "dev": "npm run build:worker && electron-vite dev"

--- a/packages/desktop/src/__tests__/sync-worker.test.ts
+++ b/packages/desktop/src/__tests__/sync-worker.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Worker } from 'node:worker_threads';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workerPath = join(__dirname, '..', '..', 'out', 'worker', 'sync-worker.cjs');
+
+interface WorkerMsg { kind: string; id?: number; [key: string]: unknown }
+
+function isMsg(msg: unknown): msg is WorkerMsg {
+  return typeof msg === 'object' && msg !== null && 'kind' in msg;
+}
+
+describe('Sync Worker', () => {
+  let worker: Worker;
+  let testDataDir: string;
+  let nextId = 1;
+
+  function sendSync(id: number, overrides?: Record<string, unknown>): void {
+    worker.postMessage({
+      kind: 'sync',
+      id,
+      bucketPath: 's3://test-bucket/test',
+      profile: 'default',
+      dataDir: testDataDir,
+      tier: 'daily',
+      files: [],
+      ...overrides,
+    });
+  }
+
+  function waitForResult(id: number): Promise<WorkerMsg> {
+    return new Promise<WorkerMsg>((resolve) => {
+      const handler = (msg: unknown): void => {
+        if (isMsg(msg) && msg.id === id && (msg.kind === 'complete' || msg.kind === 'error')) {
+          worker.off('message', handler);
+          resolve(msg);
+        }
+      };
+      worker.on('message', handler);
+    });
+  }
+
+  beforeAll(async () => {
+    testDataDir = await mkdtemp(join(tmpdir(), 'costgoblin-sync-test-'));
+    worker = new Worker(workerPath);
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => { reject(new Error('Worker ready timeout')); }, 5000);
+      worker.once('message', (msg) => {
+        clearTimeout(timeout);
+        expect(msg).toEqual({ kind: 'ready' });
+        resolve();
+      });
+      worker.once('error', (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  afterAll(async () => {
+    await worker.terminate();
+    await rm(testDataDir, { recursive: true, force: true });
+  });
+
+  it('completes sync with empty files', async () => {
+    const id = nextId++;
+    sendSync(id);
+    const result = await waitForResult(id);
+    expect(result).toHaveProperty('id', id);
+    expect(result.kind).toBe('complete');
+    expect(result).toHaveProperty('filesDownloaded', 0);
+    expect(result).toHaveProperty('rowsProcessed', 0);
+  });
+
+  it('ignores malformed messages without crashing', async () => {
+    worker.postMessage('invalid');
+    worker.postMessage(null);
+    worker.postMessage({ kind: 'sync', id: 999 }); // missing required fields
+    worker.postMessage({ kind: 'cancel' }); // missing id
+
+    // Worker should still respond to valid messages
+    const id = nextId++;
+    sendSync(id);
+    const result = await waitForResult(id);
+    expect(result.kind).toBe('complete');
+  });
+
+  it('handles cancel without crashing', async () => {
+    const id = nextId++;
+    sendSync(id);
+    worker.postMessage({ kind: 'cancel', id });
+    const result = await waitForResult(id);
+    // Either completed before cancel arrived, or was cancelled
+    expect(['complete', 'error']).toContain(result.kind);
+    expect(result.id).toBe(id);
+  });
+
+  it('remains healthy after cancellation', async () => {
+    const cancelId = nextId++;
+    sendSync(cancelId);
+    worker.postMessage({ kind: 'cancel', id: cancelId });
+    await waitForResult(cancelId);
+
+    const afterId = nextId++;
+    sendSync(afterId);
+    const result = await waitForResult(afterId);
+    expect(result.kind).toBe('complete');
+  });
+
+  it('handles sequential syncs with correct IDs', async () => {
+    const ids = [nextId++, nextId++, nextId++];
+    for (const id of ids) {
+      sendSync(id);
+      const result = await waitForResult(id);
+      expect(result.id).toBe(id);
+    }
+  });
+
+  it('handles concurrent syncs without cross-talk', async () => {
+    const id1 = nextId++;
+    const id2 = nextId++;
+    sendSync(id1, { bucketPath: 's3://bucket/a' });
+    sendSync(id2, { bucketPath: 's3://bucket/b' });
+    const [r1, r2] = await Promise.all([waitForResult(id1), waitForResult(id2)]);
+    expect(r1.id).toBe(id1);
+    expect(r2.id).toBe(id2);
+  });
+});

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -254,6 +254,9 @@ function handleCancelPending(): void {
   for (const id of queuedIds) {
     cancelledIds.add(id);
   }
+  for (const id of runningIds) {
+    cancelledIds.add(id);
+  }
 }
 
 port.on('message', (msg: unknown) => {

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { getDataInventory, syncSelectedFiles } from '@costgoblin/core';
+import { getDataInventory } from '@costgoblin/core';
 import type { AutoSyncStatus } from '@costgoblin/core';
 import {
   startAutoSync,
@@ -11,6 +11,7 @@ import {
   writeAutoSyncIntervalMinutes,
 } from '../auto-sync.js';
 import type { AppContext } from './context.js';
+import type { SyncClient } from '../sync-client.js';
 
 type Tier = 'daily' | 'hourly' | 'cost-optimization';
 
@@ -27,7 +28,7 @@ export function registerAutoSyncHandlers(app: AppContext): void {
     return path.join(path.dirname(ctx.dataDir), 'app-preferences.json');
   }
 
-  function buildAutoSyncDeps() {
+  function buildAutoSyncDeps(syncClient: SyncClient) {
     return {
       getPrefsPath: autoSyncPrefsPath,
       getConfig: async () => {
@@ -55,18 +56,21 @@ export function registerAutoSyncHandlers(app: AppContext): void {
       syncPeriods: async (files: { key: string; contentHash: string; size: number }[], tier: string) => {
         const config = await getConfig();
         const provider = config.providers[0];
-        if (provider === undefined) return { filesDownloaded: 0 };
+        if (provider === undefined) return { filesDownloaded: 0, rowsProcessed: 0 };
         const bucket = tier === 'hourly'
           ? provider.sync.hourly?.bucket ?? provider.sync.daily.bucket
           : tier === 'cost-optimization'
             ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
             : provider.sync.daily.bucket;
-        return syncSelectedFiles({
+
+        // Use worker thread via SyncClient
+        return syncClient.syncPeriods({
           bucketPath: bucket,
           profile: provider.credentials.profile,
           dataDir: ctx.dataDir,
-          expectedDataType: asTier(tier),
+          tier: asTier(tier),
           files,
+          // No onProgress for background sync (silent operation)
         });
       },
     };
@@ -81,7 +85,7 @@ export function registerAutoSyncHandlers(app: AppContext): void {
     await writeAutoSyncEnabled(prefsPath, enabled);
     if (enabled) {
       const minutes = await readAutoSyncIntervalMinutes(prefsPath);
-      startAutoSync(buildAutoSyncDeps(), minutes);
+      startAutoSync(buildAutoSyncDeps(ctx.syncClient), minutes);
     } else {
       stopAutoSync();
     }
@@ -100,7 +104,7 @@ export function registerAutoSyncHandlers(app: AppContext): void {
     const enabled = await readAutoSyncEnabled(prefsPath);
     if (enabled) {
       const stored = await readAutoSyncIntervalMinutes(prefsPath);
-      startAutoSync(buildAutoSyncDeps(), stored);
+      startAutoSync(buildAutoSyncDeps(ctx.syncClient), stored);
     }
   });
 
@@ -113,7 +117,7 @@ export function registerAutoSyncHandlers(app: AppContext): void {
     const enabled = await readAutoSyncEnabled(prefsPath);
     if (enabled) {
       const minutes = await readAutoSyncIntervalMinutes(prefsPath);
-      startAutoSync(buildAutoSyncDeps(), minutes);
+      startAutoSync(buildAutoSyncDeps(ctx.syncClient), minutes);
     }
   }).catch(() => { /* auto-sync startup failure is non-fatal */ });
 }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -92,6 +92,7 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
 }
 export interface IpcContext {
   readonly db: DuckDBClient;
+  readonly syncClient: import('../sync-client.js').SyncClient;
   readonly configPath: string;
   readonly dimensionsPath: string;
   readonly orgTreePath: string;

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -4,7 +4,6 @@ import {
   getEtagFileName,
   getRawDirPrefix,
   parseEtagsJson,
-  syncSelectedFiles,
   logger,
 } from '@costgoblin/core';
 import type {
@@ -30,7 +29,8 @@ function resolveDataType(syncId: string): ExpectedDataType {
 
 export function registerSyncHandlers(app: AppContext): void {
   const { ctx, state, getConfig } = app;
-  const syncAbortControllers = new Map<string, AbortController>();
+  const syncWorkerIds = new Map<string, number>();
+  let nextWorkerId = 0;
 
   ipcMain.handle('sync:status', (_event, syncId: string = 'default'): SyncStatus => {
     return state.syncStatuses[syncId] ?? { status: 'idle', lastSync: null };
@@ -127,20 +127,19 @@ export function registerSyncHandlers(app: AppContext): void {
       bucketPath = provider.sync.daily.bucket;
     }
 
-    const controller = new AbortController();
-    syncAbortControllers.set(syncId, controller);
+    const workerId = nextWorkerId++;
+    syncWorkerIds.set(syncId, workerId);
     state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: fileEntries.length, filesDone: 0, message: '' };
 
     const tier = resolveDataType(syncId);
 
     try {
-      const result = await syncSelectedFiles({
+      const result = await ctx.syncClient.syncPeriods({
         bucketPath,
         profile: provider.credentials.profile,
         dataDir: ctx.dataDir,
-        expectedDataType: tier,
+        tier,
         files: fileEntries,
-        signal: controller.signal,
         onProgress: (progress) => {
           state.syncStatuses[syncId] = {
             status: 'syncing',
@@ -153,11 +152,11 @@ export function registerSyncHandlers(app: AppContext): void {
         },
       });
 
-      syncAbortControllers.delete(syncId);
+      syncWorkerIds.delete(syncId);
       state.syncStatuses[syncId] = { status: 'completed', lastSync: new Date(), filesDownloaded: result.filesDownloaded };
       return result;
     } catch (err: unknown) {
-      syncAbortControllers.delete(syncId);
+      syncWorkerIds.delete(syncId);
       const raw = err instanceof Error ? err : new Error(String(err));
       if (raw.message === 'Download cancelled') {
         state.syncStatuses[syncId] = { status: 'idle', lastSync: null };
@@ -171,9 +170,9 @@ export function registerSyncHandlers(app: AppContext): void {
   });
 
   ipcMain.handle('data:cancel-sync', (_event, syncId: string = 'default'): void => {
-    const controller = syncAbortControllers.get(syncId);
-    if (controller !== undefined) {
-      controller.abort();
+    const workerId = syncWorkerIds.get(syncId);
+    if (workerId !== undefined) {
+      ctx.syncClient.cancelSync(workerId);
       logger.info(`Sync '${syncId}' cancelled by user`);
     }
   });

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -7,6 +7,8 @@ import { logger } from '@costgoblin/core';
 import type { LogEntry } from '@costgoblin/core';
 import { createDuckDBClient } from './duckdb-client.js';
 import type { DuckDBClient } from './duckdb-client.js';
+import { createSyncClient } from './sync-client.js';
+import type { SyncClient } from './sync-client.js';
 import { registerIpcHandlers } from './ipc.js';
 
 // Log level: debug in dev (NODE_ENV=development or electron-vite serving
@@ -99,13 +101,14 @@ function resolveConfigPath(base: string, name: string): string {
   return typeof env === 'string' && env.length > 0 ? env : join(base, `${name}.yaml`);
 }
 
-async function createWindow(db: DuckDBClient): Promise<void> {
+async function createWindow(db: DuckDBClient, syncClient: SyncClient): Promise<void> {
   const userDataPath = app.getPath('userData');
   const dataDir = process.env['COSTGOBLIN_DATA_DIR'] ?? join(userDataPath, 'data');
   const configBase = process.env['COSTGOBLIN_CONFIG_DIR'] ?? join(userDataPath, 'config');
 
   registerIpcHandlers({
     db,
+    syncClient,
     configPath: resolveConfigPath(configBase, 'costgoblin'),
     dimensionsPath: resolveConfigPath(configBase, 'dimensions'),
     orgTreePath: resolveConfigPath(configBase, 'org-tree'),
@@ -157,18 +160,22 @@ async function createWindow(db: DuckDBClient): Promise<void> {
 async function main(): Promise<void> {
   await app.whenReady();
 
-  // Worker bundle is built by `npm run build:worker` (esbuild) into out/worker/
+  // Worker bundles are built by `npm run build:worker` (esbuild) into out/worker/
   // — sibling to out/main/ where this file lives. We resolve up one level then
-  // into out/worker/ to find it.
-  const workerPath = join(__dirname, '..', 'worker', 'duckdb-worker.cjs');
-  const db = await createDuckDBClient(workerPath);
+  // into out/worker/ to find them.
+  const duckdbWorkerPath = join(__dirname, '..', 'worker', 'duckdb-worker.cjs');
+  const db = await createDuckDBClient(duckdbWorkerPath);
   logger.info('DuckDB worker ready');
 
-  await createWindow(db);
+  const syncWorkerPath = join(__dirname, '..', 'worker', 'sync-worker.cjs');
+  const syncClient = await createSyncClient(syncWorkerPath);
+  logger.info('Sync worker ready');
+
+  await createWindow(db, syncClient);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      void createWindow(db);
+      void createWindow(db, syncClient);
     }
   });
 }

--- a/packages/desktop/src/main/sync-client.ts
+++ b/packages/desktop/src/main/sync-client.ts
@@ -1,0 +1,176 @@
+import { Worker } from 'node:worker_threads';
+import { logger } from '@costgoblin/core';
+import type { ManifestFileEntry, SyncProgress } from '@costgoblin/core';
+
+export interface SyncOptions {
+  readonly bucketPath: string;
+  readonly profile: string;
+  readonly dataDir: string;
+  readonly tier?: 'daily' | 'hourly' | 'cost-optimization' | undefined;
+  readonly files: readonly ManifestFileEntry[];
+  readonly onProgress?: ((progress: SyncProgress) => void) | undefined;
+}
+
+export interface SyncResult {
+  readonly filesDownloaded: number;
+  readonly rowsProcessed: number;
+}
+
+export interface SyncClient {
+  syncPeriods(options: SyncOptions): Promise<SyncResult>;
+  cancelSync(id: number): void;
+  terminate(): Promise<void>;
+}
+
+type WorkerResponse =
+  | { kind: 'ready' }
+  | { kind: 'progress'; id: number; phase: 'downloading' | 'repartitioning' | 'done'; filesDone: number; filesTotal: number; message?: string }
+  | { kind: 'complete'; id: number; filesDownloaded: number; rowsProcessed: number }
+  | { kind: 'error'; id: number; message: string };
+
+function hasProps(msg: unknown): msg is Record<string, unknown> {
+  return typeof msg === 'object' && msg !== null;
+}
+
+function isWorkerResponse(msg: unknown): msg is WorkerResponse {
+  if (!hasProps(msg)) return false;
+  if (msg['kind'] === 'ready') return true;
+  if ((msg['kind'] === 'progress' || msg['kind'] === 'complete' || msg['kind'] === 'error') && typeof msg['id'] === 'number') {
+    if (msg['kind'] === 'progress') {
+      return (
+        (msg['phase'] === 'downloading' || msg['phase'] === 'repartitioning' || msg['phase'] === 'done') &&
+        typeof msg['filesDone'] === 'number' &&
+        typeof msg['filesTotal'] === 'number'
+      );
+    }
+    if (msg['kind'] === 'complete') {
+      return typeof msg['filesDownloaded'] === 'number' && typeof msg['rowsProcessed'] === 'number';
+    }
+    return typeof msg['message'] === 'string';
+  }
+  return false;
+}
+
+interface PendingSync {
+  resolve: (result: SyncResult) => void;
+  reject: (err: Error) => void;
+  onProgress?: ((progress: SyncProgress) => void) | undefined;
+}
+
+export async function createSyncClient(workerPath: string): Promise<SyncClient> {
+  const worker = new Worker(workerPath);
+  const pending = new Map<number, PendingSync>();
+  let nextId = 0;
+  let fatalError: Error | null = null;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const onMessage = (msg: unknown): void => {
+      if (!isWorkerResponse(msg)) return;
+      if (msg.kind === 'ready') {
+        worker.off('message', onMessage);
+        resolve();
+        return;
+      }
+      if (msg.kind === 'error' && msg.id === -1) {
+        worker.off('message', onMessage);
+        const err = new Error(msg.message);
+        fatalError = err;
+        reject(err);
+        return;
+      }
+    };
+    worker.on('message', onMessage);
+    worker.once('error', (err) => { fatalError = err; reject(err); });
+  });
+
+  worker.on('message', (msg: unknown) => {
+    if (!isWorkerResponse(msg)) return;
+    if (msg.kind === 'ready') return;
+
+    const entry = pending.get(msg.id);
+    if (entry === undefined) return;
+
+    if (msg.kind === 'progress') {
+      entry.onProgress?.({
+        phase: msg.phase,
+        filesTotal: msg.filesTotal,
+        filesDone: msg.filesDone,
+        ...(msg.message !== undefined ? { message: msg.message } : {}),
+      });
+    } else {
+      pending.delete(msg.id);
+      if (msg.kind === 'complete') {
+        entry.resolve({ filesDownloaded: msg.filesDownloaded, rowsProcessed: msg.rowsProcessed });
+      } else {
+        entry.reject(new Error(msg.message));
+      }
+    }
+  });
+
+  worker.on('error', (err) => {
+    fatalError = err;
+    for (const entry of pending.values()) entry.reject(err);
+    pending.clear();
+  });
+
+  worker.on('exit', (code) => {
+    if (code !== 0) {
+      const err = new Error(`Sync worker exited unexpectedly with code ${String(code)}`);
+      fatalError ??= err;
+      for (const entry of pending.values()) entry.reject(err);
+      pending.clear();
+    }
+  });
+
+  await ready;
+
+  return {
+    syncPeriods(options: SyncOptions): Promise<SyncResult> {
+      if (fatalError !== null) return Promise.reject(fatalError);
+      const id = nextId++;
+      const startedAt = Date.now();
+      const startedAtIso = new Date(startedAt).toISOString();
+      return new Promise<SyncResult>((resolve, reject) => {
+        pending.set(id, {
+          resolve: (result) => {
+            logger.debug('sync:complete', {
+              id,
+              startedAt: startedAtIso,
+              durationMs: Date.now() - startedAt,
+              filesDownloaded: result.filesDownloaded,
+              rowsProcessed: result.rowsProcessed,
+              bucketPath: options.bucketPath,
+            });
+            resolve(result);
+          },
+          reject: (err) => {
+            logger.debug('sync:failed', {
+              id,
+              startedAt: startedAtIso,
+              durationMs: Date.now() - startedAt,
+              error: err.message,
+              bucketPath: options.bucketPath,
+            });
+            reject(err);
+          },
+          onProgress: options.onProgress,
+        });
+        worker.postMessage({
+          kind: 'sync',
+          id,
+          bucketPath: options.bucketPath,
+          profile: options.profile,
+          dataDir: options.dataDir,
+          tier: options.tier ?? 'daily',
+          files: options.files,
+        });
+      });
+    },
+    cancelSync(id: number): void {
+      worker.postMessage({ kind: 'cancel', id });
+    },
+    async terminate(): Promise<void> {
+      await worker.terminate();
+    },
+  };
+}

--- a/packages/desktop/src/main/sync-worker.ts
+++ b/packages/desktop/src/main/sync-worker.ts
@@ -1,0 +1,187 @@
+import { parentPort } from 'node:worker_threads';
+import { syncSelectedFiles } from '@costgoblin/core';
+import type { SelectiveSyncOptions, ManifestFileEntry, SyncProgress } from '@costgoblin/core';
+
+if (parentPort === null) {
+  throw new Error('sync-worker.ts must be run as a Node.js Worker thread');
+}
+const port = parentPort;
+
+// ---------------------------------------------------------------------------
+// Message protocol types
+// ---------------------------------------------------------------------------
+
+interface SyncRequest {
+  readonly kind: 'sync';
+  readonly id: number;
+  readonly bucketPath: string;
+  readonly profile: string;
+  readonly dataDir: string;
+  readonly tier: string;
+  readonly files: readonly ManifestFileEntry[];
+}
+
+interface CancelRequest {
+  readonly kind: 'cancel';
+  readonly id: number;
+}
+
+interface ReadyResponse {
+  readonly kind: 'ready';
+}
+
+interface ProgressResponse {
+  readonly kind: 'progress';
+  readonly id: number;
+  readonly phase: 'downloading' | 'repartitioning' | 'done';
+  readonly filesDone: number;
+  readonly filesTotal: number;
+  readonly message?: string;
+}
+
+interface CompleteResponse {
+  readonly kind: 'complete';
+  readonly id: number;
+  readonly filesDownloaded: number;
+  readonly rowsProcessed: number;
+}
+
+interface ErrorResponse {
+  readonly kind: 'error';
+  readonly id: number;
+  readonly message: string;
+}
+
+type WorkerResponse = ReadyResponse | ProgressResponse | CompleteResponse | ErrorResponse;
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+function hasProps(msg: unknown): msg is Record<string, unknown> {
+  return typeof msg === 'object' && msg !== null;
+}
+
+function isSyncRequest(msg: unknown): msg is SyncRequest {
+  if (!hasProps(msg)) return false;
+  return (
+    msg['kind'] === 'sync' &&
+    typeof msg['id'] === 'number' &&
+    typeof msg['bucketPath'] === 'string' &&
+    typeof msg['profile'] === 'string' &&
+    typeof msg['dataDir'] === 'string' &&
+    typeof msg['tier'] === 'string' &&
+    Array.isArray(msg['files'])
+  );
+}
+
+function isCancelRequest(msg: unknown): msg is CancelRequest {
+  if (!hasProps(msg)) return false;
+  return msg['kind'] === 'cancel' && typeof msg['id'] === 'number';
+}
+
+// ---------------------------------------------------------------------------
+// Sync state tracking
+// ---------------------------------------------------------------------------
+
+const activeControllers = new Map<number, AbortController>();
+const cancelledIds = new Set<number>();
+
+// ---------------------------------------------------------------------------
+// Message sending
+// ---------------------------------------------------------------------------
+
+function send(msg: WorkerResponse): void {
+  port.postMessage(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Sync request handler
+// ---------------------------------------------------------------------------
+
+async function handleSyncRequest(req: SyncRequest): Promise<void> {
+  // Check if already cancelled before starting
+  if (cancelledIds.has(req.id)) {
+    cancelledIds.delete(req.id);
+    send({ kind: 'error', id: req.id, message: 'Download cancelled' });
+    return;
+  }
+
+  const controller = new AbortController();
+  activeControllers.set(req.id, controller);
+
+  try {
+    const options: SelectiveSyncOptions = {
+      bucketPath: req.bucketPath,
+      profile: req.profile,
+      dataDir: req.dataDir,
+      expectedDataType: req.tier as 'daily' | 'hourly' | 'cost-optimization' | undefined,
+      files: req.files,
+      signal: controller.signal,
+      onProgress: (progress: SyncProgress) => {
+        // Skip sending progress if cancelled
+        if (cancelledIds.has(req.id)) return;
+
+        // Only include message if it exists (exactOptionalPropertyTypes: true)
+        send({
+          kind: 'progress',
+          id: req.id,
+          phase: progress.phase,
+          filesDone: progress.filesDone,
+          filesTotal: progress.filesTotal,
+          ...(progress.message !== undefined ? { message: progress.message } : {}),
+        });
+      },
+    };
+
+    const result = await syncSelectedFiles(options);
+
+    // Skip sending result if cancelled during execution
+    if (cancelledIds.has(req.id)) {
+      cancelledIds.delete(req.id);
+      send({ kind: 'error', id: req.id, message: 'Download cancelled' });
+    } else {
+      send({
+        kind: 'complete',
+        id: req.id,
+        filesDownloaded: result.filesDownloaded,
+        rowsProcessed: result.rowsProcessed,
+      });
+    }
+  } catch (err: unknown) {
+    // Check if this was a cancellation
+    if (cancelledIds.has(req.id)) {
+      cancelledIds.delete(req.id);
+      send({ kind: 'error', id: req.id, message: 'Download cancelled' });
+    } else {
+      const message = err instanceof Error ? err.message : String(err);
+      send({ kind: 'error', id: req.id, message });
+    }
+  } finally {
+    activeControllers.delete(req.id);
+  }
+}
+
+function handleCancelRequest(req: CancelRequest): void {
+  cancelledIds.add(req.id);
+  const controller = activeControllers.get(req.id);
+  if (controller !== undefined) {
+    controller.abort();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Worker initialization
+// ---------------------------------------------------------------------------
+
+// Send ready signal immediately (no async initialization needed)
+send({ kind: 'ready' });
+
+// Handle incoming messages
+port.on('message', (msg: unknown) => {
+  if (isSyncRequest(msg)) {
+    void handleSyncRequest(msg);
+  } else if (isCancelRequest(msg)) {
+    handleCancelRequest(msg);
+  }
+});


### PR DESCRIPTION
Move DuckDB query execution and S3 sync operations into dedicated Electron worker threads. Today both run on the main process, which can stall IPC responsiveness during heavy queries or large downloads. The DuckDB worker owns the database instance exclusively; the sync worker streams progress events back to main.