### PR TITLE
Fill in legal page placeholders

### DIFF
--- a/docs/imprint.html
+++ b/docs/imprint.html
@@ -185,7 +185,7 @@
     </address>
 
     <h2>Contact</h2>
-    <p>Email: <a href="mailto:[contact@example.com]"><span class="todo">[contact@example.com]</span></a></p>
+    <p>Email: <a href="mailto:etienne.chabert.de@gmail.com">etienne.chabert.de@gmail.com</a></p>
 
     <h2>Responsible for content</h2>
     <p>The operator named above is responsible for all content on this site.</p>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -192,7 +192,7 @@
       Friedrichstr. 155<br>
       10117 Berlin<br>
       Germany<br>
-      Email: <span class="todo">[contact@example.com]</span>
+      Email: <a href="mailto:etienne.chabert.de@gmail.com">etienne.chabert.de@gmail.com</a>
     </address>
 
     <h2>2. Overview</h2>
@@ -327,7 +327,7 @@
       personal data infringes the GDPR (Art. 77). The authority competent
       for this site depends on the controller's place of residence:
     </p>
-    <p><span class="todo">[Enter the competent German state data-protection authority, e.g. BayLDA for Bavaria, LfDI Baden-Württemberg, BlnBDI for Berlin]</span></p>
+    <p>Berliner Beauftragte für Datenschutz und Informationsfreiheit (BlnBDI), Friedrichstr. 219, 10969 Berlin, <a href="https://www.datenschutz-berlin.de">www.datenschutz-berlin.de</a></p>
 
     <h2>11. No automated decision-making</h2>
     <p>No automated decision-making or profiling under Art. 22 GDPR takes place.</p>


### PR DESCRIPTION
## Summary
- Replace placeholder email with real contact address in imprint and privacy pages
- Fill in Berlin's data-protection authority (BlnBDI) in privacy policy