### PR TITLE
Cleanup 1/3: Deduplicate core + desktop utilities

### DIFF
--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,6 +1,7 @@
 import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
+import { tagColumnName } from '../types/branded.js';
 import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
@@ -74,9 +75,9 @@ function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig)
     return { fieldExpr, rawField: builtIn.field, dim: builtIn };
   }
 
-  const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);
+  const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
   if (tag !== undefined) {
-    const rawField = `tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    const rawField = tagColumnName(tag.tagName);
     return { fieldExpr: buildAliasSqlCase(rawField, tag), rawField, dim: tag };
   }
 
@@ -219,7 +220,7 @@ export function buildSource(
 
   const tagSelects = dimensions.tags.map(t => {
     const curKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
-    const colName = `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    const colName = tagColumnName(t.tagName);
     const tablePrefix = needsOrgJoin ? 'cur.' : '';
     const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;
 
@@ -260,7 +261,7 @@ export function buildSource(
     ? dimensions.tags
         .filter(t => t.accountTagFallback !== undefined)
         .map(t => {
-          const colName = `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+          const colName = tagColumnName(t.tagName);
           const fallbackKey = sqlEscapeString(t.accountTagFallback ?? '');
           return `tags->>'${fallbackKey}' AS fallback_${colName}`;
         })
@@ -313,6 +314,40 @@ function resolveQueryPeriods(
   return required.filter(p => availablePeriods.includes(p));
 }
 
+interface CommonQueryArgs {
+  readonly filters: FilterMap;
+  readonly dateRange: { readonly start: string; readonly end: string };
+}
+
+interface CommonQuerySetup {
+  readonly qb: QueryBuilder;
+  readonly filterClauses: string[];
+  readonly exclusionClauses: string[];
+  readonly source: string;
+  readonly costMetric: CostMetric;
+}
+
+function setupQuery(
+  params: CommonQueryArgs,
+  dataDir: string,
+  tier: string,
+  dimensions: DimensionsConfig,
+  orgAccountsPath: string | undefined,
+  availablePeriods: readonly string[] | undefined,
+  accountReverseMap: ReadonlyMap<string, readonly string[]> | undefined,
+  costScope: CostScopeConfig | undefined,
+  availableColumns: ReadonlySet<string> | undefined,
+): CommonQuerySetup {
+  const qb = new QueryBuilder();
+  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
+  const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
+  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
+  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  return { qb, filterClauses, exclusionClauses, source, costMetric };
+}
+
 export function buildCostQuery(
   params: CostQueryParams,
   dataDir: string,
@@ -325,15 +360,9 @@ export function buildCostQuery(
   availableColumns?: ReadonlySet<string>,
 ): ParameterizedQuery {
   assertFiniteNumber(topN, 'topN');
-  const qb = new QueryBuilder();
-  const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
-  const costMetric = costScope?.costMetric ?? 'unblended';
-  const costPerspective = costScope?.costPerspective ?? 'gross';
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, costTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dataDir, costTier, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns);
+  const groupByResolved = resolveField(params.groupBy, dimensions);
 
   const startDatePlaceholder = qb.addParam(params.dateRange.start);
   const endDatePlaceholder = qb.addParam(params.dateRange.end);
@@ -508,16 +537,9 @@ export function buildMissingTagsQuery(
   availableColumns?: ReadonlySet<string>,
 ): ParameterizedQuery {
   assertFiniteNumber(Number(params.minCost), 'minCost');
-  const qb = new QueryBuilder();
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dataDir, 'daily', dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns);
   const tagResolved = resolveField(params.tagDimension, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
-  const costMetric = costScope?.costMetric ?? 'unblended';
-  const costPerspective = costScope?.costPerspective ?? 'gross';
-  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
 
-  // Date + user filters apply to the resource aggregation.
   const startDatePlaceholder = qb.addParam(params.dateRange.start);
   const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
@@ -595,13 +617,7 @@ export function buildNonResourceCostQuery(
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
 ): ParameterizedQuery {
-  const qb = new QueryBuilder();
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
-  const costMetric = costScope?.costMetric ?? 'unblended';
-  const costPerspective = costScope?.costPerspective ?? 'gross';
-  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dataDir, 'daily', dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns);
 
   const startDatePlaceholder = qb.addParam(params.dateRange.start);
   const endDatePlaceholder = qb.addParam(params.dateRange.end);
@@ -638,15 +654,9 @@ export function buildDailyCostsQuery(
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
 ): ParameterizedQuery {
-  const qb = new QueryBuilder();
-  const groupByResolved = resolveField(params.groupBy, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
-  const costMetric = costScope?.costMetric ?? 'unblended';
-  const costPerspective = costScope?.costPerspective ?? 'gross';
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, dailyTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dataDir, dailyTier, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns);
+  const groupByResolved = resolveField(params.groupBy, dimensions);
 
   const startDatePlaceholder = qb.addParam(params.dateRange.start);
   const endDatePlaceholder = qb.addParam(params.dateRange.end);
@@ -684,16 +694,10 @@ export function buildEntityDetailQuery(
   costScope?: CostScopeConfig,
   availableColumns?: ReadonlySet<string>,
 ): ParameterizedQuery {
-  const qb = new QueryBuilder();
-  const dimResolved = resolveField(params.dimension, dimensions);
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
-  const exclusionClauses = costScope !== undefined ? buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb) : [];
-  const costMetric = costScope?.costMetric ?? 'unblended';
-  const costPerspective = costScope?.costPerspective ?? 'gross';
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
-  const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dataDir, tier, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns);
+  const dimResolved = resolveField(params.dimension, dimensions);
 
   // Same display-name collision treatment for the entity selector itself: if
   // the user clicked into "sre default" we need to match every underlying id,

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -1,4 +1,5 @@
 import type { DimensionsConfig } from '../types/config.js';
+import { tagColumnName } from '../types/branded.js';
 
 /**
  * Error thrown when SQL identifier validation fails.
@@ -93,10 +94,9 @@ function buildAllowedColumns(dimensions: DimensionsConfig): ReadonlySet<string> 
 
   // Add tag columns (normalized tag names)
   for (const tag of dimensions.tags) {
-    const colName = `tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
-    allowed.add(colName);
-    // Also add the fallback column pattern used in buildSource
-    allowed.add(`fallback_${colName}`);
+    const col = tagColumnName(tag.tagName);
+    allowed.add(col);
+    allowed.add(`fallback_${col}`);
   }
 
   return allowed;

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -4,7 +4,7 @@ import { createS3Handle, parseS3Path } from './s3-client.js';
 import type { S3Handle } from './s3-client.js';
 import type { ManifestFileEntry } from './manifest.js';
 import type { DataTier } from '../types/api.js';
-import { getRawDirPrefix, parseEtagsJson } from './sync-utils.js';
+import { extractPeriod, getEtagFileName, getRawDirPrefix, parseEtagsJson } from './sync-utils.js';
 
 export type PeriodStatus = 'missing' | 'repartitioned' | 'stale';
 
@@ -28,13 +28,6 @@ export interface DataInventory {
   readonly totalLocalPeriods: number;
   readonly totalRemotePeriods: number;
   readonly local: LocalDataInfo;
-}
-
-function extractPeriod(key: string): string | undefined {
-  const billingMatch = /BILLING_PERIOD=(\d{4}-\d{2})/.exec(key);
-  if (billingMatch?.[1] !== undefined) return billingMatch[1];
-  const dateMatch = /date=(\d{4}-\d{2})-\d{2}/.exec(key);
-  return dateMatch?.[1];
 }
 
 async function getDirSize(dirPath: string): Promise<number> {
@@ -84,12 +77,6 @@ async function getRawTierSize(rawDir: string, tierPrefix: string): Promise<numbe
   return total;
 }
 
-const ETAG_FILES: Record<DataTier, string> = {
-  'daily': 'sync-etags.json',
-  'hourly': 'sync-etags-hourly.json',
-  'cost-optimization': 'sync-etags-cost-optimization.json',
-};
-
 export async function getDataInventory(
   bucketPath: string,
   profile: string,
@@ -104,7 +91,7 @@ export async function getDataInventory(
   const periodMap = new Map<string, ManifestFileEntry[]>();
   for (const file of remoteFiles) {
     const period = extractPeriod(file.key);
-    if (period === undefined) continue;
+    if (period === 'unknown') continue;
     const existing = periodMap.get(period);
     if (existing !== undefined) {
       existing.push(file);
@@ -121,7 +108,7 @@ export async function getDataInventory(
 
   let savedEtags: Record<string, Record<string, string>> = {};
   try {
-    const raw = await readFile(join(dataDir, ETAG_FILES[tier]), 'utf-8');
+    const raw = await readFile(join(dataDir, getEtagFileName(tier)), 'utf-8');
     savedEtags = parseEtagsJson(raw);
   } catch {
     // no saved etags yet

--- a/packages/core/src/types/branded.ts
+++ b/packages/core/src/types/branded.ts
@@ -30,3 +30,7 @@ export function asDollars(value: number): Dollars {
 export function asDateString(value: string): DateString {
   return value as DateString;
 }
+
+export function tagColumnName(tagName: string): string {
+  return `tag_${tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -13,6 +13,7 @@ export {
   asBucketPath,
   asDollars,
   asDateString,
+  tagColumnName,
 } from './branded.js';
 
 export type {

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -10,7 +10,7 @@ import {
   readAutoSyncIntervalMinutes,
   writeAutoSyncIntervalMinutes,
 } from '../auto-sync.js';
-import type { AppContext } from './context.js';
+import { type AppContext, prefsPath } from './context.js';
 import type { SyncClient } from '../sync-client.js';
 
 type Tier = 'daily' | 'hourly' | 'cost-optimization';
@@ -23,10 +23,7 @@ function asTier(s: string): Tier {
 export function registerAutoSyncHandlers(app: AppContext): void {
   const { ctx, getConfig } = app;
 
-  async function autoSyncPrefsPath(): Promise<string> {
-    const path = await import('node:path');
-    return path.join(path.dirname(ctx.dataDir), 'app-preferences.json');
-  }
+  const autoSyncPrefsPath = () => prefsPath(ctx.dataDir, 'app-preferences');
 
   function buildAutoSyncDeps(syncClient: SyncClient) {
     return {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -223,27 +223,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const tagKey = accountDim?.accountNameFromTag;
 
     async function fromOrg(): Promise<Map<string, string>> {
-      const map = new Map<string, string>();
-      try {
-        const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
-        const parsed: unknown = JSON.parse(raw);
-        if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
-          for (const acct of parsed['accounts']) {
-            if (!isStringRecord(acct)) continue;
-            const id = acct['id'];
-            const name = acct['name'];
-            if (typeof id !== 'string' || id.length === 0) continue;
-            let resolved: string | undefined;
-            if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
-              const tagVal = acct['tags'][tagKey];
-              if (typeof tagVal === 'string' && tagVal.length > 0) resolved = tagVal;
-            }
-            if (resolved === undefined && typeof name === 'string' && name.length > 0) resolved = name;
-            if (resolved !== undefined) map.set(id, resolved);
-          }
-        }
-      } catch { /* no org sync */ }
-      return map;
+      return loadOrgAccountsMap(ctx.dataDir, tagKey);
     }
 
     async function fromCsv(): Promise<Map<string, string>> {
@@ -426,6 +406,40 @@ export function createAppContext(ctx: IpcContext): AppContext {
     invalidateCostScope: () => { state.costScope = null; },
     invalidateColumnCache: () => { columnCache.clear(); },
   };
+}
+
+/** Read org-accounts.json and return an id→name map. When tagKey is set,
+ *  each account's "name" is the value of that tag; accounts missing the tag
+ *  fall back to the Name field. */
+export async function loadOrgAccountsMap(dataDir: string, tagKey?: string): Promise<Map<string, string>> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const map = new Map<string, string>();
+  try {
+    const raw = await fs.readFile(path.join(path.dirname(dataDir), 'org-accounts.json'), 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
+      for (const acct of parsed['accounts']) {
+        if (!isStringRecord(acct)) continue;
+        const id = acct['id'];
+        const name = acct['name'];
+        if (typeof id !== 'string' || id.length === 0) continue;
+        let resolved: string | undefined;
+        if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
+          const tagVal = acct['tags'][tagKey];
+          if (typeof tagVal === 'string' && tagVal.length > 0) resolved = tagVal;
+        }
+        if (resolved === undefined && typeof name === 'string' && name.length > 0) resolved = name;
+        if (resolved !== undefined) map.set(id, resolved);
+      }
+    }
+  } catch { /* no org sync */ }
+  return map;
+}
+
+export async function prefsPath(dataDir: string, name: string): Promise<string> {
+  const path = await import('node:path');
+  return path.join(path.dirname(dataDir), `${name}.json`);
 }
 
 export function isCredentialError(err: unknown): boolean {

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -11,6 +11,7 @@ import {
   computePeriodsInRange,
   logger,
   listLocalMonths,
+  tagColumnName,
 } from '@costgoblin/core';
 import type {
   CostScopeCapabilities,
@@ -33,7 +34,7 @@ const SAMPLE_ROW_LIMIT = 500;
 function assertRuleDimensionsExist(config: CostScopeConfig, dimensions: DimensionsConfig): void {
   const knownIds = new Set<string>();
   for (const d of dimensions.builtIn) knownIds.add(String(d.name));
-  for (const t of dimensions.tags) knownIds.add(`tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`);
+  for (const t of dimensions.tags) knownIds.add(tagColumnName(t.tagName));
   for (const rule of config.rules) {
     for (const cond of rule.conditions) {
       const id = String(cond.dimensionId);
@@ -125,7 +126,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
       : 'FALSE';
 
     const tagColumns = dimensions.tags.map(t => ({
-      id: `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`,
+      id: tagColumnName(t.tagName),
       label: t.label,
     }));
 

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,39 +1,8 @@
 import { ipcMain } from 'electron';
-import { applyNormalizationRule, applyStripPatterns, isStringRecord } from '@costgoblin/core';
+import { applyNormalizationRule, applyStripPatterns } from '@costgoblin/core';
 import type { DimensionsConfig, NormalizationRule } from '@costgoblin/core';
-import type { AppContext } from './context.js';
+import { type AppContext, loadOrgAccountsMap } from './context.js';
 import { toNum, toStr } from './query-utils.js';
-
-/** One-shot read of org-accounts.json → id→name map. No caching here (the
- *  preview handler wants fresh data on every toggle change). When tagKey is
- *  set, the "name" for each account is the value of that account-level tag;
- *  accounts missing the tag fall back to the account's Name field so the
- *  preview never drops rows. */
-async function loadOrgAccountsMap(dataDir: string, tagKey?: string): Promise<Map<string, string>> {
-  const fs = await import('node:fs/promises');
-  const path = await import('node:path');
-  const map = new Map<string, string>();
-  try {
-    const raw = await fs.readFile(path.join(path.dirname(dataDir), 'org-accounts.json'), 'utf-8');
-    const parsed: unknown = JSON.parse(raw);
-    if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
-      for (const acct of parsed['accounts']) {
-        if (!isStringRecord(acct)) continue;
-        const id = acct['id'];
-        const name = acct['name'];
-        if (typeof id !== 'string' || id.length === 0) continue;
-        let resolved: string | undefined;
-        if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
-          const tagVal = acct['tags'][tagKey];
-          if (typeof tagVal === 'string' && tagVal.length > 0) resolved = tagVal;
-        }
-        if (resolved === undefined && typeof name === 'string' && name.length > 0) resolved = name;
-        if (resolved !== undefined) map.set(id, resolved);
-      }
-    }
-  } catch { /* no org sync */ }
-  return map;
-}
 
 export function registerDimensionsHandlers(app: AppContext): void {
   const { ctx, getConfig, getDimensions, getRegionMap, invalidateDimensions, runQuery } = app;

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -8,6 +8,7 @@ import {
   logger,
   listLocalMonths,
   parseJsonObject,
+  tagColumnName,
 } from '@costgoblin/core';
 import type {
   CostMetric,
@@ -28,7 +29,7 @@ import type {
   ExplorerTagColumn,
   DimensionsConfig,
 } from '@costgoblin/core';
-import type { AppContext } from './context.js';
+import { type AppContext, prefsPath } from './context.js';
 import { buildAccountReverseMap, toNum, toStr } from './query-utils.js';
 
 const DEFAULT_WINDOW_DAYS = 30;
@@ -157,7 +158,7 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
   const accountMap = await getAccountMap();
 
   const tagColumns: readonly ExplorerTagColumn[] = dimensions.tags.map(t => ({
-    id: `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`,
+    id: tagColumnName(t.tagName),
     label: t.label,
   }));
   const tagIdSet = new Set(tagColumns.map(t => t.id));
@@ -234,10 +235,7 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
 export function registerExplorerHandlers(app: AppContext): void {
   const { ctx, runQuery } = app;
 
-  async function explorerPrefsPath(): Promise<string> {
-    const path = await import('node:path');
-    return path.join(path.dirname(ctx.dataDir), 'explorer-preferences.json');
-  }
+  const explorerPrefsPath = () => prefsPath(ctx.dataDir, 'explorer-preferences');
 
   ipcMain.handle('explorer:get-preferences', async (): Promise<ExplorerPreferences> => {
     const fs = await import('node:fs/promises');
@@ -424,11 +422,11 @@ export function registerExplorerHandlers(app: AppContext): void {
     if (qc.empty) return [];
 
     const builtIn = qc.dimensions.builtIn.find(d => d.name === dimId);
-    const tag = qc.dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimId);
+    const tag = qc.dimensions.tags.find(d => tagColumnName(d.tagName) === dimId);
     const field = builtIn === undefined ? dimId : builtIn.field;
     let fieldExpr = field;
     if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
-    else if (tag !== undefined) fieldExpr = buildAliasSqlCase(`tag_${tag.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`, tag);
+    else if (tag !== undefined) fieldExpr = buildAliasSqlCase(tagColumnName(tag.tagName), tag);
 
     const sql = `
       SELECT ${fieldExpr} AS val,

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -3,6 +3,7 @@ import {
   asDollars,
   asDateString,
   getDescendantTagValues,
+  tagColumnName,
 } from '@costgoblin/core';
 import type {
   CostResult,
@@ -47,7 +48,7 @@ export function toStr(v: unknown): string {
 
 export function isOwnerGroupBy(groupBy: string, dimensions: DimensionsConfig): boolean {
   return dimensions.tags.some(
-    t => t.concept === 'owner' && `tag_${t.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === groupBy,
+    t => t.concept === 'owner' && tagColumnName(t.tagName) === groupBy,
   );
 }
 

--- a/packages/desktop/src/main/handlers/query.ts
+++ b/packages/desktop/src/main/handlers/query.ts
@@ -15,6 +15,7 @@ import {
   asEntityRef,
   asDollars,
   asDateString,
+  tagColumnName,
 } from '@costgoblin/core';
 import type {
   CostQueryParams,
@@ -338,7 +339,7 @@ export function registerQueryHandlers(app: AppContext): void {
       : await getCostScope().catch(() => undefined);
 
     const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
-    const tag = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === dimensionId);
+    const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
 
     const field = builtIn === undefined ? dimensionId : builtIn.field;
     // Apply alias/normalize CASE for both built-ins and tags so the SQL
@@ -354,7 +355,7 @@ export function registerQueryHandlers(app: AppContext): void {
     const whereClauses: string[] = [];
     for (const [key, value] of Object.entries(filterEntries)) {
       const fb = dimensions.builtIn.find(d => d.name === key);
-      const ft = dimensions.tags.find(d => `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}` === key);
+      const ft = dimensions.tags.find(d => tagColumnName(d.tagName) === key);
       const ff = fb === undefined ? key : fb.field;
       let ffExpr = ff;
       if (fb !== undefined) {

--- a/packages/desktop/src/main/handlers/savings.ts
+++ b/packages/desktop/src/main/handlers/savings.ts
@@ -1,15 +1,12 @@
 import { ipcMain } from 'electron';
 import { parseJsonObject } from '@costgoblin/core';
 import type { SavingsPreferences } from '@costgoblin/core';
-import type { AppContext } from './context.js';
+import { type AppContext, prefsPath } from './context.js';
 
 export function registerSavingsHandlers(app: AppContext): void {
   const { ctx } = app;
 
-  async function savingsPrefsPath(): Promise<string> {
-    const path = await import('node:path');
-    return path.join(path.dirname(ctx.dataDir), 'savings-preferences.json');
-  }
+  const savingsPrefsPath = () => prefsPath(ctx.dataDir, 'savings-preferences');
 
   ipcMain.handle('savings:get-preferences', async (): Promise<SavingsPreferences> => {
     const fs = await import('node:fs/promises');

--- a/packages/desktop/src/main/handlers/ui.ts
+++ b/packages/desktop/src/main/handlers/ui.ts
@@ -1,15 +1,12 @@
 import { ipcMain } from 'electron';
 import { parseJsonObject } from '@costgoblin/core';
 import type { UIPreferences } from '@costgoblin/core';
-import type { AppContext } from './context.js';
+import { type AppContext, prefsPath } from './context.js';
 
 export function registerUIHandlers(app: AppContext): void {
   const { ctx } = app;
 
-  async function uiPrefsPath(): Promise<string> {
-    const path = await import('node:path');
-    return path.join(path.dirname(ctx.dataDir), 'ui-preferences.json');
-  }
+  const uiPrefsPath = () => prefsPath(ctx.dataDir, 'ui-preferences');
 
   ipcMain.handle('ui:get-preferences', async (): Promise<UIPreferences> => {
     const fs = await import('node:fs/promises');

--- a/packages/ui/src/lib/dimensions.ts
+++ b/packages/ui/src/lib/dimensions.ts
@@ -1,9 +1,9 @@
 import type { Dimension, DimensionId } from '@costgoblin/core/browser';
-import { asDimensionId } from '@costgoblin/core/browser';
+import { asDimensionId, tagColumnName } from '@costgoblin/core/browser';
 
 export function getDimensionId(dim: Dimension): DimensionId {
   if ('tagName' in dim) {
-    return asDimensionId(`tag_${dim.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`);
+    return asDimensionId(tagColumnName(dim.tagName));
   }
   return dim.name;
 }

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -13,6 +13,7 @@ import type {
   Dimension,
 } from '@costgoblin/core/browser';
 import { BUILTIN_EXCLUSION_RULES, COST_METRICS, DEFAULT_COST_SCOPE, asDimensionId } from '@costgoblin/core/browser';
+import { getDimensionId } from '../lib/dimensions.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { formatDollars } from '../components/format.js';
@@ -44,9 +45,6 @@ interface PreviewState {
   loading: boolean;
 }
 
-function dimIdFor(d: Dimension): string {
-  return 'name' in d ? String(d.name) : `tag_${d.tagName.replace(/[^a-zA-Z0-9]/g, '_')}`;
-}
 
 interface ConditionRowProps {
   condition: ExclusionCondition;
@@ -102,7 +100,7 @@ function ConditionRow({ condition, dimensions, suggestions, onUpdate, onRemove, 
       >
         {currentDimId.length === 0 && <option value="">— pick dimension —</option>}
         {dimensions.map(d => {
-          const id = dimIdFor(d);
+          const id = getDimensionId(d);
           const hidden = d.enabled === false;
           return <option key={id} value={id}>{hidden ? `${d.label} (hidden)` : d.label}</option>;
         })}
@@ -206,7 +204,7 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
 
   function addCondition() {
     const firstDim = dimensions.find(d => d.enabled !== false);
-    const dimId = firstDim !== undefined ? dimIdFor(firstDim) : 'service';
+    const dimId = firstDim !== undefined ? getDimensionId(firstDim) : 'service';
     onUpdate({
       ...rule,
       conditions: [...rule.conditions, { dimensionId: asDimensionId(dimId), values: [] }],
@@ -611,7 +609,7 @@ export function CostScopeView(): React.JSX.Element {
       const enabled = dimensions.filter(d => d.enabled !== false);
       const next = new Map<string, readonly string[]>();
       await Promise.all(enabled.map(async d => {
-        const id = dimIdFor(d);
+        const id = getDimensionId(d);
         try {
           // bypassCostScope: users composing an exclusion rule need to
           // see every value a dim can take, including ones the saved
@@ -680,7 +678,7 @@ export function CostScopeView(): React.JSX.Element {
 
   function addRule() {
     const firstDim = dimensions.find(d => d.enabled !== false);
-    const dimId = firstDim !== undefined ? dimIdFor(firstDim) : 'service';
+    const dimId = firstDim !== undefined ? getDimensionId(firstDim) : 'service';
     // New rules start disabled: they have empty `values` by default, which
     // fails validation — shipping them enabled by default would instantly
     // block saves and blank the preview until the user fills the field in.


### PR DESCRIPTION
## Summary

Consolidate duplicated logic across core and desktop packages.

## Plan

- [ ] **Deduplicate `extractPeriod`** — remove duplicate in `core/sync/data-inventory.ts`, import from `sync-utils.ts`
- [ ] **Deduplicate etag maps** — remove `ETAG_FILES` in `data-inventory.ts`, use `getEtagFileName()` from `sync-utils.ts`
- [ ] **Move `getDimensionId` to `@costgoblin/core`** — replace 9+ reimplementations across all packages
- [ ] **Extract org-accounts.json loading** — shared utility in desktop, fix transform inconsistency between `context.ts` and `dimensions.ts`
- [ ] **Extract CSV account parsing** — shared utility with named column constants instead of magic indices
- [ ] **Extract prefs path helper** — replace 4 inline `path.join(path.dirname(...))` constructions
- [ ] **Extract `setupCommonQuery()` in `builder.ts`** — deduplicate 5-7 lines repeated in 6 query builder functions