### PR TITLE
Pie chart: fallback to related dimension on single-value filter

### DIFF
--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -5,9 +5,14 @@ import { HeatmapChart } from '../components/heatmap-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { HeatmapCell } from '../components/heatmap-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { DailyCostsResult } from '@costgoblin/core/browser';
+import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
+
+interface DailyQueryResult {
+  readonly result: DailyCostsResult;
+  readonly groupBy: DimensionId;
+}
 
 interface BuiltCells {
   readonly cells: readonly HeatmapCell[];
@@ -55,17 +60,26 @@ export function HeatmapWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const query = useQuery(
-    () => api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+  const query = useQuery<DailyQueryResult>(
+    async () => {
+      const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+      const fallbackDim = getDimensionFallback(specGroupBy);
+      if (primary.groups.length <= 1 && fallbackDim !== undefined) {
+        const fallback = await api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
+        return { result: fallback, groupBy: fallbackDim };
+      }
+      return { result: primary, groupBy: specGroupBy };
+    },
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
+  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
   const { cells, groups, dates } = useMemo(
-    () => buildCells(query.status === 'success' ? query.data : null, topN),
+    () => buildCells(query.status === 'success' ? query.data.result : null, topN),
     [query, topN],
   );
 
-  const label = dimensionLabelFor(dimensions, specGroupBy);
+  const label = dimensionLabelFor(dimensions, activeGroupBy);
 
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
 
@@ -76,7 +90,7 @@ export function HeatmapWidget({
       dates={dates}
       title={spec.title ?? `${label} × Day`}
       subtitle="Click a cell to filter"
-      onCellClick={(group) => { onSetFilter(specGroupBy, asTagValue(group)); }}
+      onCellClick={(group) => { onSetFilter(activeGroupBy, asTagValue(group)); }}
     />
   );
 }

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -5,9 +5,14 @@ import { LineChart } from '../components/line-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { LineSeries } from '../components/line-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { DailyCostsResult } from '@costgoblin/core/browser';
+import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
+
+interface DailyQueryResult {
+  readonly result: DailyCostsResult;
+  readonly groupBy: DimensionId;
+}
 
 function buildSeries(data: DailyCostsResult | null, topN: number): LineSeries[] {
   if (data === null) return [];
@@ -45,18 +50,27 @@ export function LineWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const query = useQuery(
-    () => api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+  const query = useQuery<DailyQueryResult>(
+    async () => {
+      const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+      const fallbackDim = getDimensionFallback(specGroupBy);
+      if (primary.groups.length <= 1 && fallbackDim !== undefined) {
+        const fallback = await api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
+        return { result: fallback, groupBy: fallbackDim };
+      }
+      return { result: primary, groupBy: specGroupBy };
+    },
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
+  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
   const topN = spec.topN ?? 6;
   const series = useMemo(
-    () => buildSeries(query.status === 'success' ? query.data : null, topN),
+    () => buildSeries(query.status === 'success' ? query.data.result : null, topN),
     [query, topN],
   );
 
-  const label = dimensionLabelFor(dimensions, specGroupBy);
+  const label = dimensionLabelFor(dimensions, activeGroupBy);
 
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
 
@@ -65,7 +79,7 @@ export function LineWidget({
       series={series}
       title={spec.title ?? `${label} over time`}
       subtitle={`Top ${String(topN)} • Click to filter, dbl-click to hide`}
-      onSeriesClick={(name) => { onSetFilter(specGroupBy, asTagValue(name)); }}
+      onSeriesClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
     />
   );
 }

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -6,9 +6,14 @@ import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { PieSlice } from '../components/pie-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult } from '@costgoblin/core/browser';
+import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
+
+interface PieQueryResult {
+  readonly result: CostResult;
+  readonly groupBy: DimensionId;
+}
 
 function rowsToSlices(data: CostResult | null): PieSlice[] {
   if (data === null) return [];
@@ -38,16 +43,26 @@ export function PieWidget({
   const baseFilters = mergeFilters(globalFilters, spec.filters);
 
   const fk = filtersKey(baseFilters);
-  const query = useQuery(
-    () => api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity }),
+  const query = useQuery<PieQueryResult>(
+    async () => {
+      const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity });
+      const fallbackDim = getDimensionFallback(specGroupBy);
+      if (primary.rows.length <= 1 && fallbackDim !== undefined) {
+        const fallback = await api.queryCosts({ groupBy: fallbackDim, dateRange, filters: baseFilters, granularity });
+        return { result: fallback, groupBy: fallbackDim };
+      }
+      return { result: primary, groupBy: specGroupBy };
+    },
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
+
+  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
   const slices = useMemo(
-    () => rowsToSlices(query.status === 'success' ? query.data : null),
+    () => rowsToSlices(query.status === 'success' ? query.data.result : null),
     [query],
   );
 
-  const label = dimensionLabelFor(dimensions, specGroupBy);
+  const label = dimensionLabelFor(dimensions, activeGroupBy);
 
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
 
@@ -56,9 +71,9 @@ export function PieWidget({
       data={slices}
       title={specTitle ?? label}
       subtitle="Click to filter"
-      onSliceClick={(name) => { onSetFilter(specGroupBy, asTagValue(name)); }}
-      onSliceHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: specGroupBy }); }}
-      externalHoveredName={focus.hoveredDimension === specGroupBy ? focus.hoveredEntity : null}
+      onSliceClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
+      onSliceHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: activeGroupBy }); }}
+      externalHoveredName={focus.hoveredDimension === activeGroupBy ? focus.hoveredEntity : null}
     />
   );
 }

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -6,9 +6,14 @@ import { StackedBarChart } from '../components/stacked-bar-chart.js';
 import type { BarDay } from '../components/stacked-bar-chart.js';
 import type { HistogramTab } from '../components/stacked-bar-chart.js';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
-import type { DailyCostsResult } from '@costgoblin/core/browser';
+import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { filtersKey, mergeFilters } from './widget.js';
+import { filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
+
+interface DailyQueryResult {
+  readonly result: DailyCostsResult;
+  readonly groupBy: DimensionId;
+}
 
 function getISOWeekStart(dateStr: string): string {
   const d = new Date(dateStr);
@@ -61,15 +66,23 @@ export function StackedBarWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const query = useQuery(
-    () => api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+  const query = useQuery<DailyQueryResult>(
+    async () => {
+      const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+      const fallbackDim = getDimensionFallback(specGroupBy);
+      if (primary.groups.length <= 1 && fallbackDim !== undefined) {
+        const fallback = await api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
+        return { result: fallback, groupBy: fallbackDim };
+      }
+      return { result: primary, groupBy: specGroupBy };
+    },
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const periodDays = daysBetween(dateRange.start, dateRange.end);
   const useWeekly = periodDays > 90;
   const barDays = useMemo(
-    () => dailyToBarDays(query.status === 'success' ? query.data : null, useWeekly),
+    () => dailyToBarDays(query.status === 'success' ? query.data.result : null, useWeekly),
     [query, useWeekly],
   );
   const loading = query.status === 'loading';

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -6,9 +6,14 @@ import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { TopNBar } from '../components/top-n-bar-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult } from '@costgoblin/core/browser';
+import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
+
+interface CostQueryResult {
+  readonly result: CostResult;
+  readonly groupBy: DimensionId;
+}
 
 function rowsToBars(data: CostResult | null): TopNBar[] {
   if (data === null) return [];
@@ -36,16 +41,26 @@ export function TopNBarWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const query = useQuery(
-    () => api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+  const query = useQuery<CostQueryResult>(
+    async () => {
+      const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+      const fallbackDim = getDimensionFallback(specGroupBy);
+      if (primary.rows.length <= 1 && fallbackDim !== undefined) {
+        const fallback = await api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
+        return { result: fallback, groupBy: fallbackDim };
+      }
+      return { result: primary, groupBy: specGroupBy };
+    },
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
+
+  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
   const bars = useMemo(
-    () => rowsToBars(query.status === 'success' ? query.data : null),
+    () => rowsToBars(query.status === 'success' ? query.data.result : null),
     [query],
   );
 
-  const label = dimensionLabelFor(dimensions, specGroupBy);
+  const label = dimensionLabelFor(dimensions, activeGroupBy);
 
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
 
@@ -55,9 +70,9 @@ export function TopNBarWidget({
       title={spec.title ?? label}
       subtitle="Click to filter"
       topN={spec.topN ?? 12}
-      onBarClick={(name) => { onSetFilter(specGroupBy, asTagValue(name)); }}
-      onBarHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: specGroupBy }); }}
-      externalHoveredName={focus.hoveredDimension === specGroupBy ? focus.hoveredEntity : null}
+      onBarClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
+      onBarHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: activeGroupBy }); }}
+      externalHoveredName={focus.hoveredDimension === activeGroupBy ? focus.hoveredEntity : null}
     />
   );
 }

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -5,9 +5,14 @@ import { TreemapChart } from '../components/treemap-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { TreemapCell } from '../components/treemap-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult } from '@costgoblin/core/browser';
+import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
+
+interface CostQueryResult {
+  readonly result: CostResult;
+  readonly groupBy: DimensionId;
+}
 
 function rowsToCells(data: CostResult | null): TreemapCell[] {
   if (data === null) return [];
@@ -28,16 +33,25 @@ export function TreemapWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const query = useQuery(
-    () => api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+  const query = useQuery<CostQueryResult>(
+    async () => {
+      const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+      const fallbackDim = getDimensionFallback(specGroupBy);
+      if (primary.rows.length <= 1 && fallbackDim !== undefined) {
+        const fallback = await api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
+        return { result: fallback, groupBy: fallbackDim };
+      }
+      return { result: primary, groupBy: specGroupBy };
+    },
     [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
+  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
   const cells = useMemo(
-    () => rowsToCells(query.status === 'success' ? query.data : null),
+    () => rowsToCells(query.status === 'success' ? query.data.result : null),
     [query],
   );
-  const label = dimensionLabelFor(dimensions, specGroupBy);
+  const label = dimensionLabelFor(dimensions, activeGroupBy);
 
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
 
@@ -46,7 +60,7 @@ export function TreemapWidget({
       data={cells}
       title={spec.title ?? label}
       subtitle="Click to filter"
-      onCellClick={(name) => { onSetFilter(specGroupBy, asTagValue(name)); }}
+      onCellClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
     />
   );
 }

--- a/packages/ui/src/widgets/widget.ts
+++ b/packages/ui/src/widgets/widget.ts
@@ -11,7 +11,17 @@ import type {
   WidgetSize,
   WidgetSpec,
 } from '@costgoblin/core/browser';
+import { asDimensionId } from '@costgoblin/core/browser';
 import { getDimensionId, getDimensionLabel } from '../lib/dimensions.js';
+
+const DIMENSION_FALLBACKS: ReadonlyMap<DimensionId, DimensionId> = new Map([
+  [asDimensionId('service'), asDimensionId('service_family')],
+  [asDimensionId('service_family'), asDimensionId('service')],
+]);
+
+export function getDimensionFallback(dimId: DimensionId): DimensionId | undefined {
+  return DIMENSION_FALLBACKS.get(dimId);
+}
 
 /** Props every widget renderer receives. The host view owns the global
  *  FilterBar/DateRangePicker; each widget owns its own data fetching and


### PR DESCRIPTION
## Summary

- When a filter on **AWS Service** or **Service Category** reduces the pie chart to a single slice (useless view), automatically re-queries with the other related dimension
- E.g. filtering by `service_family: "Compute"` on a `service_family` pie → falls back to showing the `service` breakdown instead
- Title, click-to-filter, and hover tracking all update to reflect the active dimension