### PR TITLE
Dynamic GROUP BY dashboard table widget

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -9,6 +9,8 @@ import type {
   ExplorerPreferences,
   ExplorerRowsParams,
   ExplorerRowsResult,
+  AggregatedTableParams,
+  AggregatedTableResult,
 } from './explorer.js';
 import type {
   CostQueryParams,
@@ -138,6 +140,7 @@ export interface CostApi {
    *  fires when sort / filters / range / scope changes — the overview
    *  query handles the histogram independently. */
   queryExplorerRows(params: ExplorerRowsParams): Promise<ExplorerRowsResult>;
+  queryAggregatedTable(params: AggregatedTableParams): Promise<AggregatedTableResult>;
   /** Facet values for a single dim under the explorer's other filters.
    *  Rolls the current dim out of the filter set so the dropdown shows
    *  every value remaining under the other filters. */

--- a/packages/core/src/types/explorer.ts
+++ b/packages/core/src/types/explorer.ts
@@ -105,6 +105,26 @@ export interface ExplorerRowsResult {
   readonly tagColumns: readonly ExplorerTagColumn[];
 }
 
+export interface AggregatedTableParams extends ExplorerBaseParams {
+  readonly groupByColumns: readonly string[];
+  readonly sort?: ExplorerSort;
+  readonly rowLimit: number;
+}
+
+export interface AggregatedTableRow {
+  readonly values: Readonly<Record<string, string>>;
+  readonly cost: number;
+  readonly listCost: number;
+  readonly usageAmount: number;
+  readonly rowCount: number;
+}
+
+export interface AggregatedTableResult {
+  readonly rows: readonly AggregatedTableRow[];
+  readonly totalRows: number;
+  readonly tagColumns: readonly ExplorerTagColumn[];
+}
+
 export interface ExplorerFilterValue {
   readonly value: string;
   readonly label: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -105,4 +105,7 @@ export type {
   ExplorerFilterValue,
   ExplorerFilterValuesParams,
   ExplorerPreferences,
+  AggregatedTableParams,
+  AggregatedTableRow,
+  AggregatedTableResult,
 } from './explorer.js';

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -41,9 +41,7 @@ const DEFAULT_BUILT_INS: readonly BuiltInDimension[] = [
   // Very high cardinality — disabled by default so the normal filter/nav
   // pickers stay scannable. The Explorer references it directly so
   // click-to-filter on a resource cell works whether or not this dim is
-  // enabled, and users who want a dedicated "per-resource" view can flip
-  // it on in Dimensions.
-  { name: asDimensionId('resource_id'), label: 'Resource', field: 'resource_id', description: 'AWS resource ID or ARN (i-0abc…, arn:aws:rds:…). High-cardinality — enable when investigating a specific resource.', enabled: false },
+  { name: asDimensionId('resource_id'), label: 'Resource', field: 'resource_id', description: 'AWS resource ID or ARN (i-0abc…, arn:aws:rds:…). High-cardinality — useful for drilling into specific resources.' },
 ];
 
 /** Renames we want propagated to existing configs. Only overrides the stored

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -28,6 +28,9 @@ import type {
   ExplorerDailyRow,
   ExplorerTagColumn,
   DimensionsConfig,
+  AggregatedTableParams,
+  AggregatedTableRow,
+  AggregatedTableResult,
 } from '@costgoblin/core';
 import { type AppContext, prefsPath } from './context.js';
 import { buildAccountReverseMap, toNum, toStr } from './query-utils.js';
@@ -405,6 +408,88 @@ export function registerExplorerHandlers(app: AppContext): void {
     }
 
     return { sampleRows, tagColumns: qc.tagColumns };
+  });
+
+  ipcMain.handle('explorer:query-aggregated-table', async (_event, payload: unknown): Promise<AggregatedTableResult> => {
+    const params = payload as AggregatedTableParams;
+    const qc = await prepareQueryContext(app, params);
+    const rowLimit = clampRowLimit(params.rowLimit);
+
+    if (qc.empty) return { rows: [], totalRows: 0, tagColumns: qc.tagColumns };
+
+    const groupByColumns = params.groupByColumns.filter(
+      col => SORTABLE_SCALAR_COLUMNS.has(col) || qc.tagIdSet.has(col),
+    );
+
+    if (groupByColumns.length === 0) {
+      const sql = `
+        SELECT
+          CAST(SUM(cost) AS DOUBLE) AS cost,
+          CAST(SUM(list_cost) AS DOUBLE) AS list_cost,
+          CAST(SUM(usage_amount) AS DOUBLE) AS usage_amount,
+          CAST(COUNT(*) AS DOUBLE) AS row_count
+        FROM ${qc.source}
+        ${qc.whereStr}
+      `.trim();
+      const rows = await runQuery(sql);
+      const r = rows[0];
+      if (r === undefined) return { rows: [], totalRows: 0, tagColumns: qc.tagColumns };
+      return {
+        rows: [{ values: {}, cost: toNum(r['cost']), listCost: toNum(r['list_cost']), usageAmount: toNum(r['usage_amount']), rowCount: toNum(r['row_count']) }],
+        totalRows: 1,
+        tagColumns: qc.tagColumns,
+      };
+    }
+
+    const selectCols = groupByColumns.map(col => {
+      if (col === 'usage_date') return `usage_date::VARCHAR AS usage_date`;
+      return col;
+    });
+    const orderBy = buildOrderBy(params.sort, qc.tagIdSet);
+
+    const countSql = `
+      SELECT CAST(COUNT(*) AS DOUBLE) AS n FROM (
+        SELECT 1 FROM ${qc.source} ${qc.whereStr}
+        GROUP BY ${groupByColumns.join(', ')}
+      )
+    `.trim();
+    const dataSql = `
+      SELECT
+        ${selectCols.join(', ')},
+        CAST(SUM(cost) AS DOUBLE) AS cost,
+        CAST(SUM(list_cost) AS DOUBLE) AS list_cost,
+        CAST(SUM(usage_amount) AS DOUBLE) AS usage_amount,
+        CAST(COUNT(*) AS DOUBLE) AS row_count
+      FROM ${qc.source}
+      ${qc.whereStr}
+      GROUP BY ${groupByColumns.join(', ')}
+      ORDER BY ${orderBy}
+      LIMIT ${String(rowLimit)}
+    `.trim();
+
+    let totalRows = 0;
+    let resultRows: AggregatedTableRow[] = [];
+    try {
+      const [countResult, dataResult] = await Promise.all([runQuery(countSql), runQuery(dataSql)]);
+      totalRows = countResult[0] !== undefined ? toNum(countResult[0]['n']) : 0;
+      resultRows = dataResult.map(r => {
+        const values: Record<string, string> = {};
+        for (const col of groupByColumns) {
+          values[col] = toStr(r[col]);
+        }
+        return {
+          values,
+          cost: toNum(r['cost']),
+          listCost: toNum(r['list_cost']),
+          usageAmount: toNum(r['usage_amount']),
+          rowCount: toNum(r['row_count']),
+        };
+      });
+    } catch (err) {
+      logger.warn(`explorer: aggregated table query failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return { rows: resultRows, totalRows, tagColumns: qc.tagColumns };
   });
 
   ipcMain.handle('explorer:filter-values', async (_event, payload: unknown): Promise<ExplorerFilterValue[]> => {

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -445,7 +445,17 @@ export function registerExplorerHandlers(app: AppContext): void {
       if (col === 'usage_date') return `usage_date::VARCHAR AS usage_date`;
       return col;
     });
-    const orderBy = buildOrderBy(params.sort, qc.tagIdSet);
+    const orderBy = (() => {
+      if (params.sort === undefined) return 'SUM(cost) DESC';
+      const dir = params.sort.direction === 'asc' ? 'ASC' : 'DESC';
+      const col = params.sort.column;
+      if (col === 'cost') return `SUM(cost) ${dir}`;
+      if (col === 'list_cost') return `SUM(list_cost) ${dir}`;
+      if (col === 'usage_amount') return `SUM(usage_amount) ${dir}`;
+      if (col === 'row_count') return `COUNT(*) ${dir}`;
+      if (groupByColumns.includes(col)) return `${col} ${dir}`;
+      return 'SUM(cost) DESC';
+    })();
 
     const countSql = `
       SELECT CAST(COUNT(*) AS DOUBLE) AS n FROM (

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -451,7 +451,7 @@ export function registerExplorerHandlers(app: AppContext): void {
       SELECT CAST(COUNT(*) AS DOUBLE) AS n FROM (
         SELECT 1 FROM ${qc.source} ${qc.whereStr}
         GROUP BY ${groupByColumns.join(', ')}
-      )
+      ) AS _cnt
     `.trim();
     const dataSql = `
       SELECT
@@ -467,27 +467,21 @@ export function registerExplorerHandlers(app: AppContext): void {
       LIMIT ${String(rowLimit)}
     `.trim();
 
-    let totalRows = 0;
-    let resultRows: AggregatedTableRow[] = [];
-    try {
-      const [countResult, dataResult] = await Promise.all([runQuery(countSql), runQuery(dataSql)]);
-      totalRows = countResult[0] !== undefined ? toNum(countResult[0]['n']) : 0;
-      resultRows = dataResult.map(r => {
-        const values: Record<string, string> = {};
-        for (const col of groupByColumns) {
-          values[col] = toStr(r[col]);
-        }
-        return {
-          values,
-          cost: toNum(r['cost']),
-          listCost: toNum(r['list_cost']),
-          usageAmount: toNum(r['usage_amount']),
-          rowCount: toNum(r['row_count']),
-        };
-      });
-    } catch (err) {
-      logger.warn(`explorer: aggregated table query failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    const [countResult, dataResult] = await Promise.all([runQuery(countSql), runQuery(dataSql)]);
+    const totalRows = countResult[0] !== undefined ? toNum(countResult[0]['n']) : 0;
+    const resultRows: AggregatedTableRow[] = dataResult.map(r => {
+      const values: Record<string, string> = {};
+      for (const col of groupByColumns) {
+        values[col] = toStr(r[col]);
+      }
+      return {
+        values,
+        cost: toNum(r['cost']),
+        listCost: toNum(r['list_cost']),
+        usageAmount: toNum(r['usage_amount']),
+        rowCount: toNum(r['row_count']),
+      };
+    });
 
     return { rows: resultRows, totalRows, tagColumns: qc.tagColumns };
   });

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -37,6 +37,8 @@ import type {
   ExplorerPreferences,
   ExplorerRowsParams,
   ExplorerRowsResult,
+  AggregatedTableParams,
+  AggregatedTableResult,
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
@@ -230,6 +232,9 @@ const api: CostApi = {
   },
   queryExplorerRows(params: ExplorerRowsParams): Promise<ExplorerRowsResult> {
     return invoke<ExplorerRowsResult>('explorer:query-rows', params);
+  },
+  queryAggregatedTable(params: AggregatedTableParams): Promise<AggregatedTableResult> {
+    return invoke<AggregatedTableResult>('explorer:query-aggregated-table', params);
   },
   getExplorerFilterValues(params: ExplorerFilterValuesParams): Promise<ExplorerFilterValue[]> {
     return invoke<ExplorerFilterValue[]>('explorer:filter-values', params);

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -330,6 +330,16 @@ export class MockCostApi implements CostApi {
       ],
     });
   }
+  queryAggregatedTable(): Promise<import('@costgoblin/core/browser').AggregatedTableResult> {
+    return Promise.resolve({
+      rows: [
+        { values: { service: 'Amazon EC2', region: 'eu-central-1' }, cost: 1_180.5, listCost: 1_200, usageAmount: 24, rowCount: 500 },
+        { values: { service: 'Amazon RDS', region: 'us-east-1' }, cost: 420, listCost: 500, usageAmount: 12, rowCount: 200 },
+      ],
+      totalRows: 2,
+      tagColumns: [{ id: 'tag_team', label: 'Team' }, { id: 'tag_env', label: 'Environment' }],
+    });
+  }
   getExplorerFilterValues(): Promise<ExplorerFilterValue[]> {
     return Promise.resolve([
       { value: 'Amazon EC2', label: 'Amazon EC2', cost: 18_000, rows: 8_400 },

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ExplorerSampleRow, ExplorerSort, ExplorerTagColumn } from '@costgoblin/core/browser';
+import type { AggregatedTableRow, ExplorerSort, ExplorerTagColumn } from '@costgoblin/core/browser';
 import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
 
@@ -18,8 +18,8 @@ export interface ColumnSpec {
 }
 
 export const BASE_COLUMNS: readonly ColumnSpec[] = [
-  { key: 'usage_date', label: 'Date', dimId: null, align: 'left', mono: true },
-  { key: 'usage_hour', label: 'Hour', dimId: null, align: 'left', mono: true },
+  { key: 'usage_date', label: 'Date', dimId: 'usage_date', align: 'left', mono: true },
+  { key: 'usage_hour', label: 'Hour', dimId: 'usage_hour', align: 'left', mono: true },
   { key: 'cost', label: 'Cost', dimId: null, align: 'right', mono: true },
   { key: 'list_cost', label: 'List', dimId: null, align: 'right', mono: true },
   { key: 'service', label: 'Service', dimId: 'service', align: 'left' },
@@ -34,7 +34,7 @@ export const BASE_COLUMNS: readonly ColumnSpec[] = [
 
 export const TRAILING_COLUMNS: readonly ColumnSpec[] = [
   { key: 'resource_id', label: 'Resource', dimId: 'resource_id', align: 'left', mono: true, truncate: true },
-  { key: 'description', label: 'Description', dimId: null, align: 'left', truncate: true },
+  { key: 'description', label: 'Description', dimId: 'description', align: 'left', truncate: true },
 ];
 
 
@@ -206,7 +206,7 @@ interface DataTableProps {
   readonly autoHiddenKeys: ReadonlySet<string>;
   readonly onHiddenColumnsChange: (next: readonly string[]) => void;
   readonly onColumnOrderChange: (next: readonly string[]) => void;
-  readonly rows: readonly ExplorerSampleRow[];
+  readonly rows: readonly AggregatedTableRow[];
   readonly totalRows: number;
   readonly sort: ExplorerSort | undefined;
   readonly onSort: (columnKey: string) => void;
@@ -274,7 +274,7 @@ export function DataTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, 
               const isExpanded = expandedIdx === i;
               return (
                 <ExpandableRow
-                  key={`${String(i)}-${r.resourceId}-${r.date}`}
+                  key={String(i)}
                   row={r}
                   columns={columns}
                   allColumns={allColumns}
@@ -323,10 +323,10 @@ function ColumnHeader({ spec, sort, onSort }: { spec: ColumnSpec; sort: Explorer
   );
 }
 
-function RowCell({ spec, row, onFilterAdd }: { spec: ColumnSpec; row: ExplorerSampleRow; onFilterAdd: (dimId: string, value: string) => void }) {
+function RowCell({ spec, row, onFilterAdd }: { spec: ColumnSpec; row: AggregatedTableRow; onFilterAdd: (dimId: string, value: string) => void }) {
   const display = renderCell(spec, row);
-  const rawValue = filterValueFor(spec, row);
-  const titleText = spec.truncate === true ? stringValueFor(spec, row) : undefined;
+  const rawValue = spec.dimId !== null ? (row.values[spec.key] ?? '') : null;
+  const titleText = spec.truncate === true ? (row.values[spec.key] ?? '') : undefined;
   const classes = [
     'px-2 py-1 whitespace-nowrap',
     spec.align === 'right' ? 'text-right' : '',
@@ -347,83 +347,22 @@ function RowCell({ spec, row, onFilterAdd }: { spec: ColumnSpec; row: ExplorerSa
   return <td className={classes} title={titleText}>{display}</td>;
 }
 
-function stringValueFor(spec: ColumnSpec, row: ExplorerSampleRow): string {
+function renderCell(spec: ColumnSpec, row: AggregatedTableRow): React.ReactNode {
   switch (spec.key) {
-    case 'resource_id': return row.resourceId;
-    case 'description': return row.description;
-    default: return row.tags[spec.key] ?? '';
-  }
-}
-
-function renderCell(spec: ColumnSpec, row: ExplorerSampleRow): React.ReactNode {
-  switch (spec.key) {
-    case 'usage_date': return row.date;
-    case 'usage_hour': {
-      if (row.hour.length === 0) return '';
-      const time = row.hour.includes(' ') ? row.hour.split(' ')[1] ?? row.hour : row.hour;
-      return time.slice(0, 8);
-    }
     case 'cost': {
       const cls = row.cost < 0 ? 'text-warning' : '';
       return <span className={cls}>{formatSignedDollars(row.cost)}</span>;
     }
     case 'list_cost': return formatSignedDollars(row.listCost);
-    case 'service': return row.service;
-    case 'account_name': return row.accountName.length > 0 ? row.accountName : row.accountId;
-    case 'line_item_type': return row.lineItemType;
-    case 'region': return row.region;
-    case 'service_family': return row.serviceFamily;
-    case 'usage_type': return row.usageType;
-    case 'operation': return row.operation;
     case 'usage_amount': return row.usageAmount === 0 ? '' : row.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 });
-    case 'resource_id': return row.resourceId;
-    case 'description': return row.description;
-    default: return row.tags[spec.key] ?? '';
-  }
-}
-
-function filterValueFor(spec: ColumnSpec, row: ExplorerSampleRow): string | null {
-  switch (spec.key) {
-    case 'service': return row.service;
-    case 'account_name': return row.accountName.length > 0 ? row.accountName : row.accountId;
-    case 'line_item_type': return row.lineItemType;
-    case 'region': return row.region;
-    case 'service_family': return row.serviceFamily;
-    case 'usage_type': return row.usageType;
-    case 'operation': return row.operation;
-    case 'resource_id': return row.resourceId.length > 0 ? row.resourceId : null;
-    default: {
-      if (spec.dimId !== null && spec.dimId.startsWith('tag_')) {
-        const v = row.tags[spec.key];
-        return v === undefined || v.length === 0 ? null : v;
-      }
-      return null;
-    }
+    default: return row.values[spec.key] ?? '';
   }
 }
 
 // --- Expandable Row ---
 
-const ROW_FIELDS: readonly { key: string; label: string; render: (r: ExplorerSampleRow) => string }[] = [
-  { key: 'date', label: 'Date', render: r => r.date },
-  { key: 'hour', label: 'Hour', render: r => r.hour },
-  { key: 'cost', label: 'Cost', render: r => formatSignedDollars(r.cost) },
-  { key: 'listCost', label: 'List Cost', render: r => formatSignedDollars(r.listCost) },
-  { key: 'service', label: 'Service', render: r => r.service },
-  { key: 'serviceFamily', label: 'Family', render: r => r.serviceFamily },
-  { key: 'accountId', label: 'Account ID', render: r => r.accountId },
-  { key: 'accountName', label: 'Account Name', render: r => r.accountName },
-  { key: 'region', label: 'Region', render: r => r.region },
-  { key: 'lineItemType', label: 'Line Type', render: r => r.lineItemType },
-  { key: 'operation', label: 'Operation', render: r => r.operation },
-  { key: 'usageType', label: 'Usage Type', render: r => r.usageType },
-  { key: 'usageAmount', label: 'Usage Amount', render: r => r.usageAmount === 0 ? '' : r.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 }) },
-  { key: 'resourceId', label: 'Resource', render: r => r.resourceId },
-  { key: 'description', label: 'Description', render: r => r.description },
-];
-
 function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterAdd }: {
-  row: ExplorerSampleRow;
+  row: AggregatedTableRow;
   columns: readonly ColumnSpec[];
   allColumns: readonly ColumnSpec[];
   expanded: boolean;
@@ -454,28 +393,36 @@ function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterA
   );
 }
 
-function RowDetail({ row, allColumns }: { row: ExplorerSampleRow; allColumns: readonly ColumnSpec[] }) {
-  const tagEntries = Object.entries(row.tags).filter(([, v]) => v.length > 0);
-  const tagLabels = new Map(allColumns.filter(c => c.dimId !== null && c.dimId.startsWith('tag_')).map(c => [c.key, c.label]));
+function RowDetail({ row, allColumns }: { row: AggregatedTableRow; allColumns: readonly ColumnSpec[] }) {
+  const entries = Object.entries(row.values).filter(([, v]) => v.length > 0);
+  const labelMap = new Map(allColumns.map(c => [c.key, c.label]));
 
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-x-4 gap-y-0.5 text-[11px]">
-      {ROW_FIELDS.map(f => {
-        const val = f.render(row);
-        if (val.length === 0) return null;
-        return (
-          <div key={f.key} className="flex gap-1.5 py-0.5 min-w-0">
-            <span className="text-text-muted shrink-0">{f.label}</span>
-            <span className="text-text-primary truncate" title={val}>{val}</span>
-          </div>
-        );
-      })}
-      {tagEntries.map(([key, val]) => (
+      {entries.map(([key, val]) => (
         <div key={key} className="flex gap-1.5 py-0.5 min-w-0">
-          <span className="text-text-muted shrink-0">{tagLabels.get(key) ?? key}</span>
+          <span className="text-text-muted shrink-0">{labelMap.get(key) ?? key}</span>
           <span className="text-text-primary truncate" title={val}>{val}</span>
         </div>
       ))}
+      <div className="flex gap-1.5 py-0.5 min-w-0">
+        <span className="text-text-muted shrink-0">Cost</span>
+        <span className="text-text-primary">{formatSignedDollars(row.cost)}</span>
+      </div>
+      <div className="flex gap-1.5 py-0.5 min-w-0">
+        <span className="text-text-muted shrink-0">List Cost</span>
+        <span className="text-text-primary">{formatSignedDollars(row.listCost)}</span>
+      </div>
+      {row.usageAmount > 0 && (
+        <div className="flex gap-1.5 py-0.5 min-w-0">
+          <span className="text-text-muted shrink-0">Usage</span>
+          <span className="text-text-primary">{row.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</span>
+        </div>
+      )}
+      <div className="flex gap-1.5 py-0.5 min-w-0">
+        <span className="text-text-muted shrink-0">Line Items</span>
+        <span className="text-text-primary">{row.rowCount.toLocaleString()}</span>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -45,11 +45,6 @@ export function TableWidget({
     [fk, dateRange.start, dateRange.end, granularity, api],
   );
 
-  const rowsQuery = useQuery(
-    () => api.queryExplorerRows({ filters: explorerFilters, dateRange, granularity, ...(sort !== undefined ? { sort } : {}), rowLimit: ROW_LIMIT }),
-    [fk, dateRange.start, dateRange.end, granularity, sort?.column, sort?.direction, api],
-  );
-
   const tagColumns = overviewQuery.status === 'success' ? overviewQuery.data.tagColumns : [];
   const totalRows = overviewQuery.status === 'success' ? overviewQuery.data.totalRows : 0;
 
@@ -60,10 +55,28 @@ export function TableWidget({
 
   const enabledSet = useMemo(() => new Set(enabledColumns), [enabledColumns]);
 
-  const orderedColumns = useMemo(() => {
+  const groupByColumns = useMemo(
+    () => allColumns.filter(c => c.dimId !== null && enabledSet.has(c.key)).map(c => c.key),
+    [allColumns, enabledSet],
+  );
+
+  const groupByKey = groupByColumns.join(',');
+
+  const dataQuery = useQuery(
+    () => api.queryAggregatedTable({
+      filters: explorerFilters,
+      dateRange,
+      granularity,
+      groupByColumns,
+      ...(sort !== undefined ? { sort } : {}),
+      rowLimit: ROW_LIMIT,
+    }),
+    [fk, dateRange.start, dateRange.end, granularity, groupByKey, sort?.column, sort?.direction, api],
+  );
+
+  const visibleColumns = useMemo(() => {
     const enabled = allColumns.filter(c => enabledSet.has(c.key));
-    const order = [...enabledColumns];
-    return applyColumnOrder(enabled, order);
+    return applyColumnOrder(enabled, [...enabledColumns]);
   }, [allColumns, enabledSet, enabledColumns]);
 
   const hiddenColumns = useMemo(
@@ -93,12 +106,13 @@ export function TableWidget({
   }, [allColumns]);
 
   const handleOrderChange = useCallback(() => {
-    // no-op: column order is controlled by enabledColumns in the views editor
+    // no-op: column order controlled by enabledColumns in views editor
   }, []);
 
-  const rows = rowsQuery.status === 'success' ? rowsQuery.data.sampleRows : [];
-  const loading = rowsQuery.status === 'loading' || overviewQuery.status === 'loading';
-  const error = rowsQuery.status === 'error' ? rowsQuery.error.message : null;
+  const rows = dataQuery.status === 'success' ? dataQuery.data.rows : [];
+  const aggregatedTotal = dataQuery.status === 'success' ? dataQuery.data.totalRows : totalRows;
+  const loading = dataQuery.status === 'loading' || overviewQuery.status === 'loading';
+  const error = dataQuery.status === 'error' ? dataQuery.error.message : null;
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden p-4">
@@ -106,14 +120,14 @@ export function TableWidget({
         <h3 className="text-sm font-medium text-text-secondary mb-3">{spec.title}</h3>
       )}
       <DataTable
-        columns={orderedColumns}
+        columns={visibleColumns}
         allColumns={allColumns}
         hiddenColumns={hiddenColumns}
         autoHiddenKeys={emptySet}
         onHiddenColumnsChange={handleHiddenChange}
         onColumnOrderChange={handleOrderChange}
         rows={rows}
-        totalRows={totalRows}
+        totalRows={aggregatedTotal}
         sort={sort}
         onSort={handleSort}
         onFilterAdd={handleFilterAdd}


### PR DESCRIPTION
## Summary

The dashboard table widget now dynamically aggregates rows based on which columns are enabled. Enabled dimension columns define the SQL GROUP BY; cost, list cost, and usage amount are always SUMmed. Disabling a column collapses rows that only differed in that dimension.

- **Cost + Resource + Description** enabled → one row per unique combination, costs summed
- Enable **Date** → rows split by date (same resource appears multiple times)
- Disable **Date** → daily rows collapse back, costs sum up
- Expand any row to see all values + aggregated metrics + line item count

### Changes

- New `AggregatedTableParams`/`AggregatedTableRow`/`AggregatedTableResult` types
- New `queryAggregatedTable` CostApi method + IPC handler
- DataTable component renders aggregated rows (values map + metrics)
- `usage_date` and `description` now have `dimId` so they participate in GROUP BY