### PR TITLE
Expandable row sub-table with raw line items

### DIFF
--- a/packages/core/src/types/explorer.ts
+++ b/packages/core/src/types/explorer.ts
@@ -109,6 +109,7 @@ export interface AggregatedTableParams extends ExplorerBaseParams {
   readonly groupByColumns: readonly string[];
   readonly sort?: ExplorerSort;
   readonly rowLimit: number;
+  readonly rowFilters?: Readonly<Record<string, string>> | undefined;
 }
 
 export interface AggregatedTableRow {

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -417,6 +417,21 @@ export function registerExplorerHandlers(app: AppContext): void {
 
     if (qc.empty) return { rows: [], totalRows: 0, tagColumns: qc.tagColumns };
 
+    let whereStr = qc.whereStr;
+    if (params.rowFilters !== undefined) {
+      const extra: string[] = [];
+      for (const [col, val] of Object.entries(params.rowFilters)) {
+        if (val.length === 0) continue;
+        if (!SORTABLE_SCALAR_COLUMNS.has(col) && !qc.tagIdSet.has(col)) continue;
+        const escaped = val.replace(/'/g, "''");
+        const colExpr = col === 'usage_date' ? `usage_date::VARCHAR` : col;
+        extra.push(`${colExpr} = '${escaped}'`);
+      }
+      if (extra.length > 0) {
+        whereStr = `${whereStr} AND ${extra.join(' AND ')}`;
+      }
+    }
+
     const groupByColumns = params.groupByColumns.filter(
       col => SORTABLE_SCALAR_COLUMNS.has(col) || qc.tagIdSet.has(col),
     );
@@ -429,7 +444,7 @@ export function registerExplorerHandlers(app: AppContext): void {
           CAST(SUM(usage_amount) AS DOUBLE) AS usage_amount,
           CAST(COUNT(*) AS DOUBLE) AS row_count
         FROM ${qc.source}
-        ${qc.whereStr}
+        ${whereStr}
       `.trim();
       const rows = await runQuery(sql);
       const r = rows[0];
@@ -459,7 +474,7 @@ export function registerExplorerHandlers(app: AppContext): void {
 
     const countSql = `
       SELECT CAST(COUNT(*) AS DOUBLE) AS n FROM (
-        SELECT 1 FROM ${qc.source} ${qc.whereStr}
+        SELECT 1 FROM ${qc.source} ${whereStr}
         GROUP BY ${groupByColumns.join(', ')}
       ) AS _cnt
     `.trim();
@@ -471,7 +486,7 @@ export function registerExplorerHandlers(app: AppContext): void {
         CAST(SUM(usage_amount) AS DOUBLE) AS usage_amount,
         CAST(COUNT(*) AS DOUBLE) AS row_count
       FROM ${qc.source}
-      ${qc.whereStr}
+      ${whereStr}
       GROUP BY ${groupByColumns.join(', ')}
       ORDER BY ${orderBy}
       LIMIT ${String(rowLimit)}

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { AggregatedTableRow, ExplorerSort, ExplorerTagColumn } from '@costgoblin/core/browser';
+import type { AggregatedTableRow, ExplorerSampleRow, ExplorerSort, ExplorerTagColumn } from '@costgoblin/core/browser';
 import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
 
@@ -214,9 +214,10 @@ interface DataTableProps {
   readonly loading: boolean;
   readonly error: string | null;
   readonly maxHeight?: string;
+  readonly fetchDetailRows?: ((row: AggregatedTableRow) => Promise<readonly ExplorerSampleRow[]>) | undefined;
 }
 
-export function DataTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, onHiddenColumnsChange, onColumnOrderChange, rows, totalRows, sort, onSort, onFilterAdd, loading, error, maxHeight = '560px' }: DataTableProps) {
+export function DataTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, onHiddenColumnsChange, onColumnOrderChange, rows, totalRows, sort, onSort, onFilterAdd, loading, error, maxHeight = '560px', fetchDetailRows }: DataTableProps) {
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
 
   const toggleExpand = useCallback((idx: number) => {
@@ -281,6 +282,7 @@ export function DataTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, 
                   expanded={isExpanded}
                   onToggle={() => { toggleExpand(i); }}
                   onFilterAdd={onFilterAdd}
+                  fetchDetailRows={fetchDetailRows}
                 />
               );
             })}
@@ -361,13 +363,14 @@ function renderCell(spec: ColumnSpec, row: AggregatedTableRow): React.ReactNode 
 
 // --- Expandable Row ---
 
-function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterAdd }: {
+function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterAdd, fetchDetailRows }: {
   row: AggregatedTableRow;
   columns: readonly ColumnSpec[];
   allColumns: readonly ColumnSpec[];
   expanded: boolean;
   onToggle: () => void;
   onFilterAdd: (dimId: string, value: string) => void;
+  fetchDetailRows?: ((r: AggregatedTableRow) => Promise<readonly ExplorerSampleRow[]>) | undefined;
 }) {
   return (
     <>
@@ -385,7 +388,7 @@ function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterA
       {expanded && (
         <tr className="bg-bg-tertiary/20">
           <td colSpan={columns.length} className="px-3 py-2">
-            <RowDetail row={row} allColumns={allColumns} />
+            <RowDetail row={row} allColumns={allColumns} fetchDetailRows={fetchDetailRows} />
           </td>
         </tr>
       )}
@@ -393,36 +396,92 @@ function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterA
   );
 }
 
-function RowDetail({ row, allColumns }: { row: AggregatedTableRow; allColumns: readonly ColumnSpec[] }) {
+const DETAIL_COLUMNS: readonly { key: string; label: string; align: 'left' | 'right'; render: (r: ExplorerSampleRow) => string }[] = [
+  { key: 'date', label: 'Date', align: 'left', render: r => r.date },
+  { key: 'cost', label: 'Cost', align: 'right', render: r => formatSignedDollars(r.cost) },
+  { key: 'service', label: 'Service', align: 'left', render: r => r.service },
+  { key: 'accountName', label: 'Account', align: 'left', render: r => r.accountName.length > 0 ? r.accountName : r.accountId },
+  { key: 'region', label: 'Region', align: 'left', render: r => r.region },
+  { key: 'description', label: 'Description', align: 'left', render: r => r.description },
+  { key: 'resourceId', label: 'Resource', align: 'left', render: r => r.resourceId },
+  { key: 'lineItemType', label: 'Line type', align: 'left', render: r => r.lineItemType },
+];
+
+function RowDetail({ row, allColumns, fetchDetailRows }: {
+  row: AggregatedTableRow;
+  allColumns: readonly ColumnSpec[];
+  fetchDetailRows?: ((r: AggregatedTableRow) => Promise<readonly ExplorerSampleRow[]>) | undefined;
+}) {
+  const [detailRows, setDetailRows] = useState<readonly ExplorerSampleRow[] | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  useEffect(() => {
+    if (fetchDetailRows === undefined) return;
+    setDetailLoading(true);
+    fetchDetailRows(row)
+      .then(rows => { setDetailRows(rows); })
+      .catch(() => { setDetailRows([]); })
+      .finally(() => { setDetailLoading(false); });
+  }, [row, fetchDetailRows]);
+
   const entries = Object.entries(row.values).filter(([, v]) => v.length > 0);
   const labelMap = new Map(allColumns.map(c => [c.key, c.label]));
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-x-4 gap-y-0.5 text-[11px]">
-      {entries.map(([key, val]) => (
-        <div key={key} className="flex gap-1.5 py-0.5 min-w-0">
-          <span className="text-text-muted shrink-0">{labelMap.get(key) ?? key}</span>
-          <span className="text-text-primary truncate" title={val}>{val}</span>
-        </div>
-      ))}
-      <div className="flex gap-1.5 py-0.5 min-w-0">
-        <span className="text-text-muted shrink-0">Cost</span>
-        <span className="text-text-primary">{formatSignedDollars(row.cost)}</span>
-      </div>
-      <div className="flex gap-1.5 py-0.5 min-w-0">
-        <span className="text-text-muted shrink-0">List Cost</span>
-        <span className="text-text-primary">{formatSignedDollars(row.listCost)}</span>
-      </div>
-      {row.usageAmount > 0 && (
+    <div className="space-y-3">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-x-4 gap-y-0.5 text-[11px]">
+        {entries.map(([key, val]) => (
+          <div key={key} className="flex gap-1.5 py-0.5 min-w-0">
+            <span className="text-text-muted shrink-0">{labelMap.get(key) ?? key}</span>
+            <span className="text-text-primary truncate" title={val}>{val}</span>
+          </div>
+        ))}
         <div className="flex gap-1.5 py-0.5 min-w-0">
-          <span className="text-text-muted shrink-0">Usage</span>
-          <span className="text-text-primary">{row.usageAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</span>
+          <span className="text-text-muted shrink-0">Cost</span>
+          <span className="text-text-primary">{formatSignedDollars(row.cost)}</span>
+        </div>
+        <div className="flex gap-1.5 py-0.5 min-w-0">
+          <span className="text-text-muted shrink-0">Line Items</span>
+          <span className="text-text-primary">{row.rowCount.toLocaleString()}</span>
+        </div>
+      </div>
+
+      {fetchDetailRows !== undefined && (
+        <div>
+          {detailLoading && <CoinRainLoader height={80} count={3} />}
+          {detailRows !== null && detailRows.length > 0 && (
+            <div className="border border-border/60 rounded overflow-auto max-h-[300px]">
+              <table className="text-[10px] w-full border-collapse">
+                <thead className="sticky top-0 z-10 bg-bg-tertiary/95 backdrop-blur-sm">
+                  <tr className="text-left text-text-muted">
+                    {DETAIL_COLUMNS.map(c => (
+                      <th key={c.key} className={`px-2 py-1 font-medium whitespace-nowrap ${c.align === 'right' ? 'text-right' : ''}`}>{c.label}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {detailRows.map((dr, i) => (
+                    <tr key={String(i)} className="border-t border-border/30 hover:bg-bg-tertiary/20">
+                      {DETAIL_COLUMNS.map(c => (
+                        <td
+                          key={c.key}
+                          className={`px-2 py-0.5 whitespace-nowrap ${c.align === 'right' ? 'text-right tabular-nums' : ''} ${c.key === 'resourceId' || c.key === 'description' ? 'max-w-[200px] overflow-hidden text-ellipsis' : ''}`}
+                          title={c.render(dr)}
+                        >
+                          {c.render(dr)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {detailRows !== null && detailRows.length === 0 && !detailLoading && (
+            <div className="text-[10px] text-text-muted text-center py-2">No detail rows available.</div>
+          )}
         </div>
       )}
-      <div className="flex gap-1.5 py-0.5 min-w-0">
-        <span className="text-text-muted shrink-0">Line Items</span>
-        <span className="text-text-primary">{row.rowCount.toLocaleString()}</span>
-      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { AggregatedTableRow, ExplorerSampleRow, ExplorerSort, ExplorerTagColumn } from '@costgoblin/core/browser';
+import type { AggregatedTableRow, ExplorerSort, ExplorerTagColumn } from '@costgoblin/core/browser';
 import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
 
@@ -214,7 +214,7 @@ interface DataTableProps {
   readonly loading: boolean;
   readonly error: string | null;
   readonly maxHeight?: string;
-  readonly fetchDetailRows?: ((row: AggregatedTableRow) => Promise<readonly ExplorerSampleRow[]>) | undefined;
+  readonly fetchDetailRows?: ((row: AggregatedTableRow) => Promise<readonly AggregatedTableRow[]>) | undefined;
 }
 
 export function DataTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, onHiddenColumnsChange, onColumnOrderChange, rows, totalRows, sort, onSort, onFilterAdd, loading, error, maxHeight = '560px', fetchDetailRows }: DataTableProps) {
@@ -370,7 +370,7 @@ function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterA
   expanded: boolean;
   onToggle: () => void;
   onFilterAdd: (dimId: string, value: string) => void;
-  fetchDetailRows?: ((r: AggregatedTableRow) => Promise<readonly ExplorerSampleRow[]>) | undefined;
+  fetchDetailRows?: ((r: AggregatedTableRow) => Promise<readonly AggregatedTableRow[]>) | undefined;
 }) {
   return (
     <>
@@ -396,23 +396,12 @@ function ExpandableRow({ row, columns, allColumns, expanded, onToggle, onFilterA
   );
 }
 
-const DETAIL_COLUMNS: readonly { key: string; label: string; align: 'left' | 'right'; render: (r: ExplorerSampleRow) => string }[] = [
-  { key: 'date', label: 'Date', align: 'left', render: r => r.date },
-  { key: 'cost', label: 'Cost', align: 'right', render: r => formatSignedDollars(r.cost) },
-  { key: 'service', label: 'Service', align: 'left', render: r => r.service },
-  { key: 'accountName', label: 'Account', align: 'left', render: r => r.accountName.length > 0 ? r.accountName : r.accountId },
-  { key: 'region', label: 'Region', align: 'left', render: r => r.region },
-  { key: 'description', label: 'Description', align: 'left', render: r => r.description },
-  { key: 'resourceId', label: 'Resource', align: 'left', render: r => r.resourceId },
-  { key: 'lineItemType', label: 'Line type', align: 'left', render: r => r.lineItemType },
-];
-
 function RowDetail({ row, allColumns, fetchDetailRows }: {
   row: AggregatedTableRow;
   allColumns: readonly ColumnSpec[];
-  fetchDetailRows?: ((r: AggregatedTableRow) => Promise<readonly ExplorerSampleRow[]>) | undefined;
+  fetchDetailRows?: ((r: AggregatedTableRow) => Promise<readonly AggregatedTableRow[]>) | undefined;
 }) {
-  const [detailRows, setDetailRows] = useState<readonly ExplorerSampleRow[] | null>(null);
+  const [detailRows, setDetailRows] = useState<readonly AggregatedTableRow[] | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
 
   useEffect(() => {
@@ -426,6 +415,17 @@ function RowDetail({ row, allColumns, fetchDetailRows }: {
 
   const entries = Object.entries(row.values).filter(([, v]) => v.length > 0);
   const labelMap = new Map(allColumns.map(c => [c.key, c.label]));
+
+  const detailColSpecs = useMemo(() => {
+    if (detailRows === null || detailRows.length === 0) return [];
+    const first = detailRows[0];
+    if (first === undefined) return [];
+    const dimCols = Object.keys(first.values)
+      .map(key => allColumns.find(c => c.key === key))
+      .filter((c): c is ColumnSpec => c !== undefined);
+    const costCol: ColumnSpec = { key: 'cost', label: 'Cost', dimId: null, align: 'right', mono: true };
+    return [...dimCols, costCol];
+  }, [detailRows, allColumns]);
 
   return (
     <div className="space-y-3">
@@ -454,7 +454,7 @@ function RowDetail({ row, allColumns, fetchDetailRows }: {
               <table className="text-[10px] w-full border-collapse">
                 <thead className="sticky top-0 z-10 bg-bg-tertiary/95 backdrop-blur-sm">
                   <tr className="text-left text-text-muted">
-                    {DETAIL_COLUMNS.map(c => (
+                    {detailColSpecs.map(c => (
                       <th key={c.key} className={`px-2 py-1 font-medium whitespace-nowrap ${c.align === 'right' ? 'text-right' : ''}`}>{c.label}</th>
                     ))}
                   </tr>
@@ -462,15 +462,18 @@ function RowDetail({ row, allColumns, fetchDetailRows }: {
                 <tbody>
                   {detailRows.map((dr, i) => (
                     <tr key={String(i)} className="border-t border-border/30 hover:bg-bg-tertiary/20">
-                      {DETAIL_COLUMNS.map(c => (
-                        <td
-                          key={c.key}
-                          className={`px-2 py-0.5 whitespace-nowrap ${c.align === 'right' ? 'text-right tabular-nums' : ''} ${c.key === 'resourceId' || c.key === 'description' ? 'max-w-[200px] overflow-hidden text-ellipsis' : ''}`}
-                          title={c.render(dr)}
-                        >
-                          {c.render(dr)}
-                        </td>
-                      ))}
+                      {detailColSpecs.map(c => {
+                        const val = c.key === 'cost' ? formatSignedDollars(dr.cost) : (dr.values[c.key] ?? '');
+                        return (
+                          <td
+                            key={c.key}
+                            className={`px-2 py-0.5 whitespace-nowrap ${c.align === 'right' ? 'text-right tabular-nums' : ''} ${c.truncate === true ? 'max-w-[200px] overflow-hidden text-ellipsis' : ''}`}
+                            title={val}
+                          >
+                            {val}
+                          </td>
+                        );
+                      })}
                     </tr>
                   ))}
                 </tbody>

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -424,7 +424,9 @@ function RowDetail({ row, allColumns, fetchDetailRows }: {
       .map(key => allColumns.find(c => c.key === key))
       .filter((c): c is ColumnSpec => c !== undefined);
     const costCol: ColumnSpec = { key: 'cost', label: 'Cost', dimId: null, align: 'right', mono: true };
-    return [...dimCols, costCol];
+    const result = [...dimCols];
+    result.splice(1, 0, costCol);
+    return result;
   }, [detailRows, allColumns]);
 
   return (

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -110,21 +110,17 @@ export function TableWidget({
   }, []);
 
   const fetchDetailRows = useCallback(async (row: AggregatedTableRow) => {
-    const detailFilters: Record<string, readonly string[]> = {};
-    for (const [k, v] of Object.entries(explorerFilters)) {
-      detailFilters[k] = v;
-    }
-    for (const [k, v] of Object.entries(row.values)) {
-      if (v.length > 0) detailFilters[k] = [v];
-    }
-    const result = await api.queryExplorerRows({
-      filters: detailFilters,
+    const allDimKeys = allColumns.filter(c => c.dimId !== null).map(c => c.key);
+    const result = await api.queryAggregatedTable({
+      filters: explorerFilters,
       dateRange,
       granularity,
+      groupByColumns: allDimKeys,
       rowLimit: 100,
+      rowFilters: row.values,
     });
-    return result.sampleRows;
-  }, [api, explorerFilters, dateRange, granularity]);
+    return result.rows;
+  }, [api, explorerFilters, dateRange, granularity, allColumns]);
 
   const rows = dataQuery.status === 'success' ? dataQuery.data.rows : [];
   const aggregatedTotal = dataQuery.status === 'success' ? dataQuery.data.totalRows : totalRows;

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -3,7 +3,7 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { DataTable, buildAllColumns, applyColumnOrder } from '../components/data-table.js';
 import { asDimensionId, asTagValue, OVERVIEW_SEED_VIEW } from '@costgoblin/core/browser';
-import type { ExplorerFilterMap, ExplorerSort, ExplorerSortDirection } from '@costgoblin/core/browser';
+import type { AggregatedTableRow, ExplorerFilterMap, ExplorerSort, ExplorerSortDirection } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { filtersKey, mergeFilters } from './widget.js';
 
@@ -109,6 +109,23 @@ export function TableWidget({
     // no-op: column order controlled by enabledColumns in views editor
   }, []);
 
+  const fetchDetailRows = useCallback(async (row: AggregatedTableRow) => {
+    const detailFilters: Record<string, readonly string[]> = {};
+    for (const [k, v] of Object.entries(explorerFilters)) {
+      detailFilters[k] = v;
+    }
+    for (const [k, v] of Object.entries(row.values)) {
+      if (v.length > 0) detailFilters[k] = [v];
+    }
+    const result = await api.queryExplorerRows({
+      filters: detailFilters,
+      dateRange,
+      granularity,
+      rowLimit: 100,
+    });
+    return result.sampleRows;
+  }, [api, explorerFilters, dateRange, granularity]);
+
   const rows = dataQuery.status === 'success' ? dataQuery.data.rows : [];
   const aggregatedTotal = dataQuery.status === 'success' ? dataQuery.data.totalRows : totalRows;
   const loading = dataQuery.status === 'loading' || overviewQuery.status === 'loading';
@@ -134,6 +151,7 @@ export function TableWidget({
         loading={loading}
         error={error}
         maxHeight="400px"
+        fetchDetailRows={fetchDetailRows}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

When expanding an aggregated row in the dashboard table, a mini table of raw CUR line items loads inside the detail panel.

- Fetches up to 100 raw rows via `queryExplorerRows` using the aggregated row's dimension values as filters
- Shows date, cost, service, account, region, description, resource, line type
- CoinRainLoader while fetching
- Scrollable with 300px max height
- Complements the aggregated summary (cost total, line item count) already shown