### PR TITLE
Debug query panel with in-flight badge and EXPLAIN support

### DIFF
--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -4,14 +4,15 @@ import { logger } from '@costgoblin/core';
 export type RawRow = Readonly<Record<string, unknown>>;
 
 export interface DuckDBClient {
-  runQuery(sql: string): Promise<RawRow[]>;
-  runPreparedQuery(sql: string, params: readonly unknown[]): Promise<RawRow[]>;
+  runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]>;
+  runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]>;
   cancelPendingQueries(): void;
   terminate(): Promise<void>;
 }
 
 type WorkerResponse =
   | { kind: 'ready' }
+  | { kind: 'started'; id: number }
   | { kind: 'rows'; id: number; rows: RawRow[] }
   | { kind: 'error'; id: number; message: string };
 
@@ -19,6 +20,7 @@ function isWorkerResponse(msg: unknown): msg is WorkerResponse {
   if (typeof msg !== 'object' || msg === null) return false;
   const m = msg as Record<string, unknown>;
   if (m['kind'] === 'ready') return true;
+  if (m['kind'] === 'started' && typeof m['id'] === 'number') return true;
   if ((m['kind'] === 'rows' || m['kind'] === 'error') && typeof m['id'] === 'number') {
     if (m['kind'] === 'rows') return Array.isArray(m['rows']);
     return typeof m['message'] === 'string';
@@ -29,6 +31,7 @@ function isWorkerResponse(msg: unknown): msg is WorkerResponse {
 interface PendingQuery {
   resolve: (rows: RawRow[]) => void;
   reject: (err: Error) => void;
+  onStarted?: (() => void) | undefined;
 }
 
 export async function createDuckDBClient(workerPath: string): Promise<DuckDBClient> {
@@ -60,6 +63,11 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
   worker.on('message', (msg: unknown) => {
     if (!isWorkerResponse(msg)) return;
     if (msg.kind === 'ready') return;
+    if (msg.kind === 'started') {
+      const entry = pending.get(msg.id);
+      if (entry?.onStarted !== undefined) entry.onStarted();
+      return;
+    }
     const entry = pending.get(msg.id);
     if (entry === undefined) return;
     pending.delete(msg.id);
@@ -85,13 +93,14 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
   await ready;
 
   return {
-    runQuery(sql: string): Promise<RawRow[]> {
+    runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]> {
       if (fatalError !== null) return Promise.reject(fatalError);
       const id = nextId++;
       const startedAt = Date.now();
       const startedAtIso = new Date(startedAt).toISOString();
       return new Promise<RawRow[]>((resolve, reject) => {
         pending.set(id, {
+          onStarted,
           resolve: (rows) => {
             logger.debug('duckdb:query', {
               id,
@@ -116,13 +125,14 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
         worker.postMessage({ kind: 'query', id, sql });
       });
     },
-    runPreparedQuery(sql: string, params: readonly unknown[]): Promise<RawRow[]> {
+    runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]> {
       if (fatalError !== null) return Promise.reject(fatalError);
       const id = nextId++;
       const startedAt = Date.now();
       const startedAtIso = new Date(startedAt).toISOString();
       return new Promise<RawRow[]>((resolve, reject) => {
         pending.set(id, {
+          onStarted,
           resolve: (rows) => {
             logger.debug('duckdb:prepared-query', {
               id,

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -20,6 +20,7 @@ const port = parentPort;
 
 type WorkerResponse =
   | { kind: 'ready' }
+  | { kind: 'started'; id: number }
   | { kind: 'rows'; id: number; rows: Readonly<Record<string, unknown>>[] }
   | { kind: 'error'; id: number; message: string };
 
@@ -182,6 +183,7 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
   const pool = await getPool();
   const conn = await pool.acquire();
   queuedIds.delete(req.id);
+  send({ kind: 'started', id: req.id });
 
   try {
     // Check after acquiring — cancel may have arrived while queued
@@ -222,6 +224,7 @@ async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; 
   const pool = await getPool();
   const conn = await pool.acquire();
   queuedIds.delete(req.id);
+  send({ kind: 'started', id: req.id });
 
   try {
     // Check after acquiring — cancel may have arrived while queued

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -1,4 +1,5 @@
 import type { DuckDBClient, RawRow } from '../duckdb-client.js';
+import { QueryLog } from '../query-log.js';
 import {
   asDimensionId,
   applyNormalizationRule,
@@ -138,6 +139,7 @@ export interface AppContext {
    *  or line_item_net_*. Cached per-tier for the session; invalidated on
    *  explicit reset via invalidateColumnCache. */
   readonly getAvailableColumns: (tier: 'daily' | 'hourly') => Promise<ReadonlySet<string>>;
+  readonly queryLog: QueryLog;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
   readonly runPreparedQuery: (sql: string, params: readonly unknown[]) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
@@ -383,6 +385,8 @@ export function createAppContext(ctx: IpcContext): AppContext {
     return fetch;
   }
 
+  const queryLog = new QueryLog();
+
   return {
     ctx,
     state,
@@ -396,8 +400,9 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getRegionMap,
     getOrgAccountsPath,
     getAvailableColumns,
-    runQuery: (sql: string) => ctx.db.runQuery(sql),
-    runPreparedQuery: (sql: string, params: readonly unknown[]) => ctx.db.runPreparedQuery(sql, params),
+    queryLog,
+    runQuery: queryLog.wrapQuery((sql, onStarted) => ctx.db.runQuery(sql, onStarted)),
+    runPreparedQuery: queryLog.wrapPreparedQuery((sql, params, onStarted) => ctx.db.runPreparedQuery(sql, params, onStarted)),
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; state.regionMap = null; },
     invalidateViews: () => { state.views = null; },

--- a/packages/desktop/src/main/handlers/debug.ts
+++ b/packages/desktop/src/main/handlers/debug.ts
@@ -1,0 +1,28 @@
+import { ipcMain } from 'electron';
+import type { AppContext } from './context.js';
+
+export function registerDebugHandlers(app: AppContext): void {
+  ipcMain.handle('debug:get-query-log', () => {
+    return app.queryLog.getEntries();
+  });
+
+  ipcMain.handle('debug:run-explain', async (_event, queryId: number): Promise<string> => {
+    const entry = app.queryLog.getEntryForExplain(queryId);
+    if (entry === undefined) return 'Query not found in log';
+    const sql = `EXPLAIN ANALYZE ${entry.sql}`;
+    try {
+      const rows = await app.runPreparedQuery(sql, entry.params);
+      return rows.map(r => Object.values(r).join('\t')).join('\n');
+    } catch (err: unknown) {
+      return `EXPLAIN failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  });
+
+  ipcMain.handle('debug:clear-completed', () => {
+    app.queryLog.clearCompleted();
+  });
+
+  ipcMain.handle('debug:clear-query-log', () => {
+    app.queryLog.clear();
+  });
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { registerAutoSyncHandlers } from './handlers/auto-sync.js';
 import { registerViewsHandlers } from './handlers/views.js';
 import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
+import { registerDebugHandlers } from './handlers/debug.js';
 
 export type { IpcContext };
 
@@ -28,4 +29,5 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   registerViewsHandlers(app);
   registerCostScopeHandlers(app);
   registerExplorerHandlers(app);
+  registerDebugHandlers(app);
 }

--- a/packages/desktop/src/main/query-log.ts
+++ b/packages/desktop/src/main/query-log.ts
@@ -1,0 +1,122 @@
+import type { RawRow } from './duckdb-client.js';
+
+export type QueryStatus = 'queued' | 'running' | 'success' | 'error';
+
+export interface QueryLogEntry {
+  readonly id: number;
+  readonly sql: string;
+  readonly paramCount: number;
+  readonly status: QueryStatus;
+  readonly startedAt: number;
+  readonly durationMs: number | null;
+  readonly rowCount: number | null;
+  readonly error: string | null;
+}
+
+interface InternalEntry {
+  id: number;
+  sql: string;
+  params: readonly unknown[];
+  paramCount: number;
+  status: QueryStatus;
+  startedAt: number;
+  durationMs: number | null;
+  rowCount: number | null;
+  error: string | null;
+}
+
+const MAX_ENTRIES = 200;
+
+export class QueryLog {
+  private entries: InternalEntry[] = [];
+  private nextId = 0;
+
+  start(sql: string, params: readonly unknown[]): number {
+    const id = this.nextId++;
+    this.entries.push({
+      id,
+      sql,
+      params,
+      paramCount: params.length,
+      status: 'queued',
+      startedAt: Date.now(),
+      durationMs: null,
+      rowCount: null,
+      error: null,
+    });
+    if (this.entries.length > MAX_ENTRIES) {
+      this.entries = this.entries.slice(-MAX_ENTRIES);
+    }
+    return id;
+  }
+
+  markRunning(id: number): void {
+    const entry = this.entries.find(e => e.id === id);
+    if (entry !== undefined && entry.status === 'queued') {
+      entry.status = 'running';
+    }
+  }
+
+  complete(id: number, rowCount: number): void {
+    const entry = this.entries.find(e => e.id === id);
+    if (entry === undefined) return;
+    entry.status = 'success';
+    entry.durationMs = Date.now() - entry.startedAt;
+    entry.rowCount = rowCount;
+  }
+
+  fail(id: number, message: string): void {
+    const entry = this.entries.find(e => e.id === id);
+    if (entry === undefined) return;
+    entry.status = 'error';
+    entry.durationMs = Date.now() - entry.startedAt;
+    entry.error = message;
+  }
+
+  getEntries(): QueryLogEntry[] {
+    return this.entries.map(e => ({
+      id: e.id,
+      sql: e.sql,
+      paramCount: e.paramCount,
+      status: e.status,
+      startedAt: e.startedAt,
+      durationMs: e.durationMs,
+      rowCount: e.rowCount,
+      error: e.error,
+    }));
+  }
+
+  getEntryForExplain(id: number): { sql: string; params: readonly unknown[] } | undefined {
+    const entry = this.entries.find(e => e.id === id);
+    if (entry === undefined) return undefined;
+    return { sql: entry.sql, params: entry.params };
+  }
+
+  clearCompleted(): void {
+    this.entries = this.entries.filter(e => e.status === 'running' || e.status === 'queued');
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+
+  wrapQuery(fn: (sql: string, onStarted?: () => void) => Promise<RawRow[]>): (sql: string) => Promise<RawRow[]> {
+    return (sql: string) => {
+      const id = this.start(sql, []);
+      return fn(sql, () => { this.markRunning(id); }).then(
+        (rows) => { this.complete(id, rows.length); return rows; },
+        (err: unknown) => { this.fail(id, err instanceof Error ? err.message : String(err)); throw err; },
+      );
+    };
+  }
+
+  wrapPreparedQuery(fn: (sql: string, params: readonly unknown[], onStarted?: () => void) => Promise<RawRow[]>): (sql: string, params: readonly unknown[]) => Promise<RawRow[]> {
+    return (sql: string, params: readonly unknown[]) => {
+      const id = this.start(sql, params);
+      return fn(sql, params, () => { this.markRunning(id); }).then(
+        (rows) => { this.complete(id, rows.length); return rows; },
+        (err: unknown) => { this.fail(id, err instanceof Error ? err.message : String(err)); throw err; },
+      );
+    };
+  }
+}

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -42,6 +42,20 @@ import type {
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
+// Debug query log entry — mirrors QueryLogEntry from main/query-log.ts
+// ---------------------------------------------------------------------------
+interface DebugQueryLogEntry {
+  readonly id: number;
+  readonly sql: string;
+  readonly paramCount: number;
+  readonly status: 'queued' | 'running' | 'success' | 'error';
+  readonly startedAt: number;
+  readonly durationMs: number | null;
+  readonly rowCount: number | null;
+  readonly error: string | null;
+}
+
+// ---------------------------------------------------------------------------
 // Performance instrumentation — active only when COSTGOBLIN_PERF_MODE=1
 // ---------------------------------------------------------------------------
 const perfMode = process.env['COSTGOBLIN_PERF_MODE'] === '1';
@@ -53,17 +67,22 @@ interface IpcTiming {
 }
 
 const ipcTimings: IpcTiming[] = [];
+let inFlightCount = 0;
 
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
   const start = perfMode ? performance.now() : 0;
+  const isDebug = channel.startsWith('debug:');
+  if (!isDebug) inFlightCount++;
   const result = ipcRenderer.invoke(channel, ...args) as Promise<T>;
-  if (!perfMode) return result;
   return result.finally(() => {
-    ipcTimings.push({
-      channel,
-      durationMs: Math.round((performance.now() - start) * 100) / 100,
-      timestamp: new Date().toISOString(),
-    });
+    if (!isDebug) inFlightCount--;
+    if (perfMode) {
+      ipcTimings.push({
+        channel,
+        durationMs: Math.round((performance.now() - start) * 100) / 100,
+        timestamp: new Date().toISOString(),
+      });
+    }
   });
 }
 
@@ -246,11 +265,25 @@ const api: CostApi = {
     return invoke<undefined>('explorer:save-preferences', prefs).then(() => undefined);
   },
   cancelPendingQueries(): Promise<void> {
+    void invoke<undefined>('debug:clear-completed');
     return invoke<undefined>('query:cancel-pending').then(() => undefined);
   },
 };
 
 contextBridge.exposeInMainWorld('costgoblin', api);
+
+contextBridge.exposeInMainWorld('costgoblinDebug', {
+  getInFlightCount(): number { return inFlightCount; },
+  getQueryLog(): Promise<DebugQueryLogEntry[]> {
+    return invoke<DebugQueryLogEntry[]>('debug:get-query-log');
+  },
+  runExplain(queryId: number): Promise<string> {
+    return invoke<string>('debug:run-explain', queryId);
+  },
+  clearLog(): Promise<void> {
+    return invoke<undefined>('debug:clear-query-log').then(() => undefined);
+  },
+});
 
 if (perfMode) {
   contextBridge.exposeInMainWorld('costgoblinPerf', {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, Profiler } from 'react';
 import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
+import { DebugPanel, useDebugBadge } from './debug-panel.js';
 
 // ---------------------------------------------------------------------------
 // React Profiler — collects render timings when perf mode is active
@@ -80,6 +81,15 @@ function MoonIcon() {
   );
 }
 
+function TerminalIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </svg>
+  );
+}
+
 type SetupCheck =
   | { status: 'checking' }
   | { status: 'needs-setup' }
@@ -115,6 +125,8 @@ function AppShell(): React.JSX.Element {
   // most commonly expired credentials. Surfaced as a red dot on the Sync
   // nav button so the user notices without having to open the tab.
   const [syncError, setSyncError] = useState<string | null>(null);
+  const [debugOpen, setDebugOpen] = useState(false);
+  const inFlightCount = useDebugBadge();
 
   useEffect(() => {
     void api.getSetupStatus().then(({ configured }) => {
@@ -308,6 +320,24 @@ function AppShell(): React.JSX.Element {
           <div className="flex items-center justify-end gap-1 [-webkit-app-region:no-drag]">
             <button
               type="button"
+              onClick={() => { setDebugOpen(prev => !prev); }}
+              className={[
+                'relative rounded-md p-1.5 transition-colors',
+                debugOpen
+                  ? 'bg-bg-tertiary text-text-primary'
+                  : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
+              ].join(' ')}
+              aria-label="Debug panel"
+            >
+              <TerminalIcon />
+              {inFlightCount > 0 && (
+                <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold text-white">
+                  {String(inFlightCount)}
+                </span>
+              )}
+            </button>
+            <button
+              type="button"
               onClick={handleToggleTheme}
               className="rounded-md p-1.5 text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
               aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
@@ -411,6 +441,7 @@ function AppShell(): React.JSX.Element {
           />
         </Profiler>
       )}
+      {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} />}
     </div>
   );
 }

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -1,0 +1,216 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const debug = globalThis.costgoblinDebug;
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${String(Math.round(ms))}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleTimeString();
+}
+
+function serializeLog(entries: DebugQueryLogEntry[]): string {
+  return entries.map(e => {
+    const labels: Record<string, string> = { queued: 'QUE', running: 'RUN', success: 'OK', error: 'ERR' };
+    const status = labels[e.status] ?? e.status;
+    const duration = e.durationMs !== null ? formatDuration(e.durationMs) : '...';
+    const rows = e.rowCount !== null ? `${String(e.rowCount)} rows` : '';
+    const header = `[${status}] ${formatTimestamp(e.startedAt)}  ${duration}  ${rows}`;
+    const error = e.error !== null ? `\nError: ${e.error}` : '';
+    return `${header}\n${e.sql}${error}`;
+  }).join('\n\n---\n\n');
+}
+
+function sqlPreview(sql: string): string {
+  const oneLine = sql.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 100 ? `${oneLine.slice(0, 100)}...` : oneLine;
+}
+
+function StatusDot({ status }: { status: DebugQueryLogEntry['status'] }): React.JSX.Element {
+  if (status === 'running') {
+    return <span className="inline-block h-2 w-2 shrink-0 rounded-full bg-accent animate-pulse" />;
+  }
+  if (status === 'queued') {
+    return <span className="inline-block h-2 w-2 shrink-0 rounded-full bg-warning animate-pulse" />;
+  }
+  if (status === 'error') {
+    return <span className="inline-block h-2 w-2 shrink-0 rounded-full bg-negative" />;
+  }
+  return <span className="inline-block h-2 w-2 shrink-0 rounded-full bg-positive" />;
+}
+
+function QueryRow({ entry }: { entry: DebugQueryLogEntry }): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const [explainResult, setExplainResult] = useState<string | null>(null);
+  const [explainLoading, setExplainLoading] = useState(false);
+
+  const handleExplain = useCallback(() => {
+    setExplainLoading(true);
+    void debug.runExplain(entry.id).then((result) => {
+      setExplainResult(result);
+      setExplainLoading(false);
+    });
+  }, [entry.id]);
+
+  return (
+    <div className="border-b border-border/50 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => { setExpanded(!expanded); }}
+        className="w-full text-left px-3 py-2 hover:bg-bg-tertiary/30 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <StatusDot status={entry.status} />
+          <span className="flex-1 text-xs font-mono text-text-secondary truncate">
+            {sqlPreview(entry.sql)}
+          </span>
+          <span className="text-xs text-text-muted shrink-0">
+            {entry.durationMs !== null ? formatDuration(entry.durationMs) : entry.status === 'queued' ? 'queued' : '...'}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 mt-0.5 ml-4">
+          <span className="text-[10px] text-text-muted">{formatTimestamp(entry.startedAt)}</span>
+          {entry.rowCount !== null && (
+            <span className="text-[10px] text-text-muted">{String(entry.rowCount)} rows</span>
+          )}
+          {entry.paramCount > 0 && (
+            <span className="text-[10px] text-text-muted">{String(entry.paramCount)} params</span>
+          )}
+          {entry.error !== null && (
+            <span className="text-[10px] text-negative truncate">{entry.error}</span>
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2">
+          <pre className="text-[11px] font-mono text-text-secondary bg-bg-primary rounded p-2 overflow-x-auto whitespace-pre-wrap max-h-48 overflow-y-auto">
+            {entry.sql}
+          </pre>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleExplain}
+              disabled={explainLoading || entry.status === 'running' || entry.status === 'queued'}
+              className="text-[11px] px-2 py-0.5 rounded bg-bg-tertiary text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/80 transition-colors disabled:opacity-40"
+            >
+              {explainLoading ? 'Running...' : 'EXPLAIN ANALYZE'}
+            </button>
+          </div>
+          {explainResult !== null && (
+            <pre className="text-[11px] font-mono text-text-secondary bg-bg-primary rounded p-2 overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto">
+              {explainResult}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DebugPanel({ onClose }: { onClose: () => void }): React.JSX.Element {
+  const [entries, setEntries] = useState<DebugQueryLogEntry[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    function poll(): void {
+      void debug.getQueryLog().then((log) => {
+        if (!cancelled) setEntries(log);
+      });
+    }
+    poll();
+    const timer = setInterval(poll, 500);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, []);
+
+  const runningCount = entries.filter(e => e.status === 'running').length;
+  const queuedCount = entries.filter(e => e.status === 'queued').length;
+  const reversed = [...entries].reverse();
+
+  return (
+    <div className="fixed top-[4.5rem] right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0 [-webkit-app-region:no-drag]">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-semibold text-text-primary">Query Log</h2>
+          <span className="text-xs text-text-muted">
+            {String(entries.length)} queries
+            {(runningCount > 0 || queuedCount > 0) && (
+              <span className="ml-1">
+                {runningCount > 0 && <span className="text-accent">{String(runningCount)} running</span>}
+                {runningCount > 0 && queuedCount > 0 && <span className="text-text-muted">, </span>}
+                {queuedCount > 0 && <span className="text-warning">{String(queuedCount)} queued</span>}
+              </span>
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => { void navigator.clipboard.writeText(serializeLog(entries)); }}
+            className="text-xs px-2 py-1 rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+          >
+            Copy
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const blob = new Blob([serializeLog(entries)], { type: 'text/plain' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `query-log-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.txt`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            className="text-xs px-2 py-1 rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={() => { void debug.clearLog().then(() => { setEntries([]); }); }}
+            className="text-xs px-2 py-1 rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Query list */}
+      <div className="flex-1 overflow-y-auto">
+        {reversed.length === 0 && (
+          <p className="text-xs text-text-muted text-center py-8">No queries yet</p>
+        )}
+        {reversed.map(entry => (
+          <QueryRow key={entry.id} entry={entry} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function useDebugBadge(): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCount(debug.getInFlightCount());
+    }, 300);
+    return () => { clearInterval(timer); };
+  }, []);
+
+  return count;
+}

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -1,6 +1,24 @@
 import type { CostApi } from '@costgoblin/core/browser';
 
 declare global {
+  interface DebugQueryLogEntry {
+    readonly id: number;
+    readonly sql: string;
+    readonly paramCount: number;
+    readonly status: 'queued' | 'running' | 'success' | 'error';
+    readonly startedAt: number;
+    readonly durationMs: number | null;
+    readonly rowCount: number | null;
+    readonly error: string | null;
+  }
+
+  interface DebugApi {
+    getInFlightCount(): number;
+    getQueryLog(): Promise<DebugQueryLogEntry[]>;
+    runExplain(queryId: number): Promise<string>;
+    clearLog(): Promise<void>;
+  }
+
   interface IpcTiming {
     readonly channel: string;
     readonly durationMs: number;
@@ -25,10 +43,12 @@ declare global {
 
   interface Window {
     costgoblin: CostApi;
+    costgoblinDebug: DebugApi;
     costgoblinPerf?: PerfApi;
     __PERF_REACT__?: RenderTiming[];
   }
   var costgoblin: CostApi;
+  var costgoblinDebug: DebugApi;
   var costgoblinPerf: PerfApi | undefined;
   var __PERF_REACT__: RenderTiming[] | undefined;
 }


### PR DESCRIPTION
## Summary
- Adds a debug button (terminal icon) in the header with a live badge showing in-flight IPC query count
- Clicking opens a 75%-width slide-out panel showing the full query log: SQL, timing, row counts, and running/queued status
- Queries get real status from the DuckDB connection pool — `started` messages from the worker distinguish truly running queries from backlog
- EXPLAIN ANALYZE can be triggered on any completed query
- Copy and Export buttons to extract the full log
- Completed queries are auto-cleared on view navigation