### PR TITLE
Configurable data freshness lag (lagDays) in Cost Scope

### DIFF
--- a/packages/core/src/config/cost-scope-serialize.ts
+++ b/packages/core/src/config/cost-scope-serialize.ts
@@ -1,4 +1,5 @@
 import type { CostScopeConfig, ExclusionCondition, ExclusionRule } from '../types/cost-scope.js';
+import { DEFAULT_LAG_DAYS } from '../types/cost-scope.js';
 
 interface YamlCondition { dimensionId: string; values: string[] }
 interface YamlRule {
@@ -13,6 +14,7 @@ interface YamlRule {
 export interface YamlCostScope {
   costMetric: string;
   costPerspective?: string;
+  lagDays?: number;
   rules: YamlRule[];
 }
 
@@ -32,6 +34,7 @@ function ruleToYaml(r: ExclusionRule): YamlRule {
 }
 
 export function costScopeToYaml(cfg: CostScopeConfig): YamlCostScope {
+  const lagDays = cfg.lagDays ?? DEFAULT_LAG_DAYS;
   return {
     costMetric: cfg.costMetric,
     // Only emit when non-default — keeps legacy YAMLs from churning
@@ -39,6 +42,7 @@ export function costScopeToYaml(cfg: CostScopeConfig): YamlCostScope {
     ...(cfg.costPerspective !== undefined && cfg.costPerspective !== 'gross'
       ? { costPerspective: cfg.costPerspective }
       : {}),
+    ...(lagDays !== DEFAULT_LAG_DAYS ? { lagDays } : {}),
     rules: cfg.rules.map(ruleToYaml),
   };
 }

--- a/packages/core/src/config/cost-scope-validator.ts
+++ b/packages/core/src/config/cost-scope-validator.ts
@@ -1,4 +1,4 @@
-import { assertArray, assertObject, assertString, ConfigValidationError } from './validator.js';
+import { assertArray, assertNumber, assertObject, assertString, ConfigValidationError } from './validator.js';
 import { asDimensionId } from '../types/branded.js';
 import type {
   CostMetric,
@@ -78,11 +78,21 @@ export function validateCostScope(raw: unknown): CostScopeConfig {
     }
     costPerspective = raw['costPerspective'];
   }
+  let lagDays: number | undefined;
+  if (raw['lagDays'] !== undefined) {
+    assertNumber(raw['lagDays'], 'costScope.lagDays');
+    if (raw['lagDays'] < 0 || !Number.isInteger(raw['lagDays'])) {
+      throw new ConfigValidationError('costScope.lagDays must be a non-negative integer');
+    }
+    lagDays = raw['lagDays'];
+  }
+
   assertArray(raw['rules'], 'costScope.rules');
   const rules = raw['rules'].map((r, i) => validateRule(r, `costScope.rules[${String(i)}]`));
   return {
     costMetric: raw['costMetric'],
     ...(costPerspective !== undefined ? { costPerspective } : {}),
+    ...(lagDays !== undefined ? { lagDays } : {}),
     rules,
   };
 }

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -50,11 +50,20 @@ export interface ExclusionRule {
   readonly conditions: readonly ExclusionCondition[];
 }
 
+/** Number of most-recent days to exclude from all date ranges. AWS CUR
+ *  data is not consolidated immediately, so the latest day(s) are
+ *  typically incomplete. `0` = include today, `1` = end at yesterday,
+ *  `2` (default) = end at the day before yesterday. */
+export const DEFAULT_LAG_DAYS = 2;
+
 export interface CostScopeConfig {
   readonly costMetric: CostMetric;
   /** Optional. Defaults to 'gross' when omitted (back-compat with
    *  earlier on-disk configs that predate the perspective axis). */
   readonly costPerspective?: CostPerspective;
+  /** How many recent days to trim from query date ranges. Defaults to
+   *  `DEFAULT_LAG_DAYS` (2) when omitted. */
+  readonly lagDays?: number | undefined;
   readonly rules: readonly ExclusionRule[];
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -88,7 +88,7 @@ export type {
   CostScopePreviewResult,
   CostScopeSampleRow,
 } from './cost-scope.js';
-export { COST_METRICS, COST_PERSPECTIVES } from './cost-scope.js';
+export { COST_METRICS, COST_PERSPECTIVES, DEFAULT_LAG_DAYS } from './cost-scope.js';
 
 export type {
   ExplorerFilterMap,

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import { stringify } from 'yaml';
 import {
   DEFAULT_COST_SCOPE,
+  DEFAULT_LAG_DAYS,
   ConfigValidationError,
   costScopeToYaml,
   validateCostScope,
@@ -83,7 +84,8 @@ export function registerCostScopeHandlers(app: AppContext): void {
     const enabledRules = config.rules.filter(r => r.enabled);
 
     const windowDays = 30;
-    const endDate = new Date();
+    const lagDays = config.lagDays ?? DEFAULT_LAG_DAYS;
+    const endDate = new Date(Date.now() - lagDays * 24 * 60 * 60 * 1000);
     const startDate = new Date(endDate.getTime() - (windowDays - 1) * 24 * 60 * 60 * 1000);
     const endStr = endDate.toISOString().slice(0, 10);
     const startStr = startDate.toISOString().slice(0, 10);

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -5,6 +5,7 @@ import {
   buildRuleMatchExpr,
   buildAliasSqlCase,
   computePeriodsInRange,
+  DEFAULT_LAG_DAYS,
   logger,
   listLocalMonths,
   parseJsonObject,
@@ -57,9 +58,9 @@ function resolveDateRange(raw: { start?: string; end?: string } | undefined): { 
     const days = Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1;
     return { startStr: toIsoDate(start), endStr: toIsoDate(end), windowDays: days };
   }
-  const yesterday = new Date(Date.now() - 86_400_000);
-  const fallbackEnd = toIsoDate(yesterday);
-  const fallbackStart = toIsoDate(new Date(yesterday.getTime() - (DEFAULT_WINDOW_DAYS - 1) * 86_400_000));
+  const latestDate = new Date(Date.now() - DEFAULT_LAG_DAYS * 86_400_000);
+  const fallbackEnd = toIsoDate(latestDate);
+  const fallbackStart = toIsoDate(new Date(latestDate.getTime() - (DEFAULT_WINDOW_DAYS - 1) * 86_400_000));
   return { startStr: fallbackStart, endStr: fallbackEnd, windowDays: DEFAULT_WINDOW_DAYS };
 }
 

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { DateString } from '@costgoblin/core/browser';
-import { asDateString } from '@costgoblin/core/browser';
+import { DEFAULT_LAG_DAYS, asDateString } from '@costgoblin/core/browser';
 import { daysAgo } from '../lib/dates.js';
 
 export type Granularity = 'daily' | 'hourly';
@@ -30,23 +30,25 @@ interface DateRangePickerProps {
    *  daily tier (Explorer), where offering hourly presets would lead to
    *  empty result sets. */
   hideHourly?: boolean;
+  /** Number of most-recent days excluded from ranges. */
+  lagDays?: number;
 }
 
-export function getDefaultDateRange(): DateRange {
-  return { start: daysAgo(31), end: daysAgo(1) };
+export function getDefaultDateRange(lagDays: number = DEFAULT_LAG_DAYS): DateRange {
+  return { start: daysAgo(30 + lagDays), end: daysAgo(lagDays) };
 }
 
-export function DateRangePicker({ value, granularity, onChange, hideHourly }: DateRangePickerProps) {
+export function DateRangePicker({ value, granularity, onChange, hideHourly, lagDays = DEFAULT_LAG_DAYS }: DateRangePickerProps) {
   const [showCustom, setShowCustom] = useState(false);
-  const yesterday = daysAgo(1);
+  const latestDate = daysAgo(lagDays);
 
   function isActive(days: number): boolean {
-    return value.start === daysAgo(days + 1) && value.end === yesterday;
+    return value.start === daysAgo(days + lagDays) && value.end === latestDate;
   }
 
   function handlePreset(days: number, g: Granularity) {
     setShowCustom(false);
-    onChange({ start: daysAgo(days + 1), end: yesterday }, g);
+    onChange({ start: daysAgo(days + lagDays), end: latestDate }, g);
   }
 
   function handleCustomToggle() {
@@ -118,6 +120,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly }: Da
           <input
             type="date"
             value={value.start}
+            max={latestDate}
             onChange={(e) => { onChange({ ...value, start: asDateString(e.target.value) }, 'daily'); }}
             className="rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
           />
@@ -125,6 +128,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly }: Da
           <input
             type="date"
             value={value.end}
+            max={latestDate}
             onChange={(e) => { onChange({ ...value, end: asDateString(e.target.value) }, 'daily'); }}
             className="rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
           />

--- a/packages/ui/src/hooks/use-lag-days.ts
+++ b/packages/ui/src/hooks/use-lag-days.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+import { DEFAULT_LAG_DAYS } from '@costgoblin/core/browser';
+import { useCostApi } from './use-cost-api.js';
+
+export function useLagDays(): number {
+  const api = useCostApi();
+  const [lagDays, setLagDays] = useState(DEFAULT_LAG_DAYS);
+  useEffect(() => {
+    void api.getCostScope().then(scope => {
+      setLagDays(scope.lagDays ?? DEFAULT_LAG_DAYS);
+    });
+  }, [api]);
+  return lagDays;
+}

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -12,7 +12,7 @@ import type {
   ExclusionRule,
   Dimension,
 } from '@costgoblin/core/browser';
-import { BUILTIN_EXCLUSION_RULES, COST_METRICS, DEFAULT_COST_SCOPE, asDimensionId } from '@costgoblin/core/browser';
+import { BUILTIN_EXCLUSION_RULES, COST_METRICS, DEFAULT_COST_SCOPE, DEFAULT_LAG_DAYS, asDimensionId } from '@costgoblin/core/browser';
 import { getDimensionId } from '../lib/dimensions.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
@@ -666,6 +666,20 @@ export function CostScopeView(): React.JSX.Element {
     updateDraft(perspective === 'gross' ? base : { ...base, costPerspective: perspective });
   }
 
+  function handleLagDaysChange(value: number) {
+    const clamped = Math.max(0, Math.round(value));
+    // Rebuild without lagDays when it matches the default so the
+    // serializer writes clean YAML. exactOptionalPropertyTypes forbids
+    // writing `undefined`, so enumerate retained fields.
+    const next: CostScopeConfig = {
+      costMetric: draft.costMetric,
+      ...(draft.costPerspective !== undefined ? { costPerspective: draft.costPerspective } : {}),
+      ...(clamped !== DEFAULT_LAG_DAYS ? { lagDays: clamped } : {}),
+      rules: draft.rules,
+    };
+    updateDraft(next);
+  }
+
   function updateRule(index: number, next: ExclusionRule) {
     const rules = draft.rules.map((r, i) => i === index ? next : r);
     updateDraft({ ...draft, rules });
@@ -861,6 +875,30 @@ export function CostScopeView(): React.JSX.Element {
                     Enable <em>Include Net Columns</em> on your CUR report in AWS Billing.
                   </div>
                 )}
+              </div>
+
+              {/* Data freshness lag */}
+              <div className="pt-2 mt-2 border-t border-border">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-text-primary">Data freshness</div>
+                    <div className="text-xs text-text-muted mt-0.5">
+                      Exclude the most recent N days from all date ranges. AWS billing data
+                      typically lags 1–2 days before it is fully consolidated.
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <input
+                      type="number"
+                      min={0}
+                      max={7}
+                      value={draft.lagDays ?? DEFAULT_LAG_DAYS}
+                      onChange={e => { handleLagDaysChange(Number(e.target.value)); }}
+                      className="w-16 rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary text-right tabular-nums"
+                    />
+                    <span className="text-xs text-text-muted">days</span>
+                  </div>
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -7,9 +7,11 @@ import type {
   TrendRow,
   EntityRef,
 } from '@costgoblin/core/browser';
-import { asDimensionId, asDateString, asDollars } from '@costgoblin/core/browser';
+import { DEFAULT_LAG_DAYS, asDimensionId, asDollars } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
+import { daysAgo } from '../lib/dates.js';
 import { getDimensionId } from '../lib/dimensions.js';
 import { BubbleChart } from '../components/bubble-chart.js';
 import { DimensionSelector } from '../components/dimension-selector.js';
@@ -23,12 +25,8 @@ const PERIOD_PRESETS = [
   { label: '180d', days: 180 },
 ] as const;
 
-function getDateRange(days: number): { start: DateString; end: DateString } {
-  const today = new Date();
-  const end = asDateString(today.toISOString().slice(0, 10));
-  const startDate = new Date(today.getTime() - days * 24 * 60 * 60 * 1000);
-  const start = asDateString(startDate.toISOString().slice(0, 10));
-  return { start, end };
+function getDateRange(days: number, lagDays: number = DEFAULT_LAG_DAYS): { start: DateString; end: DateString } {
+  return { start: daysAgo(days + lagDays), end: daysAgo(lagDays) };
 }
 
 type Direction = 'increases' | 'savings';
@@ -76,6 +74,7 @@ interface CostTrendsProps {
 
 export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps = {}) {
   const api = useCostApi();
+  const lagDays = useLagDays();
   const dimensionsQuery = useQuery(() => api.getDimensions(), []);
 
   const [state, setState] = useState<TrendsState>({
@@ -99,13 +98,13 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
       if (activeDimensionId === null) return Promise.resolve(null);
       return api.queryTrends({
         groupBy: activeDimensionId,
-        dateRange: getDateRange(state.periodDays),
+        dateRange: getDateRange(state.periodDays, lagDays),
         filters: {},
         deltaThreshold: asDollars(state.deltaThreshold),
         percentThreshold: state.percentThreshold,
       });
     },
-    [activeDimensionId, state.periodDays, state.deltaThreshold, state.percentThreshold, api],
+    [activeDimensionId, state.periodDays, state.deltaThreshold, state.percentThreshold, lagDays, api],
   );
 
   const trendData: TrendResult | null =

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -10,6 +10,7 @@ import type {
   ViewSpec,
 } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
 import {
   CostFocusDispatchProvider,
@@ -57,7 +58,8 @@ function previousRangeFor(dr: DateRange): DateRange {
 
 function CustomViewInner({ spec, headerSubtitle, onEntityClick }: CustomViewProps) {
   const api = useCostApi();
-  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const lagDays = useLagDays();
+  const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [filters, setFilters] = useState<FilterMap>({});
 
@@ -96,6 +98,7 @@ function CustomViewInner({ spec, headerSubtitle, onEntityClick }: CustomViewProp
           value={dateRange}
           granularity={granularity}
           onChange={(range, g) => { setDateRange(range); setGranularity(g); }}
+          lagDays={lagDays}
         />
       </div>
 

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@costgoblin/core/browser';
 import { asDimensionId, asEntityRef, asTagValue } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
 import { formatDollars, formatPercent } from '../components/format.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
@@ -75,7 +76,8 @@ function handleCsvExport(data: EntityDetailResult, entity: string) {
 
 export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetailProps>) {
   const api = useCostApi();
-  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const lagDays = useLagDays();
+  const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [histogramTab, setHistogramTab] = useState<HistogramTab>('service');
   const [histogramExpanded, setHistogramExpanded] = useState(false);
@@ -181,7 +183,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
           </div>
         </div>
         <div className="flex items-center gap-3">
-          <DateRangePicker value={dateRange} granularity={granularity} onChange={(range, g) => { setDateRange(range); setGranularity(g); }} />
+          <DateRangePicker value={dateRange} granularity={granularity} onChange={(range, g) => { setDateRange(range); setGranularity(g); }} lagDays={lagDays} />
           {data !== null && (
             <button
               type="button"

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -14,6 +14,7 @@ import type {
   Granularity,
 } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { useLagDays } from '../hooks/use-lag-days.js';
 import { formatDollars } from '../components/format.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
@@ -78,11 +79,12 @@ const DEFAULT_HIDDEN: ReadonlySet<string> = new Set([
 
 export function ExplorerView(): React.JSX.Element {
   const api = useCostApi();
+  const lagDays = useLagDays();
   const [filters, setFilters] = useState<ExplorerFilterMap>({});
   const [sort, setSort] = useState<ExplorerSort | undefined>(undefined);
   const [dimensions, setDimensions] = useState<Dimension[]>([]);
   const [capabilities, setCapabilities] = useState<CostScopeCapabilities | null>(null);
-  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [applyCostScope, setApplyCostScope] = useState(false);
   const [costMetric, setCostMetric] = useState<CostMetric>('unblended');
@@ -345,6 +347,7 @@ export function ExplorerView(): React.JSX.Element {
           value={dateRange}
           granularity={granularity}
           onChange={(range, g) => { setDateRange(range); setGranularity(g); }}
+          lagDays={lagDays}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Add `lagDays` to `CostScopeConfig` (optional, default 2) — controls how many recent days are excluded from all date ranges to account for incomplete AWS CUR data
- New "Data freshness" control in the Cost Scope settings view
- All views (Explorer, Dashboards, Entity Detail, Cost Trends) respect the setting via a `useLagDays` hook
- Fixes Cost Trends view which was incorrectly including today in its date range