### PR TITLE
Reduce Cost Overview from 15 to 11 queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: dev reset test e2e perf lint help
+.PHONY: dev prod reset test e2e perf lint help
 .DEFAULT_GOAL := help
 
 dev: ## Launch Electron in dev mode
 	cd packages/desktop && npm run dev
+
+prod: ## Build and launch Electron in production mode
+	npm run build --workspace=packages/desktop
+	npx electron packages/desktop/out/main/main.js
 
 reset: ## Wipe app data and config — next launch shows wizard
 	rm -rf "$(HOME)/Library/Application Support/@costgoblin"

--- a/e2e/debug-explain.test.ts
+++ b/e2e/debug-explain.test.ts
@@ -1,0 +1,50 @@
+import { test, expect, _electron, type ElectronApplication } from '@playwright/test';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const ROOT = join(import.meta.dirname, '..');
+const DESKTOP_DIR = join(ROOT, 'packages', 'desktop');
+
+test('run EXPLAIN ANALYZE on Cost Overview queries', async () => {
+  const app = await _electron.launch({
+    args: [join(DESKTOP_DIR, 'out', 'main', 'main.js')],
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      COSTGOBLIN_DATA_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'data'),
+      COSTGOBLIN_CONFIG_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'config'),
+    },
+  });
+  const page = await app.firstWindow();
+  await expect(page).toHaveTitle('CostGoblin');
+  await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible({ timeout: 10_000 });
+
+  // Wait for all queries to complete
+  await page.waitForTimeout(8000);
+
+  const log: { id: number; sql: string; status: string; durationMs: number | null; rowCount: number | null }[] =
+    await page.evaluate(() => globalThis.costgoblinDebug.getQueryLog());
+
+  const completed = log.filter(e => e.status === 'success');
+  console.log(`\n${String(completed.length)} completed queries. Running EXPLAIN ANALYZE on the first 3...\n`);
+
+  // Pick representative queries: shortest SQL (simple), longest duration, and the table data query
+  const sorted = [...completed].sort((a, b) => (b.durationMs ?? 0) - (a.durationMs ?? 0));
+  const picks = sorted.slice(0, 3);
+
+  for (const entry of picks) {
+    const preview = entry.sql.replace(/\s+/g, ' ').trim().slice(0, 100);
+    console.log(`\n${'='.repeat(80)}`);
+    console.log(`Query #${String(entry.id)} — ${String(entry.durationMs)}ms — ${String(entry.rowCount)} rows`);
+    console.log(`SQL: ${preview}...`);
+    console.log(`${'='.repeat(80)}`);
+
+    const explain: string = await page.evaluate(
+      (qid) => globalThis.costgoblinDebug.runExplain(qid),
+      entry.id,
+    );
+    console.log(explain);
+  }
+
+  await app.close();
+});

--- a/e2e/debug-query-count.test.ts
+++ b/e2e/debug-query-count.test.ts
@@ -1,0 +1,58 @@
+import { test, expect, _electron, type ElectronApplication, type Page } from '@playwright/test';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const ROOT = join(import.meta.dirname, '..');
+const DESKTOP_DIR = join(ROOT, 'packages', 'desktop');
+
+function launchApp(): Promise<ElectronApplication> {
+  return _electron.launch({
+    args: [join(DESKTOP_DIR, 'out', 'main', 'main.js')],
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      COSTGOBLIN_DATA_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'data'),
+      COSTGOBLIN_CONFIG_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'config'),
+    },
+  });
+}
+
+test('capture Cost Overview query log', async () => {
+  const app = await launchApp();
+  const page = await app.firstWindow();
+  await expect(page).toHaveTitle('CostGoblin');
+
+  // Wait for Cost Overview to fully load
+  await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible({ timeout: 10_000 });
+
+  // Wait for queries to settle — no more "Loading" text
+  try {
+    await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: 15_000 });
+  } catch { /* may never appear */ }
+  await page.waitForTimeout(3000);
+
+  // Read the query log from the debug API
+  const log = await page.evaluate(() => globalThis.costgoblinDebug.getQueryLog());
+
+  console.log(`\n=== TOTAL QUERIES: ${String(log.length)} ===\n`);
+
+  for (const entry of log) {
+    const status = entry.status === 'success' ? 'OK' : entry.status === 'error' ? 'ERR' : entry.status;
+    const duration = entry.durationMs !== null ? `${String(entry.durationMs)}ms` : '...';
+    const rows = entry.rowCount !== null ? `${String(entry.rowCount)}r` : '';
+    const sqlPreview = entry.sql.replace(/\s+/g, ' ').trim().slice(0, 120);
+    console.log(`[${String(entry.id).padStart(2)}] ${status.padEnd(7)} ${duration.padStart(8)} ${rows.padStart(6)}  ${sqlPreview}`);
+  }
+
+  console.log(`\n=== BREAKDOWN ===`);
+  const bySqlPrefix = new Map<string, number>();
+  for (const entry of log) {
+    const prefix = entry.sql.replace(/\s+/g, ' ').trim().slice(0, 60);
+    bySqlPrefix.set(prefix, (bySqlPrefix.get(prefix) ?? 0) + 1);
+  }
+  for (const [prefix, count] of [...bySqlPrefix.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(count).padStart(2)}x  ${prefix}`);
+  }
+
+  await app.close();
+});

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -387,6 +387,20 @@ export function createAppContext(ctx: IpcContext): AppContext {
 
   const queryLog = new QueryLog();
 
+  const wrappedRunQuery = queryLog.wrapQuery((sql, onStarted) => ctx.db.runQuery(sql, onStarted));
+  const wrappedRunPreparedQuery = queryLog.wrapPreparedQuery((sql, params, onStarted) => ctx.db.runPreparedQuery(sql, params, onStarted));
+
+  const inflightQueries = new Map<string, Promise<RawRow[]>>();
+
+  function dedup(key: string, run: () => Promise<RawRow[]>): Promise<RawRow[]> {
+    const existing = inflightQueries.get(key);
+    if (existing !== undefined) return existing;
+    const promise = run();
+    inflightQueries.set(key, promise);
+    void promise.finally(() => { inflightQueries.delete(key); });
+    return promise;
+  }
+
   return {
     ctx,
     state,
@@ -401,8 +415,11 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getOrgAccountsPath,
     getAvailableColumns,
     queryLog,
-    runQuery: queryLog.wrapQuery((sql, onStarted) => ctx.db.runQuery(sql, onStarted)),
-    runPreparedQuery: queryLog.wrapPreparedQuery((sql, params, onStarted) => ctx.db.runPreparedQuery(sql, params, onStarted)),
+    runQuery: (sql: string) => dedup(sql, () => wrappedRunQuery(sql)),
+    runPreparedQuery: (sql: string, params: readonly unknown[]) => dedup(
+      `${sql}\0${JSON.stringify(params)}`,
+      () => wrappedRunPreparedQuery(sql, params),
+    ),
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => { state.dimensions = null; state.accountMap = null; state.regionMap = null; },
     invalidateViews: () => { state.views = null; },

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -120,7 +120,7 @@ function AppShell(): React.JSX.Element {
   const [missingPeriods, setMissingPeriods] = useState(0);
   const [isDark, setIsDark] = useState(true);
   const [setupCheck, setSetupCheck] = useState<SetupCheck>({ status: 'checking' });
-  const [viewsConfig, setViewsConfig] = useState(FALLBACK_VIEWS);
+  const [viewsConfig, setViewsConfig] = useState<ViewsConfig | null>(null);
   // Sync-health signal. Non-null whenever something AWS-side is broken —
   // most commonly expired credentials. Surfaced as a red dot on the Sync
   // nav button so the user notices without having to open the tab.
@@ -146,19 +146,17 @@ function AppShell(): React.JSX.Element {
     // call also bootstraps the file for new installations.
     api.getViewsConfig()
       .then((cfg) => {
-        if (cfg.views.length > 0) {
-          setViewsConfig(cfg);
-          setView(prev => {
-            if (prev.page !== 'custom') return prev;
-            const exists = cfg.views.some(v => v.id === prev.viewId);
-            const firstId = cfg.views[0]?.id;
-            return exists || firstId === undefined ? prev : { page: 'custom', viewId: firstId };
-          });
-        }
+        const resolved = cfg.views.length > 0 ? cfg : FALLBACK_VIEWS;
+        setViewsConfig(resolved);
+        setView(prev => {
+          if (prev.page !== 'custom') return prev;
+          const exists = resolved.views.some(v => v.id === prev.viewId);
+          const firstId = resolved.views[0]?.id;
+          return exists || firstId === undefined ? prev : { page: 'custom', viewId: firstId };
+        });
       })
       .catch(() => {
-        // Keep fallback — ensures Cost Overview always renders even if YAML
-        // parsing fails (corrupted file, schema migration in progress).
+        setViewsConfig(FALLBACK_VIEWS);
       });
   }, [api, setupCheck]);
 
@@ -250,7 +248,7 @@ function AppShell(): React.JSX.Element {
   function handleBack() {
     confirmLeave(() => {
       void api.cancelPendingQueries();
-      const firstId = viewsConfig.views[0]?.id ?? OVERVIEW_SEED_VIEW.id;
+      const firstId = viewsConfig?.views[0]?.id ?? OVERVIEW_SEED_VIEW.id;
       setView({ page: 'custom', viewId: firstId });
     });
   }
@@ -268,9 +266,16 @@ function AppShell(): React.JSX.Element {
     return <SetupWizard onComplete={handleSetupComplete} />;
   }
 
+  if (viewsConfig === null) {
+    return <div className="min-h-screen bg-bg-primary" />;
+  }
+
+  // Narrowed — viewsConfig is non-null from here on.
+  const views = viewsConfig;
+
   // User-defined views populate the left nav before the static analytical
   // views (Trends / Missing Tags / Savings).
-  const customNav: { id: string; label: string }[] = viewsConfig.views.map(v => ({ id: v.id, label: v.name }));
+  const customNav: { id: string; label: string }[] = views.views.map(v => ({ id: v.id, label: v.name }));
   const leftNav = [...customNav, ...STATIC_LEFT_NAV];
 
   function activeNavId(): string | null {
@@ -288,7 +293,7 @@ function AppShell(): React.JSX.Element {
   const active = activeNavId();
 
   function findViewSpec(id: string): ViewSpec | null {
-    return viewsConfig.views.find(v => v.id === id) ?? null;
+    return views.views.find(v => v.id === id) ?? null;
   }
 
   return (

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -60,17 +60,21 @@ export function HeatmapWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
+  const fallbackDim = getDimensionFallback(specGroupBy);
   const query = useQuery<DailyQueryResult>(
     async () => {
-      const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-      const fallbackDim = getDimensionFallback(specGroupBy);
-      if (primary.groups.length <= 1 && fallbackDim !== undefined) {
-        const fallback = await api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
-        return { result: fallback, groupBy: fallbackDim };
+      if (fallbackDim === undefined) {
+        const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+        return { result, groupBy: specGroupBy };
       }
-      return { result: primary, groupBy: specGroupBy };
+      const [primary, fallback] = await Promise.all([
+        api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+        api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+      ]);
+      if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
+      return { result: fallback, groupBy: fallbackDim };
     },
-    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -50,17 +50,21 @@ export function LineWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
+  const fallbackDim = getDimensionFallback(specGroupBy);
   const query = useQuery<DailyQueryResult>(
     async () => {
-      const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-      const fallbackDim = getDimensionFallback(specGroupBy);
-      if (primary.groups.length <= 1 && fallbackDim !== undefined) {
-        const fallback = await api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
-        return { result: fallback, groupBy: fallbackDim };
+      if (fallbackDim === undefined) {
+        const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+        return { result, groupBy: specGroupBy };
       }
-      return { result: primary, groupBy: specGroupBy };
+      const [primary, fallback] = await Promise.all([
+        api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+        api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+      ]);
+      if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
+      return { result: fallback, groupBy: fallbackDim };
     },
-    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -43,17 +43,21 @@ export function PieWidget({
   const baseFilters = mergeFilters(globalFilters, spec.filters);
 
   const fk = filtersKey(baseFilters);
+  const fallbackDim = getDimensionFallback(specGroupBy);
   const query = useQuery<PieQueryResult>(
     async () => {
-      const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity });
-      const fallbackDim = getDimensionFallback(specGroupBy);
-      if (primary.rows.length <= 1 && fallbackDim !== undefined) {
-        const fallback = await api.queryCosts({ groupBy: fallbackDim, dateRange, filters: baseFilters, granularity });
-        return { result: fallback, groupBy: fallbackDim };
+      if (fallbackDim === undefined) {
+        const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity });
+        return { result, groupBy: specGroupBy };
       }
-      return { result: primary, groupBy: specGroupBy };
+      const [primary, fallback] = await Promise.all([
+        api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity }),
+        api.queryCosts({ groupBy: fallbackDim, dateRange, filters: baseFilters, granularity }),
+      ]);
+      if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
+      return { result: fallback, groupBy: fallbackDim };
     },
-    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -66,17 +66,21 @@ export function StackedBarWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
+  const fallbackDim = getDimensionFallback(specGroupBy);
   const query = useQuery<DailyQueryResult>(
     async () => {
-      const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-      const fallbackDim = getDimensionFallback(specGroupBy);
-      if (primary.groups.length <= 1 && fallbackDim !== undefined) {
-        const fallback = await api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
-        return { result: fallback, groupBy: fallbackDim };
+      if (fallbackDim === undefined) {
+        const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+        return { result, groupBy: specGroupBy };
       }
-      return { result: primary, groupBy: specGroupBy };
+      const [primary, fallback] = await Promise.all([
+        api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+        api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+      ]);
+      if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
+      return { result: fallback, groupBy: fallbackDim };
     },
-    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const periodDays = daysBetween(dateRange.start, dateRange.end);

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -41,17 +41,21 @@ export function TopNBarWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
+  const fallbackDim = getDimensionFallback(specGroupBy);
   const query = useQuery<CostQueryResult>(
     async () => {
-      const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-      const fallbackDim = getDimensionFallback(specGroupBy);
-      if (primary.rows.length <= 1 && fallbackDim !== undefined) {
-        const fallback = await api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
-        return { result: fallback, groupBy: fallbackDim };
+      if (fallbackDim === undefined) {
+        const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+        return { result, groupBy: specGroupBy };
       }
-      return { result: primary, groupBy: specGroupBy };
+      const [primary, fallback] = await Promise.all([
+        api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+        api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+      ]);
+      if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
+      return { result: fallback, groupBy: fallbackDim };
     },
-    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -33,17 +33,21 @@ export function TreemapWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
+  const fallbackDim = getDimensionFallback(specGroupBy);
   const query = useQuery<CostQueryResult>(
     async () => {
-      const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-      const fallbackDim = getDimensionFallback(specGroupBy);
-      if (primary.rows.length <= 1 && fallbackDim !== undefined) {
-        const fallback = await api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity });
-        return { result: fallback, groupBy: fallbackDim };
+      if (fallbackDim === undefined) {
+        const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+        return { result, groupBy: specGroupBy };
       }
-      return { result: primary, groupBy: specGroupBy };
+      const [primary, fallback] = await Promise.all([
+        api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+        api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+      ]);
+      if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
+      return { result: fallback, groupBy: fallbackDim };
     },
-    [specGroupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;


### PR DESCRIPTION
## Summary
- Fix viewsConfig double-render: delay widget mount until views.yaml loads, eliminating the seed-to-file re-mount that doubled table queries
- Add in-flight query deduplication: identical SQL+params share the same promise
- Parallelize fallback queries in all 6 widget types (Promise.all instead of sequential)
- Add `make prod` for production-mode launch
- Add Playwright scripts for query count and EXPLAIN analysis