### PR TITLE
Fix SonarCloud bugs (sorting, hooks, accessibility)

### DIFF
--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -17,7 +17,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const dailyDir = path.join(ctx.dataDir, 'aws', 'raw');
     let dirs: string[] = [];
     try {
-      dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort();
+      dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort((a, b) => a.localeCompare(b));
     } catch { /* no data */ }
     const recentDirs = dirs.slice(-2);
     const rawParquet = recentDirs.length > 0
@@ -99,7 +99,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
     let dirs: string[] = [];
     try {
-      dirs = (await fs.readdir(rawDir)).filter(d => d.startsWith('daily-')).sort();
+      dirs = (await fs.readdir(rawDir)).filter(d => d.startsWith('daily-')).sort((a, b) => a.localeCompare(b));
     } catch { /* no data */ }
     const latest = dirs.at(-1);
     if (latest === undefined) return { values: [], distinctCount: 0, period: '' };

--- a/packages/ui/src/components/line-chart.tsx
+++ b/packages/ui/src/components/line-chart.tsx
@@ -55,7 +55,7 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
   const sortedDates = useMemo(() => {
     const all = new Set<string>();
     for (const s of series) for (const p of s.points) all.add(p.date);
-    return [...all].sort();
+    return [...all].sort((a, b) => a.localeCompare(b));
   }, [series]);
 
   const minDate = sortedDates[0];

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -190,7 +190,7 @@ function PieChartInner({
                   x={14}
                   y={y + 8}
                   fontSize={isHovered ? 12 : 11}
-                  fill={(() => { if (isDimmed) return '#4b5563'; if (isHovered) return '#f3f4f6'; return '#9ca3af'; })()}
+                  fill={isDimmed ? '#4b5563' : isHovered ? '#f3f4f6' : '#9ca3af'}
                   fontWeight={isHovered ? 600 : 400}
                   style={{ transition: 'all 0.12s' }}
                 >

--- a/packages/ui/src/components/top-n-bar-chart.tsx
+++ b/packages/ui/src/components/top-n-bar-chart.tsx
@@ -127,9 +127,12 @@ function TopNBarChartInner({
               return (
                 <li
                   key={row.name}
+                  role="button"
+                  tabIndex={onBarClick !== undefined ? 0 : undefined}
                   onMouseEnter={() => { handleEnter(row.name); }}
                   onMouseLeave={handleLeave}
                   onClick={() => { onBarClick?.(row.name); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onBarClick?.(row.name); } }}
                   className="flex items-center gap-3 rounded px-1 transition-colors"
                   style={{
                     cursor: onBarClick !== undefined ? 'pointer' : 'default',

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -74,7 +74,7 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
   }
 
   const allTagKeys = orgData !== null
-    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort()
+    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b))
     : [];
   // OU count is derivable from the per-account ouPath. Distinct non-empty
   // paths approximate the number of OUs the user has placed accounts into.

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -903,7 +903,7 @@ export function DimensionsView() {
 
   // Account tag keys from org sync
   const accountTagKeys = orgData !== null
-    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort()
+    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b))
     : [];
 
   // Which resource tags are already mapped as dimensions

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -23,19 +23,20 @@ export function BubbleWidget({
   onEntityClick,
 }: WidgetCommonProps) {
   const api = useCostApi();
-  if (spec.type !== 'bubble') return null;
-  const specGroupBy = spec.groupBy;
+  const specGroupBy = spec.type === 'bubble' ? spec.groupBy : undefined;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
   const query = useQuery(
-    () => api.queryTrends({
-      groupBy: specGroupBy,
-      dateRange,
-      filters,
-      deltaThreshold: DEFAULT_DELTA_THRESHOLD,
-      percentThreshold: DEFAULT_PERCENT_THRESHOLD,
-    }),
+    () => specGroupBy !== undefined
+      ? api.queryTrends({
+          groupBy: specGroupBy,
+          dateRange,
+          filters,
+          deltaThreshold: DEFAULT_DELTA_THRESHOLD,
+          percentThreshold: DEFAULT_PERCENT_THRESHOLD,
+        })
+      : Promise.resolve(null),
     [specGroupBy, dateRange.start, dateRange.end, fk, api],
   );
 
@@ -44,6 +45,7 @@ export function BubbleWidget({
     [query],
   );
 
+  if (spec.type !== 'bubble' || specGroupBy === undefined) return null;
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
 
   return (

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -54,15 +54,15 @@ export function HeatmapWidget({
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
-  if (spec.type !== 'heatmap') return null;
-  const specGroupBy = spec.groupBy;
-  const topN = spec.topN ?? 12;
+  const specGroupBy = spec.type === 'heatmap' ? spec.groupBy : undefined;
+  const topN = spec.type === 'heatmap' ? (spec.topN ?? 12) : 12;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = getDimensionFallback(specGroupBy);
-  const query = useQuery<DailyQueryResult>(
+  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const query = useQuery<DailyQueryResult | null>(
     async () => {
+      if (specGroupBy === undefined) return null;
       if (fallbackDim === undefined) {
         const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
         return { result, groupBy: specGroupBy };
@@ -77,11 +77,13 @@ export function HeatmapWidget({
     [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
-  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const { cells, groups, dates } = useMemo(
-    () => buildCells(query.status === 'success' ? query.data.result : null, topN),
+    () => buildCells(query.status === 'success' && query.data !== null ? query.data.result : null, topN),
     [query, topN],
   );
+
+  if (spec.type !== 'heatmap' || specGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -45,14 +45,14 @@ export function LineWidget({
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
-  if (spec.type !== 'line') return null;
-  const specGroupBy = spec.groupBy;
+  const specGroupBy = spec.type === 'line' ? spec.groupBy : undefined;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = getDimensionFallback(specGroupBy);
-  const query = useQuery<DailyQueryResult>(
+  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const query = useQuery<DailyQueryResult | null>(
     async () => {
+      if (specGroupBy === undefined) return null;
       if (fallbackDim === undefined) {
         const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
         return { result, groupBy: specGroupBy };
@@ -67,12 +67,14 @@ export function LineWidget({
     [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
-  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
-  const topN = spec.topN ?? 6;
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
+  const topN = spec.type === 'line' ? (spec.topN ?? 6) : 6;
   const series = useMemo(
-    () => buildSeries(query.status === 'success' ? query.data.result : null, topN),
+    () => buildSeries(query.status === 'success' && query.data !== null ? query.data.result : null, topN),
     [query, topN],
   );
+
+  if (spec.type !== 'line' || specGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -36,16 +36,16 @@ export function PieWidget({
   const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
-  if (spec.type !== 'pie') return null;
-  const specGroupBy = spec.groupBy;
+  const specGroupBy = spec.type === 'pie' ? spec.groupBy : undefined;
   const specTitle = spec.title;
 
   const baseFilters = mergeFilters(globalFilters, spec.filters);
 
   const fk = filtersKey(baseFilters);
-  const fallbackDim = getDimensionFallback(specGroupBy);
-  const query = useQuery<PieQueryResult>(
+  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const query = useQuery<PieQueryResult | null>(
     async () => {
+      if (specGroupBy === undefined) return null;
       if (fallbackDim === undefined) {
         const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity });
         return { result, groupBy: specGroupBy };
@@ -60,11 +60,13 @@ export function PieWidget({
     [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
-  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const slices = useMemo(
-    () => rowsToSlices(query.status === 'success' ? query.data.result : null),
+    () => rowsToSlices(query.status === 'success' && query.data !== null ? query.data.result : null),
     [query],
   );
+
+  if (spec.type !== 'pie' || specGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -61,14 +61,14 @@ export function StackedBarWidget({
   const api = useCostApi();
   const focus = useCostFocus();
   const [tab, setTab] = useState<HistogramTab>('service');
-  if (spec.type !== 'stackedBar') return null;
-  const specGroupBy = spec.groupBy;
+  const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = getDimensionFallback(specGroupBy);
-  const query = useQuery<DailyQueryResult>(
+  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const query = useQuery<DailyQueryResult | null>(
     async () => {
+      if (specGroupBy === undefined) return null;
       if (fallbackDim === undefined) {
         const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
         return { result, groupBy: specGroupBy };
@@ -86,9 +86,12 @@ export function StackedBarWidget({
   const periodDays = daysBetween(dateRange.start, dateRange.end);
   const useWeekly = periodDays > 90;
   const barDays = useMemo(
-    () => dailyToBarDays(query.status === 'success' ? query.data.result : null, useWeekly),
+    () => dailyToBarDays(query.status === 'success' && query.data !== null ? query.data.result : null, useWeekly),
     [query, useWeekly],
   );
+
+  if (spec.type !== 'stackedBar') return null;
+
   const loading = query.status === 'loading';
 
   const title = spec.title

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -22,9 +22,8 @@ export function TableWidget({
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
-  if (spec.type !== 'table') return null;
 
-  const specEnabled = spec.enabledColumns ?? DEFAULT_ENABLED;
+  const specEnabled = spec.type === 'table' ? (spec.enabledColumns ?? DEFAULT_ENABLED) : DEFAULT_ENABLED;
 
   const widgetFilters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(widgetFilters);
@@ -121,6 +120,8 @@ export function TableWidget({
     });
     return result.rows;
   }, [api, explorerFilters, dateRange, granularity, allColumns]);
+
+  if (spec.type !== 'table') return null;
 
   const rows = dataQuery.status === 'success' ? dataQuery.data.rows : [];
   const aggregatedTotal = dataQuery.status === 'success' ? dataQuery.data.totalRows : totalRows;

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -36,14 +36,14 @@ export function TopNBarWidget({
   const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
-  if (spec.type !== 'topNBar') return null;
-  const specGroupBy = spec.groupBy;
+  const specGroupBy = spec.type === 'topNBar' ? spec.groupBy : undefined;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = getDimensionFallback(specGroupBy);
-  const query = useQuery<CostQueryResult>(
+  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const query = useQuery<CostQueryResult | null>(
     async () => {
+      if (specGroupBy === undefined) return null;
       if (fallbackDim === undefined) {
         const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
         return { result, groupBy: specGroupBy };
@@ -58,11 +58,13 @@ export function TopNBarWidget({
     [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
-  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const bars = useMemo(
-    () => rowsToBars(query.status === 'success' ? query.data.result : null),
+    () => rowsToBars(query.status === 'success' && query.data !== null ? query.data.result : null),
     [query],
   );
+
+  if (spec.type !== 'topNBar' || specGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -28,14 +28,14 @@ export function TreemapWidget({
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
-  if (spec.type !== 'treemap') return null;
-  const specGroupBy = spec.groupBy;
+  const specGroupBy = spec.type === 'treemap' ? spec.groupBy : undefined;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = getDimensionFallback(specGroupBy);
-  const query = useQuery<CostQueryResult>(
+  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const query = useQuery<CostQueryResult | null>(
     async () => {
+      if (specGroupBy === undefined) return null;
       if (fallbackDim === undefined) {
         const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
         return { result, groupBy: specGroupBy };
@@ -50,11 +50,14 @@ export function TreemapWidget({
     [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
   );
 
-  const activeGroupBy = query.status === 'success' ? query.data.groupBy : specGroupBy;
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const cells = useMemo(
-    () => rowsToCells(query.status === 'success' ? query.data.result : null),
+    () => rowsToCells(query.status === 'success' && query.data !== null ? query.data.result : null),
     [query],
   );
+
+  if (spec.type !== 'treemap' || specGroupBy === undefined || activeGroupBy === undefined) return null;
+
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
   if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;


### PR DESCRIPTION
## Summary
- **S2871**: Use `localeCompare` for string array sorting (5 instances across line-chart, dimensions, data-management-org, dimensions handler)
- **S6440**: Move React hooks above early returns in all 8 widget components so hooks are never called conditionally
- **S2681**: Replace IIFE with chained if-returns in pie-chart fill with a ternary expression
- **S1082**: Add `onKeyDown`, `role="button"`, and `tabIndex` to clickable `<li>` in top-n-bar-chart