### PR TITLE
Reduce cognitive complexity and nesting depth

### DIFF
--- a/packages/core/src/__fixtures__/generate.ts
+++ b/packages/core/src/__fixtures__/generate.ts
@@ -168,6 +168,66 @@ function weightedPick<T extends { costShare: number }>(arr: readonly T[], rand: 
   return arr.at(-1)!;
 }
 
+function generateDailyDates(): string[] {
+  const dates: string[] = [];
+  for (let m = 1; m <= 2; m++) {
+    const daysInMonth = m === 1 ? 31 : 28;
+    for (let d = 1; d <= daysInMonth; d++) {
+      dates.push(`2026-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`);
+    }
+  }
+  return dates;
+}
+
+function pickLineItemType(lineItemTypes: string[], litWeights: number[], rand: () => number): string {
+  const litR = rand();
+  let litCum = 0;
+  for (let j = 0; j < lineItemTypes.length; j++) {
+    litCum += litWeights[j]!;
+    if (litR <= litCum) return lineItemTypes[j]!;
+  }
+  return 'Usage';
+}
+
+function optionalTag(rand: () => number, missingRate: number, values: readonly string[]): string | null {
+  return rand() < missingRate ? null : pick(values, rand);
+}
+
+function generateRow(
+  date: string,
+  profileData: Profile,
+  syntheticAccounts: { id: string; name: string; costShare: number }[],
+  rand: () => number,
+  owners: string[],
+  products: string[],
+  envs: string[],
+  lineItemTypes: string[],
+  litWeights: number[],
+): string {
+  const service = weightedPick(profileData.services, rand);
+  const account = weightedPick(syntheticAccounts, rand);
+  const region = pick(profileData.regions.slice(0, 5), rand);
+
+  const owner = optionalTag(rand, Math.max(profileData.tags['owner']?.missingPercent ?? 0.08, 0.08), owners);
+  const product = optionalTag(rand, Math.max(profileData.tags['product']?.missingPercent ?? 0.12, 0.12), products);
+  const env = optionalTag(rand, Math.max(profileData.tags['environment']?.missingPercent ?? 0.03, 0.03), envs);
+
+  const baseCost = Math.exp(rand() * 6 - 2) * service.costShare * 10;
+  const cost = Math.round(baseCost * 100) / 100;
+  const lineItemType = pickLineItemType(lineItemTypes, litWeights, rand);
+  const listCost = Math.round(cost * (1 + rand() * 0.3) * 100) / 100;
+  const usageAmount = Math.round(rand() * 1000 * 100) / 100;
+  const resourceId = `arn:aws:${service.name.toLowerCase()}:${region}:${account.id}:resource/${String(Math.floor(rand() * 10000))}`;
+
+  const tagEntries: string[] = [];
+  if (owner !== null) tagEntries.push(`'user_team': '${owner}'`);
+  if (product !== null) tagEntries.push(`'user_system': '${product}'`);
+  if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
+  const tagsMap = `MAP {${tagEntries.join(', ')}}`;
+
+  return `(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', '${lineItemType}', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(listCost)}, '${lineItemType}', 'RunInstances', 'Usage', ${tagsMap})`;
+}
+
 async function generate(): Promise<void> {
   process.stdout.write('Generating synthetic fixtures...\n');
 
@@ -197,8 +257,6 @@ async function generate(): Promise<void> {
     costShare: a.costShare,
   }));
 
-  const services = profileData.services;
-
   const owners = [
     'backend', 'frontend', 'platform', 'data-eng', 'security',
     'payments', 'identity', 'cards', 'sre', 'devops', 'ml', 'mobile',
@@ -214,60 +272,14 @@ async function generate(): Promise<void> {
   const lineItemTypes = ['Usage', 'Fee', 'Credit', 'Tax'];
   const litWeights = [0.89, 0.06, 0.04, 0.01];
 
-  // Generate daily data: 2 months (Jan + Feb 2026)
-  const dailyDates: string[] = [];
-  for (let m = 1; m <= 2; m++) {
-    const daysInMonth = m === 1 ? 31 : 28;
-    for (let d = 1; d <= daysInMonth; d++) {
-      dailyDates.push(`2026-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`);
-    }
-  }
+  const dailyDates = generateDailyDates();
 
-  // Generate rows
   const ROWS_PER_DAY = 50;
   const rows: string[] = [];
 
   for (const date of dailyDates) {
     for (let i = 0; i < ROWS_PER_DAY; i++) {
-      const service = weightedPick(services, rand);
-      const account = weightedPick(syntheticAccounts, rand);
-      const region = pick(profileData.regions.slice(0, 5), rand);
-
-      const ownerMissingRate = Math.max(profileData.tags['owner']?.missingPercent ?? 0.08, 0.08);
-      const ownerMissing = rand() < ownerMissingRate;
-      const owner = ownerMissing ? null : pick(owners, rand);
-
-      const productMissingRate = Math.max(profileData.tags['product']?.missingPercent ?? 0.12, 0.12);
-      const productMissing = rand() < productMissingRate;
-      const product = productMissing ? null : pick(products, rand);
-
-      const envMissingRate = Math.max(profileData.tags['environment']?.missingPercent ?? 0.03, 0.03);
-      const envMissing = rand() < envMissingRate;
-      const env = envMissing ? null : pick(envs, rand);
-
-      // Cost: log-normal distribution roughly matching profile
-      const baseCost = Math.exp(rand() * 6 - 2) * service.costShare * 10;
-      const cost = Math.round(baseCost * 100) / 100;
-
-      const litR = rand();
-      let litCum = 0;
-      let lineItemType = 'Usage';
-      for (let j = 0; j < lineItemTypes.length; j++) {
-        litCum += litWeights[j]!;
-        if (litR <= litCum) { lineItemType = lineItemTypes[j]!; break; }
-      }
-
-      const listCost = Math.round(cost * (1 + rand() * 0.3) * 100) / 100;
-      const usageAmount = Math.round(rand() * 1000 * 100) / 100;
-      const resourceId = `arn:aws:${service.name.toLowerCase()}:${region}:${account.id}:resource/${String(Math.floor(rand() * 10000))}`;
-
-      const tagEntries: string[] = [];
-      if (owner !== null) tagEntries.push(`'user_team': '${owner}'`);
-      if (product !== null) tagEntries.push(`'user_system': '${product}'`);
-      if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
-      const tagsMap = `MAP {${tagEntries.join(', ')}}`;
-
-      rows.push(`(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', '${lineItemType}', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(listCost)}, '${lineItemType}', 'RunInstances', 'Usage', ${tagsMap})`);
+      rows.push(generateRow(date, profileData, syntheticAccounts, rand, owners, products, envs, lineItemTypes, litWeights));
     }
   }
 

--- a/packages/core/src/__fixtures__/setup.ts
+++ b/packages/core/src/__fixtures__/setup.ts
@@ -34,6 +34,47 @@ function weightedPick<T extends { costShare: number }>(arr: readonly T[], rand: 
   return last;
 }
 
+interface FixtureConfig {
+  services: { name: string; costShare: number }[];
+  accounts: { id: string; name: string; costShare: number }[];
+  regions: string[];
+  owners: string[];
+  products: string[];
+  envs: string[];
+}
+
+function generateDailyDates(): string[] {
+  const dates: string[] = [];
+  for (let m = 1; m <= 2; m++) {
+    const daysInMonth = m === 1 ? 31 : 28;
+    for (let d = 1; d <= daysInMonth; d++) {
+      dates.push(`2026-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`);
+    }
+  }
+  return dates;
+}
+
+function generateFixtureRow(date: string, cfg: FixtureConfig, rand: () => number): string {
+  const service = weightedPick(cfg.services, rand);
+  const account = weightedPick(cfg.accounts, rand);
+  const region = pick(cfg.regions, rand);
+  const owner = rand() < 0.08 ? null : pick(cfg.owners, rand);
+  const product = rand() < 0.12 ? null : pick(cfg.products, rand);
+  const env = rand() < 0.03 ? null : pick(cfg.envs, rand);
+  const cost = Math.round(Math.exp(rand() * 6 - 2) * service.costShare * 10 * 100) / 100;
+  const listCost = Math.round(cost * (1 + rand() * 0.3) * 100) / 100;
+  const usageAmount = Math.round(rand() * 1000 * 100) / 100;
+  const resourceId = `arn:aws:${service.name.toLowerCase()}:${region}:${account.id}:resource/${String(Math.floor(rand() * 10000))}`;
+
+  const tagEntries: string[] = [];
+  if (owner !== null) tagEntries.push(`'user_team': '${owner}'`);
+  if (product !== null) tagEntries.push(`'user_system': '${product}'`);
+  if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
+
+  const netCost = Math.round(cost * 0.97 * 100) / 100;
+  return `(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', 'Usage', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(cost)}, ${String(netCost)}, ${String(listCost)}, NULL, NULL, NULL, NULL, 'Usage', 'RunInstances', 'Usage', MAP {${tagEntries.join(', ')}})`;
+}
+
 export async function setup(): Promise<void> {
   const dailyParquet = join(SYNTHETIC_DIR, 'aws', 'raw', 'daily-2026-01', 'data.parquet');
   try {
@@ -47,75 +88,45 @@ export async function setup(): Promise<void> {
   const db = await DuckDBInstance.create();
   const conn = await db.connect();
 
-  const services = [
-    { name: 'AmazonEC2', costShare: 0.25 },
-    { name: 'AmazonRDS', costShare: 0.2 },
-    { name: 'AmazonS3', costShare: 0.1 },
-    { name: 'AWSLambda', costShare: 0.08 },
-    { name: 'AmazonCloudWatch', costShare: 0.07 },
-    { name: 'AmazonDynamoDB', costShare: 0.06 },
-    { name: 'AmazonVPC', costShare: 0.05 },
-    { name: 'AWSBackup', costShare: 0.05 },
-    { name: 'AmazonECR', costShare: 0.04 },
-    { name: 'AmazonSNS', costShare: 0.03 },
-    { name: 'AmazonSQS', costShare: 0.02 },
-    { name: 'AWSCloudTrail', costShare: 0.02 },
-    { name: 'AmazonRoute53', costShare: 0.015 },
-    { name: 'AmazonEFS', costShare: 0.015 },
-  ];
+  const cfg: FixtureConfig = {
+    services: [
+      { name: 'AmazonEC2', costShare: 0.25 },
+      { name: 'AmazonRDS', costShare: 0.2 },
+      { name: 'AmazonS3', costShare: 0.1 },
+      { name: 'AWSLambda', costShare: 0.08 },
+      { name: 'AmazonCloudWatch', costShare: 0.07 },
+      { name: 'AmazonDynamoDB', costShare: 0.06 },
+      { name: 'AmazonVPC', costShare: 0.05 },
+      { name: 'AWSBackup', costShare: 0.05 },
+      { name: 'AmazonECR', costShare: 0.04 },
+      { name: 'AmazonSNS', costShare: 0.03 },
+      { name: 'AmazonSQS', costShare: 0.02 },
+      { name: 'AWSCloudTrail', costShare: 0.02 },
+      { name: 'AmazonRoute53', costShare: 0.015 },
+      { name: 'AmazonEFS', costShare: 0.015 },
+    ],
+    accounts: [
+      { id: '100000000000', name: 'Acme Corp Main', costShare: 0.3 },
+      { id: '100000000001', name: 'Payments Production', costShare: 0.2 },
+      { id: '100000000002', name: 'Cards Production', costShare: 0.15 },
+      { id: '100000000003', name: 'Identity Production', costShare: 0.1 },
+      { id: '100000000004', name: 'Platform Engineering', costShare: 0.08 },
+      { id: '100000000005', name: 'Security Operations', costShare: 0.07 },
+      { id: '100000000006', name: 'Data Analytics', costShare: 0.05 },
+      { id: '100000000007', name: 'CI/CD Platform', costShare: 0.05 },
+    ],
+    regions: ['eu-central-1', 'us-east-1', 'eu-west-1', 'us-west-2', 'ap-southeast-1'],
+    owners: ['backend', 'frontend', 'platform', 'data-eng', 'security', 'payments', 'identity', 'sre'],
+    products: ['api-gateway', 'auth-service', 'billing-engine', 'data-pipeline', 'event-bus', 'ledger'],
+    envs: ['production', 'staging', 'testing', 'sandbox'],
+  };
 
-  const accounts = [
-    { id: '100000000000', name: 'Acme Corp Main', costShare: 0.3 },
-    { id: '100000000001', name: 'Payments Production', costShare: 0.2 },
-    { id: '100000000002', name: 'Cards Production', costShare: 0.15 },
-    { id: '100000000003', name: 'Identity Production', costShare: 0.1 },
-    { id: '100000000004', name: 'Platform Engineering', costShare: 0.08 },
-    { id: '100000000005', name: 'Security Operations', costShare: 0.07 },
-    { id: '100000000006', name: 'Data Analytics', costShare: 0.05 },
-    { id: '100000000007', name: 'CI/CD Platform', costShare: 0.05 },
-  ];
-
-  const regions = ['eu-central-1', 'us-east-1', 'eu-west-1', 'us-west-2', 'ap-southeast-1'];
-  const owners = ['backend', 'frontend', 'platform', 'data-eng', 'security', 'payments', 'identity', 'sre'];
-  const products = ['api-gateway', 'auth-service', 'billing-engine', 'data-pipeline', 'event-bus', 'ledger'];
-  const envs = ['production', 'staging', 'testing', 'sandbox'];
-
-  const dailyDates: string[] = [];
-  for (let m = 1; m <= 2; m++) {
-    const daysInMonth = m === 1 ? 31 : 28;
-    for (let d = 1; d <= daysInMonth; d++) {
-      dailyDates.push(`2026-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`);
-    }
-  }
+  const dailyDates = generateDailyDates();
 
   const rows: string[] = [];
   for (const date of dailyDates) {
     for (let i = 0; i < 50; i++) {
-      const service = weightedPick(services, rand);
-      const account = weightedPick(accounts, rand);
-      const region = pick(regions, rand);
-      const owner = rand() < 0.08 ? null : pick(owners, rand);
-      const product = rand() < 0.12 ? null : pick(products, rand);
-      const env = rand() < 0.03 ? null : pick(envs, rand);
-      const cost = Math.round(Math.exp(rand() * 6 - 2) * service.costShare * 10 * 100) / 100;
-      const listCost = Math.round(cost * (1 + rand() * 0.3) * 100) / 100;
-      const usageAmount = Math.round(rand() * 1000 * 100) / 100;
-      const resourceId = `arn:aws:${service.name.toLowerCase()}:${region}:${account.id}:resource/${String(Math.floor(rand() * 10000))}`;
-
-      const tagEntries: string[] = [];
-      if (owner !== null) tagEntries.push(`'user_team': '${owner}'`);
-      if (product !== null) tagEntries.push(`'user_system': '${product}'`);
-      if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
-
-      // Synthetic fixture:
-      //  - blended = unblended (no consolidated-billing variance)
-      //  - net_unblended = unblended * 0.97 (simulates 3% promotional credit)
-      //  - RI/SP effective cost NULL so amortized falls through to
-      //    unblended via COALESCE; same for net variants.
-      // Real CUR has these columns populated for rows covered by an RI
-      // or SP and when "Include Net Columns" is enabled.
-      const netCost = Math.round(cost * 0.97 * 100) / 100;
-      rows.push(`(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', 'Compute', 'Usage', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(cost)}, ${String(netCost)}, ${String(listCost)}, NULL, NULL, NULL, NULL, 'Usage', 'RunInstances', 'Usage', MAP {${tagEntries.join(', ')}})`);
+      rows.push(generateFixtureRow(date, cfg, rand));
     }
   }
 

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -110,126 +110,113 @@ export function validateConfig(raw: unknown): CostGoblinConfig {
   return { providers, defaults };
 }
 
+function validateNormalize(value: unknown, ctx: string): NormalizationRule | undefined {
+  if (value === undefined) return undefined;
+  assertString(value, `${ctx}.normalize`);
+  if (!isValidNormalizationRule(value)) {
+    throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
+  }
+  return value;
+}
+
+function validateAliases(value: unknown, ctx: string): Record<string, string[]> | undefined {
+  if (value === undefined) return undefined;
+  assertObject(value, `${ctx}.aliases`);
+  const result: Record<string, string[]> = {};
+  for (const [key, arr] of Object.entries(value)) {
+    assertArray(arr, `${ctx}.aliases.${key}`);
+    result[key] = arr.map((v, j) => {
+      assertString(v, `${ctx}.aliases.${key}[${String(j)}]`);
+      return v;
+    });
+  }
+  return result;
+}
+
+function validateStringArray(value: unknown, ctx: string): string[] {
+  assertArray(value, ctx);
+  return value.map((v, j) => {
+    assertString(v, `${ctx}[${String(j)}]`);
+    return v;
+  });
+}
+
+function validateBuiltInDimension(dim: unknown, i: number) {
+  const ctx = `builtIn[${String(i)}]`;
+  assertObject(dim, ctx);
+  assertString(dim['name'], `${ctx}.name`);
+  assertString(dim['label'], `${ctx}.label`);
+  assertString(dim['field'], `${ctx}.field`);
+  const displayField = dim['displayField'] === undefined ? undefined : (assertString(dim['displayField'], `${ctx}.displayField`), dim['displayField']);
+  const enabled = dim['enabled'] === false ? false : undefined;
+  const description = dim['description'] === undefined ? undefined : (assertString(dim['description'], `${ctx}.description`), dim['description']);
+  const useOrgAccounts = dim['useOrgAccounts'] === true ? true : undefined;
+  const accountNameFromTag = typeof dim['accountNameFromTag'] === 'string' && dim['accountNameFromTag'].length > 0
+    ? dim['accountNameFromTag']
+    : undefined;
+  const nameStripPatterns = dim['nameStripPatterns'] === undefined
+    ? undefined
+    : validateStringArray(dim['nameStripPatterns'], `${ctx}.nameStripPatterns`);
+  const normalize = validateNormalize(dim['normalize'], ctx);
+  const aliases = validateAliases(dim['aliases'], ctx);
+  return {
+    name: asDimensionId(dim['name']),
+    label: dim['label'],
+    field: dim['field'],
+    ...(displayField === undefined ? {} : { displayField }),
+    ...(enabled === false ? { enabled } : {}),
+    ...(description === undefined ? {} : { description }),
+    ...(normalize === undefined ? {} : { normalize }),
+    ...(aliases === undefined ? {} : { aliases }),
+    ...(useOrgAccounts === true ? { useOrgAccounts } : {}),
+    ...(accountNameFromTag === undefined ? {} : { accountNameFromTag }),
+    ...(nameStripPatterns === undefined || nameStripPatterns.length === 0 ? {} : { nameStripPatterns }),
+  };
+}
+
+function validateTagDimension(tag: unknown, i: number) {
+  const ctx = `tags[${String(i)}]`;
+  assertObject(tag, ctx);
+  assertString(tag['tagName'], `${ctx}.tagName`);
+  assertString(tag['label'], `${ctx}.label`);
+
+  const concept = tag['concept'] === undefined ? undefined : (() => {
+    assertString(tag['concept'], `${ctx}.concept`);
+    const validConcepts = new Set(['owner', 'product', 'environment']);
+    if (!validConcepts.has(tag['concept'])) {
+      throw new ConfigValidationError(`${ctx}.concept must be 'owner', 'product', or 'environment'`);
+    }
+    return tag['concept'] as 'owner' | 'product' | 'environment';
+  })();
+  const normalize = validateNormalize(tag['normalize'], ctx);
+  const separator = tag['separator'] === undefined ? undefined : (assertString(tag['separator'], `${ctx}.separator`), tag['separator']);
+  const aliases = validateAliases(tag['aliases'], ctx);
+  const enabled = tag['enabled'] === false ? false : undefined;
+
+  return {
+    tagName: tag['tagName'],
+    label: tag['label'],
+    ...(concept === undefined ? {} : { concept }),
+    ...(normalize === undefined ? {} : { normalize }),
+    ...(separator === undefined ? {} : { separator }),
+    ...(aliases === undefined ? {} : { aliases }),
+    ...(typeof tag['accountTagFallback'] === 'string' ? { accountTagFallback: tag['accountTagFallback'] } : {}),
+    ...(typeof tag['missingValueTemplate'] === 'string' ? { missingValueTemplate: tag['missingValueTemplate'] } : {}),
+    ...(enabled === false ? { enabled } : {}),
+  };
+}
+
 export function validateDimensions(raw: unknown): DimensionsConfig {
   assertObject(raw, 'dimensions');
   assertArray(raw['builtIn'], 'builtIn');
   assertArray(raw['tags'], 'tags');
 
-  const builtIn = raw['builtIn'].map((dim, i) => {
-    const ctx = `builtIn[${String(i)}]`;
-    assertObject(dim, ctx);
-    assertString(dim['name'], `${ctx}.name`);
-    assertString(dim['label'], `${ctx}.label`);
-    assertString(dim['field'], `${ctx}.field`);
-    const displayField = dim['displayField'] === undefined ? undefined : (assertString(dim['displayField'], `${ctx}.displayField`), dim['displayField']);
-    const enabled = dim['enabled'] === false ? false : undefined;
-    const description = dim['description'] === undefined ? undefined : (assertString(dim['description'], `${ctx}.description`), dim['description']);
-    const useOrgAccounts = dim['useOrgAccounts'] === true ? true : undefined;
-    const accountNameFromTag = typeof dim['accountNameFromTag'] === 'string' && dim['accountNameFromTag'].length > 0
-      ? dim['accountNameFromTag']
-      : undefined;
-    let nameStripPatterns: string[] | undefined;
-    if (dim['nameStripPatterns'] !== undefined) {
-      assertArray(dim['nameStripPatterns'], `${ctx}.nameStripPatterns`);
-      nameStripPatterns = dim['nameStripPatterns'].map((p, j) => {
-        assertString(p, `${ctx}.nameStripPatterns[${String(j)}]`);
-        return p;
-      });
-    }
-    const normalize = dim['normalize'] === undefined ? undefined : (() => {
-      assertString(dim['normalize'], `${ctx}.normalize`);
-      if (!isValidNormalizationRule(dim['normalize'])) {
-        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
-      }
-      return dim['normalize'];
-    })();
-    let aliases: Record<string, string[]> | undefined;
-    if (dim['aliases'] !== undefined) {
-      assertObject(dim['aliases'], `${ctx}.aliases`);
-      const aliasObj = dim['aliases'];
-      aliases = {};
-      for (const [key, value] of Object.entries(aliasObj)) {
-        assertArray(value, `${ctx}.aliases.${key}`);
-        aliases[key] = value.map((v, j) => {
-          assertString(v, `${ctx}.aliases.${key}[${String(j)}]`);
-          return v;
-        });
-      }
-    }
-    return {
-      name: asDimensionId(dim['name']),
-      label: dim['label'],
-      field: dim['field'],
-      ...(displayField === undefined ? {} : { displayField }),
-      ...(enabled === false ? { enabled } : {}),
-      ...(description === undefined ? {} : { description }),
-      ...(normalize === undefined ? {} : { normalize }),
-      ...(aliases === undefined ? {} : { aliases }),
-      ...(useOrgAccounts === true ? { useOrgAccounts } : {}),
-      ...(accountNameFromTag === undefined ? {} : { accountNameFromTag }),
-      ...(nameStripPatterns === undefined || nameStripPatterns.length === 0 ? {} : { nameStripPatterns }),
-    };
-  });
-
-  const tags = raw['tags'].map((tag, i) => {
-    const ctx = `tags[${String(i)}]`;
-    assertObject(tag, ctx);
-    assertString(tag['tagName'], `${ctx}.tagName`);
-    assertString(tag['label'], `${ctx}.label`);
-
-    const concept = tag['concept'] === undefined ? undefined : (() => {
-      assertString(tag['concept'], `${ctx}.concept`);
-      const validConcepts = new Set(['owner', 'product', 'environment']);
-      if (!validConcepts.has(tag['concept'])) {
-        throw new ConfigValidationError(`${ctx}.concept must be 'owner', 'product', or 'environment'`);
-      }
-      return tag['concept'] as 'owner' | 'product' | 'environment';
-    })();
-    const normalize = tag['normalize'] === undefined ? undefined : (() => {
-      assertString(tag['normalize'], `${ctx}.normalize`);
-      if (!isValidNormalizationRule(tag['normalize'])) {
-        throw new ConfigValidationError(`${ctx}.normalize must be 'lowercase', 'uppercase', 'lowercase-kebab', 'lowercase-underscore', or 'camelCase'`);
-      }
-      return tag['normalize'];
-    })();
-    const separator = tag['separator'] === undefined ? undefined : (assertString(tag['separator'], `${ctx}.separator`), tag['separator']);
-
-    let aliases: Record<string, string[]> | undefined;
-    if (tag['aliases'] !== undefined) {
-      assertObject(tag['aliases'], `${ctx}.aliases`);
-      const aliasObj = tag['aliases'];
-      aliases = {};
-      for (const [key, value] of Object.entries(aliasObj)) {
-        assertArray(value, `${ctx}.aliases.${key}`);
-        const arr = value;
-        aliases[key] = arr.map((v, j) => {
-          assertString(v, `${ctx}.aliases.${key}[${String(j)}]`);
-          return v;
-        });
-      }
-    }
-
-    const enabled = tag['enabled'] === false ? false : undefined;
-    return {
-      tagName: tag['tagName'],
-      label: tag['label'],
-      ...(concept === undefined ? {} : { concept }),
-      ...(normalize === undefined ? {} : { normalize }),
-      ...(separator === undefined ? {} : { separator }),
-      ...(aliases === undefined ? {} : { aliases }),
-      ...(typeof tag['accountTagFallback'] === 'string' ? { accountTagFallback: tag['accountTagFallback'] } : {}),
-      ...(typeof tag['missingValueTemplate'] === 'string' ? { missingValueTemplate: tag['missingValueTemplate'] } : {}),
-      ...(enabled === false ? { enabled } : {}),
-    };
-  });
+  const builtIn = raw['builtIn'].map((dim, i) => validateBuiltInDimension(dim, i));
+  const tags = raw['tags'].map((tag, i) => validateTagDimension(tag, i));
 
   let order: string[] | undefined;
   if (raw['order'] !== undefined) {
-    assertArray(raw['order'], 'order');
-    order = raw['order'].map((v, i) => {
-      assertString(v, `order[${String(i)}]`);
-      return v;
-    });
+    order = validateStringArray(raw['order'], 'order');
   }
 
   return { builtIn, tags, ...(order === undefined ? {} : { order }) };

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -132,43 +132,36 @@ interface NormalizableDimension {
   readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
 }
 
+const NORMALIZE_SQL: Record<NormalizationRule, (expr: string) => string> = {
+  'lowercase': (expr) => `LOWER(${expr})`,
+  'uppercase': (expr) => `UPPER(${expr})`,
+  'lowercase-kebab': (expr) => `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\\1-\\2'), '[_\\s]+', '-', 'g'))`,
+  'lowercase-underscore': (expr) => `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\\1_\\2'), '[-\\s]+', '_', 'g'))`,
+  'camelCase': (expr) => `LOWER(REPLACE(REPLACE(REPLACE(${expr}, '-', ''), '_', ''), ' ', ''))`,
+};
+
+function buildAliasCases(
+  fieldExpr: string,
+  aliases: Readonly<Record<string, readonly string[]>>,
+): string[] {
+  return Object.entries(aliases).map(([canonical, aliasList]) => {
+    const allValues = aliasList.map(a => `'${a.replaceAll("'", "''")}'`).join(', ');
+    return `WHEN ${fieldExpr} IN (${allValues}) THEN '${canonical.replaceAll("'", "''")}'`;
+  });
+}
+
 export function buildAliasSqlCase(
   fieldExpr: string,
   dimension: NormalizableDimension,
 ): string {
-  const cases: string[] = [];
-
   if (dimension.normalize !== undefined) {
-    switch (dimension.normalize) {
-      case 'lowercase':
-        fieldExpr = `LOWER(${fieldExpr})`;
-        break;
-      case 'uppercase':
-        fieldExpr = `UPPER(${fieldExpr})`;
-        break;
-      case 'lowercase-kebab':
-        fieldExpr = `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${fieldExpr}, '([a-z])([A-Z])', '\\1-\\2'), '[_\\s]+', '-', 'g'))`;
-        break;
-      case 'lowercase-underscore':
-        fieldExpr = `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${fieldExpr}, '([a-z])([A-Z])', '\\1_\\2'), '[-\\s]+', '_', 'g'))`;
-        break;
-      case 'camelCase':
-        // SQL approximation for grouping — true camelCase applied in TypeScript
-        fieldExpr = `LOWER(REPLACE(REPLACE(REPLACE(${fieldExpr}, '-', ''), '_', ''), ' ', ''))`;
-        break;
-    }
+    fieldExpr = NORMALIZE_SQL[dimension.normalize](fieldExpr);
   }
 
-  if (dimension.aliases !== undefined) {
-    for (const [canonical, aliasList] of Object.entries(dimension.aliases)) {
-      const allValues = aliasList.map(a => `'${a.replaceAll("'", "''")}'`).join(', ');
-      cases.push(`WHEN ${fieldExpr} IN (${allValues}) THEN '${canonical.replaceAll("'", "''")}'`);
-    }
-  }
+  if (dimension.aliases === undefined) return fieldExpr;
 
-  if (cases.length === 0) {
-    return fieldExpr;
-  }
+  const cases = buildAliasCases(fieldExpr, dimension.aliases);
+  if (cases.length === 0) return fieldExpr;
 
   return `CASE ${cases.join(' ')} ELSE ${fieldExpr} END`;
 }

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -205,6 +205,30 @@ function buildExclusionClauses(
  * DuckDB errors when any glob in the list matches zero files — so callers
  * must pre-filter `periods` to months that actually exist on disk.
  */
+function buildTagSelect(
+  t: DimensionsConfig['tags'][number],
+  needsOrgJoin: boolean,
+): string {
+  const curKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
+  const colName = tagColumnName(t.tagName);
+  const tablePrefix = needsOrgJoin ? 'cur.' : '';
+  const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;
+
+  if (t.accountTagFallback === undefined || !needsOrgJoin) {
+    return `${resourceExpr} AS ${colName}`;
+  }
+
+  const fallbackExpr = `acct_tags.fallback_${colName}`;
+  if (t.missingValueTemplate !== undefined && t.missingValueTemplate.length > 0 && t.missingValueTemplate !== '{fallback}') {
+    const parts = t.missingValueTemplate.split('{fallback}');
+    const prefix = sqlEscapeString(parts[0] ?? '');
+    const suffix = sqlEscapeString(parts[1] ?? '');
+    const formatted = `'${prefix}' || ${fallbackExpr} || '${suffix}'`;
+    return `COALESCE(NULLIF(${resourceExpr}, ''), ${formatted}) AS ${colName}`;
+  }
+  return `COALESCE(NULLIF(${resourceExpr}, ''), ${fallbackExpr}) AS ${colName}`;
+}
+
 export function buildSource(
   dataDir: string,
   tier: string,
@@ -218,27 +242,7 @@ export function buildSource(
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
 
-  const tagSelects = dimensions.tags.map(t => {
-    const curKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
-    const colName = tagColumnName(t.tagName);
-    const tablePrefix = needsOrgJoin ? 'cur.' : '';
-    const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;
-
-    if (t.accountTagFallback !== undefined && needsOrgJoin) {
-      const fallbackExpr = `acct_tags.fallback_${colName}`;
-      // Apply missingValueTemplate if set — e.g. "unknown-{fallback}" → 'unknown-' || account_tag
-      if (t.missingValueTemplate !== undefined && t.missingValueTemplate.length > 0 && t.missingValueTemplate !== '{fallback}') {
-        const parts = t.missingValueTemplate.split('{fallback}');
-        const prefix = sqlEscapeString(parts[0] ?? '');
-        const suffix = sqlEscapeString(parts[1] ?? '');
-        const formatted = `'${prefix}' || ${fallbackExpr} || '${suffix}'`;
-        return `COALESCE(NULLIF(${resourceExpr}, ''), ${formatted}) AS ${colName}`;
-      }
-      return `COALESCE(NULLIF(${resourceExpr}, ''), ${fallbackExpr}) AS ${colName}`;
-    }
-
-    return `${resourceExpr} AS ${colName}`;
-  });
+  const tagSelects = dimensions.tags.map(t => buildTagSelect(t, needsOrgJoin));
 
   const tagClause = tagSelects.length > 0 ? `,\n      ${tagSelects.join(',\n      ')}` : '';
 

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -22,6 +22,41 @@ import type { CostMetric, CostPerspective } from '../types/cost-scope.js';
  *  unit tests). When provided, optional columns missing from the set
  *  are dropped from the expression so the query doesn't error on CURs
  *  that ship without resource IDs / net columns / etc. */
+function coalesceCol(prefix: string, col: string): string {
+  return `COALESCE(${prefix}${col}, 0)`;
+}
+
+function unblendedExpr(prefix: string, net: boolean, has: (col: string) => boolean): string {
+  if (net && has('line_item_net_unblended_cost')) {
+    return coalesceCol(prefix, 'line_item_net_unblended_cost');
+  }
+  return coalesceCol(prefix, 'line_item_unblended_cost');
+}
+
+function blendedExpr(prefix: string, net: boolean, has: (col: string) => boolean): string {
+  if (net && has('line_item_net_unblended_cost')) {
+    return coalesceCol(prefix, 'line_item_net_unblended_cost');
+  }
+  if (has('line_item_blended_cost')) {
+    return coalesceCol(prefix, 'line_item_blended_cost');
+  }
+  return coalesceCol(prefix, 'line_item_unblended_cost');
+}
+
+function amortizedExpr(prefix: string, net: boolean, has: (col: string) => boolean): string {
+  const parts: string[] = [];
+  if (net) {
+    if (has('reservation_net_effective_cost')) parts.push(`${prefix}reservation_net_effective_cost`);
+    if (has('savings_plan_net_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_net_savings_plan_effective_cost`);
+    if (has('line_item_net_unblended_cost')) parts.push(`${prefix}line_item_net_unblended_cost`);
+  } else {
+    if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
+    if (has('savings_plan_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_savings_plan_effective_cost`);
+  }
+  parts.push(`${prefix}line_item_unblended_cost`);
+  return `COALESCE(${parts.join(', ')}, 0)`;
+}
+
 export function costExprFor(
   metric: CostMetric,
   prefix: string,
@@ -31,51 +66,8 @@ export function costExprFor(
   const has = (col: string): boolean => availableColumns === undefined || availableColumns.has(col);
   const net = perspective === 'net';
   switch (metric) {
-    case 'unblended': {
-      // Unblended + net: line_item_net_unblended_cost if available,
-      // otherwise fall back to the gross column (universal). Unblended +
-      // gross: the one column every CUR has.
-      if (net && has('line_item_net_unblended_cost')) {
-        return `COALESCE(${prefix}line_item_net_unblended_cost, 0)`;
-      }
-      return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
-    }
-    case 'blended': {
-      // AWS doesn't publish a `line_item_net_blended_cost` — the net
-      // variant of blended isn't a first-class CUR column. Best we can
-      // do for blended+net is use net_unblended (closest semantics for
-      // net accounting) when available, or fall through to gross
-      // blended otherwise. Gross blended falls back to unblended when
-      // the column is missing (some stripped-down CURs omit it).
-      if (net && has('line_item_net_unblended_cost')) {
-        return `COALESCE(${prefix}line_item_net_unblended_cost, 0)`;
-      }
-      if (has('line_item_blended_cost')) {
-        return `COALESCE(${prefix}line_item_blended_cost, 0)`;
-      }
-      return `COALESCE(${prefix}line_item_unblended_cost, 0)`;
-    }
-    case 'amortized': {
-      // Covered usage rows carry reservation_effective_cost (RI) or
-      // savings_plan_savings_plan_effective_cost (SP — the double
-      // prefix is AWS's snake_case conversion of
-      // savingsPlan/SavingsPlanEffectiveCost); non-covered rows fall
-      // back to unblended. Net variants are reservation_net_effective_cost
-      // and savings_plan_net_savings_plan_effective_cost, paired with
-      // line_item_net_unblended_cost as the fall-through. Any columns
-      // missing are dropped from the COALESCE chain.
-      const parts: string[] = [];
-      if (net) {
-        if (has('reservation_net_effective_cost')) parts.push(`${prefix}reservation_net_effective_cost`);
-        if (has('savings_plan_net_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_net_savings_plan_effective_cost`);
-        if (has('line_item_net_unblended_cost')) parts.push(`${prefix}line_item_net_unblended_cost`);
-      } else {
-        if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
-        if (has('savings_plan_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_savings_plan_effective_cost`);
-      }
-      // line_item_unblended_cost is the final, universal fall-through.
-      parts.push(`${prefix}line_item_unblended_cost`);
-      return `COALESCE(${parts.join(', ')}, 0)`;
-    }
+    case 'unblended': return unblendedExpr(prefix, net, has);
+    case 'blended': return blendedExpr(prefix, net, has);
+    case 'amortized': return amortizedExpr(prefix, net, has);
   }
 }

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -119,6 +119,42 @@ async function saveEtags(
   await writeFile(etagPath, JSON.stringify(savedEtags, null, 2));
 }
 
+function groupFilesByDate(periodFiles: readonly ManifestFileEntry[]): Map<string, ManifestFileEntry[]> {
+  const dateGroups = new Map<string, ManifestFileEntry[]>();
+  for (const file of periodFiles) {
+    const date = extractDate(file.key);
+    if (date === undefined) continue;
+    const existing = dateGroups.get(date);
+    if (existing !== undefined) {
+      existing.push(file);
+    } else {
+      dateGroups.set(date, [file]);
+    }
+  }
+  return dateGroups;
+}
+
+function makeLineHandler(
+  onProgress: ProgressCallback | undefined,
+  totalFiles: number,
+  counter: { filesDone: number },
+): (line: string) => void {
+  return (line) => {
+    logger.info(`[aws] ${line}`);
+    if (line.startsWith('download:')) {
+      counter.filesDone++;
+    }
+    if (onProgress !== undefined) {
+      onProgress({
+        phase: 'downloading',
+        filesTotal: totalFiles,
+        filesDone: counter.filesDone,
+        message: line.startsWith('Completed') ? line : undefined,
+      });
+    }
+  };
+}
+
 async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ filesDownloaded: number; rowsProcessed: number }> {
   const { bucketPath, profile, dataDir, files, onProgress } = options;
   const s3Path = parseS3Path(bucketPath);
@@ -128,25 +164,13 @@ async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ fi
   const periods = groupByPeriod(files);
   const periodList = [...periods.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   const totalFiles = files.length;
-  let globalFilesDone = 0;
+  const counter = { filesDone: 0 };
   let totalFilesDownloaded = 0;
 
   for (const [period, periodFiles] of periodList) {
     if (options.signal?.aborted) break;
 
-    // Group files by date within the period
-    const dateGroups = new Map<string, ManifestFileEntry[]>();
-    for (const file of periodFiles) {
-      const date = extractDate(file.key);
-      if (date === undefined) continue;
-      const existing = dateGroups.get(date);
-      if (existing !== undefined) {
-        existing.push(file);
-      } else {
-        dateGroups.set(date, [file]);
-      }
-    }
-
+    const dateGroups = groupFilesByDate(periodFiles);
     logger.info(`Processing cost optimization period ${period}: ${String(dateGroups.size)} dates`);
 
     for (const [date, dateFiles] of dateGroups) {
@@ -165,23 +189,9 @@ async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ fi
         dest: stagingDir,
         profile,
         signal: options.signal,
-        onLine: (line) => {
-          logger.info(`[aws] ${line}`);
-          if (line.startsWith('download:')) {
-            globalFilesDone++;
-          }
-          if (onProgress !== undefined) {
-            onProgress({
-              phase: 'downloading',
-              filesTotal: totalFiles,
-              filesDone: globalFilesDone,
-              message: line.startsWith('Completed') ? line : undefined,
-            });
-          }
-        },
+        onLine: makeLineHandler(onProgress, totalFiles, counter),
       });
 
-      // Move downloaded files to the output dir (already daily-partitioned)
       const dateDir = join(outputDir, `usage_date=${date}`);
       await mkdir(dateDir, { recursive: true });
 

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -90,6 +90,46 @@ function retentionCutoff(days: number): string {
   return `${String(d.getFullYear())}-${String(d.getMonth() + 1).padStart(2, '0')}`;
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function syncTier(
+  deps: AutoSyncDeps,
+  tier: { name: string; retention: number },
+): Promise<'ok' | 'skip' | 'error'> {
+  const cutoff = retentionCutoff(tier.retention);
+  let inventory: Awaited<ReturnType<typeof deps.getInventory>>;
+  try {
+    inventory = await deps.getInventory(tier.name);
+  } catch (err: unknown) {
+    logger.info(`Auto-sync: failed to get ${tier.name} inventory — ${errorMessage(err)}`);
+    return 'skip';
+  }
+
+  const missing = inventory.periods
+    .filter(p => (p.localStatus === 'missing' || p.localStatus === 'stale') && p.period >= cutoff);
+
+  if (missing.length === 0) {
+    logger.info(`Auto-sync: ${tier.name} — nothing to sync`);
+    return 'skip';
+  }
+
+  const files = missing.flatMap(p => [...p.files]);
+  logger.info(`Auto-sync: ${tier.name} — syncing ${String(missing.length)} periods (${String(files.length)} files)`);
+  status = { state: 'syncing', tier: tier.name, filesDone: 0, filesTotal: files.length };
+
+  try {
+    const result = await deps.syncPeriods(files, tier.name);
+    logger.info(`Auto-sync: ${tier.name} — synced ${String(result.filesDownloaded)} files`);
+    return 'ok';
+  } catch (err: unknown) {
+    logger.info(`Auto-sync: ${tier.name} — sync failed: ${errorMessage(err)}`);
+    status = { state: 'error', message: errorMessage(err), lastRun: new Date().toISOString() };
+    return 'error';
+  }
+}
+
 async function runOnce(deps: AutoSyncDeps): Promise<void> {
   if (running) return;
   running = true;
@@ -122,34 +162,8 @@ async function runOnce(deps: AutoSyncDeps): Promise<void> {
     }
 
     for (const tier of tiers) {
-      const cutoff = retentionCutoff(tier.retention);
-      let inventory: Awaited<ReturnType<typeof deps.getInventory>>;
-      try {
-        inventory = await deps.getInventory(tier.name);
-      } catch (err: unknown) {
-        logger.info(`Auto-sync: failed to get ${tier.name} inventory — ${err instanceof Error ? err.message : String(err)}`);
-        continue;
-      }
-
-      const missing = inventory.periods
-        .filter(p => (p.localStatus === 'missing' || p.localStatus === 'stale') && p.period >= cutoff);
-
-      if (missing.length === 0) {
-        logger.info(`Auto-sync: ${tier.name} — nothing to sync`);
-        continue;
-      }
-
-      const files = missing.flatMap(p => [...p.files]);
-      logger.info(`Auto-sync: ${tier.name} — syncing ${String(missing.length)} periods (${String(files.length)} files)`);
-
-      status = { state: 'syncing', tier: tier.name, filesDone: 0, filesTotal: files.length };
-
-      try {
-        const result = await deps.syncPeriods(files, tier.name);
-        logger.info(`Auto-sync: ${tier.name} — synced ${String(result.filesDownloaded)} files`);
-      } catch (err: unknown) {
-        logger.info(`Auto-sync: ${tier.name} — sync failed: ${err instanceof Error ? err.message : String(err)}`);
-        status = { state: 'error', message: err instanceof Error ? err.message : String(err), lastRun: new Date().toISOString() };
+      const tierResult = await syncTier(deps, tier);
+      if (tierResult === 'error') {
         running = false;
         return;
       }
@@ -158,7 +172,7 @@ async function runOnce(deps: AutoSyncDeps): Promise<void> {
     const now = new Date().toISOString();
     status = { state: 'idle', lastRun: now, nextRun: new Date(Date.now() + currentIntervalMs).toISOString() };
   } catch (err: unknown) {
-    status = { state: 'error', message: err instanceof Error ? err.message : String(err), lastRun: new Date().toISOString() };
+    status = { state: 'error', message: errorMessage(err), lastRun: new Date().toISOString() };
   }
 
   running = false;

--- a/packages/desktop/src/main/aws-org-client.ts
+++ b/packages/desktop/src/main/aws-org-client.ts
@@ -32,33 +32,19 @@ async function getOrganizationsModule(): Promise<typeof import('@aws-sdk/client-
   return import('@aws-sdk/client-organizations');
 }
 
-export async function syncOrgAccounts(
-  profile: string,
+type OrgClient = InstanceType<Awaited<ReturnType<typeof getOrganizationsModule>>['OrganizationsClient']>;
+type OrgModule = Awaited<ReturnType<typeof getOrganizationsModule>>;
+
+async function listAllAccounts(
+  client: OrgClient,
+  module: OrgModule,
   onProgress?: (progress: OrgSyncProgress) => void,
-): Promise<OrgSyncResult> {
-  const {
-    OrganizationsClient,
-    ListAccountsCommand,
-    ListRootsCommand,
-    ListOrganizationalUnitsForParentCommand,
-    ListAccountsForParentCommand,
-    ListTagsForResourceCommand,
-    DescribeOrganizationCommand,
-  } = await getOrganizationsModule();
-
-  const config = profile === 'default' ? {} : { profile };
-  const client = new OrganizationsClient(config);
-
-  // Get org ID
-  const orgResp = await client.send(new DescribeOrganizationCommand({}));
-  const orgId = orgResp.Organization?.Id ?? 'unknown';
-
-  // 1. List all accounts
+): Promise<{ id: string; name: string; email: string; status: string; joinedTimestamp: string }[]> {
   onProgress?.({ phase: 'accounts', done: 0, total: 0 });
   const allAccounts: { id: string; name: string; email: string; status: string; joinedTimestamp: string }[] = [];
   let nextToken: string | undefined;
   do {
-    const resp = await client.send(new ListAccountsCommand({ NextToken: nextToken }));
+    const resp = await client.send(new module.ListAccountsCommand({ NextToken: nextToken }));
     for (const acct of resp.Accounts ?? []) {
       allAccounts.push({
         id: acct.Id ?? '',
@@ -71,14 +57,16 @@ export async function syncOrgAccounts(
     nextToken = resp.NextToken;
     onProgress?.({ phase: 'accounts', done: allAccounts.length, total: allAccounts.length });
   } while (nextToken !== undefined);
+  return allAccounts;
+}
 
-  logger.info(`Discovered ${String(allAccounts.length)} accounts`);
-
-  // 2. Build OU tree to resolve paths
+async function buildOuTree(
+  client: OrgClient,
+  module: OrgModule,
+  rootId: string,
+  onProgress?: (progress: OrgSyncProgress) => void,
+): Promise<OUNode[]> {
   onProgress?.({ phase: 'ous', done: 0, total: 0 });
-  const roots = await client.send(new ListRootsCommand({}));
-  const rootId = roots.Roots?.[0]?.Id ?? '';
-
   const ouNodes: OUNode[] = [];
   const queue = [rootId];
   while (queue.length > 0) {
@@ -86,7 +74,7 @@ export async function syncOrgAccounts(
     if (parentId === undefined) break;
     let ouToken: string | undefined;
     do {
-      const resp = await client.send(new ListOrganizationalUnitsForParentCommand({
+      const resp = await client.send(new module.ListOrganizationalUnitsForParentCommand({
         ParentId: parentId,
         NextToken: ouToken,
       }));
@@ -100,14 +88,19 @@ export async function syncOrgAccounts(
     } while (ouToken !== undefined);
     onProgress?.({ phase: 'ous', done: ouNodes.length, total: ouNodes.length });
   }
+  return ouNodes;
+}
 
-  // Build a map of account → parent OU
+async function buildAccountParentMap(
+  client: OrgClient,
+  module: OrgModule,
+  parentIds: string[],
+): Promise<Map<string, string>> {
   const accountParentMap = new Map<string, string>();
-  const parentsToScan = [rootId, ...ouNodes.map(ou => ou.id)];
-  for (const parentId of parentsToScan) {
+  for (const parentId of parentIds) {
     let acctToken: string | undefined;
     do {
-      const resp = await client.send(new ListAccountsForParentCommand({
+      const resp = await client.send(new module.ListAccountsForParentCommand({
         ParentId: parentId,
         NextToken: acctToken,
       }));
@@ -119,10 +112,16 @@ export async function syncOrgAccounts(
       acctToken = resp.NextToken;
     } while (acctToken !== undefined);
   }
+  return accountParentMap;
+}
 
-  // Resolve OU path for each account
+function makeOuPathResolver(
+  ouNodes: OUNode[],
+  accountParentMap: Map<string, string>,
+  rootId: string,
+): (accountId: string) => string {
   const ouMap = new Map(ouNodes.map(ou => [ou.id, ou]));
-  function resolveOuPath(accountId: string): string {
+  return (accountId: string): string => {
     const parts: string[] = [];
     let current = accountParentMap.get(accountId);
     while (current !== undefined && current !== rootId) {
@@ -132,49 +131,72 @@ export async function syncOrgAccounts(
       current = ou.parentId;
     }
     return parts.join(' / ');
-  }
+  };
+}
 
-  // 3. Fetch tags for each account
+async function fetchAccountTags(
+  client: OrgClient,
+  module: OrgModule,
+  accountId: string,
+): Promise<Record<string, string>> {
+  const tags: Record<string, string> = {};
+  let tagToken: string | undefined;
+  do {
+    const resp = await client.send(new module.ListTagsForResourceCommand({
+      ResourceId: accountId,
+      NextToken: tagToken,
+    }));
+    for (const tag of resp.Tags ?? []) {
+      if (tag.Key !== undefined && tag.Value !== undefined) {
+        tags[tag.Key] = tag.Value;
+      }
+    }
+    tagToken = resp.NextToken;
+  } while (tagToken !== undefined);
+  return tags;
+}
+
+export async function syncOrgAccounts(
+  profile: string,
+  onProgress?: (progress: OrgSyncProgress) => void,
+): Promise<OrgSyncResult> {
+  const module = await getOrganizationsModule();
+  const config = profile === 'default' ? {} : { profile };
+  const client = new module.OrganizationsClient(config);
+
+  const orgResp = await client.send(new module.DescribeOrganizationCommand({}));
+  const orgId = orgResp.Organization?.Id ?? 'unknown';
+
+  const allAccounts = await listAllAccounts(client, module, onProgress);
+  logger.info(`Discovered ${String(allAccounts.length)} accounts`);
+
+  const roots = await client.send(new module.ListRootsCommand({}));
+  const rootId = roots.Roots?.[0]?.Id ?? '';
+
+  const ouNodes = await buildOuTree(client, module, rootId, onProgress);
+  const parentIds = [rootId, ...ouNodes.map(ou => ou.id)];
+  const accountParentMap = await buildAccountParentMap(client, module, parentIds);
+  const resolveOuPath = makeOuPathResolver(ouNodes, accountParentMap, rootId);
+
   const results: OrgAccount[] = [];
   for (let i = 0; i < allAccounts.length; i++) {
     const acct = allAccounts[i];
     if (acct === undefined) continue;
     onProgress?.({ phase: 'tags', done: i, total: allAccounts.length });
 
-    const tags: Record<string, string> = {};
+    let tags: Record<string, string> = {};
     try {
-      let tagToken: string | undefined;
-      do {
-        const resp = await client.send(new ListTagsForResourceCommand({
-          ResourceId: acct.id,
-          NextToken: tagToken,
-        }));
-        for (const tag of resp.Tags ?? []) {
-          if (tag.Key !== undefined && tag.Value !== undefined) {
-            tags[tag.Key] = tag.Value;
-          }
-        }
-        tagToken = resp.NextToken;
-      } while (tagToken !== undefined);
+      tags = await fetchAccountTags(client, module, acct.id);
     } catch {
       logger.info(`Failed to fetch tags for ${acct.id}, skipping`);
     }
 
-    results.push({
-      ...acct,
-      ouPath: resolveOuPath(acct.id),
-      tags,
-    });
+    results.push({ ...acct, ouPath: resolveOuPath(acct.id), tags });
   }
   onProgress?.({ phase: 'tags', done: allAccounts.length, total: allAccounts.length });
 
   logger.info(`Org sync complete: ${String(results.length)} accounts with tags`);
-
-  return {
-    accounts: results,
-    orgId,
-    syncedAt: new Date().toISOString(),
-  };
+  return { accounts: results, orgId, syncedAt: new Date().toISOString() };
 }
 
 export type { OrgAccount, OrgSyncProgress, OrgSyncResult };

--- a/packages/desktop/src/main/aws-ssm-client.ts
+++ b/packages/desktop/src/main/aws-ssm-client.ts
@@ -43,6 +43,32 @@ async function resolveProfileRegion(profile: string): Promise<string> {
 
 const FIELDS = ['longName', 'geolocationCountry', 'geolocationRegion'] as const;
 
+function applyParameterToPartial(partial: Map<string, Partial<RegionInfo>>, name: string, value: string): void {
+  if (value.length === 0) return;
+  const parts = name.split('/');
+  const code = parts.at(-2) ?? '';
+  const field = parts.at(-1) ?? '';
+  if (code.length === 0) return;
+  const entry = partial.get(code) ?? {};
+  if (field === 'longName') entry.longName = value;
+  else if (field === 'geolocationCountry') entry.country = value;
+  else if (field === 'geolocationRegion') entry.continent = value;
+  partial.set(code, entry);
+}
+
+function buildRegionsFromPartial(partial: Map<string, Partial<RegionInfo>>): Record<string, RegionInfo> {
+  const regions: Record<string, RegionInfo> = {};
+  for (const [code, entry] of partial) {
+    if (typeof entry.longName !== 'string' || entry.longName.length === 0) continue;
+    regions[code] = {
+      longName: entry.longName,
+      country: entry.country ?? '',
+      continent: entry.continent ?? '',
+    };
+  }
+  return regions;
+}
+
 /** Pulls AWS-published region metadata from SSM Parameter Store.
  *  Parameters live under /aws/service/global-infrastructure/regions/<code>/<field>
  *  as public params — same source the AWS CLI uses. We list the region codes
@@ -76,9 +102,6 @@ export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
 
   logger.info(`SSM region sync: discovered ${String(codes.length)} regions`);
 
-  // 2. Build the full list of (code, field) lookups and batch 10 at a time.
-  //    A batch may span multiple regions — we recover the region+field from
-  //    each returned Name rather than tracking it positionally.
   const partial = new Map<string, Partial<RegionInfo>>();
   const allNames: string[] = [];
   for (const c of codes) {
@@ -91,36 +114,14 @@ export async function syncRegionNames(profile: string): Promise<RegionNameMap> {
     try {
       const resp = await client.send(new GetParametersCommand({ Names: batch }));
       for (const p of resp.Parameters ?? []) {
-        const name = p.Name ?? '';
-        const value = p.Value ?? '';
-        if (value.length === 0) continue;
-        // /aws/service/global-infrastructure/regions/<code>/<field>
-        const parts = name.split('/');
-        const code = parts.at(-2) ?? '';
-        const field = parts.at(-1) ?? '';
-        if (code.length === 0) continue;
-        const entry = partial.get(code) ?? {};
-        if (field === 'longName') entry.longName = value;
-        else if (field === 'geolocationCountry') entry.country = value;
-        else if (field === 'geolocationRegion') entry.continent = value;
-        partial.set(code, entry);
+        applyParameterToPartial(partial, p.Name ?? '', p.Value ?? '');
       }
     } catch (err: unknown) {
       logger.info(`SSM region sync: batch ${String(i)} failed: ${String(err)}`);
     }
   }
 
-  // Only emit regions that got at least a longName — country/continent default
-  // to empty strings so the consumer can still treat them as present-but-unknown.
-  const regions: Record<string, RegionInfo> = {};
-  for (const [code, entry] of partial) {
-    if (typeof entry.longName !== 'string' || entry.longName.length === 0) continue;
-    regions[code] = {
-      longName: entry.longName,
-      country: entry.country ?? '',
-      continent: entry.continent ?? '',
-    };
-  }
+  const regions = buildRegionsFromPartial(partial);
 
   logger.info(`SSM region sync: resolved ${String(Object.keys(regions).length)} regions with metadata`);
 

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -4,6 +4,53 @@ import type { DimensionsConfig, NormalizationRule } from '@costgoblin/core';
 import { type AppContext, loadOrgAccountsMap } from './context.js';
 import { toNum, toStr } from './query-utils.js';
 
+type ValueCostPair = { value: string; cost: number };
+
+function mergeValuesByLabel(values: ValueCostPair[], labelFn: (v: string) => string): ValueCostPair[] {
+  const merged = new Map<string, number>();
+  for (const v of values) {
+    const label = labelFn(v.value);
+    merged.set(label, (merged.get(label) ?? 0) + v.cost);
+  }
+  return [...merged.entries()].map(([value, cost]) => ({ value, cost })).sort((a, b) => b.cost - a.cost);
+}
+
+async function applyRegionPreview(
+  values: ValueCostPair[],
+  opts: { dimName?: string; useRegionNames?: boolean } | undefined,
+  getRegionMap: () => Promise<ReadonlyMap<string, { longName: string; country: string; continent: string }>>,
+): Promise<ValueCostPair[]> {
+  const regionMap = await getRegionMap();
+  const pick: ((info: { longName: string; country: string; continent: string }) => string) | null =
+    opts?.dimName === 'region_country' ? (i) => i.country
+      : opts?.dimName === 'region_continent' ? (i) => i.continent
+        : opts?.useRegionNames === true ? (i) => i.longName
+          : null;
+  if (pick === null || regionMap.size === 0) return values;
+  return mergeValuesByLabel(values, (raw) => {
+    const info = regionMap.get(raw);
+    if (info === undefined) return raw;
+    const label = pick(info);
+    return label.length > 0 ? label : raw;
+  });
+}
+
+function applyNormalizeAndStrip(
+  values: ValueCostPair[],
+  field: string,
+  opts: { normalize?: NormalizationRule; nameStripPatterns?: readonly string[] } | undefined,
+): ValueCostPair[] {
+  const stripPatterns = field === 'account_id' ? opts?.nameStripPatterns : undefined;
+  const normalize = opts?.normalize;
+  if (normalize === undefined && (stripPatterns === undefined || stripPatterns.length === 0)) return values;
+  return mergeValuesByLabel(values, (raw) => {
+    let key = raw;
+    if (normalize !== undefined) key = applyNormalizationRule(key, normalize);
+    if (stripPatterns !== undefined && stripPatterns.length > 0) key = applyStripPatterns(key, stripPatterns);
+    return key;
+  });
+}
+
 export function registerDimensionsHandlers(app: AppContext): void {
   const { ctx, getConfig, getDimensions, getRegionMap, invalidateDimensions, runQuery } = app;
 
@@ -132,56 +179,18 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const distinctCount = distinctRows[0] !== undefined ? toNum(distinctRows[0]['n']) : 0;
     let values = valueRows.map(r => ({ value: toStr(r['val']), cost: toNum(r['cost']) }));
 
-    // Account-specific: map each id to its org-data name for the preview. We
-    // read org-accounts.json fresh every call so the preview reflects the
-    // toggle before the config is saved (otherwise the cached accountMap
-    // might be from the wrong source).
     if (field === 'account_id' && opts?.useOrgAccounts === true) {
       const orgMap = await loadOrgAccountsMap(ctx.dataDir, opts.accountNameFromTag);
       if (orgMap.size > 0) {
         values = values.map(v => ({ value: orgMap.get(v.value) ?? v.value, cost: v.cost }));
       }
     }
-    // Region: facet the preview by the dim the user is editing.
-    //   - region (with useRegionNames=true): long names from SSM
-    //   - region_country: ISO country code
-    //   - region_continent: AWS geo bucket
-    //   - anything else: raw codes fall through
-    // Rows with an empty value for the requested facet get collapsed together
-    // so the preview chips match what the live query will produce.
+
     if (field === 'region') {
-      const regionMap = await getRegionMap();
-      const pick: ((info: { longName: string; country: string; continent: string }) => string) | null =
-        opts?.dimName === 'region_country' ? (i) => i.country
-          : opts?.dimName === 'region_continent' ? (i) => i.continent
-            : opts?.useRegionNames === true ? (i) => i.longName
-              : null;
-      if (pick !== null && regionMap.size > 0) {
-        const merged = new Map<string, number>();
-        for (const v of values) {
-          const info = regionMap.get(v.value);
-          const label = info === undefined ? v.value : (pick(info).length > 0 ? pick(info) : v.value);
-          merged.set(label, (merged.get(label) ?? 0) + v.cost);
-        }
-        values = [...merged.entries()].map(([value, cost]) => ({ value, cost })).sort((a, b) => b.cost - a.cost);
-      }
+      values = await applyRegionPreview(values, opts, getRegionMap);
     }
-    // Apply the same display-time transforms the live queries use. Order
-    // matches the editor's visual top-down flow: normalize first, then strip.
-    // After either runs, re-aggregate by the resulting key so two raw values
-    // that collapse to the same display value don't show up as duplicate chips.
-    const stripPatterns = field === 'account_id' ? opts?.nameStripPatterns : undefined;
-    const normalize = opts?.normalize;
-    if (normalize !== undefined || (stripPatterns !== undefined && stripPatterns.length > 0)) {
-      const merged = new Map<string, number>();
-      for (const v of values) {
-        let key = v.value;
-        if (normalize !== undefined) key = applyNormalizationRule(key, normalize);
-        if (stripPatterns !== undefined && stripPatterns.length > 0) key = applyStripPatterns(key, stripPatterns);
-        merged.set(key, (merged.get(key) ?? 0) + v.cost);
-      }
-      values = [...merged.entries()].map(([value, cost]) => ({ value, cost })).sort((a, b) => b.cost - a.cost);
-    }
+
+    values = applyNormalizeAndStrip(values, field, opts);
 
     return { values, distinctCount, period: latest.replace(/^daily-/, '') };
   });

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -13,6 +13,76 @@ import {
   toStr,
 } from './query-utils.js';
 
+function resolveFieldExpr(
+  dimensionId: string,
+  dimensions: import('@costgoblin/core').DimensionsConfig,
+): { field: string; fieldExpr: string } {
+  const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
+  const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
+  const field = builtIn === undefined ? dimensionId : builtIn.field;
+  let fieldExpr = field;
+  if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
+  else if (tag !== undefined) fieldExpr = buildAliasSqlCase(field, tag);
+  return { field, fieldExpr };
+}
+
+function buildFilterWhereClauses(
+  filterEntries: Record<string, string>,
+  dimensions: import('@costgoblin/core').DimensionsConfig,
+  accountReverseMap: Map<string, readonly string[]>,
+): string[] {
+  const clauses: string[] = [];
+  for (const [key, value] of Object.entries(filterEntries)) {
+    const fb = dimensions.builtIn.find(d => d.name === key);
+    const ft = dimensions.tags.find(d => tagColumnName(d.tagName) === key);
+    const ff = fb === undefined ? key : fb.field;
+    let ffExpr = ff;
+    if (fb !== undefined) ffExpr = buildAliasSqlCase(ff, fb);
+    else if (ft !== undefined) ffExpr = buildAliasSqlCase(ff, ft);
+
+    if (ff === 'account_id') {
+      const ids = accountReverseMap.get(value);
+      if (ids !== undefined && ids.length > 0) {
+        const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+        clauses.push(`${ff} IN (${list})`);
+        continue;
+      }
+    }
+    clauses.push(`${ffExpr} = '${value.replaceAll("'", "''")}'`);
+  }
+  return clauses;
+}
+
+function buildExclusionWhereClauses(
+  costScope: import('@costgoblin/core').CostScopeConfig | undefined,
+  dimensions: import('@costgoblin/core').DimensionsConfig,
+  accountReverseMap: Map<string, readonly string[]>,
+): string[] {
+  if (costScope === undefined) return [];
+  const clauses: string[] = [];
+  for (const rule of costScope.rules) {
+    if (!rule.enabled) continue;
+    const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+    if (matchExpr !== null) clauses.push(`NOT (${matchExpr})`);
+  }
+  return clauses;
+}
+
+function mergeAccountRows(
+  rows: import('../duckdb-client.js').RawRow[],
+  accountMap: Map<string, string>,
+): { value: string; label: string; count: number }[] {
+  const merged = new Map<string, number>();
+  for (const r of rows) {
+    const rawVal = toStr(r['val']);
+    const name = accountMap.get(rawVal) ?? rawVal;
+    merged.set(name, (merged.get(name) ?? 0) + toNum(r['total_cost']));
+  }
+  return [...merged.entries()]
+    .map(([name, cost]) => ({ value: name, label: name, count: cost }))
+    .sort((a, b) => b.count - a.count);
+}
+
 export function registerFilterHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runQuery } = app;
 
@@ -20,78 +90,23 @@ export function registerFilterHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = buildAccountReverseMap(accountMap);
-    // Honour the cost-scope exclusions here too — a user who has
-    // excluded Tax / RI purchases doesn't want those values showing up
-    // in filter dropdowns either. The Cost Scope editor sets
-    // bypassCostScope=true so its rule-condition autocomplete still
-    // sees every available value when composing new rules.
     const costScope = opts?.bypassCostScope === true
       ? undefined
       : await getCostScope().catch(() => undefined);
 
-    const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
-    const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
-
-    const field = builtIn === undefined ? dimensionId : builtIn.field;
-    // Apply alias/normalize CASE for both built-ins and tags so the SQL
-    // returns the same display values the cost queries see — including the
-    // SSM-derived friendly region names spliced into Region's aliases.
-    let fieldExpr = field;
-    if (builtIn !== undefined) {
-      fieldExpr = buildAliasSqlCase(field, builtIn);
-    } else if (tag !== undefined) {
-      fieldExpr = buildAliasSqlCase(field, tag);
-    }
-
-    const whereClauses: string[] = [];
-    for (const [key, value] of Object.entries(filterEntries)) {
-      const fb = dimensions.builtIn.find(d => d.name === key);
-      const ft = dimensions.tags.find(d => tagColumnName(d.tagName) === key);
-      const ff = fb === undefined ? key : fb.field;
-      let ffExpr = ff;
-      if (fb !== undefined) {
-        ffExpr = buildAliasSqlCase(ff, fb);
-      } else if (ft !== undefined) {
-        ffExpr = buildAliasSqlCase(ff, ft);
-      }
-      // Account filters carry display names that may collapse N ids — same
-      // expansion the SQL builder does in buildFilterClauses.
-      if (ff === 'account_id') {
-        const ids = accountReverseMap.get(value);
-        if (ids !== undefined && ids.length > 0) {
-          const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
-          whereClauses.push(`${ff} IN (${list})`);
-          continue;
-        }
-      }
-      whereClauses.push(`${ffExpr} = '${value.replaceAll("'", "''")}'`);
-    }
-
+    const { fieldExpr } = resolveFieldExpr(dimensionId, dimensions);
+    const whereClauses = [
+      ...buildFilterWhereClauses(filterEntries, dimensions, accountReverseMap),
+      ...buildExclusionWhereClauses(costScope, dimensions, accountReverseMap),
+    ];
     if (dateRange !== undefined) {
       whereClauses.push(`usage_date BETWEEN '${dateRange.start}' AND '${dateRange.end}'`);
     }
 
-    if (costScope !== undefined) {
-      // NOT (rule_match) per enabled rule — same shape buildExclusionClauses
-      // emits for the main query builders. Apply the dim's reverse map
-      // (account collapse) when the condition targets account_id.
-      for (const rule of costScope.rules) {
-        if (!rule.enabled) continue;
-        const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
-        if (matchExpr === null) continue;
-        whereClauses.push(`NOT (${matchExpr})`);
-      }
-    }
-
     const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
-
     const orgPath = await getOrgAccountsPath();
     const periods = dateRange === undefined ? undefined : computePeriodsInRange(dateRange);
     const availableColumns = await getAvailableColumns('daily');
-    // filter-values doesn't need a specific metric — just needs source
-    // with the fewest column constraints. Pass 'unblended' (always
-    // present) plus the probed column set so the source query doesn't
-    // reference missing columns.
     const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, 'unblended', availableColumns);
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
@@ -105,21 +120,8 @@ export function registerFilterHandlers(app: AppContext): void {
 
     const rows = await runQuery(sql);
     const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
-    if (isAccountDim) {
-      // Roll N raw ids that resolve to the same display name into one entry —
-      // value AND label are the display name so the picker shows a single row
-      // and downstream filter matching uses the same display name (which the
-      // SQL builder expands back to all underlying ids).
-      const merged = new Map<string, number>();
-      for (const r of rows) {
-        const rawVal = toStr(r['val']);
-        const name = accountMap.get(rawVal) ?? rawVal;
-        merged.set(name, (merged.get(name) ?? 0) + toNum(r['total_cost']));
-      }
-      return [...merged.entries()]
-        .map(([name, cost]) => ({ value: name, label: name, count: cost }))
-        .sort((a, b) => b.count - a.count);
-    }
+    if (isAccountDim) return mergeAccountRows(rows, accountMap);
+
     return rows.map(r => {
       const rawVal = toStr(r['val']);
       return { value: rawVal, label: rawVal, count: toNum(r['total_cost']) };

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -362,6 +362,43 @@ export function buildEntityDetailResult(rows: RawRow[], entity: string): EntityD
   };
 }
 
+function mergeDescendantCosts(
+  descendants: readonly string[],
+  entityCostMap: Map<string, CostRow>,
+  consumedEntities: Set<string>,
+  skipName?: string,
+  baseCost?: number,
+  baseServices?: Record<string, number>,
+): { totalCost: number; mergedServices: Record<string, number> } {
+  let totalCost = baseCost ?? 0;
+  const mergedServices: Record<string, number> = baseServices !== undefined
+    ? { ...baseServices }
+    : {};
+  for (const desc of descendants) {
+    if (desc === skipName) continue;
+    consumedEntities.add(desc);
+    const row = entityCostMap.get(desc);
+    if (row === undefined) continue;
+    totalCost += row.totalCost;
+    for (const [svc, cost] of Object.entries(row.serviceCosts)) {
+      mergedServices[svc] = (mergedServices[svc] ?? 0) + cost;
+    }
+  }
+  return { totalCost, mergedServices };
+}
+
+function makeVirtualRow(name: string, totalCost: number, mergedServices: Record<string, number>): CostRow | null {
+  if (totalCost <= 0) return null;
+  return {
+    entity: asEntityRef(name),
+    totalCost: asDollars(totalCost),
+    serviceCosts: Object.fromEntries(
+      Object.entries(mergedServices).map(([k, v]) => [k, asDollars(v)]),
+    ),
+    isVirtual: true,
+  };
+}
+
 export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[]): CostResult {
   const entityCostMap = new Map<string, CostRow>();
   for (const row of result.rows) {
@@ -374,69 +411,32 @@ export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[])
   for (const node of tree) {
     if (node.virtual) {
       const descendants = getDescendantTagValues(node);
-      let totalCost = 0;
-      const mergedServices: Record<string, number> = {};
-
-      for (const desc of descendants) {
-        consumedEntities.add(desc);
-        const row = entityCostMap.get(desc);
-        if (row !== undefined) {
-          totalCost += row.totalCost;
-          for (const [svc, cost] of Object.entries(row.serviceCosts)) {
-            mergedServices[svc] = (mergedServices[svc] ?? 0) + cost;
-          }
-        }
-      }
-
-      if (totalCost > 0) {
-        rolledUpRows.push({
-          entity: asEntityRef(node.name),
-          totalCost: asDollars(totalCost),
-          serviceCosts: Object.fromEntries(
-            Object.entries(mergedServices).map(([k, v]) => [k, asDollars(v)]),
-          ),
-          isVirtual: true,
-        });
-      }
-    } else {
-      const descendants = node.children === undefined ? [] : getDescendantTagValues(node);
-      for (const desc of descendants) {
-        if (desc !== node.name) consumedEntities.add(desc);
-      }
-
-      const row = entityCostMap.get(node.name);
-      if (node.children !== undefined && node.children.length > 0) {
-        let totalCost = row === undefined ? 0 : row.totalCost;
-        const mergedServices: Record<string, number> = row === undefined
-          ? {}
-          : Object.fromEntries(Object.entries(row.serviceCosts).map(([k, v]) => [k, Number(v)]));
-
-        for (const desc of descendants) {
-          if (desc === node.name) continue;
-          consumedEntities.add(desc);
-          const childRow = entityCostMap.get(desc);
-          if (childRow !== undefined) {
-            totalCost += childRow.totalCost;
-            for (const [svc, cost] of Object.entries(childRow.serviceCosts)) {
-              mergedServices[svc] = (mergedServices[svc] ?? 0) + cost;
-            }
-          }
-        }
-
-        if (totalCost > 0) {
-          rolledUpRows.push({
-            entity: asEntityRef(node.name),
-            totalCost: asDollars(totalCost),
-            serviceCosts: Object.fromEntries(
-              Object.entries(mergedServices).map(([k, v]) => [k, asDollars(v)]),
-            ),
-            isVirtual: true,
-          });
-        }
-      } else if (row !== undefined) {
-        rolledUpRows.push(row);
-      }
+      const { totalCost, mergedServices } = mergeDescendantCosts(descendants, entityCostMap, consumedEntities);
+      const row = makeVirtualRow(node.name, totalCost, mergedServices);
+      if (row !== null) rolledUpRows.push(row);
+      continue;
     }
+
+    const descendants = node.children === undefined ? [] : getDescendantTagValues(node);
+    for (const desc of descendants) {
+      if (desc !== node.name) consumedEntities.add(desc);
+    }
+
+    const existingRow = entityCostMap.get(node.name);
+    if (node.children === undefined || node.children.length === 0) {
+      if (existingRow !== undefined) rolledUpRows.push(existingRow);
+      continue;
+    }
+
+    const baseCost = existingRow === undefined ? 0 : existingRow.totalCost;
+    const baseServices = existingRow === undefined
+      ? {}
+      : Object.fromEntries(Object.entries(existingRow.serviceCosts).map(([k, v]) => [k, Number(v)]));
+    const { totalCost, mergedServices } = mergeDescendantCosts(
+      descendants, entityCostMap, consumedEntities, node.name, baseCost, baseServices,
+    );
+    const row = makeVirtualRow(node.name, totalCost, mergedServices);
+    if (row !== null) rolledUpRows.push(row);
   }
 
   for (const row of result.rows) {
@@ -445,8 +445,5 @@ export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[])
     }
   }
 
-  return {
-    ...result,
-    rows: rolledUpRows,
-  };
+  return { ...result, rows: rolledUpRows };
 }

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -2,6 +2,31 @@ import { ipcMain, shell } from 'electron';
 import { logger, parseS3Path, isStringRecord, parseJsonObject } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
+const REQUIRED_CUR_COLUMNS = [
+  'line_item_usage_start_date', 'line_item_usage_account_id',
+  'line_item_unblended_cost', 'product_servicecode',
+  'product_product_family', 'product_region_code', 'resource_tags',
+];
+
+function classifyManifestColumns(columnNames: string[]): { detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] } {
+  if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
+    return { detectedType: 'cost-optimization', missingColumns: [] };
+  }
+  if (columnNames.includes('line_item_usage_start_date')) {
+    return { detectedType: 'daily', missingColumns: REQUIRED_CUR_COLUMNS.filter(c => !columnNames.includes(c)) };
+  }
+  return { detectedType: 'unknown', missingColumns: [] };
+}
+
+function parseManifestColumnNames(body: string): string[] {
+  const columns = parseJsonObject(body)?.['columns'];
+  if (!Array.isArray(columns)) return [];
+  return columns
+    .filter(isStringRecord)
+    .map(c => typeof c['name'] === 'string' ? c['name'] : '')
+    .filter(n => n.length > 0);
+}
+
 export function registerSetupHandlers(app: AppContext): void {
   const { ctx, invalidateConfig, invalidateDimensions } = app;
 
@@ -108,18 +133,10 @@ export function registerSetupHandlers(app: AppContext): void {
         })
         .filter(p => p.length > 0);
 
-      const hasData = prefixes.includes('data');
-      const hasMetadata = prefixes.includes('metadata');
-      const isCurReport = hasData && hasMetadata;
+      const isCurReport = prefixes.includes('data') && prefixes.includes('metadata');
 
       let detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown' = 'unknown';
       let missingColumns: string[] = [];
-
-      const requiredCurColumns = [
-        'line_item_usage_start_date', 'line_item_usage_account_id',
-        'line_item_unblended_cost', 'product_servicecode',
-        'product_product_family', 'product_region_code', 'resource_tags',
-      ];
 
       if (isCurReport) {
         try {
@@ -128,26 +145,15 @@ export function registerSetupHandlers(app: AppContext): void {
             Prefix: `${params.prefix}metadata/`,
             MaxKeys: 10,
           }));
-
           const manifestKey = (metaList.Contents ?? []).find(c => c.Key?.endsWith('.json'))?.Key;
           if (manifestKey !== undefined) {
             const manifestResponse = await client.send(new GetObjectCommand({ Bucket: params.bucket, Key: manifestKey }));
             const body = await manifestResponse.Body?.transformToString();
             if (body !== undefined) {
-              const columns = parseJsonObject(body)?.['columns'];
-              const columnNames: string[] = Array.isArray(columns)
-                ? columns
-                  .filter(isStringRecord)
-                  .map(c => typeof c['name'] === 'string' ? c['name'] : '')
-                  .filter(n => n.length > 0)
-                : [];
-
-              if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
-                detectedType = 'cost-optimization';
-              } else if (columnNames.includes('line_item_usage_start_date')) {
-                detectedType = 'daily';
-                missingColumns = requiredCurColumns.filter(c => !columnNames.includes(c));
-              }
+              const columnNames = parseManifestColumnNames(body);
+              const classification = classifyManifestColumns(columnNames);
+              detectedType = classification.detectedType;
+              missingColumns = classification.missingColumns;
             }
           }
         } catch {

--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -37,6 +37,22 @@ function createCoin(id: number, containerWidth: number, containerHeight: number)
   };
 }
 
+function updateCoin(c: Coin, containerWidth: number, containerHeight: number): Coin {
+  let { x, y, vx, vy, rotation, rotationSpeed, scale } = c;
+  vy += 0.034;
+  vx += Math.sin(Date.now() / 800 + c.id * 2) * 0.013;
+  vx *= 0.98;
+  x += vx;
+  y += vy;
+  rotation += rotationSpeed;
+  if (rotation >= ROTATION_MAX) { rotation = ROTATION_MAX; rotationSpeed = -Math.abs(rotationSpeed); }
+  else if (rotation <= ROTATION_MIN) { rotation = ROTATION_MIN; rotationSpeed = Math.abs(rotationSpeed); }
+  if (x < 0) { x = 0; vx = Math.abs(vx) * 0.5; }
+  if (x > containerWidth - COIN_SIZE * scale) { x = containerWidth - COIN_SIZE * scale; vx = -Math.abs(vx) * 0.5; }
+  if (y > containerHeight + COIN_SIZE) return createCoin(c.id, containerWidth, containerHeight);
+  return { ...c, x, y, vx, vy, rotation, scale };
+}
+
 export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: number; count?: number }>) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [coins, setCoins] = useState<Coin[]>([]);
@@ -56,26 +72,7 @@ export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: 
     const w = el.offsetWidth;
 
     const tick = () => {
-      setCoins(prev => prev.map(c => {
-        let { x, y, vx, vy, rotation, rotationSpeed, scale } = c;
-        vy += 0.034;
-        vx += Math.sin(Date.now() / 800 + c.id * 2) * 0.013;
-        vx *= 0.98;
-        x += vx;
-        y += vy;
-        rotation += rotationSpeed;
-        if (rotation >= ROTATION_MAX) { rotation = ROTATION_MAX; rotationSpeed = -Math.abs(rotationSpeed); }
-        else if (rotation <= ROTATION_MIN) { rotation = ROTATION_MIN; rotationSpeed = Math.abs(rotationSpeed); }
-
-        if (x < 0) { x = 0; vx = Math.abs(vx) * 0.5; }
-        if (x > w - COIN_SIZE * scale) { x = w - COIN_SIZE * scale; vx = -Math.abs(vx) * 0.5; }
-
-        if (y > height + COIN_SIZE) {
-          return createCoin(c.id, w, height);
-        }
-
-        return { ...c, x, y, vx, vy, rotation, scale };
-      }));
+      setCoins(prev => prev.map(c => updateCoin(c, w, height)));
       frameRef.current = requestAnimationFrame(tick);
     };
 

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -570,6 +570,37 @@ function describeDraftError(draft: CostScopeConfig): string | null {
   return null;
 }
 
+function PerspectiveToggle({ current, netDisabled, onChange }: Readonly<{
+  current: CostPerspective;
+  netDisabled: boolean;
+  onChange: (p: CostPerspective) => void;
+}>): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5 shrink-0">
+      {(['gross', 'net'] as const).map(perspective => {
+        const disabled = perspective === 'net' && netDisabled;
+        const active = current === perspective;
+        return (
+          <button
+            key={perspective}
+            type="button"
+            disabled={disabled}
+            onClick={() => { onChange(perspective); }}
+            className={[
+              'px-3 py-1 text-xs rounded-md transition-colors capitalize',
+              active ? 'bg-accent text-bg-primary' : 'text-text-secondary hover:text-text-primary',
+              disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
+            ].join(' ')}
+            title={disabled ? 'Requires line_item_net_unblended_cost — enable "Include Net Columns" on the CUR report.' : undefined}
+          >
+            {perspective}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function CostScopeView(): React.JSX.Element {
   const api = useCostApi();
   const [draft, setDraft] = useState(DEFAULT_COST_SCOPE);
@@ -845,28 +876,11 @@ export function CostScopeView(): React.JSX.Element {
                       Net applies credits, refunds, and promotional discounts on top of the chosen metric.
                     </div>
                   </div>
-                  <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5 shrink-0">
-                    {(['gross', 'net'] as const).map(perspective => {
-                      const disabled = perspective === 'net' && capabilities !== null && !capabilities.hasNetColumns;
-                      const active = (draft.costPerspective ?? 'gross') === perspective;
-                      return (
-                        <button
-                          key={perspective}
-                          type="button"
-                          disabled={disabled}
-                          onClick={() => { handlePerspectiveChange(perspective); }}
-                          className={[
-                            'px-3 py-1 text-xs rounded-md transition-colors capitalize',
-                            active ? 'bg-accent text-bg-primary' : 'text-text-secondary hover:text-text-primary',
-                            disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
-                          ].join(' ')}
-                          title={disabled ? 'Requires line_item_net_unblended_cost — enable "Include Net Columns" on the CUR report.' : undefined}
-                        >
-                          {perspective}
-                        </button>
-                      );
-                    })}
-                  </div>
+                  <PerspectiveToggle
+                    current={draft.costPerspective ?? 'gross'}
+                    netDisabled={capabilities !== null && !capabilities.hasNetColumns}
+                    onChange={handlePerspectiveChange}
+                  />
                 </div>
                 {(draft.costPerspective ?? 'gross') === 'net' && capabilities !== null && !capabilities.hasNetColumns && (
                   <div className="mt-2 text-xs text-warning">

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -22,6 +22,35 @@ function phaseLabel(phase: string, total: number): string {
   }
 }
 
+function SyncStatusBanner({ syncState }: Readonly<{ syncState: OrgSyncState }>): React.JSX.Element | null {
+  if (syncState.status === 'syncing') {
+    return (
+      <div className="mt-3 rounded-lg border border-accent/50 bg-positive-muted px-3 py-2">
+        <div className="flex items-center gap-2 text-xs text-accent">
+          <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+          <span className="capitalize">{syncState.phase}</span>
+          {syncState.total > 0 && <span>— {String(syncState.done)}/{String(syncState.total)}</span>}
+        </div>
+      </div>
+    );
+  }
+  if (syncState.status === 'error') {
+    return (
+      <div className="mt-3 rounded-lg border border-negative/50 bg-negative-muted px-3 py-2 text-xs text-negative">
+        {syncState.message}
+      </div>
+    );
+  }
+  if (syncState.status === 'done') {
+    return (
+      <div className="mt-3 rounded-lg border border-accent/50 bg-positive-muted px-3 py-2 text-xs text-accent">
+        Synced {String(syncState.count)} accounts
+      </div>
+    );
+  }
+  return null;
+}
+
 export function OrgAccountsSection({ profile }: Readonly<{ profile: string | null }>) {
   const api = useCostApi();
   const [refreshKey, setRefreshKey] = useState(0);
@@ -101,25 +130,7 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
               This replaces the manual CSV export.
             </p>
 
-            {syncState.status === 'syncing' && (
-              <div className="mt-3 rounded-lg border border-accent/50 bg-positive-muted px-3 py-2">
-                <div className="flex items-center gap-2 text-xs text-accent">
-                  <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
-                  <span className="capitalize">{syncState.phase}</span>
-                  {syncState.total > 0 && <span>— {String(syncState.done)}/{String(syncState.total)}</span>}
-                </div>
-              </div>
-            )}
-            {syncState.status === 'error' && (
-              <div className="mt-3 rounded-lg border border-negative/50 bg-negative-muted px-3 py-2 text-xs text-negative">
-                {syncState.message}
-              </div>
-            )}
-            {syncState.status === 'done' && (
-              <div className="mt-3 rounded-lg border border-accent/50 bg-positive-muted px-3 py-2 text-xs text-accent">
-                Synced {String(syncState.count)} accounts
-              </div>
-            )}
+            <SyncStatusBanner syncState={syncState} />
 
             {profile !== null && syncState.status !== 'syncing' && (
               <button

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -12,16 +12,9 @@ import { ConfirmModal } from '../components/confirm-modal.js';
  *  reorder space so a tag can be dropped above a built-in and vice-versa. */
 interface DragRef { orderIdx: number }
 
-/** Stable identifiers for the unified `order` array in DimensionsConfig.
- *  A built-in is keyed by its name; a tag is keyed by its tagName. The
- *  `builtin:`/`tag:` prefix avoids any chance of collision if a user names
- *  a tag after a built-in. Keep in sync with the YAML schema. */
 function builtInKey(name: string): string { return `builtin:${name}`; }
 function tagKey(tagName: string): string { return `tag:${tagName}`; }
 
-/** Default order for configs that predate the `order` field: built-ins
- *  first in config order, then tags. Restricted to enabled items only —
- *  disabled dims aren't part of the unified ordering. */
 function defaultOrder(config: DimensionsConfig): string[] {
   const keys: string[] = [];
   for (const d of config.builtIn) {
@@ -33,10 +26,7 @@ function defaultOrder(config: DimensionsConfig): string[] {
   return keys;
 }
 
-/** Normalize the current `order` against the live config: drop entries
- *  pointing at disabled/removed dims, append any newly-enabled dims at
- *  the end so they show up without requiring an explicit write. */
-function reconcileOrder(config: DimensionsConfig): string[] {
+function collectValidKeys(config: DimensionsConfig): Set<string> {
   const valid = new Set<string>();
   for (const d of config.builtIn) {
     if (d.enabled !== false) valid.add(builtInKey(d.name));
@@ -44,6 +34,11 @@ function reconcileOrder(config: DimensionsConfig): string[] {
   for (const t of config.tags) {
     if (t.enabled !== false) valid.add(tagKey(t.tagName));
   }
+  return valid;
+}
+
+function reconcileOrder(config: DimensionsConfig): string[] {
+  const valid = collectValidKeys(config);
   const seen = new Set<string>();
   const out: string[] = [];
   for (const key of config.order ?? defaultOrder(config)) {
@@ -512,6 +507,125 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+type TagSource = 'resource' | 'account' | 'both' | 'template';
+
+function sourceColor(source: TagSource, aliased: boolean): string {
+  if (aliased) return 'bg-rose-500/10 border-rose-500/30 text-rose-300';
+  switch (source) {
+    case 'template': return 'bg-warning/10 border-warning/30 text-warning italic';
+    case 'both': return 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300';
+    case 'account': return 'bg-violet-500/10 border-violet-500/30 text-violet-300';
+    case 'resource': return 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
+  }
+}
+
+function applyPreviewNormalize(v: string, rule: string): string {
+  switch (rule) {
+    case 'lowercase': return v.toLowerCase();
+    case 'uppercase': return v.toUpperCase();
+    case 'lowercase-kebab': return v.replaceAll(/([a-z])([A-Z])/g, '$1-$2').replaceAll('_', '-').replaceAll(' ', '-').toLowerCase();
+    case 'lowercase-underscore': return v.replaceAll(/([a-z])([A-Z])/g, '$1_$2').replaceAll('-', '_').replaceAll(' ', '_').toLowerCase();
+    case 'camelCase': return v.replaceAll(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, (_, c: string) => c.toLowerCase());
+    default: return v;
+  }
+}
+
+function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, normalizeRule, aliasText }: Readonly<{
+  tagMatch: { sampleValues: string[] } | undefined;
+  fallbackValues: [string, number][];
+  missingValueTemplate: string;
+  normalizeRule: string;
+  aliasText: string;
+}>): React.JSX.Element | null {
+  const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
+  const accountVals = fallbackValues.map(([v]) => v);
+  const fallbackFormat = missingValueTemplate.length > 0 ? missingValueTemplate : '{fallback}';
+  const isPassthrough = fallbackFormat === '{fallback}';
+
+  const templateVals: string[] = [];
+  if (!isPassthrough && accountVals.length > 0) {
+    if (fallbackFormat.includes('{fallback}')) {
+      for (const acctVal of accountVals) templateVals.push(fallbackFormat.replaceAll('{fallback}', acctVal));
+    } else {
+      templateVals.push(fallbackFormat);
+    }
+  }
+
+  const resourceSet = new Set(resourceVals);
+  const templateSet = new Set(templateVals);
+  const allRaw = isPassthrough
+    ? [...new Set([...resourceVals, ...accountVals])]
+    : [...new Set([...resourceVals, ...templateVals])];
+  const accountSet = isPassthrough ? new Set(accountVals) : new Set<string>();
+  if (allRaw.length === 0) return null;
+
+  const normalize = (v: string): string => applyPreviewNormalize(v, normalizeRule);
+  const aliasMap = new Map<string, string>();
+  const parsed = textToAliases(aliasText);
+  if (parsed !== undefined) {
+    for (const [canonical, alts] of Object.entries(parsed)) {
+      for (const alt of alts) aliasMap.set(normalize(alt), canonical);
+    }
+  }
+
+  const transformed = allRaw.map(raw => {
+    const normalized = normalize(raw);
+    const resolved = aliasMap.get(normalized) ?? normalized;
+    const fromResource = resourceSet.has(raw);
+    const fromAccount = accountSet.has(raw);
+    const fromTemplate = templateSet.has(raw);
+    let source: TagSource;
+    if (fromTemplate) source = 'template';
+    else if (fromResource && fromAccount) source = 'both';
+    else if (fromResource) source = 'resource';
+    else source = 'account';
+    return { raw, resolved, aliased: aliasMap.has(normalized), source };
+  });
+
+  const aliasPreviewCount = transformed.filter(t => t.aliased).length;
+
+  const resolvedMap = new Map<string, TagSource>();
+  for (const t of transformed) {
+    const existing = resolvedMap.get(t.resolved);
+    if (existing === undefined) resolvedMap.set(t.resolved, t.source);
+    else if (existing !== 'both' && existing !== t.source) resolvedMap.set(t.resolved, 'both');
+  }
+  const unique = [...resolvedMap.entries()]
+    .map(([resolved, source]) => ({
+      resolved,
+      aliased: transformed.some(t => t.resolved === resolved && t.aliased),
+      source,
+    }))
+    .sort((a, b) => a.resolved.localeCompare(b.resolved));
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-text-muted">
+        Preview — {String(allRaw.length)} raw → {String(unique.length)} resolved
+        {normalizeRule.length > 0 ? ` (${normalizeRule})` : ''}
+        {aliasPreviewCount > 0 ? ` · ${String(aliasPreviewCount)} aliased` : ''}
+      </span>
+      <div className="flex items-center gap-3 text-[9px] text-text-muted mb-1">
+        <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
+        <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
+        <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
+        {aliasPreviewCount > 0 && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-rose-500/30 border border-rose-500/50" /> aliased</span>}
+        {!isPassthrough && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> formatted</span>}
+      </div>
+      <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
+        {unique.map(({ resolved, aliased, source }) => (
+          <span
+            key={resolved}
+            className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${sourceColor(source, aliased)}`}
+          >
+            {resolved}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredTags: discovered, accountTagKeys: acctTags, orgAccounts }: Readonly<{
   tag: EditingTag;
   onSave: (tag: EditingTag) => void;
@@ -701,134 +815,13 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
       </div>
 
       {/* Row 5: Merged + normalized preview of all values */}
-      {(() => {
-        // Collect values with source tracking
-        const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
-        const accountVals = fallbackValues.map(([v]) => v);
-        // Fallback format: {fallback} = raw account value, or custom like "unknown-{fallback}"
-        const fallbackFormat = state.missingValueTemplate.length > 0 ? state.missingValueTemplate : '{fallback}';
-        const isPassthrough = fallbackFormat === '{fallback}';
-
-        // Generate formatted fallback values
-        const templateVals: string[] = [];
-        if (!isPassthrough && accountVals.length > 0) {
-          if (fallbackFormat.includes('{fallback}')) {
-            for (const acctVal of accountVals) {
-              templateVals.push(fallbackFormat.replaceAll('{fallback}', acctVal));
-            }
-          } else {
-            // Static string, no variable
-            templateVals.push(fallbackFormat);
-          }
-        }
-
-        const resourceSet = new Set(resourceVals);
-        const templateSet = new Set(templateVals);
-        // When format changes the value, show template vals instead of raw account vals
-        const allRaw = isPassthrough
-          ? [...new Set([...resourceVals, ...accountVals])]
-          : [...new Set([...resourceVals, ...templateVals])];
-        const accountSet = isPassthrough ? new Set(accountVals) : new Set<string>();
-        if (allRaw.length === 0) return null;
-
-        // Apply normalization
-        const normalize = (v: string): string => {
-          switch (state.normalize) {
-            case 'lowercase': return v.toLowerCase();
-            case 'uppercase': return v.toUpperCase();
-            case 'lowercase-kebab': return v.replaceAll(/([a-z])([A-Z])/g, '$1-$2').replaceAll('_', '-').replaceAll(' ', '-').toLowerCase();
-            case 'lowercase-underscore': return v.replaceAll(/([a-z])([A-Z])/g, '$1_$2').replaceAll('-', '_').replaceAll(' ', '_').toLowerCase();
-            case 'camelCase': return v.replaceAll(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, (_, c: string) => c.toLowerCase());
-            default: return v;
-          }
-        };
-
-        // Build alias reverse map
-        const aliasMap = new Map<string, string>();
-        const parsed = textToAliases(state.aliases);
-        if (parsed !== undefined) {
-          for (const [canonical, alts] of Object.entries(parsed)) {
-            for (const alt of alts) {
-              aliasMap.set(normalize(alt), canonical);
-            }
-          }
-        }
-
-        // Transform: normalize → alias resolve → track source
-        type Source = 'resource' | 'account' | 'both' | 'template';
-        const transformed = allRaw.map(raw => {
-          const normalized = normalize(raw);
-          const resolved = aliasMap.get(normalized) ?? normalized;
-          const fromResource = resourceSet.has(raw);
-          const fromAccount = accountSet.has(raw);
-          const fromTemplate = templateSet.has(raw);
-          let source: Source;
-          if (fromTemplate) source = 'template';
-          else if (fromResource && fromAccount) source = 'both';
-          else if (fromResource) source = 'resource';
-          else source = 'account';
-          const aliased = aliasMap.has(normalized);
-          return { raw, resolved, aliased, source };
-        });
-
-        const aliasPreviewCount = transformed.filter(t => t.aliased).length;
-
-        // Deduplicate by resolved value, merge sources, sort alphabetically
-        const resolvedMap = new Map<string, Source>();
-        for (const t of transformed) {
-          const existing = resolvedMap.get(t.resolved);
-          if (existing === undefined) {
-            resolvedMap.set(t.resolved, t.source);
-          } else if (existing !== 'both' && existing !== t.source) {
-            resolvedMap.set(t.resolved, 'both');
-          }
-        }
-        const unique = [...resolvedMap.entries()]
-          .map(([resolved, source]) => ({
-            resolved,
-            aliased: transformed.some(t => t.resolved === resolved && t.aliased),
-            source,
-          }))
-          .sort((a, b) => a.resolved.localeCompare(b.resolved));
-
-        return (
-          <div className="flex flex-col gap-1">
-            <span className="text-xs text-text-muted">
-              Preview — {String(allRaw.length)} raw → {String(unique.length)} resolved
-              {state.normalize.length > 0 ? ` (${state.normalize})` : ''}
-              {aliasPreviewCount > 0 ? ` · ${String(aliasPreviewCount)} aliased` : ''}
-            </span>
-            <div className="flex items-center gap-3 text-[9px] text-text-muted mb-1">
-              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-cyan-500/30 border border-cyan-500/50" /> resource</span>
-              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-violet-500/30 border border-violet-500/50" /> account</span>
-              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-emerald-500/30 border border-emerald-500/50" /> both</span>
-              {aliasPreviewCount > 0 && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-rose-500/30 border border-rose-500/50" /> aliased</span>}
-              {!isPassthrough && <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-warning/30 border border-warning/50" /> formatted</span>}
-            </div>
-            <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
-              {unique.map(({ resolved, aliased, source }) => {
-                const colors = aliased
-                  ? 'bg-rose-500/10 border-rose-500/30 text-rose-300'
-                  : source === 'template'
-                    ? 'bg-warning/10 border-warning/30 text-warning italic'
-                    : source === 'both'
-                      ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
-                      : source === 'account'
-                        ? 'bg-violet-500/10 border-violet-500/30 text-violet-300'
-                        : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-300';
-                return (
-                <span
-                  key={resolved}
-                  className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${colors}`}
-                >
-                  {resolved}
-                </span>
-                );
-              })}
-            </div>
-          </div>
-        );
-      })()}
+      <TagValuePreview
+        tagMatch={tagMatch}
+        fallbackValues={fallbackValues}
+        missingValueTemplate={state.missingValueTemplate}
+        normalizeRule={state.normalize}
+        aliasText={state.aliases}
+      />
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -855,6 +848,192 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           onConfirm={() => { setDiscardConfirm(false); onCancel(); }}
           onCancel={() => { setDiscardConfirm(false); }}
         />
+      )}
+    </div>
+  );
+}
+
+function ToggleButton({ itemKey, hidden, onToggle }: Readonly<{ itemKey: string; hidden: boolean; onToggle: () => void }>): React.JSX.Element {
+  return (
+    <button
+      key={itemKey}
+      type="button"
+      onClick={onToggle}
+      className={[
+        'rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors',
+        hidden
+          ? 'border-border bg-bg-tertiary/20 text-text-muted line-through'
+          : 'border-accent/40 bg-accent/10 text-accent',
+      ].join(' ')}
+    >
+      {itemKey}
+    </button>
+  );
+}
+
+type DiscoveredTag = { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number };
+
+function ResourceTagsContent({ tagsQuery, discoveredTags, hiddenResourceCols, setHiddenResourceCols }: Readonly<{
+  tagsQuery: { status: string; data?: unknown; error?: Error };
+  discoveredTags: readonly DiscoveredTag[];
+  hiddenResourceCols: Set<string>;
+  setHiddenResourceCols: React.Dispatch<React.SetStateAction<Set<string>>>;
+}>): React.JSX.Element | null {
+  if (tagsQuery.status === 'loading') {
+    return (
+      <div className="rounded-xl border border-border bg-bg-secondary/50 p-8 text-center">
+        <CoinRainLoader height={80} count={4} />
+        <p className="text-xs text-text-muted mt-2">Scanning billing data for tags...</p>
+      </div>
+    );
+  }
+  if (tagsQuery.status === 'error' && tagsQuery.error !== undefined) {
+    return (
+      <div className="rounded-xl border border-negative/50 bg-negative-muted p-4 text-sm text-negative">
+        {tagsQuery.error.message}
+      </div>
+    );
+  }
+  if (tagsQuery.status !== 'success' || discoveredTags.length === 0) return null;
+
+  const visibleTags = discoveredTags.filter(t => !hiddenResourceCols.has(t.key));
+  const toggleCol = (key: string) => {
+    setHiddenResourceCols(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-1.5">
+        {[...discoveredTags].sort((a, b) => {
+          const aH = hiddenResourceCols.has(a.key) ? 1 : 0;
+          const bH = hiddenResourceCols.has(b.key) ? 1 : 0;
+          return aH - bH;
+        }).map(t => (
+          <ToggleButton key={t.key} itemKey={t.key} hidden={hiddenResourceCols.has(t.key)} onToggle={() => { toggleCol(t.key); }} />
+        ))}
+      </div>
+      {visibleTags.length > 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-auto max-h-96">
+          <table className="text-xs">
+            <thead>
+              <tr className="border-b border-border text-left text-text-muted sticky top-0 bg-bg-secondary z-10">
+                {visibleTags.map(t => (
+                  <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-mono">{t.key}</span>
+                      <span className="text-[9px] text-text-muted font-normal">{String(t.coveragePct)}% · {String(t.distinctCount)} values</span>
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: Math.max(...visibleTags.map(t => t.sampleValues.length), 0) }, (_, rowIdx) => (
+                <tr key={rowIdx} className="border-b border-border-subtle">
+                  {visibleTags.map(t => (
+                    <td key={t.key} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
+                      {t.sampleValues[rowIdx] ?? ''}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function computeAccountColumnValues(
+  accounts: readonly { tags: Readonly<Record<string, string>> }[],
+  visibleKeys: string[],
+): string[][] {
+  return visibleKeys.map(key => {
+    const counts = new Map<string, number>();
+    for (const acct of accounts) {
+      const val = acct.tags[key];
+      if (val !== undefined && val.length > 0) {
+        counts.set(val, (counts.get(val) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([v, c]) => `${v} (${String(c)})`);
+  });
+}
+
+function AccountTagsContent({ orgData, accountTagKeys, hiddenAccountCols, setHiddenAccountCols }: Readonly<{
+  orgData: { accounts: readonly { tags: Readonly<Record<string, string>> }[] } | null;
+  accountTagKeys: string[];
+  hiddenAccountCols: Set<string>;
+  setHiddenAccountCols: React.Dispatch<React.SetStateAction<Set<string>>>;
+}>): React.JSX.Element {
+  if (orgData === null) {
+    return <p className="text-xs text-text-muted">No Organization sync data yet. Run it from Data Management to populate account-level tags.</p>;
+  }
+  if (accountTagKeys.length === 0) {
+    return <p className="text-xs text-text-muted">No tags found on any accounts.</p>;
+  }
+
+  const visibleKeys = accountTagKeys.filter(k => !hiddenAccountCols.has(k));
+  const toggleCol = (key: string) => {
+    setHiddenAccountCols(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const columnValues = visibleKeys.length > 0 ? computeAccountColumnValues(orgData.accounts, visibleKeys) : [];
+  const maxRows = Math.max(...columnValues.map(c => c.length), 0);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-1.5">
+        {[...accountTagKeys].sort((a, b) => {
+          const aH = hiddenAccountCols.has(a) ? 1 : 0;
+          const bH = hiddenAccountCols.has(b) ? 1 : 0;
+          return aH - bH;
+        }).map(key => (
+          <ToggleButton key={key} itemKey={key} hidden={hiddenAccountCols.has(key)} onToggle={() => { toggleCol(key); }} />
+        ))}
+      </div>
+      {visibleKeys.length > 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-auto max-h-96">
+          <table className="text-xs">
+            <thead>
+              <tr className="border-b border-border text-left text-text-muted sticky top-0 bg-bg-secondary z-10">
+                {visibleKeys.map(key => {
+                  const count = orgData.accounts.filter(a => a.tags[key] !== undefined && a.tags[key] !== '').length;
+                  return (
+                    <th key={key} className="px-3 py-2 font-medium whitespace-nowrap">
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-mono">{key}</span>
+                        <span className="text-[9px] text-text-muted font-normal">{String(count)}/{String(orgData.accounts.length)} accts</span>
+                      </div>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: Math.min(maxRows, 15) }, (_, rowIdx) => (
+                <tr key={rowIdx} className="border-b border-border-subtle">
+                  {columnValues.map((vals, colIdx) => (
+                    <td key={visibleKeys[colIdx]} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
+                      {vals[rowIdx] ?? ''}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
@@ -1383,77 +1562,12 @@ export function DimensionsView() {
             expanded={resourceTagsExpanded}
             onToggle={() => { setResourceTagsExpanded(v => !v); }}
           >
-            {tagsQuery.status === 'loading' && (
-              <div className="rounded-xl border border-border bg-bg-secondary/50 p-8 text-center">
-                <CoinRainLoader height={80} count={4} />
-                <p className="text-xs text-text-muted mt-2">Scanning billing data for tags...</p>
-              </div>
-            )}
-            {tagsQuery.status === 'error' && (
-              <div className="rounded-xl border border-negative/50 bg-negative-muted p-4 text-sm text-negative">
-                {tagsQuery.error.message}
-              </div>
-            )}
-            {tagsQuery.status === 'success' && discoveredTags.length > 0 && (() => {
-              const visibleTags = discoveredTags.filter(t => !hiddenResourceCols.has(t.key));
-              return (
-                <div className="flex flex-col gap-3">
-                  <div className="flex flex-wrap gap-1.5">
-                    {[...discoveredTags].sort((a, b) => {
-                      const aHidden = hiddenResourceCols.has(a.key) ? 1 : 0;
-                      const bHidden = hiddenResourceCols.has(b.key) ? 1 : 0;
-                      return aHidden - bHidden;
-                    }).map(t => {
-                      const hidden = hiddenResourceCols.has(t.key);
-                      return (
-                        <button
-                          key={t.key}
-                          type="button"
-                          onClick={() => { setHiddenResourceCols(prev => { const next = new Set(prev); if (hidden) { next.delete(t.key); } else { next.add(t.key); } return next; }); }}
-                          className={[
-                            'rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors',
-                            hidden
-                              ? 'border-border bg-bg-tertiary/20 text-text-muted line-through'
-                              : 'border-accent/40 bg-accent/10 text-accent',
-                          ].join(' ')}
-                        >
-                          {t.key}
-                        </button>
-                      );
-                    })}
-                  </div>
-                  {visibleTags.length > 0 && (
-                    <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-auto max-h-96">
-                      <table className="text-xs">
-                        <thead>
-                          <tr className="border-b border-border text-left text-text-muted sticky top-0 bg-bg-secondary z-10">
-                            {visibleTags.map(t => (
-                              <th key={t.key} className="px-3 py-2 font-medium whitespace-nowrap">
-                                <div className="flex flex-col gap-0.5">
-                                  <span className="font-mono">{t.key}</span>
-                                  <span className="text-[9px] text-text-muted font-normal">{String(t.coveragePct)}% · {String(t.distinctCount)} values</span>
-                                </div>
-                              </th>
-                            ))}
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {Array.from({ length: Math.max(...visibleTags.map(t => t.sampleValues.length), 0) }, (_, rowIdx) => (
-                            <tr key={rowIdx} className="border-b border-border-subtle">
-                              {visibleTags.map(t => (
-                                <td key={t.key} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
-                                  {t.sampleValues[rowIdx] ?? ''}
-                                </td>
-                              ))}
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                </div>
-              );
-            })()}
+            <ResourceTagsContent
+              tagsQuery={tagsQuery}
+              discoveredTags={discoveredTags}
+              hiddenResourceCols={hiddenResourceCols}
+              setHiddenResourceCols={setHiddenResourceCols}
+            />
           </DebugPanel>
 
           <DebugPanel
@@ -1462,86 +1576,12 @@ export function DimensionsView() {
             expanded={accountTagsExpanded}
             onToggle={() => { setAccountTagsExpanded(v => !v); }}
           >
-            {orgData === null ? (
-              <p className="text-xs text-text-muted">No Organization sync data yet. Run it from Data Management to populate account-level tags.</p>
-            ) : accountTagKeys.length === 0 ? (
-              <p className="text-xs text-text-muted">No tags found on any accounts.</p>
-            ) : (() => {
-              const visibleKeys = accountTagKeys.filter(k => !hiddenAccountCols.has(k));
-              return (
-                <div className="flex flex-col gap-3">
-                  <div className="flex flex-wrap gap-1.5">
-                    {[...accountTagKeys].sort((a, b) => {
-                      const aH = hiddenAccountCols.has(a) ? 1 : 0;
-                      const bH = hiddenAccountCols.has(b) ? 1 : 0;
-                      return aH - bH;
-                    }).map(key => {
-                      const hidden = hiddenAccountCols.has(key);
-                      return (
-                        <button
-                          key={key}
-                          type="button"
-                          onClick={() => { setHiddenAccountCols(prev => { const next = new Set(prev); if (hidden) { next.delete(key); } else { next.add(key); } return next; }); }}
-                          className={[
-                            'rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors',
-                            hidden
-                              ? 'border-border bg-bg-tertiary/20 text-text-muted line-through'
-                              : 'border-accent/40 bg-accent/10 text-accent',
-                          ].join(' ')}
-                        >
-                          {key}
-                        </button>
-                      );
-                    })}
-                  </div>
-                  {visibleKeys.length > 0 && (
-                    <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-auto max-h-96">
-                      <table className="text-xs">
-                        <thead>
-                          <tr className="border-b border-border text-left text-text-muted sticky top-0 bg-bg-secondary z-10">
-                            {visibleKeys.map(key => {
-                              const count = orgData.accounts.filter(a => a.tags[key] !== undefined && a.tags[key] !== '').length;
-                              return (
-                                <th key={key} className="px-3 py-2 font-medium whitespace-nowrap">
-                                  <div className="flex flex-col gap-0.5">
-                                    <span className="font-mono">{key}</span>
-                                    <span className="text-[9px] text-text-muted font-normal">{String(count)}/{String(orgData.accounts.length)} accts</span>
-                                  </div>
-                                </th>
-                              );
-                            })}
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {(() => {
-                            const columnValues = visibleKeys.map(key => {
-                              const counts = new Map<string, number>();
-                              for (const acct of orgData.accounts) {
-                                const val = acct.tags[key];
-                                if (val !== undefined && val.length > 0) {
-                                  counts.set(val, (counts.get(val) ?? 0) + 1);
-                                }
-                              }
-                              return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([v, c]) => `${v} (${String(c)})`);
-                            });
-                            const maxRows = Math.max(...columnValues.map(c => c.length), 0);
-                            return Array.from({ length: Math.min(maxRows, 15) }, (_, rowIdx) => (
-                              <tr key={rowIdx} className="border-b border-border-subtle">
-                                {columnValues.map((vals, colIdx) => (
-                                  <td key={visibleKeys[colIdx]} className="px-3 py-1.5 text-text-secondary whitespace-nowrap">
-                                    {vals[rowIdx] ?? ''}
-                                  </td>
-                                ))}
-                              </tr>
-                            ));
-                          })()}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                </div>
-              );
-            })()}
+            <AccountTagsContent
+              orgData={orgData}
+              accountTagKeys={accountTagKeys}
+              hiddenAccountCols={hiddenAccountCols}
+              setHiddenAccountCols={setHiddenAccountCols}
+            />
           </DebugPanel>
         </div>
       )}

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -40,6 +40,41 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
+function flattenConfiguration(rawConfig: unknown): Record<string, string> {
+  const config: Record<string, string> = {};
+  if (!isRecord(rawConfig)) return config;
+  for (const [section, value] of Object.entries(rawConfig)) {
+    if (isRecord(value)) {
+      for (const [k, v] of Object.entries(value)) {
+        config[`${section}.${k}`] = String(v);
+      }
+    } else {
+      config[section] = String(value);
+    }
+  }
+  return config;
+}
+
+function parseUsages(costCalc: unknown): ParsedDetails['usages'] {
+  if (!isRecord(costCalc)) return [];
+  const rawUsages = costCalc['usages'];
+  if (!Array.isArray(rawUsages)) return [];
+  const usages: ParsedDetails['usages'] = [];
+  for (const u of rawUsages) {
+    if (!isRecord(u)) continue;
+    const uAmount = u['usageAmount'];
+    const amountStr = typeof uAmount === 'number' ? String(uAmount)
+      : typeof uAmount === 'string' ? uAmount
+        : '';
+    usages.push({
+      type: typeof u['usageType'] === 'string' ? u['usageType'] : '',
+      amount: amountStr,
+      unit: typeof u['unit'] === 'string' ? u['unit'] : '',
+    });
+  }
+  return usages;
+}
+
 function parseResourceDetails(json: string): ParsedDetails | null {
   if (json.length === 0) return null;
   try {
@@ -49,49 +84,10 @@ function parseResourceDetails(json: string): ParsedDetails | null {
     if (topKey === undefined) return null;
     const inner = parsed[topKey];
     if (!isRecord(inner)) return null;
-
-    const config: Record<string, string> = {};
-    const rawConfig = inner['configuration'];
-    if (isRecord(rawConfig)) {
-      for (const [section, value] of Object.entries(rawConfig)) {
-        if (isRecord(value)) {
-          for (const [k, v] of Object.entries(value)) {
-            config[`${section}.${k}`] = String(v);
-          }
-        } else {
-          config[section] = String(value);
-        }
-      }
-    }
-
-    const usages: ParsedDetails['usages'] = [];
-    const costCalc = inner['costCalculation'];
-    if (isRecord(costCalc)) {
-      const rawUsages = costCalc['usages'];
-      if (Array.isArray(rawUsages)) {
-        for (const u of rawUsages) {
-          if (!isRecord(u)) continue;
-          const uType = u['usageType'];
-          const uAmount = u['usageAmount'];
-          const uUnit = u['unit'];
-          let amountStr: string;
-          if (typeof uAmount === 'number') {
-            amountStr = String(uAmount);
-          } else if (typeof uAmount === 'string') {
-            amountStr = uAmount;
-          } else {
-            amountStr = '';
-          }
-          usages.push({
-            type: typeof uType === 'string' ? uType : '',
-            amount: amountStr,
-            unit: typeof uUnit === 'string' ? uUnit : '',
-          });
-        }
-      }
-    }
-
-    return { config, usages };
+    return {
+      config: flattenConfiguration(inner['configuration']),
+      usages: parseUsages(inner['costCalculation']),
+    };
   } catch {
     return null;
   }

--- a/packages/ui/src/views/views-editor.tsx
+++ b/packages/ui/src/views/views-editor.tsx
@@ -170,40 +170,32 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
   }
 
   function updateWidget(rowIdx: number, widgetIdx: number, w: WidgetSpec): void {
-    updateSelectedView(v => ({
-      ...v,
-      rows: v.rows.map((r, i) =>
-        i === rowIdx
-          ? { widgets: r.widgets.map((ww, j) => j === widgetIdx ? w : ww) }
-          : r,
-      ),
-    }));
+    updateSelectedView(v => {
+      const widgets = v.rows[rowIdx]?.widgets.map((ww, j) => j === widgetIdx ? w : ww);
+      if (widgets === undefined) return v;
+      return { ...v, rows: v.rows.map((r, i) => i === rowIdx ? { widgets } : r) };
+    });
   }
 
   function deleteWidget(rowIdx: number, widgetIdx: number): void {
-    updateSelectedView(v => ({
-      ...v,
-      rows: v.rows.map((r, i) =>
-        i === rowIdx
-          ? { widgets: r.widgets.filter((_, j) => j !== widgetIdx) }
-          : r,
-      ),
-    }));
+    updateSelectedView(v => {
+      const widgets = v.rows[rowIdx]?.widgets.filter((_, j) => j !== widgetIdx);
+      if (widgets === undefined) return v;
+      return { ...v, rows: v.rows.map((r, i) => i === rowIdx ? { widgets } : r) };
+    });
   }
 
   function moveWidget(rowIdx: number, widgetIdx: number, dir: -1 | 1): void {
-    updateSelectedView(v => ({
-      ...v,
-      rows: v.rows.map((r, i) => {
-        if (i !== rowIdx) return r;
-        const target = widgetIdx + dir;
-        if (target < 0 || target >= r.widgets.length) return r;
-        const next = [...r.widgets];
-        const [moved] = next.splice(widgetIdx, 1);
-        if (moved !== undefined) next.splice(target, 0, moved);
-        return { widgets: next };
-      }),
-    }));
+    updateSelectedView(v => {
+      const row = v.rows[rowIdx];
+      if (row === undefined) return v;
+      const target = widgetIdx + dir;
+      if (target < 0 || target >= row.widgets.length) return v;
+      const next = [...row.widgets];
+      const [moved] = next.splice(widgetIdx, 1);
+      if (moved !== undefined) next.splice(target, 0, moved);
+      return { ...v, rows: v.rows.map((r, i) => i === rowIdx ? { widgets: next } : r) };
+    });
   }
 
   async function handleSave(): Promise<void> {


### PR DESCRIPTION
## Summary

- Extract helper functions, use early returns, and decompose large functions to bring SonarCloud S3776 (cognitive complexity) and S2004 (nesting depth) metrics within acceptable thresholds across all three packages.
- 20 files refactored across core, desktop, and UI packages with no behavioral changes.

### Core package (7 files)
- `generate.ts` / `setup.ts`: extract row-generation helpers to reduce loop nesting
- `cost-metric.ts`: extract per-metric SQL expression builders
- `validator.ts`: extract `validateBuiltInDimension`, `validateTagDimension`, shared helpers
- `selective-sync.ts`: extract `groupFilesByDate`, `makeLineHandler`
- `normalize.ts`: replace switch with `NORMALIZE_SQL` lookup object
- `builder.ts`: extract `buildTagSelect`

### Desktop package (7 files)
- `aws-org-client.ts`: decompose into `listAllAccounts`, `buildOuTree`, `buildAccountParentMap`, `makeOuPathResolver`, `fetchAccountTags`
- `auto-sync.ts`: extract `syncTier` helper
- `setup.ts`: extract `classifyManifestColumns`, `parseManifestColumnNames`
- `aws-ssm-client.ts`: extract parameter parsing helpers
- `dimensions.ts`: extract `applyRegionPreview`, `applyNormalizeAndStrip`
- `query-filters.ts`: extract clause-building helpers
- `query-utils.ts`: extract `mergeDescendantCosts`, `makeVirtualRow`

### UI package (6 files)
- `savings.tsx`: extract `flattenConfiguration`, `parseUsages`
- `dimensions.tsx`: extract `TagValuePreview`, `ResourceTagsContent`, `AccountTagsContent` components
- `data-management-org.tsx`: extract `SyncStatusBanner` component
- `coin-rain-loader.tsx`: extract `updateCoin`
- `cost-scope.tsx`: extract `PerspectiveToggle` component
- `views-editor.tsx`: flatten widget update callbacks