### PR TITLE
Fix remaining code smells (negated conditions, nested ternaries, a11y, etc.)

### DIFF
--- a/packages/core/src/__fixtures__/generate.ts
+++ b/packages/core/src/__fixtures__/generate.ts
@@ -362,10 +362,10 @@ async function generate(): Promise<void> {
   process.stdout.write('Done!\n');
 }
 
-const args = process.argv.slice(2);
-if (args.includes('--profile')) {
+const args = new Set(process.argv.slice(2));
+if (args.has('--profile')) {
   await profile();
-} else if (args.includes('--generate')) {
+} else if (args.has('--generate')) {
   await generate();
 } else {
   process.stdout.write('Usage: npx tsx generate.ts --profile | --generate\n');

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -120,21 +120,21 @@ describe('computePeriodsInRange', () => {
 
 describe('buildSource narrowed paths', () => {
   it('emits read_parquet with a list of month paths when periods are given', () => {
-    const sql = buildSource('/data', 'daily', dimensions, undefined, ['2026-03', '2026-04']);
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions, periods: ['2026-03', '2026-04'] });
     expect(sql).toContain("'/data/aws/raw/daily-2026-03/*.parquet'");
     expect(sql).toContain("'/data/aws/raw/daily-2026-04/*.parquet'");
     expect(sql).not.toContain("daily-*/*.parquet");
   });
 
   it('falls back to the wildcard when periods are empty or omitted', () => {
-    const sql = buildSource('/data', 'daily', dimensions, undefined, []);
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions, periods: [] });
     expect(sql).toContain("read_parquet('/data/aws/raw/daily-*/*.parquet')");
-    const sql2 = buildSource('/data', 'daily', dimensions);
+    const sql2 = buildSource({ dataDir: '/data', tier: 'daily', dimensions });
     expect(sql2).toContain("read_parquet('/data/aws/raw/daily-*/*.parquet')");
   });
 
   it('uses the hourly prefix when tier is hourly', () => {
-    const sql = buildSource('/data', 'hourly', dimensions, undefined, ['2026-04']);
+    const sql = buildSource({ dataDir: '/data', tier: 'hourly', dimensions, periods: ['2026-04'] });
     expect(sql).toContain("'/data/aws/raw/hourly-2026-04/*.parquet'");
   });
 });
@@ -229,7 +229,7 @@ describe('buildSource with account tag fallback', () => {
       builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
       tags: [{ tagName: 'system', label: 'System', concept: 'product', accountTagFallback: 'sb:system' }],
     };
-    const sql = buildSource('/data', 'daily', dims, '/org-tags.json');
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
     expect(sql).toContain('COALESCE(NULLIF(');
     expect(sql).toContain('fallback_tag_system');
     expect(sql).not.toContain('unknown');
@@ -240,7 +240,7 @@ describe('buildSource with account tag fallback', () => {
       builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
       tags: [{ tagName: 'system', label: 'System', concept: 'product', accountTagFallback: 'sb:owner', missingValueTemplate: 'unknown-{fallback}' }],
     };
-    const sql = buildSource('/data', 'daily', dims, '/org-tags.json');
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
     expect(sql).toContain("'unknown-'");
     expect(sql).toContain('fallback_tag_system');
     expect(sql).toContain('COALESCE');
@@ -251,7 +251,7 @@ describe('buildSource with account tag fallback', () => {
       builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
       tags: [{ tagName: 'team', label: 'Team', accountTagFallback: 'sb:team', missingValueTemplate: '{fallback}' }],
     };
-    const sql = buildSource('/data', 'daily', dims, '/org-tags.json');
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
     expect(sql).toContain('COALESCE(NULLIF(');
     expect(sql).toContain('fallback_tag_team');
     // Should NOT contain string concatenation — {fallback} is passthrough
@@ -263,7 +263,7 @@ describe('buildSource with account tag fallback', () => {
       builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
       tags: [{ tagName: 'system', label: 'System', accountTagFallback: 'sb:system' }],
     };
-    const sql = buildSource('/data', 'daily', dims);
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims });
     expect(sql).not.toContain('LEFT JOIN');
     expect(sql).not.toContain('fallback');
   });

--- a/packages/core/src/__tests__/query-integration.test.ts
+++ b/packages/core/src/__tests__/query-integration.test.ts
@@ -99,15 +99,15 @@ describe('DuckDB query integration', () => {
   });
 
   it('reads fixture parquet files', async () => {
-    const source = buildSource(SYNTHETIC_DIR, 'daily', dimensions);
+    const source = buildSource({ dataDir: SYNTHETIC_DIR, tier: 'daily', dimensions });
     const rows = await queryAll(conn, `SELECT COUNT(*) as cnt FROM ${source}`);
     expect(Number(rows[0]?.['cnt'])).toBeGreaterThan(0);
   });
 
   it('narrowed source with specific months reads the same data as the wildcard', async () => {
     // Synthetic fixtures: daily-2026-01/ and daily-2026-02/.
-    const wide = buildSource(SYNTHETIC_DIR, 'daily', dimensions);
-    const narrow = buildSource(SYNTHETIC_DIR, 'daily', dimensions, undefined, ['2026-01', '2026-02']);
+    const wide = buildSource({ dataDir: SYNTHETIC_DIR, tier: 'daily', dimensions });
+    const narrow = buildSource({ dataDir: SYNTHETIC_DIR, tier: 'daily', dimensions, periods: ['2026-01', '2026-02'] });
     const [[wideRow], [narrowRow]] = await Promise.all([
       queryAll(conn, `SELECT COUNT(*) as cnt, SUM(cost) as total FROM ${wide}`),
       queryAll(conn, `SELECT COUNT(*) as cnt, SUM(cost) as total FROM ${narrow}`),
@@ -121,7 +121,7 @@ describe('DuckDB query integration', () => {
     // matches zero files, even when other patterns in the list match. Callers
     // must intersect required periods with what's actually on disk BEFORE
     // passing to buildSource. The query handlers do this via listLocalMonths.
-    const source = rebuildSource(SYNTHETIC_DIR, 'daily', dimensions, undefined, ['2025-11']);
+    const source = rebuildSource({ dataDir: SYNTHETIC_DIR, tier: 'daily', dimensions, periods: ['2025-11'] });
     await expect(queryAll(conn, `SELECT COUNT(*) as cnt FROM ${source}`))
       .rejects.toThrow(/No files found/);
   });
@@ -245,13 +245,13 @@ describe('DuckDB query integration', () => {
   });
 
   it('reads hourly raw files', async () => {
-    const source = buildSource(SYNTHETIC_DIR, 'hourly', dimensions);
+    const source = buildSource({ dataDir: SYNTHETIC_DIR, tier: 'hourly', dimensions });
     const rows = await queryAll(conn, `SELECT COUNT(*) as cnt FROM ${source}`);
     expect(Number(rows[0]?.['cnt'])).toBeGreaterThan(0);
   });
 
   it('hourly tier exposes both usage_date (DATE) and usage_hour (TIMESTAMP)', async () => {
-    const source = buildSource(SYNTHETIC_DIR, 'hourly', dimensions);
+    const source = buildSource({ dataDir: SYNTHETIC_DIR, tier: 'hourly', dimensions });
     const rows = await queryAll(conn, `
       SELECT typeof(usage_date) AS d_type, typeof(usage_hour) AS h_type
       FROM ${source} LIMIT 1
@@ -287,7 +287,7 @@ describe('DuckDB query integration', () => {
     const queryTotalRows = await queryAllPrepared(conn, `SELECT SUM(total_cost) AS t FROM (${result.sql})`, result.params);
     const queryTotal = Number(queryTotalRows[0]?.['t'] ?? 0);
 
-    const source = buildSource(SYNTHETIC_DIR, 'hourly', dimensions);
+    const source = buildSource({ dataDir: SYNTHETIC_DIR, tier: 'hourly', dimensions });
     const rawRows = await queryAll(conn, `
       SELECT SUM(cost) AS t FROM ${source}
       WHERE usage_date BETWEEN '${range.start}' AND '${range.end}'

--- a/packages/core/src/config/cost-scope-validator.ts
+++ b/packages/core/src/config/cost-scope-validator.ts
@@ -43,15 +43,15 @@ function validateRule(raw: unknown, ctx: string): ExclusionRule {
     validateCondition(c, `${ctx}.conditions[${String(i)}]`),
   );
   const description =
-    raw['description'] !== undefined
-      ? (assertString(raw['description'], `${ctx}.description`), raw['description'])
-      : undefined;
+    raw['description'] === undefined
+      ? undefined
+      : (assertString(raw['description'], `${ctx}.description`), raw['description']);
   const enabled = raw['enabled'] === true;
   const builtIn = raw['builtIn'] === true;
   return {
     id: raw['id'],
     name: raw['name'],
-    ...(description !== undefined ? { description } : {}),
+    ...(description === undefined ? {} : { description }),
     enabled,
     builtIn,
     conditions,

--- a/packages/core/src/config/views-serialize.ts
+++ b/packages/core/src/config/views-serialize.ts
@@ -17,8 +17,6 @@ export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
       if (w.metric !== undefined) base['metric'] = w.metric;
       return base;
     case 'pie':
-      base['groupBy'] = w.groupBy;
-      return base;
     case 'stackedBar':
     case 'bubble':
       base['groupBy'] = w.groupBy;

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -43,7 +43,7 @@ export function resolveAlias(
     if (canonical === normalizedValue) {
       return canonical;
     }
-    if (aliasList.some(a => a === normalizedValue)) {
+    if (aliasList.includes(normalizedValue)) {
       return canonical;
     }
   }
@@ -81,11 +81,10 @@ export function applyRegionFriendlyNames(
   if (regionMap.size === 0) return dims;
   const builtIn = dims.builtIn.map(d => {
     if (d.field !== 'region') return d;
-    const pick: ((e: RegionEnrichment) => string) | null =
-      d.name === 'region_country' ? (e) => e.country
-        : d.name === 'region_continent' ? (e) => e.continent
-          : d.useRegionNames === true ? (e) => e.longName
-            : null;
+    let pick: ((e: RegionEnrichment) => string) | null = null;
+    if (d.name === 'region_country') pick = (e) => e.country;
+    else if (d.name === 'region_continent') pick = (e) => e.continent;
+    else if (d.useRegionNames === true) pick = (e) => e.longName;
     if (pick === null) return d;
     const userAliases = d.aliases ?? {};
     const userCovered = new Set<string>();
@@ -135,8 +134,8 @@ interface NormalizableDimension {
 const NORMALIZE_SQL: Record<NormalizationRule, (expr: string) => string> = {
   'lowercase': (expr) => `LOWER(${expr})`,
   'uppercase': (expr) => `UPPER(${expr})`,
-  'lowercase-kebab': (expr) => `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\\1-\\2'), '[_\\s]+', '-', 'g'))`,
-  'lowercase-underscore': (expr) => `LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\\1_\\2'), '[-\\s]+', '_', 'g'))`,
+  'lowercase-kebab': (expr) => String.raw`LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\1-\2'), '[_\s]+', '-', 'g'))`,
+  'lowercase-underscore': (expr) => String.raw`LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\1_\2'), '[-\s]+', '_', 'g'))`,
   'camelCase': (expr) => `LOWER(REPLACE(REPLACE(REPLACE(${expr}, '-', ''), '_', ''), ' ', ''))`,
 };
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -229,16 +229,19 @@ function buildTagSelect(
   return `COALESCE(NULLIF(${resourceExpr}, ''), ${fallbackExpr}) AS ${colName}`;
 }
 
-export function buildSource(
-  dataDir: string,
-  tier: string,
-  dimensions: DimensionsConfig,
-  orgAccountsPath?: string,
-  periods?: readonly string[],
-  costMetric: CostMetric = 'unblended',
-  availableColumns?: ReadonlySet<string>,
-  costPerspective?: CostPerspective,
-): string {
+export interface BuildSourceOptions {
+  readonly dataDir: string;
+  readonly tier: string;
+  readonly dimensions: DimensionsConfig;
+  readonly orgAccountsPath?: string | undefined;
+  readonly periods?: readonly string[] | undefined;
+  readonly costMetric?: CostMetric | undefined;
+  readonly availableColumns?: ReadonlySet<string> | undefined;
+  readonly costPerspective?: CostPerspective | undefined;
+}
+
+export function buildSource(opts: BuildSourceOptions): string {
+  const { dataDir, tier, dimensions, orgAccountsPath, periods, costMetric = 'unblended', availableColumns, costPerspective } = opts;
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
 
@@ -256,8 +259,11 @@ export function buildSource(
     ? 'line_item_usage_start_date::DATE AS usage_date,\n      line_item_usage_start_date::TIMESTAMP AS usage_hour'
     : 'line_item_usage_start_date::DATE AS usage_date';
 
-  const parquetSource = periods !== undefined && periods.length > 0
-    ? `read_parquet([${periods.map(p => `'${dataDir}/aws/raw/${tier}-${p}/*.parquet'`).join(', ')}])`
+  const parquetPaths = periods !== undefined && periods.length > 0
+    ? periods.map(p => `'${dataDir}/aws/raw/${tier}-${p}/*.parquet'`).join(', ')
+    : undefined;
+  const parquetSource = parquetPaths !== undefined
+    ? `read_parquet([${parquetPaths}])`
     : `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
 
   // Build fallback column extractions for the org-accounts join
@@ -359,7 +365,7 @@ function setupQuery(
   const exclusionClauses = costScope === undefined ? [] : buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb);
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
   return { qb, filterClauses, exclusionClauses, source, costMetric };
 }
 
@@ -463,7 +469,7 @@ export function buildTrendQuery(
   const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
   const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
   const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource(dataDir, 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
 
   const allFilterClauses = [...filterClauses, ...exclusionClauses];
   const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
@@ -747,7 +753,7 @@ export function buildMaterializeBaseQuery(
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(dateRange, availablePeriods);
-  const source = buildSource(dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective);
+  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
 
   const whereConditions = [
     `usage_date BETWEEN '${sqlEscapeString(dateRange.start)}' AND '${sqlEscapeString(dateRange.end)}'`,

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -10,7 +10,7 @@ export {
   buildRuleMatchExpr,
   computePeriodsInRange,
 } from './builder.js';
-export type { QueryContextOptions } from './builder.js';
+export type { QueryContextOptions, BuildSourceOptions } from './builder.js';
 
 export { costExprFor } from './cost-metric.js';
 

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -5,8 +5,8 @@ import { logger } from '../logger/logger.js';
 import { parseS3Path } from './s3-client.js';
 import type { ProgressCallback } from './s3-client.js';
 import type { ManifestFileEntry } from './manifest.js';
+import type { ExpectedDataType } from './sync-utils.js';
 import {
-  type ExpectedDataType,
   extractDate,
   extractPeriodPrefix,
   getEtagFileName,
@@ -14,7 +14,7 @@ import {
   parseEtagsJson,
 } from './sync-utils.js';
 
-export type { ExpectedDataType };
+export type { ExpectedDataType } from './sync-utils.js';
 
 export interface SelectiveSyncOptions {
   readonly bucketPath: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -63,8 +63,6 @@ export type {
 export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';
 
 export type {
-  WidgetId,
-  ViewId,
   WidgetSize,
   WidgetFilterOverlay,
   SummaryMetric,

--- a/packages/core/src/types/views.ts
+++ b/packages/core/src/types/views.ts
@@ -1,8 +1,5 @@
 import type { DimensionId, TagValue } from './branded.js';
 
-export type WidgetId = string;
-export type ViewId = string;
-
 export type WidgetSize = 'small' | 'medium' | 'large' | 'full';
 
 /** Extra filter overlay applied on top of the view's global FilterBar. The
@@ -13,7 +10,7 @@ export type WidgetFilterOverlay = Readonly<Partial<Record<DimensionId, TagValue>
 export type SummaryMetric = 'total' | 'delta' | 'topEntity' | 'entityCount';
 
 interface WidgetBase {
-  readonly id: WidgetId;
+  readonly id: string;
   readonly title?: string | undefined;
   readonly size: WidgetSize;
   readonly filters?: WidgetFilterOverlay | undefined;
@@ -68,7 +65,7 @@ export interface ViewRow {
 }
 
 export interface ViewSpec {
-  readonly id: ViewId;
+  readonly id: string;
   readonly name: string;
   readonly icon?: string | undefined;
   /** Built-in seed view. The user can duplicate/clone but not delete. */

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -70,7 +70,7 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
   const backfilled = loaded.builtIn.map(d => {
     let next = d;
     const rename = LEGACY_LABEL_RENAMES[d.name];
-    if (rename !== undefined && next.label === rename.from) {
+    if (rename !== undefined && rename.from === next.label) {
       next = { ...next, label: rename.to };
     }
     if (next.description === undefined) {

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -113,7 +113,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     const availableColumns = await getAvailableColumns('daily');
 
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, config.costMetric, availableColumns, config.costPerspective);
+    const source = buildSource({ dataDir: ctx.dataDir, tier: 'daily', dimensions, orgAccountsPath: orgPath, periods, costMetric: config.costMetric, availableColumns, costPerspective: config.costPerspective });
 
     // Pre-compute each rule's positive match expression once — used to
     // build the `excluded` predicate for the main aggregate query, each
@@ -251,7 +251,9 @@ export function registerCostScopeHandlers(app: AppContext): void {
     if (dailyResult.status === 'fulfilled') {
       dailyTotals = dailyResult.value.map(r => {
         const raw = r['date'];
-        const date = typeof raw === 'string' ? raw : (raw instanceof Date ? raw.toISOString().slice(0, 10) : '');
+        let date = '';
+        if (typeof raw === 'string') date = raw;
+        else if (raw instanceof Date) date = raw.toISOString().slice(0, 10);
         return { date, keptCost: toNum(r['kept_cost']), excludedCost: toNum(r['excluded_cost']) };
       });
     } else {
@@ -267,9 +269,9 @@ export function registerCostScopeHandlers(app: AppContext): void {
           tags[t.id] = typeof v === 'string' ? v : '';
         }
         const rawDate = r['usage_date'];
-        const date = typeof rawDate === 'string'
-          ? rawDate
-          : (rawDate instanceof Date ? rawDate.toISOString().slice(0, 10) : '');
+        let date = '';
+        if (typeof rawDate === 'string') date = rawDate;
+        else if (rawDate instanceof Date) date = rawDate.toISOString().slice(0, 10);
         return {
           date,
           accountId: typeof r['account_id'] === 'string' ? r['account_id'] : '',

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -199,7 +199,7 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
     const metric = pickMetric(params.costMetric, availableColumns);
     const perspective = pickPerspective(params.costPerspective, availableColumns);
 
-    source = buildSource(ctx.dataDir, tier, dimensions, orgPath, periods, metric, availableColumns, perspective);
+    source = buildSource({ dataDir: ctx.dataDir, tier, dimensions, orgAccountsPath: orgPath, periods, costMetric: metric, availableColumns, costPerspective: perspective });
 
     const exclusionClauses: string[] = [];
     if (costScope !== undefined) {
@@ -329,7 +329,9 @@ export function registerExplorerHandlers(app: AppContext): void {
     if (dailyResult.status === 'fulfilled') {
       dailyTotals = dailyResult.value.map(r => {
         const raw = r['date'];
-        const date = typeof raw === 'string' ? raw : (raw instanceof Date ? raw.toISOString().slice(0, 10) : '');
+        let date = '';
+        if (typeof raw === 'string') date = raw;
+        else if (raw instanceof Date) date = raw.toISOString().slice(0, 10);
         return { date, cost: toNum(r['daily_cost']), rows: toNum(r['daily_rows']) };
       });
     } else {

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -107,7 +107,7 @@ export function registerFilterHandlers(app: AppContext): void {
     const orgPath = await getOrgAccountsPath();
     const periods = dateRange === undefined ? undefined : computePeriodsInRange(dateRange);
     const availableColumns = await getAvailableColumns('daily');
-    const source = buildSource(ctx.dataDir, 'daily', dimensions, orgPath, periods, 'unblended', availableColumns);
+    const source = buildSource({ dataDir: ctx.dataDir, tier: 'daily', dimensions, orgAccountsPath: orgPath, periods, costMetric: 'unblended', availableColumns });
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
       FROM ${source}

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -67,7 +67,7 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
             {sqlPreview(entry.sql)}
           </span>
           <span className="text-xs text-text-muted shrink-0">
-            {entry.durationMs === null ? (entry.status === 'queued' ? 'queued' : '...') : formatDuration(entry.durationMs)}
+            {(() => { if (entry.durationMs !== null) return formatDuration(entry.durationMs); return entry.status === 'queued' ? 'queued' : '...'; })()}
           </span>
         </div>
         <div className="flex items-center gap-3 mt-0.5 ml-4">

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -289,9 +289,9 @@ export class MockCostApi implements CostApi {
   queryExplorerOverview(): Promise<ExplorerOverviewResult> {
     const today = new Date();
     const end = today.toISOString().slice(0, 10);
-    const start = new Date(today.getTime() - 29 * 86400_000).toISOString().slice(0, 10);
+    const start = new Date(today.getTime() - 29 * 86_400_000).toISOString().slice(0, 10);
     const dailyTotals = Array.from({ length: 30 }, (_, i) => {
-      const d = new Date(today.getTime() - (29 - i) * 86400_000);
+      const d = new Date(today.getTime() - (29 - i) * 86_400_000);
       return {
         date: d.toISOString().slice(0, 10),
         cost: 3_500 + Math.sin(i / 3) * 400 + Math.random() * 300,
@@ -314,7 +314,7 @@ export class MockCostApi implements CostApi {
   queryExplorerRows(): Promise<ExplorerRowsResult> {
     const today = new Date();
     const end = today.toISOString().slice(0, 10);
-    const start = new Date(today.getTime() - 29 * 86400_000).toISOString().slice(0, 10);
+    const start = new Date(today.getTime() - 29 * 86_400_000).toISOString().slice(0, 10);
     const mockRows = [
       { date: end, hour: '', accountId: '111', accountName: 'prod-main', region: 'eu-central-1', service: 'Amazon EC2', serviceFamily: 'Compute', lineItemType: 'Usage', operation: 'RunInstances', usageType: 'EUC1-BoxUsage:t3.medium', description: '$0.0464 per On Demand Linux t3.medium Instance Hour', resourceId: 'i-0abc', usageAmount: 24, cost: 1_180.5, listCost: 1_200, tags: { tag_team: 'platform', tag_env: 'prod' } },
       { date: end, hour: '', accountId: '222', accountName: 'staging', region: 'us-east-1', service: 'Amazon RDS', serviceFamily: 'Database', lineItemType: 'Usage', operation: 'CreateDBInstance', usageType: 'RDS:db.t4g.micro', description: 'Aurora MySQL db.t4g.micro', resourceId: 'arn:rds:...', usageAmount: 12, cost: 420, listCost: 500, tags: { tag_team: 'data', tag_env: 'staging' } },

--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -97,7 +97,7 @@ function BubbleChartInner({
 
   return (
     <div className="relative">
-      <svg width={width} height={height} role="img" aria-label="Cost trend bubble chart: x-axis shows percent change, y-axis shows absolute delta, bubble size represents current cost">
+      <svg width={width} height={height} aria-label="Cost trend bubble chart: x-axis shows percent change, y-axis shows absolute delta, bubble size represents current cost">
         <Group left={MARGIN.left} top={MARGIN.top}>
           <GridRows
             scale={yScale}

--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -50,7 +50,7 @@ function updateCoin(c: Coin, containerWidth: number, containerHeight: number): C
   if (x < 0) { x = 0; vx = Math.abs(vx) * 0.5; }
   if (x > containerWidth - COIN_SIZE * scale) { x = containerWidth - COIN_SIZE * scale; vx = -Math.abs(vx) * 0.5; }
   if (y > containerHeight + COIN_SIZE) return createCoin(c.id, containerWidth, containerHeight);
-  return { ...c, x, y, vx, vy, rotation, scale };
+  return { ...c, x, y, vx, vy, rotation, rotationSpeed, scale };
 }
 
 export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: number; count?: number }>) {

--- a/packages/ui/src/components/confirm-modal.tsx
+++ b/packages/ui/src/components/confirm-modal.tsx
@@ -32,7 +32,7 @@ export function ConfirmModal({
   }, [onCancel]);
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center" role="dialog" aria-modal="true">
+    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onCancel}
@@ -66,6 +66,6 @@ export function ConfirmModal({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -169,7 +169,6 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               return (
                 <div
                   key={col.key}
-                  role="option"
                   aria-selected={checked}
                   tabIndex={0}
                   draggable
@@ -308,7 +307,8 @@ export function DataTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, 
 
 function ColumnHeader({ spec, sort, onSort }: Readonly<{ spec: ColumnSpec; sort: ExplorerSort | undefined; onSort: () => void }>) {
   const isSorted = sort?.column === spec.key;
-  const indicator = isSorted ? (sort.direction === 'asc' ? '\u2191' : '\u2193') : '';
+  const dirArrow = sort?.direction === 'asc' ? '\u2191' : '\u2193';
+  const indicator = isSorted ? dirArrow : '';
   return (
     <th className="p-0 font-medium whitespace-nowrap">
       <button

--- a/packages/ui/src/components/heatmap-chart.tsx
+++ b/packages/ui/src/components/heatmap-chart.tsx
@@ -61,7 +61,7 @@ function HeatmapInner({
   const cellH = yScale.bandwidth();
 
   return (
-    <svg width={width} height={height} role="img" aria-label="Cost heatmap: rows are groups, columns are dates, color intensity represents cost">
+    <svg width={width} height={height} aria-label="Cost heatmap: rows are groups, columns are dates, color intensity represents cost">
       <Group left={MARGIN.left} top={MARGIN.top}>
         {cells.map((c) => {
           const x = xScale(c.date) ?? 0;
@@ -76,7 +76,7 @@ function HeatmapInner({
               fill={colorScale(c.cost)}
               rx={2}
               onClick={() => { onCellClick?.(c.group, c.date); }}
-              style={{ cursor: onCellClick !== undefined ? 'pointer' : 'default' }}
+              style={{ cursor: onCellClick === undefined ? 'default' : 'pointer' }}
             >
               <title>{`${c.group} • ${c.date} — ${formatDollars(c.cost)}`}</title>
             </rect>

--- a/packages/ui/src/components/line-chart.tsx
+++ b/packages/ui/src/components/line-chart.tsx
@@ -62,8 +62,8 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
   const maxDate = sortedDates.at(-1);
 
   const xScale = useMemo(() => {
-    const start = minDate !== undefined ? new Date(minDate) : new Date();
-    const end = maxDate !== undefined ? new Date(maxDate) : new Date();
+    const start = minDate === undefined ? new Date() : new Date(minDate);
+    const end = maxDate === undefined ? new Date() : new Date(maxDate);
     return scaleTime<number>({
       domain: [start, end],
       range: [0, innerW],
@@ -107,7 +107,7 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
         const p = s.points.find(x2 => x2.date === nearest);
         const colorIdx = seriesColorIndex.get(s.name) ?? 0;
         const color = getColor(colorIdx);
-        return p !== undefined ? { name: s.name, cost: p.cost, color } : null;
+        return p === undefined ? null : { name: s.name, cost: p.cost, color };
       })
       .filter((e): e is { name: string; cost: number; color: string } => e !== null);
     showTooltip({
@@ -245,8 +245,8 @@ export function LineChart({ series, title, subtitle, height = 320, onSeriesClick
               key={s.name}
               type="button"
               onClick={() => {
-                if (onSeriesClick !== undefined) onSeriesClick(s.name);
-                else toggle(s.name);
+                if (onSeriesClick === undefined) toggle(s.name);
+                else onSeriesClick(s.name);
               }}
               onDoubleClick={() => { toggle(s.name); }}
               className="flex items-center gap-1.5 text-[11px] px-1.5 py-0.5 rounded hover:bg-bg-tertiary/40 transition-colors"

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -190,7 +190,7 @@ function PieChartInner({
                   x={14}
                   y={y + 8}
                   fontSize={isHovered ? 12 : 11}
-                  fill={isDimmed ? '#4b5563' : isHovered ? '#f3f4f6' : '#9ca3af'}
+                  fill={(() => { if (isDimmed) return '#4b5563'; return isHovered ? '#f3f4f6' : '#9ca3af'; })()}
                   fontWeight={isHovered ? 600 : 400}
                   style={{ transition: 'all 0.12s' }}
                 >

--- a/packages/ui/src/components/summary-card.tsx
+++ b/packages/ui/src/components/summary-card.tsx
@@ -41,8 +41,12 @@ export function SummaryCard({ totalCost, previousCost, dateRange }: Readonly<Sum
             {delta === null ? (
               <p className="mt-1 text-2xl font-bold tabular-nums text-text-muted">{PLACEHOLDER}</p>
             ) : (() => {
-              const deltaColor = isIncrease ? 'text-negative' : isDecrease ? 'text-positive' : 'text-text-secondary';
-              const deltaArrow = isDecrease ? '▼' : isIncrease ? '▲' : '';
+              let deltaColor = 'text-text-secondary';
+              if (isIncrease) deltaColor = 'text-negative';
+              else if (isDecrease) deltaColor = 'text-positive';
+              let deltaArrow = '';
+              if (isDecrease) deltaArrow = '▼';
+              else if (isIncrease) deltaArrow = '▲';
               return (
                 <p className={`mt-1 text-2xl font-bold tabular-nums ${deltaColor}`}>
                   {deltaArrow}

--- a/packages/ui/src/components/top-n-bar-chart.tsx
+++ b/packages/ui/src/components/top-n-bar-chart.tsx
@@ -124,24 +124,8 @@ function TopNBarChartInner({
               const barW = Math.max(ratio * barAreaWidth, 1);
               const color = getColor(i);
 
-              return (
-                <li
-                  key={row.name}
-                  role={onBarClick !== undefined ? 'button' : undefined}
-                  tabIndex={onBarClick !== undefined ? 0 : undefined}
-                  onMouseEnter={() => { handleEnter(row.name); }}
-                  onMouseLeave={handleLeave}
-                  onClick={() => { onBarClick?.(row.name); }}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onBarClick?.(row.name); } }}
-                  className="flex items-center gap-3 rounded px-1 transition-colors"
-                  style={{
-                    cursor: onBarClick !== undefined ? 'pointer' : 'default',
-                    height: ROW_HEIGHT,
-                    opacity: isDimmed ? 0.4 : 1,
-                    backgroundColor: isHovered ? 'rgba(255,255,255,0.05)' : 'transparent',
-                  }}
-                  title={`${row.name} — ${formatDollars(row.cost)}`}
-                >
+              const barContent = (
+                <>
                   <span
                     className="text-xs tabular-nums text-text-secondary text-right shrink-0"
                     style={{ width: LABEL_WIDTH - 16 }}
@@ -168,6 +152,36 @@ function TopNBarChartInner({
                       ({row.percentage.toFixed(1)}%)
                     </span>
                   </span>
+                </>
+              );
+
+              return (
+                <li
+                  key={row.name}
+                  className="rounded transition-colors"
+                  style={{
+                    height: ROW_HEIGHT,
+                    opacity: isDimmed ? 0.4 : 1,
+                    backgroundColor: isHovered ? 'rgba(255,255,255,0.05)' : 'transparent',
+                  }}
+                  title={`${row.name} — ${formatDollars(row.cost)}`}
+                  onMouseEnter={() => { handleEnter(row.name); }}
+                  onMouseLeave={handleLeave}
+                >
+                  {onBarClick === undefined ? (
+                    <div className="flex items-center gap-3 px-1" style={{ height: ROW_HEIGHT }}>
+                      {barContent}
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { onBarClick(row.name); }}
+                      className="flex items-center gap-3 px-1 w-full cursor-pointer"
+                      style={{ height: ROW_HEIGHT }}
+                    >
+                      {barContent}
+                    </button>
+                  )}
                 </li>
               );
             })}

--- a/packages/ui/src/components/treemap-chart.tsx
+++ b/packages/ui/src/components/treemap-chart.tsx
@@ -73,7 +73,7 @@ function TreemapInner({
                     fillOpacity={0.85}
                     stroke="var(--color-bg-secondary)"
                     strokeWidth={1.5}
-                    style={{ cursor: onCellClick !== undefined ? 'pointer' : 'default' }}
+                    style={{ cursor: onCellClick === undefined ? 'default' : 'pointer' }}
                     onClick={() => { onCellClick?.(name); }}
                   >
                     <title>{`${name} — ${formatDollars(cost)}`}</title>

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ export function CardTitle({
   className,
   children,
   ...props
-}: React.HTMLAttributes<HTMLHeadingElement>) {
+}: Readonly<React.HTMLAttributes<HTMLHeadingElement>>) {
   return (
     <h3
       className={cn('font-semibold leading-none tracking-tight', className)}
@@ -46,7 +46,7 @@ export function CardTitle({
 export function CardDescription({
   className,
   ...props
-}: React.HTMLAttributes<HTMLParagraphElement>) {
+}: Readonly<React.HTMLAttributes<HTMLParagraphElement>>) {
   return (
     <p
       className={cn('text-sm text-text-secondary', className)}
@@ -58,14 +58,14 @@ export function CardDescription({
 export function CardContent({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
   return <div className={cn('p-6 pt-0', className)} {...props} />;
 }
 
 export function CardFooter({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
   return (
     <div
       className={cn('flex items-center p-6 pt-0', className)}

--- a/packages/ui/src/components/view-yaml-modal.tsx
+++ b/packages/ui/src/components/view-yaml-modal.tsx
@@ -25,7 +25,7 @@ function asCustomView(v: ViewSpec): ViewSpec {
     id: v.id,
     name: v.name,
     rows: v.rows,
-    ...(v.icon !== undefined ? { icon: v.icon } : {}),
+    ...(v.icon === undefined ? {} : { icon: v.icon }),
   };
 }
 
@@ -75,14 +75,15 @@ export function ViewYamlModal(props: ViewYamlModalProps): React.JSX.Element {
       // `builtIn: true` would otherwise create an undeletable duplicate.
       props.onImport(asCustomView(first));
     } catch (err: unknown) {
-      setImportError(err instanceof ConfigValidationError ? err.message : err instanceof Error ? err.message : String(err));
+      const msg = err instanceof ConfigValidationError || err instanceof Error ? err.message : String(err);
+      setImportError(msg);
     }
   }
 
   const isExport = props.mode === 'export';
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center" role="dialog" aria-modal="true">
+    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={props.onClose}
@@ -142,7 +143,7 @@ export function ViewYamlModal(props: ViewYamlModalProps): React.JSX.Element {
           )}
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/packages/ui/src/hooks/use-unsaved-changes.tsx
+++ b/packages/ui/src/hooks/use-unsaved-changes.tsx
@@ -107,9 +107,7 @@ export function useUnsavedChanges(isDirty: boolean, label?: string): void {
   // Using a ref keeps the key across renders — a new one would cause the
   // cleanup/register pair to churn and leave stale entries behind.
   const keyRef = useRef<string | undefined>(undefined);
-  if (keyRef.current === undefined) {
-    keyRef.current = `uc-${String(Math.random()).slice(2)}-${String(Date.now())}`;
-  }
+  keyRef.current ??= `uc-${String(Math.random()).slice(2)}-${String(Date.now())}`;
   const setDirty = ctx.setDirty;
   useEffect(() => {
     const key = keyRef.current;

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -211,9 +211,9 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
     });
   }
 
-  const previewText = preview !== undefined
-    ? formatExcluded(preview.excludedCost, preview.excludedRows)
-    : '—';
+  const previewText = preview === undefined
+    ? '—'
+    : formatExcluded(preview.excludedCost, preview.excludedRows);
 
   return (
     <Card className={`transition-opacity ${rule.enabled ? '' : 'opacity-60'}`}>
@@ -284,7 +284,7 @@ function RuleCard({ rule, preview, dimensions, suggestionsByDim, onUpdate, onDel
         <div className="space-y-2">
           {rule.conditions.map((cond, i) => (
             <ConditionRow
-              key={i}
+              key={`${String(cond.dimensionId)}-${String(i)}`}
               condition={cond}
               dimensions={dimensions}
               suggestions={suggestionsByDim.get(String(cond.dimensionId)) ?? []}
@@ -450,7 +450,7 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loa
           {totalRowCount > rows.length && (
             <> of <span className="text-text-secondary tabular-nums">{totalRowCount.toLocaleString()}</span> in window</>
           )}
-          , sorted by |cost| desc.
+          {', sorted by |cost| desc.'}
         </span>
         <span className="flex items-center gap-3 shrink-0">
           {hasEnabledRules && excludedInSample > 0 && (
@@ -757,9 +757,9 @@ export function CostScopeView(): React.JSX.Element {
   }
 
   const enabledRules = draft.rules.filter(r => r.enabled);
-  const combinedText = preview.result === null
-    ? (preview.loading ? 'loading…' : 'no data')
-    : formatExcluded(preview.result.combined.excludedCost, preview.result.combined.excludedRows);
+  let combinedText: string;
+  if (preview.result !== null) combinedText = formatExcluded(preview.result.combined.excludedCost, preview.result.combined.excludedRows);
+  else combinedText = preview.loading ? 'loading…' : 'no data';
 
   function getPreviewRow(ruleId: string): CostScopePreviewRow | undefined {
     return preview.result?.perRule.find(p => p.ruleId === ruleId);
@@ -1018,13 +1018,13 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
           <SummaryTile
             label="After scope"
             value={hasData ? formatDollars(result.scopedTotalCost) : placeholder}
-            hint={hasData ? (hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled') : ''}
+            hint={(() => { if (!hasData) return ''; return hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled'; })()}
             emphasis
           />
           <SummaryTile
             label="Excluded"
             value={hasData && hasEnabledRules ? combinedText : placeholder}
-            hint={hasData ? (hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule') : ''}
+            hint={(() => { if (!hasData) return ''; return hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule'; })()}
           />
         </div>
 

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -72,9 +72,9 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
     await api.clearOrgData();
     setRefreshKey(k => k + 1);
   }
-  const selectedAccount = orgData !== null && selectedAccountId !== null
-    ? orgData.accounts.find(a => a.id === selectedAccountId) ?? null
-    : null;
+  const selectedAccount = orgData === null || selectedAccountId === null
+    ? null
+    : orgData.accounts.find(a => a.id === selectedAccountId) ?? null;
 
   async function handleSync() {
     if (profile === null) return;
@@ -213,22 +213,26 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
               <span>{String(allTagKeys.length)} tag keys (across all accounts, used as fallback when resources are under-tagged)</span>
             </li>
             <li className="flex items-center gap-2">
-              {regionInfo !== null && regionInfo.count > 0 ? (
-                <>
-                  <span className="text-accent">✓</span>
-                  <span className="text-text-secondary">{String(regionInfo.count)} region friendly names</span>
-                </>
-              ) : regionInfo?.lastError !== undefined && regionInfo.lastError !== null ? (
-                <>
-                  <span className="text-negative">✗</span>
-                  <span className="text-negative" title={regionInfo.lastError}>region friendly names — {regionInfo.lastError}</span>
-                </>
-              ) : (
-                <>
-                  <span className="text-text-muted">○</span>
-                  <span className="text-text-muted">region friendly names not synced (re-sync to populate)</span>
-                </>
-              )}
+              {(() => {
+                if (regionInfo !== null && regionInfo.count > 0) return (
+                  <>
+                    <span className="text-accent">✓</span>
+                    <span className="text-text-secondary">{String(regionInfo.count)} region friendly names</span>
+                  </>
+                );
+                if (regionInfo?.lastError !== undefined && regionInfo.lastError !== null) return (
+                  <>
+                    <span className="text-negative">✗</span>
+                    <span className="text-negative" title={regionInfo.lastError}>region friendly names — {regionInfo.lastError}</span>
+                  </>
+                );
+                return (
+                  <>
+                    <span className="text-text-muted">○</span>
+                    <span className="text-text-muted">region friendly names not synced (re-sync to populate)</span>
+                  </>
+                );
+              })()}
             </li>
           </ul>
           <div className="flex items-center justify-between px-4 py-2">

--- a/packages/ui/src/views/data-management-ssm.tsx
+++ b/packages/ui/src/views/data-management-ssm.tsx
@@ -39,9 +39,9 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
   const hasData = info !== null && info.count > 0;
   const hasError = info?.lastError !== null && info?.lastError !== undefined;
 
-  const regionEntries = info !== null
-    ? Object.entries(info.regions).sort(([a], [b]) => a.localeCompare(b))
-    : [];
+  const regionEntries = info === null
+    ? []
+    : Object.entries(info.regions).sort(([a], [b]) => a.localeCompare(b));
   const needle = regionSearch.toLowerCase();
   const filteredRegions = regionSearch.length > 0
     ? regionEntries.filter(([code, r]) =>
@@ -62,7 +62,7 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
         >
           <div className={[
             'h-2 w-2 rounded-full',
-            hasData ? 'bg-accent' : hasError ? 'bg-negative' : 'bg-text-muted',
+            (() => { if (hasData) return 'bg-accent'; return hasError ? 'bg-negative' : 'bg-text-muted'; })(),
           ].join(' ')} />
           <span className="text-sm font-medium text-text-primary">SSM Parameter Store</span>
           {hasData && <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>}
@@ -91,29 +91,33 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
 
       <ul className="px-4 pb-3 flex flex-col gap-1 text-xs">
         <li className="flex items-center gap-2">
-          {hasData ? (
-            <>
-              <span className="text-accent">✓</span>
-              <span className="text-text-secondary">{String(info.count)} regions enriched with longName + country + continent</span>
-              {info.syncedAt.length > 0 && (
-                <span className="text-text-muted ml-auto">
-                  Synced {new Date(info.syncedAt).toLocaleString()}
+          {(() => {
+            if (hasData) return (
+              <>
+                <span className="text-accent">✓</span>
+                <span className="text-text-secondary">{String(info.count)} regions enriched with longName + country + continent</span>
+                {info.syncedAt.length > 0 && (
+                  <span className="text-text-muted ml-auto">
+                    Synced {new Date(info.syncedAt).toLocaleString()}
+                  </span>
+                )}
+              </>
+            );
+            if (hasError) return (
+              <>
+                <span className="text-negative shrink-0">✗</span>
+                <span className="text-negative break-words">
+                  Last sync failed: {info.lastError ?? ''}
                 </span>
-              )}
-            </>
-          ) : hasError ? (
-            <>
-              <span className="text-negative shrink-0">✗</span>
-              <span className="text-negative break-words">
-                Last sync failed: {info.lastError ?? ''}
-              </span>
-            </>
-          ) : (
-            <>
-              <span className="text-text-muted">○</span>
-              <span className="text-text-muted">No region names cached — click Sync to fetch from SSM Parameter Store</span>
-            </>
-          )}
+              </>
+            );
+            return (
+              <>
+                <span className="text-text-muted">○</span>
+                <span className="text-text-muted">No region names cached — click Sync to fetch from SSM Parameter Store</span>
+              </>
+            );
+          })()}
         </li>
       </ul>
 

--- a/packages/ui/src/views/data-management-tier.tsx
+++ b/packages/ui/src/views/data-management-tier.tsx
@@ -64,7 +64,11 @@ export function TierPanel({
         <h3 className="text-sm font-semibold text-text-primary mb-4">{title}</h3>
         <div className="rounded-lg border border-dashed border-border p-6 text-center">
           <p className="text-sm text-text-secondary">Not configured</p>
-          {onConfigure !== undefined ? (
+          {onConfigure === undefined ? (
+            <p className="text-xs text-text-muted mt-2">
+              Add a <span className="font-mono text-text-secondary">{title.toLowerCase()}</span> section to your provider sync config in <span className="font-mono text-accent">costgoblin.yaml</span>
+            </p>
+          ) : (
             <button
               type="button"
               onClick={onConfigure}
@@ -72,10 +76,6 @@ export function TierPanel({
             >
               Configure {title.toLowerCase()} data source
             </button>
-          ) : (
-            <p className="text-xs text-text-muted mt-2">
-              Add a <span className="font-mono text-text-secondary">{title.toLowerCase()}</span> section to your provider sync config in <span className="font-mono text-accent">costgoblin.yaml</span>
-            </p>
           )}
         </div>
       </div>
@@ -115,7 +115,7 @@ export function TierPanel({
         <div className="rounded-lg border border-border bg-bg-primary/50 p-3">
           <p className="text-xs text-text-muted">Range</p>
           <p className="text-xs font-medium text-text-primary mt-1">{oldestPeriod ?? '—'}</p>
-          <p className="text-xs text-text-muted">{newestPeriod !== null ? `to ${newestPeriod}` : ''}</p>
+          <p className="text-xs text-text-muted">{newestPeriod === null ? '' : `to ${newestPeriod}`}</p>
         </div>
       </div>
 

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -451,7 +451,7 @@ export function DataManagement() {
             diskBytes={hourlyInventory?.local.diskBytes ?? 0}
             oldestPeriod={hourlyInventory?.local.oldestPeriod ?? null}
             newestPeriod={hourlyInventory?.local.newestPeriod ?? null}
-            periods={hourlyInventory !== null ? [...hourlyInventory.periods] : []}
+            periods={hourlyInventory === null ? [] : [...hourlyInventory.periods]}
             selected={hourlySelected}
             onToggle={toggleHourlyPeriod}
             onSelectAll={selectAllHourly}
@@ -472,7 +472,7 @@ export function DataManagement() {
             diskBytes={costOptInventory?.local.diskBytes ?? 0}
             oldestPeriod={costOptInventory?.local.oldestPeriod ?? null}
             newestPeriod={costOptInventory?.local.newestPeriod ?? null}
-            periods={costOptInventory !== null ? [...costOptInventory.periods] : []}
+            periods={costOptInventory === null ? [] : [...costOptInventory.periods]}
             selected={costOptSelected}
             onToggle={toggleCostOptPeriod}
             onSelectAll={selectAllCostOpt}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -316,16 +316,11 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
   // are defined entirely in terms of SSM enrichment and collapse to raw
   // codes otherwise.
   const wantsRegionEnrichment = (isRegionDim && state.useRegionNames) || isRegionCountryDim || isRegionContinentDim;
-  const regionWarning: { kind: 'missing' | 'error'; message?: string } | null =
-    wantsRegionEnrichment && regionInfoQuery.status === 'success'
-      ? regionInfo === null
-        ? { kind: 'missing' }
-        : regionInfo.lastError !== null
-          ? { kind: 'error', message: regionInfo.lastError }
-          : regionInfo.count === 0
-            ? { kind: 'missing' }
-            : null
-      : null;
+  let regionWarning: { kind: 'missing' | 'error'; message?: string } | null = null;
+  if (wantsRegionEnrichment && regionInfoQuery.status === 'success') {
+    if (regionInfo === null || regionInfo.count === 0) regionWarning = { kind: 'missing' };
+    else if (regionInfo.lastError !== null) regionWarning = { kind: 'error', message: regionInfo.lastError };
+  }
   // Both "Account Name" and "Account Tag" sources resolve via the Org sync,
   // so if it hasn't run yet the dim will display raw 12-digit IDs regardless.
   const accountWarning: boolean =
@@ -364,7 +359,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
       )}
       {showTransforms && (
         <div className="grid grid-cols-2 gap-4 items-stretch">
-          {isAccountDim ? nameSourceField : isRegionDim ? regionToggleField : <div />}
+          {(() => { if (isAccountDim) return nameSourceField; if (isRegionDim) return regionToggleField; return <div />; })()}
           {normalizationField}
         </div>
       )}
@@ -1039,6 +1034,28 @@ function AccountTagsContent({ orgData, accountTagKeys, hiddenAccountCols, setHid
   );
 }
 
+function pillClass(enabled: boolean): string {
+  return [
+    'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+    enabled
+      ? 'border-accent/50 bg-accent/10 text-accent hover:bg-accent/20'
+      : 'border-border bg-bg-tertiary/20 text-text-muted hover:border-text-muted hover:text-text-secondary',
+  ].join(' ');
+}
+
+function GripHandle({ attrs }: Readonly<{ attrs: React.HTMLAttributes<HTMLButtonElement> }>): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      {...attrs}
+      title="Drag to reorder"
+      className="flex items-center justify-center text-text-muted hover:text-text-primary cursor-grab active:cursor-grabbing"
+    >
+      <GripVertical size={16} />
+    </button>
+  );
+}
+
 export function DimensionsView() {
   const api = useCostApi();
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
@@ -1254,20 +1271,7 @@ export function DimensionsView() {
     };
   }
 
-  function GripHandle({ attrs }: Readonly<{ attrs: React.HTMLAttributes<HTMLButtonElement> }>): React.JSX.Element {
-    return (
-      <button
-        type="button"
-        {...attrs}
-        title="Drag to reorder"
-        className="flex items-center justify-center text-text-muted hover:text-text-primary cursor-grab active:cursor-grabbing"
-      >
-        <GripVertical size={16} />
-      </button>
-    );
-  }
-
-  function ReorderArrows({ orderIdx, total }: Readonly<{ orderIdx: number; total: number }>): React.JSX.Element {
+  function renderReorderArrows(orderIdx: number, total: number): React.JSX.Element {
     const canUp = orderIdx > 0;
     const canDown = orderIdx < total - 1;
     return (
@@ -1320,14 +1324,7 @@ export function DimensionsView() {
     return rows;
   })();
 
-  function pillClass(enabled: boolean): string {
-    return [
-      'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-      enabled
-        ? 'border-accent/50 bg-accent/10 text-accent hover:bg-accent/20'
-        : 'border-border bg-bg-tertiary/20 text-text-muted hover:border-text-muted hover:text-text-secondary',
-    ].join(' ');
-  }
+
 
   return (
     <div className="flex flex-col gap-8 p-6">
@@ -1417,7 +1414,7 @@ export function DimensionsView() {
 
           {orderedRows.map((row, orderIdx) => {
             const dnd = dragProps(orderIdx);
-            const arrows = <ReorderArrows orderIdx={orderIdx} total={orderedRows.length} />;
+            const arrows = renderReorderArrows(orderIdx, orderedRows.length);
 
             if (row.kind === 'builtIn') {
               const d = row.dim;
@@ -1558,7 +1555,11 @@ export function DimensionsView() {
 
           <DebugPanel
             title="Resource Tags"
-            subtitle={tagsQuery.status === 'success' && tagsQuery.data !== null ? `${String(tagsQuery.data.tags.length)} keys${tagsQuery.data.samplePeriod.length > 0 ? ` · sampled from ${tagsQuery.data.samplePeriod}` : ''}` : 'Tag keys discovered by scanning the latest CUR period'}
+            subtitle={(() => {
+              if (tagsQuery.status !== 'success' || tagsQuery.data === null) return 'Tag keys discovered by scanning the latest CUR period';
+              const suffix = tagsQuery.data.samplePeriod.length > 0 ? ` · sampled from ${tagsQuery.data.samplePeriod}` : '';
+              return `${String(tagsQuery.data.tags.length)} keys${suffix}`;
+            })()}
             expanded={resourceTagsExpanded}
             onToggle={() => { setResourceTagsExpanded(v => !v); }}
           >

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -199,7 +199,7 @@ export function MissingTags() {
       {data !== null && actionableRows.length > 0 && (
         <div className="flex flex-col gap-3">
           <h3 className="text-sm font-semibold text-text-primary">
-            Actionable
+            {'Actionable'}
             <span className="ml-2 text-xs font-normal text-text-muted">
               {String(actionableRows.length)} resources · {formatDollars(data.totalActionableCost)}
             </span>
@@ -217,7 +217,7 @@ export function MissingTags() {
       {data !== null && showLikelyUntaggable && likelyUntaggableRows.length > 0 && (
         <div className="flex flex-col gap-3">
           <h3 className="text-sm font-semibold text-text-secondary">
-            Likely not taggable
+            {'Likely not taggable'}
             <span className="ml-2 text-xs font-normal text-text-muted">
               {String(likelyUntaggableRows.length)} resources · {formatDollars(data.totalLikelyUntaggableCost)}
             </span>

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -341,7 +341,7 @@ export function Savings() {
                 const current = isExpanded ? parseResourceDetails(rec.currentDetails) : null;
                 const recommended = isExpanded ? parseResourceDetails(rec.recommendedDetails) : null;
                 return (
-                  <tbody key={String(i)}>
+                  <tbody key={`${rec.resourceArn}-${rec.accountId}-${String(i)}`}>
                   <tr className={`border-b ${isExpanded ? 'border-border bg-bg-tertiary/20' : 'border-border-subtle'} hover:bg-bg-tertiary/30 transition-colors cursor-pointer`} onClick={() => { setExpandedRow(isExpanded ? null : i); }}>
                     <td className="px-4 py-3 max-w-lg">
                       <div className="flex items-baseline gap-2">
@@ -367,7 +367,7 @@ export function Savings() {
                     </td>
                   </tr>
                   {isExpanded && (
-                    <tr key={`detail-${String(i)}`} className="border-b border-border bg-bg-tertiary/10">
+                    <tr key={`detail-${rec.resourceArn}-${rec.accountId}`} className="border-b border-border bg-bg-tertiary/10">
                       <td colSpan={7} className="px-6 py-4">
                         <div className="grid grid-cols-2 gap-6 text-xs">
                           <div className="space-y-3">
@@ -385,8 +385,8 @@ export function Savings() {
                             {current !== null && current.usages.length > 0 && (
                               <div className="space-y-1 pt-1">
                                 <p className="text-text-muted text-[10px] uppercase tracking-wider">Usage</p>
-                                {current.usages.map((u, ui) => (
-                                  <p key={ui} className="text-text-secondary">{u.amount} {u.unit} <span className="text-text-muted">({u.type.split('-').pop() ?? u.type})</span></p>
+                                {current.usages.map((u) => (
+                                  <p key={`${u.type}-${u.amount}`} className="text-text-secondary">{u.amount} {u.unit} <span className="text-text-muted">({u.type.split('-').pop() ?? u.type})</span></p>
                                 ))}
                               </div>
                             )}

--- a/packages/ui/src/views/views-editor.tsx
+++ b/packages/ui/src/views/views-editor.tsx
@@ -74,7 +74,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
 
   const dimensionsQuery = useQuery(() => api.getDimensions(), [api]);
   const dimensions: readonly Dimension[] = dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
-  const fallbackDim = dimensions[0] !== undefined ? getDimensionId(dimensions[0]) : 'service';
+  const fallbackDim = dimensions[0] === undefined ? 'service' : getDimensionId(dimensions[0]);
 
   useEffect(() => {
     let cancelled = false;
@@ -213,7 +213,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
   }
 
   async function handleReset(): Promise<void> {
-    if (!window.confirm('Reset built-in views to defaults? Your custom views will be kept (delete them manually to fully reset).')) return;
+    if (!globalThis.confirm('Reset built-in views to defaults? Your custom views will be kept (delete them manually to fully reset).')) return;
     // Client-side merge: built-ins from seed replace any current same-id built-in,
     // custom (non-builtIn) views in the editor are preserved in place. Missing
     // built-ins are prepended.
@@ -221,7 +221,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
     const seenSeedIds = new Set<string>();
     const replaced: ViewSpec[] = state.config.views.map(v => {
       const seed = seedById.get(v.id);
-      if (seed !== undefined && seed.builtIn === true) {
+      if (seed?.builtIn === true) {
         seenSeedIds.add(v.id);
         return seed;
       }
@@ -292,7 +292,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
             disabled={saving || !state.dirty}
             className="px-4 py-1.5 text-sm rounded-md bg-accent text-bg-primary font-medium hover:opacity-90 disabled:opacity-40"
           >
-            {saving ? 'Saving…' : state.dirty ? 'Save changes' : 'Saved'}
+            {(() => { if (saving) return 'Saving…'; return state.dirty ? 'Save changes' : 'Saved'; })()}
           </button>
         </div>
       </div>
@@ -385,7 +385,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
               </div>
 
               {selectedView.rows.map((row, rowIdx) => (
-                <div key={rowIdx} className="rounded-lg border border-border bg-bg-secondary/30 p-3 flex flex-col gap-2">
+                <div key={row.widgets[0]?.id ?? `row-${String(rowIdx)}`} className="rounded-lg border border-border bg-bg-secondary/30 p-3 flex flex-col gap-2">
                   <div className="flex items-center justify-between">
                     <span className="text-xs text-text-muted">Row {String(rowIdx + 1)}</span>
                     <div className="flex items-center gap-0.5">

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -28,15 +28,15 @@ export function BubbleWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
   const query = useQuery(
-    () => specGroupBy !== undefined
-      ? api.queryTrends({
+    () => specGroupBy === undefined
+      ? Promise.resolve(null)
+      : api.queryTrends({
           groupBy: specGroupBy,
           dateRange,
           filters,
           deltaThreshold: DEFAULT_DELTA_THRESHOLD,
           percentThreshold: DEFAULT_PERCENT_THRESHOLD,
-        })
-      : Promise.resolve(null),
+        }),
     [specGroupBy, dateRange.start, dateRange.end, fk, api],
   );
 

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -59,7 +59,7 @@ export function HeatmapWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
   const query = useQuery<DailyQueryResult | null>(
     async () => {
       if (specGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -49,7 +49,7 @@ export function LineWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
   const query = useQuery<DailyQueryResult | null>(
     async () => {
       if (specGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -42,7 +42,7 @@ export function PieWidget({
   const baseFilters = mergeFilters(globalFilters, spec.filters);
 
   const fk = filtersKey(baseFilters);
-  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
   const query = useQuery<PieQueryResult | null>(
     async () => {
       if (specGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -63,7 +63,7 @@ export function StackedBarWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
   const query = useQuery<DailyQueryResult | null>(
     async () => {
       if (specGroupBy === undefined) return null;
@@ -92,7 +92,9 @@ export function StackedBarWidget({
 
   const loading = query.status === 'loading';
 
-  const defaultTitle = granularity === 'hourly' ? 'Hourly Costs' : (useWeekly ? 'Weekly Costs' : 'Daily Costs');
+  let defaultTitle = 'Daily Costs';
+  if (granularity === 'hourly') defaultTitle = 'Hourly Costs';
+  else if (useWeekly) defaultTitle = 'Weekly Costs';
   const title = spec.title ?? defaultTitle;
 
   return (

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -2,6 +2,7 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { SummaryCard } from '../components/summary-card.js';
 import { asDimensionId } from '@costgoblin/core/browser';
+import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { filtersKey, mergeFilters } from './widget.js';
 
@@ -13,25 +14,27 @@ export function SummaryWidget({
   spec,
 }: WidgetCommonProps) {
   const api = useCostApi();
-  if (spec.type !== 'summary') return null;
+  const isSummary = spec.type === 'summary';
 
   const groupBy = asDimensionId('account');
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
-  const cur = useQuery(
-    () => api.queryCosts({ groupBy, dateRange, filters, granularity }),
-    [groupBy, dateRange.start, dateRange.end, fk, granularity, api],
+  const cur = useQuery<CostResult | null>(
+    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity }) : Promise.resolve(null),
+    [isSummary, groupBy, dateRange.start, dateRange.end, fk, granularity, api],
   );
-  const prev = useQuery(
-    () => api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity }),
-    [groupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+  const prev = useQuery<CostResult | null>(
+    () => isSummary ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity }) : Promise.resolve(null),
+    [isSummary, groupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
+
+  if (!isSummary) return null;
 
   // `null` means "still loading / errored" — SummaryCard renders a dash
   // placeholder rather than briefly showing $0.00.
-  const totalCost = cur.status === 'success' ? cur.data.totalCost : null;
-  const previousCost = prev.status === 'success' ? prev.data.totalCost : null;
+  const totalCost = cur.status === 'success' && cur.data !== null ? cur.data.totalCost : null;
+  const previousCost = prev.status === 'success' && prev.data !== null ? prev.data.totalCost : null;
 
   return (
     <SummaryCard totalCost={totalCost} previousCost={previousCost} dateRange={dateRange} />

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -40,7 +40,7 @@ export function TopNBarWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
   const query = useQuery<CostQueryResult | null>(
     async () => {
       if (specGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -32,7 +32,7 @@ export function TreemapWidget({
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy !== undefined ? getDimensionFallback(specGroupBy) : undefined;
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
   const query = useQuery<CostQueryResult | null>(
     async () => {
       if (specGroupBy === undefined) return null;


### PR DESCRIPTION
## Summary

- **S7735 (negated conditions)**: Flip `!== undefined ? A : B` ternaries to `=== undefined ? B : A` across widgets, charts, and views
- **S3358 (nested ternaries)**: Extract nested ternaries to if/else blocks or IIFEs in 20+ locations
- **S107 (too many params)**: Refactor `buildSource()` from 8 positional params to a single options object (`BuildSourceOptions`)
- **S6819 (semantic HTML)**: Remove `role="img"` from SVG chart elements, replace `role="dialog"` divs with `<dialog>` elements
- **S6847/S6845/S6819**: Restructure top-n-bar-chart to nest `<button>` inside `<li>` instead of applying role/tabIndex/handlers to `<li>`
- **S6440 (conditional hooks)**: Fix SummaryWidget to call hooks before early return
- **S6479 (array index keys)**: Replace array index keys with stable composite keys
- **S6759 (readonly props)**: Add `Readonly<>` to card.tsx component props
- **S6772 (ambiguous spacing)**: Fix ambiguous JSX text/element spacing
- **S7780/S7765/S7763/S7764/S7776/S7749**: Use String.raw, .includes(), export-from, globalThis, Set, proper numeric separators
- **S1854/S1871/S6564/S6606/S4624/S6478/S7721/S4144**: Fix dead stores, duplicate cases, redundant types, nullish coalescing, nested templates, move components out of parent