### PR TITLE
Reduce remaining cognitive complexity and nesting depth

### DIFF
--- a/packages/core/src/config/views-serialize.ts
+++ b/packages/core/src/config/views-serialize.ts
@@ -1,8 +1,6 @@
 import type { ViewSpec, ViewsConfig, WidgetSpec } from '../types/views.js';
 
-/** YAML-ready shape for a single widget. Keeps keys in a stable order so
- *  round-tripping a config doesn't produce noisy diffs. */
-export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
+function buildWidgetBase(w: WidgetSpec): Record<string, unknown> {
   const base: Record<string, unknown> = { id: w.id, type: w.type, size: w.size };
   if (w.title !== undefined) base['title'] = w.title;
   if (w.filters !== undefined) {
@@ -12,6 +10,17 @@ export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
     }
     if (Object.keys(f).length > 0) base['filters'] = f;
   }
+  return base;
+}
+
+function addGroupByFields(base: Record<string, unknown>, w: WidgetSpec & { groupBy: string }): void {
+  base['groupBy'] = w.groupBy;
+}
+
+/** YAML-ready shape for a single widget. Keeps keys in a stable order so
+ *  round-tripping a config doesn't produce noisy diffs. */
+export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
+  const base = buildWidgetBase(w);
   switch (w.type) {
     case 'summary':
       if (w.metric !== undefined) base['metric'] = w.metric;
@@ -19,16 +28,16 @@ export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
     case 'pie':
     case 'stackedBar':
     case 'bubble':
-      base['groupBy'] = w.groupBy;
+      addGroupByFields(base, w);
       return base;
     case 'treemap':
-      base['groupBy'] = w.groupBy;
+      addGroupByFields(base, w);
       if (w.drillTo !== undefined) base['drillTo'] = w.drillTo;
       return base;
     case 'line':
     case 'topNBar':
     case 'heatmap':
-      base['groupBy'] = w.groupBy;
+      addGroupByFields(base, w);
       if (w.topN !== undefined) base['topN'] = w.topN;
       return base;
     case 'table':

--- a/packages/core/src/config/views-validator.ts
+++ b/packages/core/src/config/views-validator.ts
@@ -48,8 +48,14 @@ function validateFilters(raw: unknown, ctx: string): WidgetFilterOverlay | undef
   return out;
 }
 
-function validateWidget(raw: unknown, ctx: string): WidgetSpec {
-  assertObject(raw, ctx);
+interface WidgetBase {
+  readonly id: string;
+  readonly size: WidgetSize;
+  readonly title?: string;
+  readonly filters?: WidgetFilterOverlay;
+}
+
+function parseWidgetBase(raw: Record<string, unknown>, ctx: string): WidgetBase {
   assertString(raw['id'], `${ctx}.id`);
   assertString(raw['type'], `${ctx}.type`);
   if (!isWidgetType(raw['type'])) {
@@ -63,82 +69,85 @@ function validateWidget(raw: unknown, ctx: string): WidgetSpec {
       `${ctx}.size must be one of: ${WIDGET_SIZES.join(', ')} (got ${raw['size']})`,
     );
   }
-
-  const id = raw['id'];
-  const type = raw['type'];
-  const size = raw['size'];
   const title = raw['title'] === undefined ? undefined : (assertString(raw['title'], `${ctx}.title`), raw['title']);
   const filters = validateFilters(raw['filters'], `${ctx}.filters`);
-
-  const base = {
-    id,
-    size,
+  return {
+    id: raw['id'],
+    size: raw['size'],
     ...(title === undefined ? {} : { title }),
     ...(filters === undefined ? {} : { filters }),
   };
+}
+
+function validateSummaryWidget(raw: Record<string, unknown>, ctx: string, base: WidgetBase): WidgetSpec {
+  let metric: SummaryMetric | undefined;
+  if (raw['metric'] !== undefined) {
+    assertString(raw['metric'], `${ctx}.metric`);
+    if (!isSummaryMetric(raw['metric'])) {
+      throw new ConfigValidationError(
+        `${ctx}.metric must be one of: ${SUMMARY_METRICS.join(', ')}`,
+      );
+    }
+    metric = raw['metric'];
+  }
+  return { type: 'summary', ...base, ...(metric === undefined ? {} : { metric }) };
+}
+
+function validateGroupByWidget(raw: Record<string, unknown>, ctx: string, base: WidgetBase, type: 'pie' | 'stackedBar' | 'bubble' | 'treemap'): WidgetSpec {
+  assertString(raw['groupBy'], `${ctx}.groupBy`);
+  const groupBy = asDimensionId(raw['groupBy']);
+  if (type === 'treemap') {
+    const drillTo = raw['drillTo'] !== undefined
+      ? (assertString(raw['drillTo'], `${ctx}.drillTo`), asDimensionId(raw['drillTo']))
+      : undefined;
+    return { type, ...base, groupBy, ...(drillTo === undefined ? {} : { drillTo }) };
+  }
+  if (type === 'pie') return { type, ...base, groupBy };
+  return { type, ...base, groupBy };
+}
+
+function validateTopNWidget(raw: Record<string, unknown>, ctx: string, base: WidgetBase, type: 'line' | 'topNBar' | 'heatmap'): WidgetSpec {
+  assertString(raw['groupBy'], `${ctx}.groupBy`);
+  let topN: number | undefined;
+  if (raw['topN'] !== undefined) {
+    assertNumber(raw['topN'], `${ctx}.topN`);
+    topN = raw['topN'];
+  }
+  return { type, ...base, groupBy: asDimensionId(raw['groupBy']), ...(topN === undefined ? {} : { topN }) };
+}
+
+function validateTableWidget(raw: Record<string, unknown>, ctx: string, base: WidgetBase): WidgetSpec {
+  let enabledColumns: string[] | undefined;
+  if (raw['enabledColumns'] !== undefined) {
+    assertArray(raw['enabledColumns'], `${ctx}.enabledColumns`);
+    enabledColumns = raw['enabledColumns'].map((c, i) => {
+      assertString(c, `${ctx}.enabledColumns[${String(i)}]`);
+      return c;
+    });
+  }
+  return { type: 'table', ...base, ...(enabledColumns === undefined ? {} : { enabledColumns }) };
+}
+
+function validateWidget(raw: unknown, ctx: string): WidgetSpec {
+  assertObject(raw, ctx);
+  const base = parseWidgetBase(raw, ctx);
+  assertString(raw['type'], `${ctx}.type`);
+  const type = raw['type'] as WidgetType;
 
   switch (type) {
-    case 'summary': {
-      let metric: SummaryMetric | undefined;
-      if (raw['metric'] !== undefined) {
-        assertString(raw['metric'], `${ctx}.metric`);
-        if (!isSummaryMetric(raw['metric'])) {
-          throw new ConfigValidationError(
-            `${ctx}.metric must be one of: ${SUMMARY_METRICS.join(', ')}`,
-          );
-        }
-        metric = raw['metric'];
-      }
-      return { type, ...base, ...(metric === undefined ? {} : { metric }) };
-    }
-    case 'pie': {
-      assertString(raw['groupBy'], `${ctx}.groupBy`);
-      return { type, ...base, groupBy: asDimensionId(raw['groupBy']) };
-    }
+    case 'summary':
+      return validateSummaryWidget(raw, ctx, base);
+    case 'pie':
     case 'stackedBar':
     case 'bubble':
-    case 'treemap': {
-      assertString(raw['groupBy'], `${ctx}.groupBy`);
-      const drillTo = type === 'treemap' && raw['drillTo'] !== undefined
-        ? (assertString(raw['drillTo'], `${ctx}.drillTo`), asDimensionId(raw['drillTo']))
-        : undefined;
-      const groupBy = asDimensionId(raw['groupBy']);
-      if (type === 'treemap') {
-        return { type, ...base, groupBy, ...(drillTo === undefined ? {} : { drillTo }) };
-      }
-      return { type, ...base, groupBy };
-    }
+    case 'treemap':
+      return validateGroupByWidget(raw, ctx, base, type);
     case 'line':
     case 'topNBar':
-    case 'heatmap': {
-      assertString(raw['groupBy'], `${ctx}.groupBy`);
-      let topN: number | undefined;
-      if (raw['topN'] !== undefined) {
-        assertNumber(raw['topN'], `${ctx}.topN`);
-        topN = raw['topN'];
-      }
-      return {
-        type,
-        ...base,
-        groupBy: asDimensionId(raw['groupBy']),
-        ...(topN === undefined ? {} : { topN }),
-      };
-    }
-    case 'table': {
-      let enabledColumns: string[] | undefined;
-      if (raw['enabledColumns'] !== undefined) {
-        assertArray(raw['enabledColumns'], `${ctx}.enabledColumns`);
-        enabledColumns = raw['enabledColumns'].map((c, i) => {
-          assertString(c, `${ctx}.enabledColumns[${String(i)}]`);
-          return c;
-        });
-      }
-      return {
-        type,
-        ...base,
-        ...(enabledColumns === undefined ? {} : { enabledColumns }),
-      };
-    }
+    case 'heatmap':
+      return validateTopNWidget(raw, ctx, base, type);
+    case 'table':
+      return validateTableWidget(raw, ctx, base);
   }
 }
 

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -74,6 +74,37 @@ export interface RegionEnrichment {
  *  compete. Codes with an empty value for the requested field are left alone
  *  so the raw code surfaces (better than collapsing everything unknown into
  *  a single bucket). */
+function pickRegionField(d: { name: string; useRegionNames?: boolean | undefined }): ((e: RegionEnrichment) => string) | null {
+  if (d.name === 'region_country') return (e) => e.country;
+  if (d.name === 'region_continent') return (e) => e.continent;
+  if (d.useRegionNames === true) return (e) => e.longName;
+  return null;
+}
+
+function mergeRegionAliases(
+  userAliases: Readonly<Record<string, readonly string[]>>,
+  regionMap: ReadonlyMap<string, RegionEnrichment>,
+  pick: (e: RegionEnrichment) => string,
+): Record<string, string[]> {
+  const userCovered = new Set<string>();
+  for (const list of Object.values(userAliases)) {
+    for (const a of list) userCovered.add(a);
+  }
+  const merged: Record<string, string[]> = {};
+  for (const [canonical, list] of Object.entries(userAliases)) {
+    merged[canonical] = [...list];
+  }
+  for (const [code, info] of regionMap) {
+    if (userCovered.has(code)) continue;
+    const label = pick(info);
+    if (label.length === 0) continue;
+    const existing = merged[label];
+    if (existing === undefined) merged[label] = [code];
+    else existing.push(code);
+  }
+  return merged;
+}
+
 export function applyRegionFriendlyNames(
   dims: import('../types/config.js').DimensionsConfig,
   regionMap: ReadonlyMap<string, RegionEnrichment>,
@@ -81,28 +112,9 @@ export function applyRegionFriendlyNames(
   if (regionMap.size === 0) return dims;
   const builtIn = dims.builtIn.map(d => {
     if (d.field !== 'region') return d;
-    let pick: ((e: RegionEnrichment) => string) | null = null;
-    if (d.name === 'region_country') pick = (e) => e.country;
-    else if (d.name === 'region_continent') pick = (e) => e.continent;
-    else if (d.useRegionNames === true) pick = (e) => e.longName;
+    const pick = pickRegionField(d);
     if (pick === null) return d;
-    const userAliases = d.aliases ?? {};
-    const userCovered = new Set<string>();
-    for (const list of Object.values(userAliases)) {
-      for (const a of list) userCovered.add(a);
-    }
-    const merged: Record<string, string[]> = {};
-    for (const [canonical, list] of Object.entries(userAliases)) {
-      merged[canonical] = [...list];
-    }
-    for (const [code, info] of regionMap) {
-      if (userCovered.has(code)) continue;
-      const label = pick(info);
-      if (label.length === 0) continue;
-      const existing = merged[label];
-      if (existing === undefined) merged[label] = [code];
-      else existing.push(code);
-    }
+    const merged = mergeRegionAliases(d.aliases ?? {}, regionMap, pick);
     return { ...d, aliases: merged };
   });
   return { ...dims, builtIn };

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -129,6 +129,49 @@ function buildFilterClauses(
   return clauses;
 }
 
+/** Try to expand account display-names back to raw IDs via the reverse map.
+ *  Returns the SQL fragment if expansion was used, or null to fall through. */
+function tryExpandAccountIds(
+  values: readonly string[],
+  rawField: string,
+  accountReverseMap: ReadonlyMap<string, readonly string[]> | undefined,
+  qb: QueryBuilder | undefined,
+): string | null {
+  if (rawField !== 'account_id' || accountReverseMap === undefined) return null;
+  const expandedIds = new Set<string>();
+  let usedReverse = false;
+  for (const v of values) {
+    const ids = accountReverseMap.get(v);
+    if (ids !== undefined && ids.length > 0) {
+      for (const id of ids) expandedIds.add(id);
+      usedReverse = true;
+    } else {
+      expandedIds.add(v);
+    }
+  }
+  if (!usedReverse) return null;
+  const list = buildSqlList([...expandedIds], qb);
+  return `${rawField} IN (${list})`;
+}
+
+/** Build the SQL fragment for a single condition within a rule. Returns null
+ *  when the condition should be skipped (empty values, unknown dimension). */
+function buildConditionSql(
+  cond: ExclusionRule['conditions'][number],
+  dimensions: DimensionsConfig,
+  accountReverseMap: ReadonlyMap<string, readonly string[]> | undefined,
+  qb: QueryBuilder | undefined,
+): string | null {
+  if (cond.values.length === 0) return null;
+  const resolved = tryResolveField(cond.dimensionId, dimensions);
+  if (resolved === null) return null;
+  const expanded = tryExpandAccountIds(cond.values, resolved.rawField, accountReverseMap, qb);
+  if (expanded !== null) return expanded;
+  const normalizedValues = cond.values.map(v => normalizeRuleValue(v, resolved.dim));
+  const list = buildSqlList(normalizedValues, qb);
+  return `${resolved.fieldExpr} IN (${list})`;
+}
+
 /** Build the positive match expression for a single rule (AND of conditions,
  *  OR within each condition's values). Used both for NOT-exclusion in queries
  *  and for the positive preview queries. Returns null when the rule has no
@@ -141,40 +184,8 @@ export function buildRuleMatchExpr(
 ): string | null {
   const conditionSqls: string[] = [];
   for (const cond of rule.conditions) {
-    if (cond.values.length === 0) continue;
-    // Skip conditions whose dimension no longer exists — happens if a user
-    // deletes/renames a dimension while a rule references it. Emitting a
-    // bogus column reference here would crash every query that threads cost
-    // scope through (which is all of them). Save-time validation prevents
-    // this on new edits; this guard covers legacy on-disk rules.
-    const resolved = tryResolveField(cond.dimensionId, dimensions);
-    if (resolved === null) continue;
-    if (resolved.rawField === 'account_id' && accountReverseMap !== undefined) {
-      const expandedIds = new Set<string>();
-      let usedReverse = false;
-      for (const v of cond.values) {
-        const ids = accountReverseMap.get(v);
-        if (ids !== undefined && ids.length > 0) {
-          for (const id of ids) expandedIds.add(id);
-          usedReverse = true;
-        } else {
-          expandedIds.add(v);
-        }
-      }
-      if (usedReverse) {
-        const list = buildSqlList([...expandedIds], qb);
-        conditionSqls.push(`${resolved.rawField} IN (${list})`);
-        continue;
-      }
-    }
-    // Apply the dim's normalize + alias transformation to each value so
-    // rule conditions stay correct when the user normalises the target
-    // dimension (e.g. a lowercase rule on `line_item_type` would otherwise
-    // turn 'RIFee' in the built-in rule into a silent no-match). The
-    // field expression already bakes in the same transformation.
-    const normalizedValues = cond.values.map(v => normalizeRuleValue(v, resolved.dim));
-    const list = buildSqlList(normalizedValues, qb);
-    conditionSqls.push(`${resolved.fieldExpr} IN (${list})`);
+    const sql = buildConditionSql(cond, dimensions, accountReverseMap, qb);
+    if (sql !== null) conditionSqls.push(sql);
   }
   if (conditionSqls.length === 0) return null;
   return conditionSqls.join(' AND ');

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -155,6 +155,38 @@ function makeLineHandler(
   };
 }
 
+async function syncDateGroup(
+  date: string,
+  dateFiles: readonly ManifestFileEntry[],
+  s3Bucket: string,
+  dataDir: string,
+  outputDir: string,
+  profile: string,
+  signal: AbortSignal | undefined,
+  onLine: (line: string) => void,
+): Promise<number> {
+  const firstFile = dateFiles[0];
+  if (firstFile === undefined) return 0;
+
+  const datePrefix = extractPeriodPrefix(firstFile.key);
+  const s3Source = `s3://${s3Bucket}/${datePrefix}`;
+  const stagingDir = join(dataDir, 'aws', 'raw', `cost-opt-${date}`);
+  await mkdir(stagingDir, { recursive: true });
+
+  await runAwsS3Sync({ source: s3Source, dest: stagingDir, profile, signal, onLine });
+
+  const dateDir = join(outputDir, `usage_date=${date}`);
+  await mkdir(dateDir, { recursive: true });
+
+  const downloaded = await readdir(stagingDir);
+  for (const f of downloaded) {
+    if (f.endsWith('.parquet')) {
+      await copyFile(join(stagingDir, f), join(dateDir, 'data.parquet'));
+    }
+  }
+  return dateFiles.length;
+}
+
 async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ filesDownloaded: number; rowsProcessed: number }> {
   const { bucketPath, profile, dataDir, files, onProgress } = options;
   const s3Path = parseS3Path(bucketPath);
@@ -175,34 +207,10 @@ async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ fi
 
     for (const [date, dateFiles] of dateGroups) {
       if (options.signal?.aborted) break;
-
-      const firstFile = dateFiles[0];
-      if (firstFile === undefined) continue;
-
-      const datePrefix = extractPeriodPrefix(firstFile.key);
-      const s3Source = `s3://${s3Path.bucket}/${datePrefix}`;
-      const stagingDir = join(dataDir, 'aws', 'raw', `cost-opt-${date}`);
-      await mkdir(stagingDir, { recursive: true });
-
-      await runAwsS3Sync({
-        source: s3Source,
-        dest: stagingDir,
-        profile,
-        signal: options.signal,
-        onLine: makeLineHandler(onProgress, totalFiles, counter),
-      });
-
-      const dateDir = join(outputDir, `usage_date=${date}`);
-      await mkdir(dateDir, { recursive: true });
-
-      const downloaded = await readdir(stagingDir);
-      for (const f of downloaded) {
-        if (f.endsWith('.parquet')) {
-          await copyFile(join(stagingDir, f), join(dateDir, 'data.parquet'));
-        }
-      }
-
-      totalFilesDownloaded += dateFiles.length;
+      totalFilesDownloaded += await syncDateGroup(
+        date, dateFiles, s3Path.bucket, dataDir, outputDir, profile,
+        options.signal, makeLineHandler(onProgress, totalFiles, counter),
+      );
     }
 
     if (onProgress !== undefined) {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -157,6 +157,76 @@ export interface AppContext {
   readonly warmupBase: () => void;
 }
 
+async function loadAccountCsv(
+  rawDir: string,
+  fs: typeof import('node:fs/promises'),
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const entries = await fs.readdir(rawDir);
+    const csvFile = entries.find(e => e.toLowerCase().endsWith('.csv') && e.toLowerCase().includes('account'));
+    if (csvFile !== undefined) {
+      const content = await fs.readFile((await import('node:path')).join(rawDir, csvFile), 'utf-8');
+      const lines = content.split('\n').filter(l => l.trim().length > 0);
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (line === undefined) continue;
+        const cols = line.split(',').map(c => c.replaceAll(/^"|"$/g, '').trim());
+        const id = cols[0] ?? '';
+        const name = cols[4] ?? '';
+        if (id.length > 0 && name.length > 0) map.set(id, name);
+      }
+    }
+  } catch { /* no raw dir */ }
+  return map;
+}
+
+function applyAccountNameTransforms(
+  raw: Map<string, string>,
+  normalize: import('@costgoblin/core').NormalizationRule | undefined,
+  patterns: readonly string[] | undefined,
+): Map<string, string> {
+  if (normalize === undefined && (patterns === undefined || patterns.length === 0)) return raw;
+  return new Map([...raw].map(([id, name]) => {
+    let v = name;
+    if (normalize !== undefined) v = applyNormalizationRule(v, normalize);
+    if (patterns !== undefined && patterns.length > 0) v = applyStripPatterns(v, patterns);
+    return [id, v];
+  }));
+}
+
+function extractAccountTagEntry(acct: unknown): { id: string; tags: Record<string, string> } | null {
+  if (!isStringRecord(acct)) return null;
+  const id = acct['id'];
+  const tags = acct['tags'];
+  if (typeof id !== 'string' || !isStringRecord(tags)) return null;
+  const stringTags: Record<string, string> = {};
+  for (const [k, v] of Object.entries(tags)) {
+    if (typeof v === 'string') stringTags[k] = v;
+  }
+  return { id, tags: stringTags };
+}
+
+async function generateFlatOrgTags(baseDir: string, flatPath: string): Promise<string | undefined> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  try {
+    const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
+    let parsed: unknown;
+    try { parsed = JSON.parse(raw); } catch { return undefined; }
+    if (!isStringRecord(parsed) || !Array.isArray(parsed['accounts'])) return undefined;
+    const tagLookup: { id: string; tags: Record<string, string> }[] = [];
+    for (const acct of parsed['accounts']) {
+      const entry = extractAccountTagEntry(acct);
+      if (entry !== null) tagLookup.push(entry);
+    }
+    await fs.writeFile(flatPath, JSON.stringify(tagLookup));
+    return flatPath;
+  } catch {
+    return undefined;
+  }
+}
+
 export function createAppContext(ctx: IpcContext): AppContext {
   const state: AppState = {
     config: null,
@@ -211,15 +281,6 @@ export function createAppContext(ctx: IpcContext): AppContext {
   }
 
   async function getAccountMap(): Promise<Map<string, string>> {
-    // Returns the Account id→name map the handlers should use for display
-    // resolution. Source depends on the Account dim's config:
-    //   - useOrgAccounts=true + accountNameFromTag set  : org-sync tag value
-    //   - useOrgAccounts=true                           : org-sync Name field
-    //   - otherwise                                     : legacy account CSV
-    // Both org and CSV are optional — if the preferred source is missing we
-    // fall through to the other one before giving up and returning an empty
-    // map. Tag-based names silently fall back to the Name field for accounts
-    // that don't carry the tag.
     if (state.accountMap !== null) return state.accountMap;
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
@@ -230,54 +291,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const preferOrg = accountDim?.useOrgAccounts === true;
     const tagKey = accountDim?.accountNameFromTag;
 
-    async function fromOrg(): Promise<Map<string, string>> {
-      return loadOrgAccountsMap(ctx.dataDir, tagKey);
-    }
-
-    async function fromCsv(): Promise<Map<string, string>> {
-      const map = new Map<string, string>();
-      try {
-        const rawDir = path.join(baseDir, 'raw');
-        const entries = await fs.readdir(rawDir);
-        const csvFile = entries.find(e => e.toLowerCase().endsWith('.csv') && e.toLowerCase().includes('account'));
-        if (csvFile !== undefined) {
-          const content = await fs.readFile(path.join(rawDir, csvFile), 'utf-8');
-          const lines = content.split('\n').filter(l => l.trim().length > 0);
-          for (let i = 1; i < lines.length; i++) {
-            const line = lines[i];
-            if (line === undefined) continue;
-            const cols = line.split(',').map(c => c.replaceAll(/^"|"$/g, '').trim());
-            const id = cols[0] ?? '';
-            const name = cols[4] ?? '';
-            if (id.length > 0 && name.length > 0) map.set(id, name);
-          }
-        }
-      } catch { /* no raw dir */ }
-      return map;
-    }
+    const fromOrg = () => loadOrgAccountsMap(ctx.dataDir, tagKey);
+    const fromCsv = () => loadAccountCsv(path.join(baseDir, 'raw'), fs);
 
     const primary = preferOrg ? await fromOrg() : await fromCsv();
     const fallback = preferOrg ? await fromCsv() : await fromOrg();
     const raw = primary.size > 0 ? primary : fallback;
 
-    // Apply the dim's display-time transforms to every resolved name. Done
-    // once here so every downstream caller — queries, preview, sidecars —
-    // sees the cleaned name without re-implementing the rule.
-    //
-    // Order matches the editor's visual top-down flow: normalize first, then
-    // strip. Users writing strip patterns under kebab/snake normalization
-    // need to anchor against the post-normalize form (e.g. '-production$'
-    // rather than '\s+production$').
-    const patterns = accountDim?.nameStripPatterns;
-    const normalize = accountDim?.normalize;
-    const map = (normalize !== undefined || (patterns !== undefined && patterns.length > 0))
-      ? new Map([...raw].map(([id, name]) => {
-          let v = name;
-          if (normalize !== undefined) v = applyNormalizationRule(v, normalize);
-          if (patterns !== undefined && patterns.length > 0) v = applyStripPatterns(v, patterns);
-          return [id, v];
-        }))
-      : raw;
+    const map = applyAccountNameTransforms(raw, accountDim?.normalize, accountDim?.nameStripPatterns);
 
     if (map.size > 0) {
       logger.info(`Loaded account mapping (${preferOrg ? 'org-data' : 'csv'} preferred): ${String(map.size)} accounts`);
@@ -295,29 +316,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
       await fs.access(flatPath);
       return flatPath;
     } catch {
-      // Try to generate from org-accounts.json if it exists
-      try {
-        const raw = await fs.readFile(path.join(baseDir, 'org-accounts.json'), 'utf-8');
-        let parsed: unknown;
-        try { parsed = JSON.parse(raw); } catch { return undefined; }
-        if (!isStringRecord(parsed) || !Array.isArray(parsed['accounts'])) return undefined;
-        const tagLookup: { id: string; tags: Record<string, string> }[] = [];
-        for (const acct of parsed['accounts']) {
-          if (!isStringRecord(acct)) continue;
-          const id = acct['id'];
-          const tags = acct['tags'];
-          if (typeof id !== 'string' || !isStringRecord(tags)) continue;
-          const stringTags: Record<string, string> = {};
-          for (const [k, v] of Object.entries(tags)) {
-            if (typeof v === 'string') stringTags[k] = v;
-          }
-          tagLookup.push({ id, tags: stringTags });
-        }
-        await fs.writeFile(flatPath, JSON.stringify(tagLookup));
-        return flatPath;
-      } catch {
-        return undefined;
-      }
+      return generateFlatOrgTags(baseDir, flatPath);
     }
   }
 
@@ -490,6 +489,16 @@ export function createAppContext(ctx: IpcContext): AppContext {
 /** Read org-accounts.json and return an id→name map. When tagKey is set,
  *  each account's "name" is the value of that tag; accounts missing the tag
  *  fall back to the Name field. */
+function resolveAccountName(acct: Record<string, unknown>, tagKey: string | undefined): string | undefined {
+  if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
+    const tagVal = acct['tags'][tagKey];
+    if (typeof tagVal === 'string' && tagVal.length > 0) return tagVal;
+  }
+  const name = acct['name'];
+  if (typeof name === 'string' && name.length > 0) return name;
+  return undefined;
+}
+
 export async function loadOrgAccountsMap(dataDir: string, tagKey?: string): Promise<Map<string, string>> {
   const fs = await import('node:fs/promises');
   const path = await import('node:path');
@@ -497,20 +506,13 @@ export async function loadOrgAccountsMap(dataDir: string, tagKey?: string): Prom
   try {
     const raw = await fs.readFile(path.join(path.dirname(dataDir), 'org-accounts.json'), 'utf-8');
     const parsed: unknown = JSON.parse(raw);
-    if (isStringRecord(parsed) && Array.isArray(parsed['accounts'])) {
-      for (const acct of parsed['accounts']) {
-        if (!isStringRecord(acct)) continue;
-        const id = acct['id'];
-        const name = acct['name'];
-        if (typeof id !== 'string' || id.length === 0) continue;
-        let resolved: string | undefined;
-        if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
-          const tagVal = acct['tags'][tagKey];
-          if (typeof tagVal === 'string' && tagVal.length > 0) resolved = tagVal;
-        }
-        if (resolved === undefined && typeof name === 'string' && name.length > 0) resolved = name;
-        if (resolved !== undefined) map.set(id, resolved);
-      }
+    if (!isStringRecord(parsed) || !Array.isArray(parsed['accounts'])) return map;
+    for (const acct of parsed['accounts']) {
+      if (!isStringRecord(acct)) continue;
+      const id = acct['id'];
+      if (typeof id !== 'string' || id.length === 0) continue;
+      const resolved = resolveAccountName(acct, tagKey);
+      if (resolved !== undefined) map.set(id, resolved);
     }
   } catch { /* no org sync */ }
   return map;

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -23,10 +23,52 @@ import type {
   CostScopeSampleRow,
   DimensionsConfig,
 } from '@costgoblin/core';
+import type { RawRow } from '../duckdb-client.js';
 import type { AppContext } from './context.js';
 import { toNum } from './query-utils.js';
 
 const SAMPLE_ROW_LIMIT = 500;
+
+function toStr(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return '';
+}
+
+function mapSampleRow(
+  r: RawRow,
+  tagColumns: readonly { id: string; label: string }[],
+): CostScopeSampleRow {
+  const tags: Record<string, string> = {};
+  for (const t of tagColumns) {
+    const v = r[t.id];
+    tags[t.id] = typeof v === 'string' ? v : '';
+  }
+  return {
+    date: toStr(r['usage_date']),
+    accountId: toStr(r['account_id']),
+    accountName: toStr(r['account_name']),
+    region: toStr(r['region']),
+    service: toStr(r['service']),
+    serviceFamily: toStr(r['service_family']),
+    lineItemType: toStr(r['line_item_type']),
+    operation: toStr(r['operation']),
+    usageType: toStr(r['usage_type']),
+    description: toStr(r['description']),
+    resourceId: toStr(r['resource_id']),
+    usageAmount: toNum(r['usage_amount']),
+    cost: toNum(r['cost']),
+    listCost: toNum(r['list_cost']),
+    excluded: toNum(r['excluded']) === 1,
+    tags,
+  };
+}
+
+function logSettledError(label: string, result: PromiseSettledResult<unknown>): void {
+  if (result.status === 'rejected') {
+    logger.warn(`cost-scope: ${label} query failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
+  }
+}
 
 // Every rule's dimensionId must resolve to a known built-in or tag dimension.
 // Dangling references silently become a bogus column reference in SQL, which
@@ -243,57 +285,24 @@ export function registerCostScopeHandlers(app: AppContext): void {
           excludedRows: toNum(row?.[`rule_${String(i)}_rows`]),
         };
       }
-    } else {
-      logger.warn(`cost-scope: agg query failed: ${aggResult.reason instanceof Error ? aggResult.reason.message : String(aggResult.reason)}`);
     }
+    logSettledError('agg', aggResult);
 
     let dailyTotals: readonly CostScopeDailyRow[] = [];
     if (dailyResult.status === 'fulfilled') {
-      dailyTotals = dailyResult.value.map(r => {
-        const raw = r['date'];
-        let date = '';
-        if (typeof raw === 'string') date = raw;
-        else if (raw instanceof Date) date = raw.toISOString().slice(0, 10);
-        return { date, keptCost: toNum(r['kept_cost']), excludedCost: toNum(r['excluded_cost']) };
-      });
-    } else {
-      logger.warn(`cost-scope: daily query failed: ${dailyResult.reason instanceof Error ? dailyResult.reason.message : String(dailyResult.reason)}`);
+      dailyTotals = dailyResult.value.map(r => ({
+        date: toStr(r['date']),
+        keptCost: toNum(r['kept_cost']),
+        excludedCost: toNum(r['excluded_cost']),
+      }));
     }
+    logSettledError('daily', dailyResult);
 
     let sampleRows: readonly CostScopeSampleRow[] = [];
     if (sampleResult.status === 'fulfilled') {
-      sampleRows = sampleResult.value.map(r => {
-        const tags: Record<string, string> = {};
-        for (const t of tagColumns) {
-          const v = r[t.id];
-          tags[t.id] = typeof v === 'string' ? v : '';
-        }
-        const rawDate = r['usage_date'];
-        let date = '';
-        if (typeof rawDate === 'string') date = rawDate;
-        else if (rawDate instanceof Date) date = rawDate.toISOString().slice(0, 10);
-        return {
-          date,
-          accountId: typeof r['account_id'] === 'string' ? r['account_id'] : '',
-          accountName: typeof r['account_name'] === 'string' ? r['account_name'] : '',
-          region: typeof r['region'] === 'string' ? r['region'] : '',
-          service: typeof r['service'] === 'string' ? r['service'] : '',
-          serviceFamily: typeof r['service_family'] === 'string' ? r['service_family'] : '',
-          lineItemType: typeof r['line_item_type'] === 'string' ? r['line_item_type'] : '',
-          operation: typeof r['operation'] === 'string' ? r['operation'] : '',
-          usageType: typeof r['usage_type'] === 'string' ? r['usage_type'] : '',
-          description: typeof r['description'] === 'string' ? r['description'] : '',
-          resourceId: typeof r['resource_id'] === 'string' ? r['resource_id'] : '',
-          usageAmount: toNum(r['usage_amount']),
-          cost: toNum(r['cost']),
-          listCost: toNum(r['list_cost']),
-          excluded: toNum(r['excluded']) === 1,
-          tags,
-        };
-      });
-    } else {
-      logger.warn(`cost-scope: sample query failed: ${sampleResult.reason instanceof Error ? sampleResult.reason.message : String(sampleResult.reason)}`);
+      sampleRows = sampleResult.value.map(r => mapSampleRow(r, tagColumns));
     }
+    logSettledError('sample', sampleResult);
 
     return {
       windowDays,

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -149,8 +149,53 @@ interface QueryContext {
   readonly accountMap: ReadonlyMap<string, string>;
 }
 
+function buildExclusionClauses(
+  costScope: { rules: readonly ExclusionRule[] } | undefined,
+  dimensions: DimensionsConfig,
+  accountReverseMap: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  if (costScope === undefined) return [];
+  const clauses: string[] = [];
+  for (const rule of costScope.rules) {
+    if (!rule.enabled) continue;
+    const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+    if (matchExpr !== null) clauses.push(`NOT (${matchExpr})`);
+  }
+  return clauses;
+}
+
+async function buildFreshSource(
+  app: AppContext,
+  params: ExplorerBaseParams,
+  startStr: string,
+  endStr: string,
+  tier: 'daily' | 'hourly',
+  periods: readonly string[],
+  dimensions: DimensionsConfig,
+  filterPredicate: string | null,
+  accountReverseMap: ReadonlyMap<string, readonly string[]>,
+): Promise<{ source: string; whereStr: string }> {
+  const { ctx, getCostScope, getOrgAccountsPath, getAvailableColumns } = app;
+  const orgPath = await getOrgAccountsPath();
+  const availableColumns = await getAvailableColumns(tier);
+  const applyCostScope = params.applyCostScope === true;
+  const costScope = applyCostScope ? await getCostScope().catch(() => undefined) : undefined;
+  const metric = pickMetric(params.costMetric, availableColumns);
+  const perspective = pickPerspective(params.costPerspective, availableColumns);
+
+  const source = buildSource({ dataDir: ctx.dataDir, tier, dimensions, orgAccountsPath: orgPath, periods, costMetric: metric, availableColumns, costPerspective: perspective });
+  const exclusions = buildExclusionClauses(costScope, dimensions, accountReverseMap);
+
+  const whereClauses: string[] = [
+    `usage_date BETWEEN '${startStr}' AND '${endStr}'`,
+    ...(filterPredicate === null ? [] : [`(${filterPredicate})`]),
+    ...exclusions,
+  ];
+  return { source, whereStr: `WHERE ${whereClauses.join(' AND ')}` };
+}
+
 async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams): Promise<QueryContext> {
-  const { ctx, getCostScope, getQueryDimensions, getOrgAccountsPath, getAvailableColumns, getAccountMap } = app;
+  const { ctx, getQueryDimensions, getAccountMap } = app;
   const { startStr, endStr, windowDays } = resolveDateRange(params.dateRange);
   const tier: 'daily' | 'hourly' = params.granularity === 'hourly' ? 'hourly' : 'daily';
 
@@ -166,76 +211,60 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
     label: t.label,
   }));
   const tagIdSet = new Set(tagColumns.map(t => t.id));
+  const shared = { startStr, endStr, windowDays, tier, tagColumns, tagIdSet, dimensions, accountMap } as const;
 
   if (periods.length === 0) {
-    return {
-      empty: true,
-      source: '',
-      whereStr: '',
-      startStr,
-      endStr,
-      windowDays,
-      tier,
-      tagColumns,
-      tagIdSet,
-      dimensions,
-      accountMap,
-    };
+    return { empty: true, source: '', whereStr: '', ...shared };
   }
 
   const accountReverseMap = buildAccountReverseMap(accountMap);
   const filterPredicate = buildExplorerFilterPredicate(params.filters, dimensions, accountReverseMap);
-
   const matSource = app.materializedBase.getSource({ start: startStr, end: endStr }, tier);
 
-  let source: string;
-  let whereStr: string;
-
-  if (matSource === undefined) {
-    const orgPath = await getOrgAccountsPath();
-    const availableColumns = await getAvailableColumns(tier);
-    const applyCostScope = params.applyCostScope === true;
-    const costScope = applyCostScope ? await getCostScope().catch(() => undefined) : undefined;
-    const metric = pickMetric(params.costMetric, availableColumns);
-    const perspective = pickPerspective(params.costPerspective, availableColumns);
-
-    source = buildSource({ dataDir: ctx.dataDir, tier, dimensions, orgAccountsPath: orgPath, periods, costMetric: metric, availableColumns, costPerspective: perspective });
-
-    const exclusionClauses: string[] = [];
-    if (costScope !== undefined) {
-      for (const rule of costScope.rules) {
-        if (!rule.enabled) continue;
-        const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
-        if (matchExpr === null) continue;
-        exclusionClauses.push(`NOT (${matchExpr})`);
-      }
-    }
-
-    const whereClauses: string[] = [
-      `usage_date BETWEEN '${startStr}' AND '${endStr}'`,
-      ...(filterPredicate === null ? [] : [`(${filterPredicate})`]),
-      ...exclusionClauses,
-    ];
-    whereStr = `WHERE ${whereClauses.join(' AND ')}`;
-  } else {
-    source = matSource;
+  if (matSource !== undefined) {
     const whereClauses: string[] = filterPredicate === null ? [] : [`(${filterPredicate})`];
-    whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+    const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+    return { empty: false, source: matSource, whereStr, ...shared };
   }
 
-  return {
-    empty: false,
-    source,
-    whereStr,
-    startStr,
-    endStr,
-    windowDays,
-    tier,
-    tagColumns,
-    tagIdSet,
-    dimensions,
-    accountMap,
-  };
+  const { source, whereStr } = await buildFreshSource(
+    app, params, startStr, endStr, tier, periods, dimensions, filterPredicate, accountReverseMap,
+  );
+  return { empty: false, source, whereStr, ...shared };
+}
+
+function appendRowFilters(
+  baseWhere: string,
+  rowFilters: Record<string, string> | undefined,
+  tagIdSet: ReadonlySet<string>,
+): string {
+  if (rowFilters === undefined) return baseWhere;
+  const extra: string[] = [];
+  for (const [col, val] of Object.entries(rowFilters)) {
+    if (val.length === 0) continue;
+    if (!SORTABLE_SCALAR_COLUMNS.has(col) && !tagIdSet.has(col)) continue;
+    const escaped = val.replaceAll("'", "''");
+    const colExpr = col === 'usage_date' ? `usage_date::VARCHAR` : col;
+    extra.push(`${colExpr} = '${escaped}'`);
+  }
+  if (extra.length === 0) return baseWhere;
+  return `${baseWhere} AND ${extra.join(' AND ')}`;
+}
+
+const AGG_SORT_COLUMNS: Record<string, (dir: string) => string> = {
+  cost: (dir) => `SUM(cost) ${dir}`,
+  list_cost: (dir) => `SUM(list_cost) ${dir}`,
+  usage_amount: (dir) => `SUM(usage_amount) ${dir}`,
+  row_count: (dir) => `COUNT(*) ${dir}`,
+};
+
+function resolveAggregatedSort(sort: ExplorerSort | undefined, groupByColumns: readonly string[]): string {
+  if (sort === undefined) return 'SUM(cost) DESC';
+  const dir = sort.direction === 'asc' ? 'ASC' : 'DESC';
+  const fn = AGG_SORT_COLUMNS[sort.column];
+  if (fn !== undefined) return fn(dir);
+  if (groupByColumns.includes(sort.column)) return `${sort.column} ${dir}`;
+  return 'SUM(cost) DESC';
 }
 
 export function registerExplorerHandlers(app: AppContext): void {
@@ -422,20 +451,7 @@ export function registerExplorerHandlers(app: AppContext): void {
 
     if (qc.empty) return { rows: [], totalRows: 0, tagColumns: qc.tagColumns };
 
-    let whereStr = qc.whereStr;
-    if (params.rowFilters !== undefined) {
-      const extra: string[] = [];
-      for (const [col, val] of Object.entries(params.rowFilters)) {
-        if (val.length === 0) continue;
-        if (!SORTABLE_SCALAR_COLUMNS.has(col) && !qc.tagIdSet.has(col)) continue;
-        const escaped = val.replaceAll("'", "''");
-        const colExpr = col === 'usage_date' ? `usage_date::VARCHAR` : col;
-        extra.push(`${colExpr} = '${escaped}'`);
-      }
-      if (extra.length > 0) {
-        whereStr = `${whereStr} AND ${extra.join(' AND ')}`;
-      }
-    }
+    const whereStr = appendRowFilters(qc.whereStr, params.rowFilters, qc.tagIdSet);
 
     const groupByColumns = params.groupByColumns.filter(
       col => SORTABLE_SCALAR_COLUMNS.has(col) || qc.tagIdSet.has(col),
@@ -465,17 +481,7 @@ export function registerExplorerHandlers(app: AppContext): void {
       if (col === 'usage_date') return `usage_date::VARCHAR AS usage_date`;
       return col;
     });
-    const orderBy = (() => {
-      if (params.sort === undefined) return 'SUM(cost) DESC';
-      const dir = params.sort.direction === 'asc' ? 'ASC' : 'DESC';
-      const col = params.sort.column;
-      if (col === 'cost') return `SUM(cost) ${dir}`;
-      if (col === 'list_cost') return `SUM(list_cost) ${dir}`;
-      if (col === 'usage_amount') return `SUM(usage_amount) ${dir}`;
-      if (col === 'row_count') return `COUNT(*) ${dir}`;
-      if (groupByColumns.includes(col)) return `${col} ${dir}`;
-      return 'SUM(cost) DESC';
-    })();
+    const orderBy = resolveAggregatedSort(params.sort, groupByColumns);
 
     const countSql = `
       SELECT CAST(COUNT(*) AS DOUBLE) AS n FROM (

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -399,6 +399,41 @@ function makeVirtualRow(name: string, totalCost: number, mergedServices: Record<
   };
 }
 
+function rollupVirtualNode(
+  node: OrgNode,
+  entityCostMap: Map<string, CostRow>,
+  consumedEntities: Set<string>,
+): CostRow | null {
+  const descendants = getDescendantTagValues(node);
+  const { totalCost, mergedServices } = mergeDescendantCosts(descendants, entityCostMap, consumedEntities);
+  return makeVirtualRow(node.name, totalCost, mergedServices);
+}
+
+function rollupRealNode(
+  node: OrgNode,
+  entityCostMap: Map<string, CostRow>,
+  consumedEntities: Set<string>,
+): CostRow | null {
+  const descendants = node.children === undefined ? [] : getDescendantTagValues(node);
+  for (const desc of descendants) {
+    if (desc !== node.name) consumedEntities.add(desc);
+  }
+
+  const existingRow = entityCostMap.get(node.name);
+  if (node.children === undefined || node.children.length === 0) {
+    return existingRow ?? null;
+  }
+
+  const baseCost = existingRow === undefined ? 0 : existingRow.totalCost;
+  const baseServices = existingRow === undefined
+    ? {}
+    : Object.fromEntries(Object.entries(existingRow.serviceCosts).map(([k, v]) => [k, Number(v)]));
+  const { totalCost, mergedServices } = mergeDescendantCosts(
+    descendants, entityCostMap, consumedEntities, node.name, baseCost, baseServices,
+  );
+  return makeVirtualRow(node.name, totalCost, mergedServices);
+}
+
 export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[]): CostResult {
   const entityCostMap = new Map<string, CostRow>();
   for (const row of result.rows) {
@@ -409,33 +444,9 @@ export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[])
   const consumedEntities = new Set<string>();
 
   for (const node of tree) {
-    if (node.virtual) {
-      const descendants = getDescendantTagValues(node);
-      const { totalCost, mergedServices } = mergeDescendantCosts(descendants, entityCostMap, consumedEntities);
-      const row = makeVirtualRow(node.name, totalCost, mergedServices);
-      if (row !== null) rolledUpRows.push(row);
-      continue;
-    }
-
-    const descendants = node.children === undefined ? [] : getDescendantTagValues(node);
-    for (const desc of descendants) {
-      if (desc !== node.name) consumedEntities.add(desc);
-    }
-
-    const existingRow = entityCostMap.get(node.name);
-    if (node.children === undefined || node.children.length === 0) {
-      if (existingRow !== undefined) rolledUpRows.push(existingRow);
-      continue;
-    }
-
-    const baseCost = existingRow === undefined ? 0 : existingRow.totalCost;
-    const baseServices = existingRow === undefined
-      ? {}
-      : Object.fromEntries(Object.entries(existingRow.serviceCosts).map(([k, v]) => [k, Number(v)]));
-    const { totalCost, mergedServices } = mergeDescendantCosts(
-      descendants, entityCostMap, consumedEntities, node.name, baseCost, baseServices,
-    );
-    const row = makeVirtualRow(node.name, totalCost, mergedServices);
+    const row = node.virtual
+      ? rollupVirtualNode(node, entityCostMap, consumedEntities)
+      : rollupRealNode(node, entityCostMap, consumedEntities);
     if (row !== null) rolledUpRows.push(row);
   }
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -142,22 +142,19 @@ function AppShell(): React.JSX.Element {
 
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
-    // Read views.yaml. The handler seeds it lazily on first access so this
-    // call also bootstraps the file for new installations.
-    api.getViewsConfig()
-      .then((cfg) => {
-        const resolved = cfg.views.length > 0 ? cfg : FALLBACK_VIEWS;
-        setViewsConfig(resolved);
-        setView(prev => {
-          if (prev.page !== 'custom') return prev;
-          const exists = resolved.views.some(v => v.id === prev.viewId);
-          const firstId = resolved.views[0]?.id;
-          return exists || firstId === undefined ? prev : { page: 'custom', viewId: firstId };
-        });
-      })
-      .catch(() => {
-        setViewsConfig(FALLBACK_VIEWS);
+    function applyViews(cfg: ViewsConfig): void {
+      const resolved = cfg.views.length > 0 ? cfg : FALLBACK_VIEWS;
+      setViewsConfig(resolved);
+      setView(prev => {
+        if (prev.page !== 'custom') return prev;
+        const exists = resolved.views.some(v => v.id === prev.viewId);
+        const firstId = resolved.views[0]?.id;
+        return exists || firstId === undefined ? prev : { page: 'custom', viewId: firstId };
       });
+    }
+    api.getViewsConfig()
+      .then(applyViews)
+      .catch(() => { setViewsConfig(FALLBACK_VIEWS); });
   }, [api, setupCheck]);
 
   useEffect(() => {

--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -70,13 +70,12 @@ export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: 
     if (el === null) return;
 
     const w = el.offsetWidth;
-
-    const tick = () => {
+    const makeTick = (): FrameRequestCallback => () => {
       setCoins(prev => prev.map(c => updateCoin(c, w, height)));
-      frameRef.current = requestAnimationFrame(tick);
+      frameRef.current = requestAnimationFrame(makeTick());
     };
 
-    frameRef.current = requestAnimationFrame(tick);
+    frameRef.current = requestAnimationFrame(makeTick());
     return () => { cancelAnimationFrame(frameRef.current); };
   }, [coins.length, height]);
 

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -636,24 +636,19 @@ export function CostScopeView(): React.JSX.Element {
   // every condition row fires its own identical fetch on mount.
   useEffect(() => {
     let cancelled = false;
+    async function fetchDimValues(d: typeof dimensions[number]): Promise<[string, readonly string[]]> {
+      const id = getDimensionId(d);
+      try {
+        const vals = await api.getFilterValues(id, {}, undefined, { bypassCostScope: true });
+        return [id, vals.map(v => v.value)];
+      } catch {
+        return [id, []];
+      }
+    }
     async function run(): Promise<void> {
       const enabled = dimensions.filter(d => d.enabled !== false);
-      const next = new Map<string, readonly string[]>();
-      await Promise.all(enabled.map(async d => {
-        const id = getDimensionId(d);
-        try {
-          // bypassCostScope: users composing an exclusion rule need to
-          // see every value a dim can take, including ones the saved
-          // cost-scope rules already exclude. Otherwise once Tax is
-          // excluded globally, the autocomplete in a new rule can't
-          // suggest 'Tax' for them to add to a second rule.
-          const vals = await api.getFilterValues(id, {}, undefined, { bypassCostScope: true });
-          next.set(id, vals.map(v => v.value));
-        } catch {
-          next.set(id, []);
-        }
-      }));
-      if (!cancelled) setSuggestionsByDim(next);
+      const entries = await Promise.all(enabled.map(fetchDimValues));
+      if (!cancelled) setSuggestionsByDim(new Map(entries));
     }
     if (dimensions.length > 0) void run();
     return () => { cancelled = true; };

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -82,6 +82,49 @@ interface EditingBuiltIn {
   useRegionNames: boolean;
 }
 
+const TRANSFORM_FREE_FIELDS = new Set(['service', 'service_family']);
+
+function buildDiscoverOptions(
+  dim: { name: string; field: string },
+  state: EditingBuiltIn,
+  normalize: NormalizationRule | undefined,
+  stripPatternList: string[],
+): Record<string, unknown> {
+  const isAccountDim = dim.field === 'account_id';
+  const isAnyRegionDim = dim.field === 'region';
+  return {
+    ...(normalize !== undefined ? { normalize } : {}),
+    ...(isAccountDim ? {
+      useOrgAccounts: true,
+      nameStripPatterns: stripPatternList,
+      ...(state.accountNameFromTag.length > 0 ? { accountNameFromTag: state.accountNameFromTag } : {}),
+    } : {}),
+    ...(isAnyRegionDim ? { dimName: dim.name, useRegionNames: state.useRegionNames } : {}),
+  };
+}
+
+function computeEnrichmentWarnings(
+  dim: { name: string; field: string },
+  state: EditingBuiltIn,
+  regionInfoQuery: { status: string; data?: { count: number; lastError: string | null } | null },
+  orgQuery: { status: string; data?: unknown },
+): { regionWarning: { kind: 'missing' | 'error'; message?: string } | null; accountWarning: boolean } {
+  const isRegionDim = dim.name === 'region';
+  const isRegionCountryDim = dim.name === 'region_country';
+  const isRegionContinentDim = dim.name === 'region_continent';
+  const isAccountDim = dim.field === 'account_id';
+
+  const wantsRegionEnrichment = (isRegionDim && state.useRegionNames) || isRegionCountryDim || isRegionContinentDim;
+  let regionWarning: { kind: 'missing' | 'error'; message?: string } | null = null;
+  if (wantsRegionEnrichment && regionInfoQuery.status === 'success') {
+    const regionInfo = regionInfoQuery.data ?? null;
+    if (regionInfo === null || regionInfo.count === 0) regionWarning = { kind: 'missing' };
+    else if (regionInfo.lastError !== null) regionWarning = { kind: 'error', message: regionInfo.lastError };
+  }
+  const accountWarning = isAccountDim && orgQuery.status === 'success' && orgQuery.data === null;
+  return { regionWarning, accountWarning };
+}
+
 function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
   dim: { name: string; field: string; editing: EditingBuiltIn };
   onSave: (edited: EditingBuiltIn) => void;
@@ -89,24 +132,11 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
   accountTagKeys: readonly string[];
 }>): React.JSX.Element {
   const isAccountDim = dim.field === 'account_id';
-  // Three dims share field='region' — distinguish by name so only the Region
-  // dim gets the longName toggle, while Country/Continent are pure derived
-  // views with no user toggle (SSM data is either there or not).
   const isRegionDim = dim.name === 'region';
-  const isRegionCountryDim = dim.name === 'region_country';
-  const isRegionContinentDim = dim.name === 'region_continent';
   const isAnyRegionDim = dim.field === 'region';
-  // AWS-controlled values arrive in a single canonical form — normalize/strip
-  // would only chip at the labels users already recognize. Aliases stay
-  // visible since folding "AmazonEC2 → EC2" is a reasonable user choice.
-  const TRANSFORM_FREE_FIELDS = new Set(['service', 'service_family']);
   const showTransforms = !TRANSFORM_FREE_FIELDS.has(dim.field);
   const api = useCostApi();
   const [state, setState] = useState(dim.editing);
-  // Surface missing enrichment data: Region needs SSM region-names sync,
-  // Account (with org-data toggle) needs the AWS Org sync. Both ship as
-  // side-effects of the org sync on the Sync tab — without them the dim's
-  // values render as raw codes / IDs.
   const regionInfoQuery = useQuery(
     () => isAnyRegionDim ? api.getRegionNamesInfo() : Promise.resolve(null),
     [isAnyRegionDim],
@@ -124,30 +154,15 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
     else onCancel();
   }
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // Parse the textarea once per render — empty lines and trailing whitespace
-  // are dropped so a stray Enter doesn't make the regex .replace() a no-op.
   const stripPatternList = state.nameStripPatterns
     .split('\n')
     .map(l => l.trim())
     .filter(l => l.length > 0);
   const stripPatternsKey = stripPatternList.join('\u0001');
   const normalize: NormalizationRule | undefined = state.normalize.length > 0 ? state.normalize as NormalizationRule : undefined;
+  const discoverOptions = buildDiscoverOptions(dim, state, normalize, stripPatternList);
   const valuesQuery = useQuery(
-    () => api.discoverColumnValues(
-      dim.field,
-      {
-        ...(normalize !== undefined ? { normalize } : {}),
-        ...(isAccountDim ? {
-          // Both "Account Name" and "Account Tag" are org-sync-sourced, so
-          // the preview always wants useOrgAccounts=true regardless of any
-          // legacy value on the saved dim.
-          useOrgAccounts: true,
-          nameStripPatterns: stripPatternList,
-          ...(state.accountNameFromTag.length > 0 ? { accountNameFromTag: state.accountNameFromTag } : {}),
-        } : {}),
-        ...(isAnyRegionDim ? { dimName: dim.name, useRegionNames: state.useRegionNames } : {}),
-      },
-    ),
+    () => api.discoverColumnValues(dim.field, discoverOptions),
     [dim.field, dim.name, isAccountDim, isAnyRegionDim, state.useOrgAccounts, state.useRegionNames, state.accountNameFromTag, stripPatternsKey, normalize],
   );
 
@@ -302,29 +317,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
     </label>
   );
 
-  // Compute enrichment-data warnings:
-  //   - Region dim ships raw codes ('eu-central-1') unless region-names.json
-  //     was synced from SSM. Warn either way: missing entirely, or last
-  //     attempt errored (typically: profile lacks ssm:GetParametersByPath).
-  //   - Account dim's org-data toggle resolves IDs → names from the AWS Org
-  //     sync. Warn when toggle is on but the sync result file is missing.
-  const regionInfo = regionInfoQuery.status === 'success' ? regionInfoQuery.data : null;
-  const orgInfo = orgQuery.status === 'success' ? orgQuery.data : null;
-  // Warn when the user's editing a dim that needs SSM data but the snapshot
-  // isn't there. Region: only when the friendly-names toggle is on (off is a
-  // valid state — raw codes). Country/Continent: always, since these dims
-  // are defined entirely in terms of SSM enrichment and collapse to raw
-  // codes otherwise.
-  const wantsRegionEnrichment = (isRegionDim && state.useRegionNames) || isRegionCountryDim || isRegionContinentDim;
-  let regionWarning: { kind: 'missing' | 'error'; message?: string } | null = null;
-  if (wantsRegionEnrichment && regionInfoQuery.status === 'success') {
-    if (regionInfo === null || regionInfo.count === 0) regionWarning = { kind: 'missing' };
-    else if (regionInfo.lastError !== null) regionWarning = { kind: 'error', message: regionInfo.lastError };
-  }
-  // Both "Account Name" and "Account Tag" sources resolve via the Org sync,
-  // so if it hasn't run yet the dim will display raw 12-digit IDs regardless.
-  const accountWarning: boolean =
-    isAccountDim && orgQuery.status === 'success' && orgInfo === null;
+  const { regionWarning, accountWarning } = computeEnrichmentWarnings(dim, state, regionInfoQuery, orgQuery);
 
   return (
     <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
@@ -525,6 +518,54 @@ function applyPreviewNormalize(v: string, rule: string): string {
   }
 }
 
+function buildTemplateVals(fallbackFormat: string, accountVals: string[]): string[] {
+  if (fallbackFormat === '{fallback}' || accountVals.length === 0) return [];
+  if (fallbackFormat.includes('{fallback}')) {
+    return accountVals.map(v => fallbackFormat.replaceAll('{fallback}', v));
+  }
+  return [fallbackFormat];
+}
+
+function buildAliasMap(aliasText: string, normalizeRule: string): Map<string, string> {
+  const aliasMap = new Map<string, string>();
+  const parsed = textToAliases(aliasText);
+  if (parsed === undefined) return aliasMap;
+  for (const [canonical, alts] of Object.entries(parsed)) {
+    for (const alt of alts) aliasMap.set(applyPreviewNormalize(alt, normalizeRule), canonical);
+  }
+  return aliasMap;
+}
+
+function classifySource(
+  raw: string,
+  resourceSet: ReadonlySet<string>,
+  accountSet: ReadonlySet<string>,
+  templateSet: ReadonlySet<string>,
+): TagSource {
+  if (templateSet.has(raw)) return 'template';
+  if (resourceSet.has(raw) && accountSet.has(raw)) return 'both';
+  if (resourceSet.has(raw)) return 'resource';
+  return 'account';
+}
+
+function deduplicateResolved(
+  transformed: readonly { resolved: string; aliased: boolean; source: TagSource }[],
+): { resolved: string; aliased: boolean; source: TagSource }[] {
+  const resolvedMap = new Map<string, TagSource>();
+  for (const t of transformed) {
+    const existing = resolvedMap.get(t.resolved);
+    if (existing === undefined) resolvedMap.set(t.resolved, t.source);
+    else if (existing !== 'both' && existing !== t.source) resolvedMap.set(t.resolved, 'both');
+  }
+  return [...resolvedMap.entries()]
+    .map(([resolved, source]) => ({
+      resolved,
+      aliased: transformed.some(t => t.resolved === resolved && t.aliased),
+      source,
+    }))
+    .sort((a, b) => a.resolved.localeCompare(b.resolved));
+}
+
 function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, normalizeRule, aliasText }: Readonly<{
   tagMatch: { sampleValues: string[] } | undefined;
   fallbackValues: [string, number][];
@@ -537,14 +578,7 @@ function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, norma
   const fallbackFormat = missingValueTemplate.length > 0 ? missingValueTemplate : '{fallback}';
   const isPassthrough = fallbackFormat === '{fallback}';
 
-  const templateVals: string[] = [];
-  if (!isPassthrough && accountVals.length > 0) {
-    if (fallbackFormat.includes('{fallback}')) {
-      for (const acctVal of accountVals) templateVals.push(fallbackFormat.replaceAll('{fallback}', acctVal));
-    } else {
-      templateVals.push(fallbackFormat);
-    }
-  }
+  const templateVals = buildTemplateVals(fallbackFormat, accountVals);
 
   const resourceSet = new Set(resourceVals);
   const templateSet = new Set(templateVals);
@@ -554,44 +588,17 @@ function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, norma
   const accountSet = isPassthrough ? new Set(accountVals) : new Set<string>();
   if (allRaw.length === 0) return null;
 
-  const normalize = (v: string): string => applyPreviewNormalize(v, normalizeRule);
-  const aliasMap = new Map<string, string>();
-  const parsed = textToAliases(aliasText);
-  if (parsed !== undefined) {
-    for (const [canonical, alts] of Object.entries(parsed)) {
-      for (const alt of alts) aliasMap.set(normalize(alt), canonical);
-    }
-  }
+  const aliasMap = buildAliasMap(aliasText, normalizeRule);
 
   const transformed = allRaw.map(raw => {
-    const normalized = normalize(raw);
+    const normalized = applyPreviewNormalize(raw, normalizeRule);
     const resolved = aliasMap.get(normalized) ?? normalized;
-    const fromResource = resourceSet.has(raw);
-    const fromAccount = accountSet.has(raw);
-    const fromTemplate = templateSet.has(raw);
-    let source: TagSource;
-    if (fromTemplate) source = 'template';
-    else if (fromResource && fromAccount) source = 'both';
-    else if (fromResource) source = 'resource';
-    else source = 'account';
+    const source = classifySource(raw, resourceSet, accountSet, templateSet);
     return { raw, resolved, aliased: aliasMap.has(normalized), source };
   });
 
   const aliasPreviewCount = transformed.filter(t => t.aliased).length;
-
-  const resolvedMap = new Map<string, TagSource>();
-  for (const t of transformed) {
-    const existing = resolvedMap.get(t.resolved);
-    if (existing === undefined) resolvedMap.set(t.resolved, t.source);
-    else if (existing !== 'both' && existing !== t.source) resolvedMap.set(t.resolved, 'both');
-  }
-  const unique = [...resolvedMap.entries()]
-    .map(([resolved, source]) => ({
-      resolved,
-      aliased: transformed.some(t => t.resolved === resolved && t.aliased),
-      source,
-    }))
-    .sort((a, b) => a.resolved.localeCompare(b.resolved));
+  const unique = deduplicateResolved(transformed);
 
   return (
     <div className="flex flex-col gap-1">
@@ -1056,6 +1063,34 @@ function GripHandle({ attrs }: Readonly<{ attrs: React.HTMLAttributes<HTMLButton
   );
 }
 
+type OrderedRow =
+  | { kind: 'builtIn'; key: string; idx: number; dim: BuiltInDimension }
+  | { kind: 'tag'; key: string; idx: number; dim: TagDimension };
+
+function resolveOrderedRow(key: string, config: DimensionsConfig): OrderedRow | null {
+  if (key.startsWith('builtin:')) {
+    const name = key.slice('builtin:'.length);
+    const idx = config.builtIn.findIndex(d => d.name === name);
+    const dim = idx >= 0 ? config.builtIn[idx] : undefined;
+    if (dim !== undefined) return { kind: 'builtIn', key, idx, dim };
+  } else if (key.startsWith('tag:')) {
+    const tagName = key.slice('tag:'.length);
+    const idx = config.tags.findIndex(t => t.tagName === tagName);
+    const dim = idx >= 0 ? config.tags[idx] : undefined;
+    if (dim !== undefined) return { kind: 'tag', key, idx, dim };
+  }
+  return null;
+}
+
+function resolveOrderedRows(config: DimensionsConfig): OrderedRow[] {
+  const rows: OrderedRow[] = [];
+  for (const key of reconcileOrder(config)) {
+    const row = resolveOrderedRow(key, config);
+    if (row !== null) rows.push(row);
+  }
+  return rows;
+}
+
 export function DimensionsView() {
   const api = useCostApi();
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
@@ -1298,31 +1333,7 @@ export function DimensionsView() {
     );
   }
 
-  // Resolve the unified display order into concrete row descriptors. Each
-  // entry carries its key (for React), its full-array index (for handlers
-  // that still take a typed idx like editingBuiltInIdx / editingIdx), and
-  // the dim object itself.
-  type OrderedRow =
-    | { kind: 'builtIn'; key: string; idx: number; dim: BuiltInDimension }
-    | { kind: 'tag'; key: string; idx: number; dim: TagDimension };
-  const orderedRows: OrderedRow[] = (() => {
-    if (config === null) return [];
-    const rows: OrderedRow[] = [];
-    for (const key of reconcileOrder(config)) {
-      if (key.startsWith('builtin:')) {
-        const name = key.slice('builtin:'.length);
-        const idx = config.builtIn.findIndex(d => d.name === name);
-        const dim = idx >= 0 ? config.builtIn[idx] : undefined;
-        if (dim !== undefined) rows.push({ kind: 'builtIn', key, idx, dim });
-      } else if (key.startsWith('tag:')) {
-        const tagName = key.slice('tag:'.length);
-        const idx = config.tags.findIndex(t => t.tagName === tagName);
-        const dim = idx >= 0 ? config.tags[idx] : undefined;
-        if (dim !== undefined) rows.push({ kind: 'tag', key, idx, dim });
-      }
-    }
-    return rows;
-  })();
+  const orderedRows = config !== null ? resolveOrderedRows(config) : [];
 
 
 


### PR DESCRIPTION
## Summary
- Extract helpers from 15 functions flagged for SonarCloud S3776 (cognitive complexity > 15) across `builder.ts`, `views-validator.ts`, `explorer.ts`, `context.ts`, `cost-scope.ts`, `selective-sync.ts`, `query-utils.ts`, `dimensions.tsx`, `normalize.ts`, and `views-serialize.ts`
- Flatten 3 deeply nested callbacks flagged for S2004 (nesting depth > 4) in `App.tsx`, `cost-scope.tsx`, and `coin-rain-loader.tsx`
- All extracted helpers stay under complexity 15 and avoid introducing new SonarCloud issues (no negated conditions in if/else, no nested ternaries)