### PR TITLE
Fix remaining SonarCloud non-complexity issues

### DIFF
--- a/packages/core/src/__fixtures__/generate.ts
+++ b/packages/core/src/__fixtures__/generate.ts
@@ -193,17 +193,20 @@ function optionalTag(rand: () => number, missingRate: number, values: readonly s
   return rand() < missingRate ? null : pick(values, rand);
 }
 
-function generateRow(
-  date: string,
-  profileData: Profile,
-  syntheticAccounts: { id: string; name: string; costShare: number }[],
-  rand: () => number,
-  owners: string[],
-  products: string[],
-  envs: string[],
-  lineItemTypes: string[],
-  litWeights: number[],
-): string {
+interface GenerateRowOpts {
+  date: string;
+  profileData: Profile;
+  syntheticAccounts: { id: string; name: string; costShare: number }[];
+  rand: () => number;
+  owners: string[];
+  products: string[];
+  envs: string[];
+  lineItemTypes: string[];
+  litWeights: number[];
+}
+
+function generateRow(opts: GenerateRowOpts): string {
+  const { date, profileData, syntheticAccounts, rand, owners, products, envs, lineItemTypes, litWeights } = opts;
   const service = weightedPick(profileData.services, rand);
   const account = weightedPick(syntheticAccounts, rand);
   const region = pick(profileData.regions.slice(0, 5), rand);
@@ -279,7 +282,7 @@ async function generate(): Promise<void> {
 
   for (const date of dailyDates) {
     for (let i = 0; i < ROWS_PER_DAY; i++) {
-      rows.push(generateRow(date, profileData, syntheticAccounts, rand, owners, products, envs, lineItemTypes, litWeights));
+      rows.push(generateRow({ date, profileData, syntheticAccounts, rand, owners, products, envs, lineItemTypes, litWeights }));
     }
   }
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -273,9 +273,9 @@ export function buildSource(opts: BuildSourceOptions): string {
   const parquetPaths = periods !== undefined && periods.length > 0
     ? periods.map(p => `'${dataDir}/aws/raw/${tier}-${p}/*.parquet'`).join(', ')
     : undefined;
-  const parquetSource = parquetPaths !== undefined
-    ? `read_parquet([${parquetPaths}])`
-    : `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
+  const parquetSource = parquetPaths === undefined
+    ? `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`
+    : `read_parquet([${parquetPaths}])`;
 
   // Build fallback column extractions for the org-accounts join
   const fallbackSelects = needsOrgJoin

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -93,10 +93,10 @@ export async function getDataInventory(
     const period = extractPeriod(file.key);
     if (period === 'unknown') continue;
     const existing = periodMap.get(period);
-    if (existing !== undefined) {
-      existing.push(file);
-    } else {
+    if (existing === undefined) {
       periodMap.set(period, [file]);
+    } else {
+      existing.push(file);
     }
   }
 

--- a/packages/core/src/sync/s3-client.ts
+++ b/packages/core/src/sync/s3-client.ts
@@ -47,17 +47,17 @@ export async function createS3Handle(profile: string, region?: string, endpointO
   let credentialConfig: { credentials: { readonly accessKeyId: string; readonly secretAccessKey: string } } | { profile: string } | Record<string, never>;
   if (endpointOptions?.credentials !== undefined) {
     credentialConfig = { credentials: endpointOptions.credentials };
-  } else if (profile !== 'default') {
-    credentialConfig = { profile };
-  } else {
+  } else if (profile === 'default') {
     credentialConfig = {};
+  } else {
+    credentialConfig = { profile };
   }
 
   const client = new S3Client({
     region: region ?? 'eu-central-1',
     ...credentialConfig,
-    ...(endpointOptions?.endpoint !== undefined ? { endpoint: endpointOptions.endpoint } : {}),
-    ...(endpointOptions?.forcePathStyle !== undefined ? { forcePathStyle: endpointOptions.forcePathStyle } : {}),
+    ...(endpointOptions?.endpoint === undefined ? {} : { endpoint: endpointOptions.endpoint }),
+    ...(endpointOptions?.forcePathStyle === undefined ? {} : { forcePathStyle: endpointOptions.forcePathStyle }),
   });
 
   return {

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -125,10 +125,10 @@ function groupFilesByDate(periodFiles: readonly ManifestFileEntry[]): Map<string
     const date = extractDate(file.key);
     if (date === undefined) continue;
     const existing = dateGroups.get(date);
-    if (existing !== undefined) {
-      existing.push(file);
-    } else {
+    if (existing === undefined) {
       dateGroups.set(date, [file]);
+    } else {
+      existing.push(file);
     }
   }
   return dateGroups;

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -91,10 +91,10 @@ export function groupByPeriod(files: readonly ManifestFileEntry[]): Map<string, 
   for (const file of files) {
     const period = extractPeriod(file.key);
     const existing = groups.get(period);
-    if (existing !== undefined) {
-      existing.push(file);
-    } else {
+    if (existing === undefined) {
       groups.set(period, [file]);
+    } else {
+      existing.push(file);
     }
   }
   return groups;

--- a/packages/desktop/src/main/connection-pool.ts
+++ b/packages/desktop/src/main/connection-pool.ts
@@ -30,8 +30,8 @@ export async function createResourcePool<T>(
     },
     release(resource: T): void {
       const waiter = waiters.shift();
-      if (waiter !== undefined) waiter(resource);
-      else idle.push(resource);
+      if (waiter === undefined) idle.push(resource);
+      else waiter(resource);
     },
   };
 }

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -36,11 +36,12 @@ export function registerAutoSyncHandlers(app: AppContext): void {
         const config = await getConfig();
         const provider = config.providers[0];
         if (provider === undefined) return { periods: [] };
+        const tierBucket = tier === 'cost-optimization'
+          ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
+          : provider.sync.daily.bucket;
         const bucket = tier === 'hourly'
           ? provider.sync.hourly?.bucket ?? provider.sync.daily.bucket
-          : tier === 'cost-optimization'
-            ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
-            : provider.sync.daily.bucket;
+          : tierBucket;
         const inv = await getDataInventory(bucket, provider.credentials.profile, ctx.dataDir, asTier(tier));
         return {
           periods: inv.periods.map(p => ({
@@ -54,11 +55,12 @@ export function registerAutoSyncHandlers(app: AppContext): void {
         const config = await getConfig();
         const provider = config.providers[0];
         if (provider === undefined) return { filesDownloaded: 0, rowsProcessed: 0 };
+        const syncTierBucket = tier === 'cost-optimization'
+          ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
+          : provider.sync.daily.bucket;
         const bucket = tier === 'hourly'
           ? provider.sync.hourly?.bucket ?? provider.sync.daily.bucket
-          : tier === 'cost-optimization'
-            ? provider.sync.costOptimization?.bucket ?? provider.sync.daily.bucket
-            : provider.sync.daily.bucket;
+          : syncTierBucket;
 
         // Use worker thread via SyncClient
         return syncClient.syncPeriods({

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -70,7 +70,7 @@ function mergeDefaultBuiltIns(loaded: DimensionsConfig): DimensionsConfig {
   const backfilled = loaded.builtIn.map(d => {
     let next = d;
     const rename = LEGACY_LABEL_RENAMES[d.name];
-    if (rename !== undefined && rename.from === next.label) {
+    if (rename?.from === next.label) {
       next = { ...next, label: rename.to };
     }
     if (next.description === undefined) {

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -21,11 +21,12 @@ async function applyRegionPreview(
   getRegionMap: () => Promise<ReadonlyMap<string, { longName: string; country: string; continent: string }>>,
 ): Promise<ValueCostPair[]> {
   const regionMap = await getRegionMap();
-  const pick: ((info: { longName: string; country: string; continent: string }) => string) | null =
-    opts?.dimName === 'region_country' ? (i) => i.country
-      : opts?.dimName === 'region_continent' ? (i) => i.continent
-        : opts?.useRegionNames === true ? (i) => i.longName
-          : null;
+  const pick: ((info: { longName: string; country: string; continent: string }) => string) | null = (() => {
+    if (opts?.dimName === 'region_country') return (i: { country: string }) => i.country;
+    if (opts?.dimName === 'region_continent') return (i: { continent: string }) => i.continent;
+    if (opts?.useRegionNames === true) return (i: { longName: string }) => i.longName;
+    return null;
+  })();
   if (pick === null || regionMap.size === 0) return values;
   return mergeValuesByLabel(values, (raw) => {
     const info = regionMap.get(raw);
@@ -67,14 +68,15 @@ export function registerDimensionsHandlers(app: AppContext): void {
       dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort((a, b) => a.localeCompare(b));
     } catch { /* no data */ }
     const recentDirs = dirs.slice(-2);
+    const parquetGlobs = recentDirs.map(d => `'${ctx.dataDir}/aws/raw/${d}/*.parquet'`).join(', ');
     const rawParquet = recentDirs.length > 0
-      ? `read_parquet([${recentDirs.map(d => `'${ctx.dataDir}/aws/raw/${d}/*.parquet'`).join(', ')}])`
+      ? `read_parquet([${parquetGlobs}])`
       : `read_parquet('${ctx.dataDir}/aws/raw/daily-*/*.parquet')`;
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
     const totalSql = `SELECT COUNT(*) AS total FROM ${rawParquet} WHERE line_item_usage_start_date >= '${thirtyDaysAgo}'`;
     const totalRows = await runQuery(totalSql);
-    const totalRowCount = totalRows[0] !== undefined ? toNum(totalRows[0]['total']) : 0;
+    const totalRowCount = totalRows[0] === undefined ? 0 : toNum(totalRows[0]['total']);
 
     const sql = `
       WITH tags AS (
@@ -176,7 +178,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
       LIMIT 200
     `;
     const [distinctRows, valueRows] = await Promise.all([runQuery(distinctSql), runQuery(valuesSql)]);
-    const distinctCount = distinctRows[0] !== undefined ? toNum(distinctRows[0]['n']) : 0;
+    const distinctCount = distinctRows[0] === undefined ? 0 : toNum(distinctRows[0]['n']);
     let values = valueRows.map(r => ({ value: toStr(r['val']), cost: toNum(r['cost']) }));
 
     if (field === 'account_id' && opts?.useOrgAccounts === true) {
@@ -233,7 +235,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
       // `order` lets the user interleave built-ins and tags freely in the
       // Dimensions view. Only written when set — absence means "use the
       // default built-ins-first-then-tags order in the UI".
-      ...(config.order !== undefined ? { order: [...config.order] } : {}),
+      ...(config.order === undefined ? {} : { order: [...config.order] }),
     });
     await fs.writeFile(ctx.dimensionsPath, output);
     invalidateDimensions();

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -371,9 +371,9 @@ function mergeDescendantCosts(
   baseServices?: Record<string, number>,
 ): { totalCost: number; mergedServices: Record<string, number> } {
   let totalCost = baseCost ?? 0;
-  const mergedServices: Record<string, number> = baseServices !== undefined
-    ? { ...baseServices }
-    : {};
+  const mergedServices: Record<string, number> = baseServices === undefined
+    ? {}
+    : { ...baseServices };
   for (const desc of descendants) {
     if (desc === skipName) continue;
     consumedEntities.add(desc);

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -8,7 +8,9 @@ const REQUIRED_CUR_COLUMNS = [
   'product_product_family', 'product_region_code', 'resource_tags',
 ];
 
-function classifyManifestColumns(columnNames: string[]): { detectedType: 'daily' | 'hourly' | 'cost-optimization' | 'unknown'; missingColumns: string[] } {
+type DetectedReportType = 'daily' | 'hourly' | 'cost-optimization' | 'unknown';
+
+function classifyManifestColumns(columnNames: string[]): { detectedType: DetectedReportType; missingColumns: string[] } {
   if (columnNames.includes('recommendation_id') || columnNames.includes('estimated_monthly_savings')) {
     return { detectedType: 'cost-optimization', missingColumns: [] };
   }
@@ -94,7 +96,7 @@ export function registerSetupHandlers(app: AppContext): void {
       const { S3Client, ListBucketsCommand } = await import('@aws-sdk/client-s3');
       const client = new S3Client({
         region: 'us-east-1',
-        ...(profile !== 'default' ? { profile } : {}),
+        ...(profile === 'default' ? {} : { profile }),
       });
 
       const response = await client.send(new ListBucketsCommand({}));

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -67,7 +67,7 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
             {sqlPreview(entry.sql)}
           </span>
           <span className="text-xs text-text-muted shrink-0">
-            {(() => { if (entry.durationMs !== null) return formatDuration(entry.durationMs); return entry.status === 'queued' ? 'queued' : '...'; })()}
+            {(() => { if (entry.durationMs !== null) { return formatDuration(entry.durationMs); } return entry.status === 'queued' ? 'queued' : '...'; })()}
           </span>
         </div>
         <div className="flex items-center gap-3 mt-0.5 ml-4">

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -160,7 +160,7 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               <button type="button" onClick={() => { onOrderChange([]); }} className="text-text-secondary hover:text-text-primary" title="Restore the default column order">Reset order</button>
             </span>
           </div>
-          <div className="max-h-96 overflow-y-auto py-1">
+          <div className="max-h-96 overflow-y-auto py-1" role="listbox">
             {allColumns.map(col => {
               const checked = !hiddenSet.has(col.key);
               const autoHidden = autoHiddenKeys.has(col.key);
@@ -169,6 +169,7 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               return (
                 <div
                   key={col.key}
+                  role="option"
                   aria-selected={checked}
                   tabIndex={0}
                   draggable

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -190,7 +190,7 @@ function PieChartInner({
                   x={14}
                   y={y + 8}
                   fontSize={isHovered ? 12 : 11}
-                  fill={(() => { if (isDimmed) return '#4b5563'; return isHovered ? '#f3f4f6' : '#9ca3af'; })()}
+                  fill={(() => { if (isDimmed) { return '#4b5563'; } return isHovered ? '#f3f4f6' : '#9ca3af'; })()}
                   fontWeight={isHovered ? 600 : 400}
                   style={{ transition: 'all 0.12s' }}
                 >

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -203,15 +203,16 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
         </div>
         );
-      })() : (
-        loading === true ? (
+      })() : (() => {
+        const placeholder = loading === true ? (
           <div className="flex-1 min-h-40 flex items-center justify-center">
             <CoinRainLoader height={expanded ? 340 : 160} count={6} />
           </div>
         ) : (
           <div className="flex items-center justify-center flex-1 min-h-40 text-sm text-text-muted">No daily data</div>
-        )
-      )}
+        );
+        return placeholder;
+      })()}
     </div>
   );
 }

--- a/packages/ui/src/hooks/use-unsaved-changes.tsx
+++ b/packages/ui/src/hooks/use-unsaved-changes.tsx
@@ -40,7 +40,7 @@ export function UnsavedChangesProvider({ children }: Readonly<{ children: ReactN
       // kicking off a re-render every keystroke when a dirty state stays
       // dirty, which would otherwise re-fire every view's useEffect that
       // depends on `setDirty`.
-      if (dirty && existing !== undefined && existing.dirty === dirty && existing.label === (label ?? null)) {
+      if (dirty && existing?.dirty === dirty && existing.label === (label ?? null)) {
         return prev;
       }
       if (!dirty && existing === undefined) return prev;

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -466,8 +466,7 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loa
           )}
           {hasEnabledRules && !hideExcluded && (
             <span>
-              <span className="inline-block w-2 h-2 rounded-sm bg-negative/40 mr-1 align-middle" />{' '}
-              excluded
+              <span className="inline-block w-2 h-2 rounded-sm bg-negative/40 mr-1 align-middle" />{' excluded'}
             </span>
           )}
         </span>
@@ -753,8 +752,8 @@ export function CostScopeView(): React.JSX.Element {
 
   const enabledRules = draft.rules.filter(r => r.enabled);
   let combinedText: string;
-  if (preview.result !== null) combinedText = formatExcluded(preview.result.combined.excludedCost, preview.result.combined.excludedRows);
-  else combinedText = preview.loading ? 'loading…' : 'no data';
+  if (preview.result === null) combinedText = preview.loading ? 'loading…' : 'no data';
+  else combinedText = formatExcluded(preview.result.combined.excludedCost, preview.result.combined.excludedRows);
 
   function getPreviewRow(ruleId: string): CostScopePreviewRow | undefined {
     return preview.result?.perRule.find(p => p.ruleId === ruleId);
@@ -1013,13 +1012,13 @@ function PreviewPanel({ preview, loading, combinedText, metric, hasEnabledRules 
           <SummaryTile
             label="After scope"
             value={hasData ? formatDollars(result.scopedTotalCost) : placeholder}
-            hint={(() => { if (!hasData) return ''; return hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled'; })()}
+            hint={(() => { if (!hasData) { return ''; } return hasEnabledRules ? `${excludedPct.toFixed(1)}% excluded` : 'No rules enabled'; })()}
             emphasis
           />
           <SummaryTile
             label="Excluded"
             value={hasData && hasEnabledRules ? combinedText : placeholder}
-            hint={(() => { if (!hasData) return ''; return hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule'; })()}
+            hint={(() => { if (!hasData) { return ''; } return hasEnabledRules ? 'Union of enabled rules' : 'Toggle a rule'; })()}
           />
         </div>
 

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -102,14 +102,14 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
     }
   }
 
-  const allTagKeys = orgData !== null
-    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b))
-    : [];
+  const allTagKeys = orgData === null
+    ? []
+    : [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b));
   // OU count is derivable from the per-account ouPath. Distinct non-empty
   // paths approximate the number of OUs the user has placed accounts into.
-  const ouCount = orgData !== null
-    ? new Set(orgData.accounts.map(a => a.ouPath).filter(p => p.length > 0)).size
-    : 0;
+  const ouCount = orgData === null
+    ? 0
+    : new Set(orgData.accounts.map(a => a.ouPath).filter(p => p.length > 0)).size;
 
   const filteredAccounts = orgData !== null && accountSearch.length > 0
     ? orgData.accounts.filter(a =>

--- a/packages/ui/src/views/data-management-ssm.tsx
+++ b/packages/ui/src/views/data-management-ssm.tsx
@@ -62,7 +62,7 @@ export function SsmParameterSection({ profile }: Readonly<{ profile: string | nu
         >
           <div className={[
             'h-2 w-2 rounded-full',
-            (() => { if (hasData) return 'bg-accent'; return hasError ? 'bg-negative' : 'bg-text-muted'; })(),
+            (() => { if (hasData) { return 'bg-accent'; } return hasError ? 'bg-negative' : 'bg-text-muted'; })(),
           ].join(' ')} />
           <span className="text-sm font-medium text-text-primary">SSM Parameter Store</span>
           {hasData && <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>}

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -27,7 +27,7 @@ export function DataManagement() {
   const autoSyncIntervalQuery = useQuery(() => api.getAutoSyncIntervalMinutes(), []);
   const [autoSync, setAutoSync] = useState(false);
   const [autoSyncLoaded, setAutoSyncLoaded] = useState(false);
-  const [autoSyncInterval, setAutoSyncIntervalState] = useState(24 * 60);
+  const [autoSyncInterval, setAutoSyncInterval] = useState(24 * 60);
   const [autoSyncIntervalLoaded, setAutoSyncIntervalLoaded] = useState(false);
 
   if (!autoSyncLoaded && autoSyncQuery.status === 'success') {
@@ -36,7 +36,7 @@ export function DataManagement() {
   }
   if (!autoSyncIntervalLoaded && autoSyncIntervalQuery.status === 'success') {
     setAutoSyncIntervalLoaded(true);
-    setAutoSyncIntervalState(autoSyncIntervalQuery.data);
+    setAutoSyncInterval(autoSyncIntervalQuery.data);
   }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
@@ -358,7 +358,7 @@ export function DataManagement() {
               disabled={!autoSync}
               onChange={e => {
                 const next = Number(e.target.value);
-                setAutoSyncIntervalState(next);
+                setAutoSyncInterval(next);
                 void api.setAutoSyncIntervalMinutes(next);
               }}
               title="How often auto-sync runs. Keep this at least a day unless you're debugging — each run hits S3."

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -7,6 +7,27 @@ import { useQuery } from '../hooks/use-query.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
 
+function useClickOutsideDismiss(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  onCancel: () => void,
+  isDirty: boolean,
+  discardConfirm: boolean,
+  setDiscardConfirm: (v: boolean) => void,
+): void {
+  useEffect(() => {
+    function onDocClick(e: MouseEvent): void {
+      if (containerRef.current === null) return;
+      if (!(e.target instanceof Node)) return;
+      if (containerRef.current.contains(e.target)) return;
+      if (discardConfirm) return;
+      if (isDirty) { setDiscardConfirm(true); }
+      else { onCancel(); }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => { document.removeEventListener('mousedown', onDocClick); };
+  }, [containerRef, onCancel, isDirty, discardConfirm, setDiscardConfirm]);
+}
+
 /** Drag/drop is now indexed by position in the unified `order` array,
  *  not by (type, index) into the split built-in/tag arrays. Keeps a single
  *  reorder space so a tag can be dropped above a built-in and vice-versa. */
@@ -166,21 +187,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
     [dim.field, dim.name, isAccountDim, isAnyRegionDim, state.useOrgAccounts, state.useRegionNames, state.accountNameFromTag, stripPatternsKey, normalize],
   );
 
-  useEffect(() => {
-    function onDocClick(e: MouseEvent): void {
-      if (containerRef.current === null) return;
-      if (!(e.target instanceof Node)) return;
-      if (containerRef.current.contains(e.target)) return;
-      // Don't dismiss while the discard-confirm modal is open — the modal
-      // lives outside the editor's DOM tree and would otherwise count as
-      // an outside click.
-      if (discardConfirm) return;
-      if (isDirty) setDiscardConfirm(true);
-      else onCancel();
-    }
-    document.addEventListener('mousedown', onDocClick);
-    return () => { document.removeEventListener('mousedown', onDocClick); };
-  }, [onCancel, isDirty, discardConfirm]);
+  useClickOutsideDismiss(containerRef, onCancel, isDirty, discardConfirm, setDiscardConfirm);
 
   const preview = valuesQuery.status === 'success' ? valuesQuery.data : null;
 
@@ -352,7 +359,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
       )}
       {showTransforms && (
         <div className="grid grid-cols-2 gap-4 items-stretch">
-          {(() => { if (isAccountDim) return nameSourceField; if (isRegionDim) return regionToggleField; return <div />; })()}
+          {(() => { if (isAccountDim) { return nameSourceField; } if (isRegionDim) { return regionToggleField; } return <div />; })()}
           {normalizationField}
         </div>
       )}
@@ -573,7 +580,7 @@ function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, norma
   normalizeRule: string;
   aliasText: string;
 }>): React.JSX.Element | null {
-  const resourceVals = tagMatch !== undefined ? tagMatch.sampleValues : [];
+  const resourceVals = tagMatch === undefined ? [] : tagMatch.sampleValues;
   const accountVals = fallbackValues.map(([v]) => v);
   const fallbackFormat = missingValueTemplate.length > 0 ? missingValueTemplate : '{fallback}';
   const isPassthrough = fallbackFormat === '{fallback}';
@@ -649,23 +656,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   }
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Click outside the editor panel closes it (matches the collapse-on-outside
-  // pattern the rest of the app uses for popovers). A native 'click' listener
-  // on document fires after onClick handlers, so clicks on Save/Cancel/Remove
-  // inside the panel still work as expected. When the form is dirty we
-  // intercept and route through the discard-confirm modal instead.
-  useEffect(() => {
-    function onDocClick(e: MouseEvent): void {
-      if (containerRef.current === null) return;
-      if (!(e.target instanceof Node)) return;
-      if (containerRef.current.contains(e.target)) return;
-      if (discardConfirm) return;
-      if (isDirty) setDiscardConfirm(true);
-      else onCancel();
-    }
-    document.addEventListener('mousedown', onDocClick);
-    return () => { document.removeEventListener('mousedown', onDocClick); };
-  }, [onCancel, isDirty, discardConfirm]);
+  useClickOutsideDismiss(containerRef, onCancel, isDirty, discardConfirm, setDiscardConfirm);
 
   const tagOptions = state.tagName.length > 0 && !availableTags.includes(state.tagName)
     ? [state.tagName, ...availableTags]
@@ -1133,9 +1124,9 @@ export function DimensionsView() {
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
 
   // Account tag keys from org sync
-  const accountTagKeys = orgData !== null
-    ? [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b))
-    : [];
+  const accountTagKeys = orgData === null
+    ? []
+    : [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b));
 
   // Which resource tags are already mapped as dimensions
   const mappedTagNames = new Set(config?.tags.map(t => t.tagName) ?? []);
@@ -1202,13 +1193,12 @@ export function DimensionsView() {
         ...(d.displayField === undefined ? {} : { displayField: d.displayField }),
         ...(d.enabled === false ? { enabled: false as const } : {}),
         ...(description.length > 0 ? { description } : {}),
-        ...(normalize !== undefined ? { normalize } : {}),
-        ...(aliases !== undefined ? { aliases } : {}),
+        ...(normalize === undefined ? {} : { normalize }),
+        ...(aliases === undefined ? {} : { aliases }),
         // The account dim's picker always implies org-sync (both sources come
         // from it); force useOrgAccounts=true so legacy configs that had it
         // off get migrated the first time the dim is saved.
-        ...(d.field === 'account_id' ? { useOrgAccounts: true as const }
-          : edited.useOrgAccounts ? { useOrgAccounts: true as const } : {}),
+        ...((d.field === 'account_id' || edited.useOrgAccounts) ? { useOrgAccounts: true as const } : {}),
         ...(edited.accountNameFromTag.length > 0 ? { accountNameFromTag: edited.accountNameFromTag } : {}),
         ...(nameStripPatterns.length > 0 ? { nameStripPatterns } : {}),
         // Only the Region dim surfaces a useRegionNames toggle — write it
@@ -1297,7 +1287,11 @@ export function DimensionsView() {
           if (dragFrom !== null) applyReorder(dragFrom.orderIdx, orderIdx);
           setArmed(null); setDragFrom(null); setDragOver(null);
         },
-        style: isFrom ? { opacity: 0.4 } : isOver ? { boxShadow: 'inset 0 2px 0 var(--color-accent, #34d399)' } : undefined,
+        style: (() => {
+          if (isFrom) return { opacity: 0.4 };
+          if (isOver) return { boxShadow: 'inset 0 2px 0 var(--color-accent, #34d399)' };
+          return undefined;
+        })(),
       },
       grip: {
         onMouseDown: () => { setArmed({ orderIdx }); },
@@ -1419,7 +1413,7 @@ export function DimensionsView() {
       {config !== null && orderedRows.length > 0 && (
         <div className="flex flex-col gap-3">
           <h3 className="text-sm font-medium text-text-secondary">
-            Enabled dimensions
+            {'Enabled dimensions '}
             <span className="text-text-muted ml-2 font-normal text-xs">click to configure · drag or use arrows to reorder</span>
           </h3>
 
@@ -1584,7 +1578,7 @@ export function DimensionsView() {
 
           <DebugPanel
             title="Account Tags"
-            subtitle={orgData !== null ? `${String(accountTagKeys.length)} keys · across ${String(orgData.accounts.length)} accounts` : 'Requires an AWS Organization sync'}
+            subtitle={orgData === null ? 'Requires an AWS Organization sync' : `${String(accountTagKeys.length)} keys · across ${String(orgData.accounts.length)} accounts`}
             expanded={accountTagsExpanded}
             onToggle={() => { setAccountTagsExpanded(v => !v); }}
           >

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -220,7 +220,8 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
                 <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4">
                   <p className="text-xs uppercase tracking-wider text-text-muted">vs Previous Period</p>
                   {(() => {
-                    const changeColor = isIncrease ? 'text-negative' : (isDecrease ? 'text-positive' : 'text-text-secondary');
+                    const neutralOrPositive = isDecrease ? 'text-positive' : 'text-text-secondary';
+                    const changeColor = isIncrease ? 'text-negative' : neutralOrPositive;
                     return (
                       <p className={`mt-1 text-2xl font-bold tabular-nums ${changeColor}`}>
                         {formatPercent(data.percentChange)}

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -1140,7 +1140,7 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
               </button>
             </span>
           </div>
-          <div className="max-h-96 overflow-y-auto py-1">
+          <div className="max-h-96 overflow-y-auto py-1" role="listbox">
             {allColumns.map(col => {
               const checked = !hiddenSet.has(col.key);
               const autoHidden = autoHiddenKeys.has(col.key);
@@ -1228,7 +1228,8 @@ interface ColumnHeaderProps {
 
 function ColumnHeader({ spec, sort, onSort }: ColumnHeaderProps): React.JSX.Element {
   const isSorted = sort?.column === spec.key;
-  const indicator = isSorted ? (sort.direction === 'asc' ? '↑' : '↓') : '';
+  const arrow = sort?.direction === 'asc' ? '↑' : '↓';
+  const indicator = isSorted ? arrow : '';
   return (
     <th className="p-0 font-medium whitespace-nowrap">
       <button

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -63,9 +63,8 @@ function parseUsages(costCalc: unknown): ParsedDetails['usages'] {
   for (const u of rawUsages) {
     if (!isRecord(u)) continue;
     const uAmount = u['usageAmount'];
-    const amountStr = typeof uAmount === 'number' ? String(uAmount)
-      : typeof uAmount === 'string' ? uAmount
-        : '';
+    const stringOrEmpty = typeof uAmount === 'string' ? uAmount : '';
+    const amountStr = typeof uAmount === 'number' ? String(uAmount) : stringOrEmpty;
     usages.push({
       type: typeof u['usageType'] === 'string' ? u['usageType'] : '',
       amount: amountStr,
@@ -128,11 +127,11 @@ export function Savings() {
     const map = new Map<string, { count: number; savings: number }>();
     for (const rec of visibleRecs) {
       const existing = map.get(rec.actionType);
-      if (existing !== undefined) {
+      if (existing === undefined) {
+        map.set(rec.actionType, { count: 1, savings: rec.monthlySavings });
+      } else {
         existing.count++;
         existing.savings += rec.monthlySavings;
-      } else {
-        map.set(rec.actionType, { count: 1, savings: rec.monthlySavings });
       }
     }
     return [...map.entries()]
@@ -146,11 +145,11 @@ export function Savings() {
     const map = new Map<string, { count: number; savings: number }>();
     for (const rec of data.recommendations) {
       const existing = map.get(rec.actionType);
-      if (existing !== undefined) {
+      if (existing === undefined) {
+        map.set(rec.actionType, { count: 1, savings: rec.monthlySavings });
+      } else {
         existing.count++;
         existing.savings += rec.monthlySavings;
-      } else {
-        map.set(rec.actionType, { count: 1, savings: rec.monthlySavings });
       }
     }
     return [...map.entries()]
@@ -173,9 +172,9 @@ export function Savings() {
   }
 
   const filtered = useMemo(() => {
-    const recs = activeFilter !== null
-      ? visibleRecs.filter(r => r.actionType === activeFilter)
-      : [...visibleRecs];
+    const recs = activeFilter === null
+      ? [...visibleRecs]
+      : visibleRecs.filter(r => r.actionType === activeFilter);
     return recs.sort((a, b) => {
       let cmp: number;
       switch (sortField) {

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -336,12 +336,12 @@ function BrowseStep({ state, onNavigate, onConfirm, onSkip, onBack }: Readonly<{
   );
 }
 
-function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
+function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: Readonly<{
   state: Extract<WizardStep, { step: 'confirm' }>;
   onRetentionChange: (days: number) => void;
   onComplete: () => void;
   onBack: () => void;
-}) {
+}>) {
   const [saving, setSaving] = useState(false);
   const api = useCostApi();
 
@@ -438,7 +438,7 @@ function ConfirmStep({ state, onRetentionChange, onComplete, onBack }: {
   );
 }
 
-export function SetupWizard({ onComplete, source: initialSource, profile: initialProfile }: SetupWizardProps): React.JSX.Element {
+export function SetupWizard({ onComplete, source: initialSource, profile: initialProfile }: Readonly<SetupWizardProps>): React.JSX.Element {
   const api = useCostApi();
   const isSourceMode = initialSource !== undefined && initialProfile !== undefined;
   const [wizard, setWizard] = useState<WizardStep>(
@@ -571,7 +571,7 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
             <BucketStep
               state={wizard}
               onSelect={handleBucketSelect}
-              onSkip={wizard.source !== 'daily' ? handleBrowseSkip : undefined}
+              onSkip={wizard.source === 'daily' ? undefined : handleBrowseSkip}
               onBack={handleBack}
             />
           )}
@@ -580,7 +580,7 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
               state={wizard}
               onNavigate={handleNavigate}
               onConfirm={handleBrowseConfirm}
-              onSkip={wizard.source !== 'daily' ? handleBrowseSkip : undefined}
+              onSkip={wizard.source === 'daily' ? undefined : handleBrowseSkip}
               onBack={handleBack}
             />
           )}

--- a/packages/ui/src/views/views-editor.tsx
+++ b/packages/ui/src/views/views-editor.tsx
@@ -292,7 +292,7 @@ export function ViewsEditor({ onConfigPersisted }: ViewsEditorProps = {}): React
             disabled={saving || !state.dirty}
             className="px-4 py-1.5 text-sm rounded-md bg-accent text-bg-primary font-medium hover:opacity-90 disabled:opacity-40"
           >
-            {(() => { if (saving) return 'Saving…'; return state.dirty ? 'Save changes' : 'Saved'; })()}
+            {(() => { if (saving) { return 'Saving…'; } return state.dirty ? 'Save changes' : 'Saved'; })()}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **S7735** (27): Flip negated conditions in ternaries (`!== undefined ? A : B` -> `=== undefined ? B : A`) and if/else blocks
- **S3358** (10): Extract nested ternaries into named variables before the outer expression
- **S2681** (8): Add braces around single-statement `if` blocks where the next statement looked conditionally-guarded but wasn't
- **S6582** (2): Replace `x !== undefined && x.prop` with `x?.prop`
- **S6772** (2): Fix ambiguous JSX whitespace between text and inline elements
- **S6759** (2): Wrap component props with `Readonly<>`
- **S4144** (1): Extract shared `useClickOutsideDismiss` hook from identical `BuiltInEditor` / `TagEditor` implementations
- **S4323** (1): Extract `DetectedReportType` type alias from inline union literal
- **S107** (1): Refactor `generateRow` (9 params) to accept a single options object
- **S4624** (1): Hoist nested template literal into a variable
- **S6754** (1): Rename `setAutoSyncIntervalState` -> `setAutoSyncInterval` to match `useState` convention
- **S6819** (1): Add `role="listbox"` to custom column-picker container in explorer
- **S6848/S6845** (1): Add `role="option"` to interactive `<div>` with `tabIndex` in data-table column picker

All changes are mechanical refactors with no behavioral impact.