### PR TITLE
Fix final SonarCloud issues

### DIFF
--- a/packages/core/src/config/views-validator.ts
+++ b/packages/core/src/config/views-validator.ts
@@ -97,9 +97,9 @@ function validateGroupByWidget(raw: Record<string, unknown>, ctx: string, base: 
   assertString(raw['groupBy'], `${ctx}.groupBy`);
   const groupBy = asDimensionId(raw['groupBy']);
   if (type === 'treemap') {
-    const drillTo = raw['drillTo'] !== undefined
-      ? (assertString(raw['drillTo'], `${ctx}.drillTo`), asDimensionId(raw['drillTo']))
-      : undefined;
+    const drillTo = raw['drillTo'] === undefined
+      ? undefined
+      : (assertString(raw['drillTo'], `${ctx}.drillTo`), asDimensionId(raw['drillTo']));
     return { type, ...base, groupBy, ...(drillTo === undefined ? {} : { drillTo }) };
   }
   if (type === 'pie') return { type, ...base, groupBy };

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -155,16 +155,19 @@ function makeLineHandler(
   };
 }
 
-async function syncDateGroup(
-  date: string,
-  dateFiles: readonly ManifestFileEntry[],
-  s3Bucket: string,
-  dataDir: string,
-  outputDir: string,
-  profile: string,
-  signal: AbortSignal | undefined,
-  onLine: (line: string) => void,
-): Promise<number> {
+interface SyncDateGroupOptions {
+  readonly date: string;
+  readonly dateFiles: readonly ManifestFileEntry[];
+  readonly s3Bucket: string;
+  readonly dataDir: string;
+  readonly outputDir: string;
+  readonly profile: string;
+  readonly signal: AbortSignal | undefined;
+  readonly onLine: (line: string) => void;
+}
+
+async function syncDateGroup(opts: SyncDateGroupOptions): Promise<number> {
+  const { date, dateFiles, s3Bucket, dataDir, outputDir, profile, signal, onLine } = opts;
   const firstFile = dateFiles[0];
   if (firstFile === undefined) return 0;
 
@@ -207,10 +210,10 @@ async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ fi
 
     for (const [date, dateFiles] of dateGroups) {
       if (options.signal?.aborted) break;
-      totalFilesDownloaded += await syncDateGroup(
-        date, dateFiles, s3Path.bucket, dataDir, outputDir, profile,
-        options.signal, makeLineHandler(onProgress, totalFiles, counter),
-      );
+      totalFilesDownloaded += await syncDateGroup({
+        date, dateFiles, s3Bucket: s3Path.bucket, dataDir, outputDir, profile,
+        signal: options.signal, onLine: makeLineHandler(onProgress, totalFiles, counter),
+      });
     }
 
     if (onProgress !== undefined) {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -320,11 +320,18 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
   }
 
+  function parseRegionEntries(regions: Record<string, unknown>, map: Map<string, RegionEnrichment>): void {
+    for (const [code, info] of Object.entries(regions)) {
+      if (!isStringRecord(info)) continue;
+      const longName = info['longName'];
+      if (typeof longName !== 'string' || longName.length === 0) continue;
+      const country = typeof info['country'] === 'string' ? info['country'] : '';
+      const continent = typeof info['continent'] === 'string' ? info['continent'] : '';
+      map.set(code, { longName, country, continent });
+    }
+  }
+
   async function getRegionMap(): Promise<Map<string, RegionEnrichment>> {
-    // SSM-derived per-region metadata. Mirrors the org sync's caching pattern:
-    // read once, hold for the session, drop on dimensions invalidation.
-    // The map feeds applyRegionFriendlyNames which picks longName, country,
-    // or continent per dim based on the dim's name.
     if (state.regionMap !== null) return state.regionMap;
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
@@ -333,14 +340,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
       const raw = await fs.readFile(path.join(path.dirname(ctx.dataDir), 'region-names.json'), 'utf-8');
       const parsed: unknown = JSON.parse(raw);
       if (isStringRecord(parsed) && isStringRecord(parsed['regions'])) {
-        for (const [code, info] of Object.entries(parsed['regions'])) {
-          if (!isStringRecord(info)) continue;
-          const longName = info['longName'];
-          if (typeof longName !== 'string' || longName.length === 0) continue;
-          const country = typeof info['country'] === 'string' ? info['country'] : '';
-          const continent = typeof info['continent'] === 'string' ? info['continent'] : '';
-          map.set(code, { longName, country, continent });
-        }
+        parseRegionEntries(parsed['regions'], map);
       }
     } catch { /* no region sync yet */ }
     state.regionMap = map;

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -164,17 +164,20 @@ function buildExclusionClauses(
   return clauses;
 }
 
-async function buildFreshSource(
-  app: AppContext,
-  params: ExplorerBaseParams,
-  startStr: string,
-  endStr: string,
-  tier: 'daily' | 'hourly',
-  periods: readonly string[],
-  dimensions: DimensionsConfig,
-  filterPredicate: string | null,
-  accountReverseMap: ReadonlyMap<string, readonly string[]>,
-): Promise<{ source: string; whereStr: string }> {
+interface BuildFreshSourceOptions {
+  readonly app: AppContext;
+  readonly params: ExplorerBaseParams;
+  readonly startStr: string;
+  readonly endStr: string;
+  readonly tier: 'daily' | 'hourly';
+  readonly periods: readonly string[];
+  readonly dimensions: DimensionsConfig;
+  readonly filterPredicate: string | null;
+  readonly accountReverseMap: ReadonlyMap<string, readonly string[]>;
+}
+
+async function buildFreshSource(opts: BuildFreshSourceOptions): Promise<{ source: string; whereStr: string }> {
+  const { app, params, startStr, endStr, tier, periods, dimensions, filterPredicate, accountReverseMap } = opts;
   const { ctx, getCostScope, getOrgAccountsPath, getAvailableColumns } = app;
   const orgPath = await getOrgAccountsPath();
   const availableColumns = await getAvailableColumns(tier);
@@ -227,9 +230,9 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
     return { empty: false, source: matSource, whereStr, ...shared };
   }
 
-  const { source, whereStr } = await buildFreshSource(
+  const { source, whereStr } = await buildFreshSource({
     app, params, startStr, endStr, tier, periods, dimensions, filterPredicate, accountReverseMap,
-  );
+  });
   return { empty: false, source, whereStr, ...shared };
 }
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, Profiler } from 'react';
+import { useState, useEffect, useCallback, Profiler } from 'react';
 import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
@@ -140,22 +140,23 @@ function AppShell(): React.JSX.Element {
     });
   }, [api]);
 
+  const applyViews = useCallback((cfg: ViewsConfig): void => {
+    const resolved = cfg.views.length > 0 ? cfg : FALLBACK_VIEWS;
+    setViewsConfig(resolved);
+    setView(prev => {
+      if (prev.page !== 'custom') return prev;
+      const exists = resolved.views.some(v => v.id === prev.viewId);
+      const firstId = resolved.views[0]?.id;
+      return exists || firstId === undefined ? prev : { page: 'custom', viewId: firstId };
+    });
+  }, []);
+
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
-    function applyViews(cfg: ViewsConfig): void {
-      const resolved = cfg.views.length > 0 ? cfg : FALLBACK_VIEWS;
-      setViewsConfig(resolved);
-      setView(prev => {
-        if (prev.page !== 'custom') return prev;
-        const exists = resolved.views.some(v => v.id === prev.viewId);
-        const firstId = resolved.views[0]?.id;
-        return exists || firstId === undefined ? prev : { page: 'custom', viewId: firstId };
-      });
-    }
     api.getViewsConfig()
       .then(applyViews)
       .catch(() => { setViewsConfig(FALLBACK_VIEWS); });
-  }, [api, setupCheck]);
+  }, [api, setupCheck, applyViews]);
 
   useEffect(() => {
     if (isDark) {

--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -70,12 +70,12 @@ export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: 
     if (el === null) return;
 
     const w = el.offsetWidth;
-    const makeTick = (): FrameRequestCallback => () => {
+    function tick() {
       setCoins(prev => prev.map(c => updateCoin(c, w, height)));
-      frameRef.current = requestAnimationFrame(makeTick());
-    };
+      frameRef.current = requestAnimationFrame(tick);
+    }
 
-    frameRef.current = requestAnimationFrame(makeTick());
+    frameRef.current = requestAnimationFrame(tick);
     return () => { cancelAnimationFrame(frameRef.current); };
   }, [coins.length, height]);
 

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -160,7 +160,7 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               <button type="button" onClick={() => { onOrderChange([]); }} className="text-text-secondary hover:text-text-primary" title="Restore the default column order">Reset order</button>
             </span>
           </div>
-          <div className="max-h-96 overflow-y-auto py-1" role="listbox">
+          <div className="max-h-96 overflow-y-auto py-1">
             {allColumns.map(col => {
               const checked = !hiddenSet.has(col.key);
               const autoHidden = autoHiddenKeys.has(col.key);
@@ -169,8 +169,6 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               return (
                 <div
                   key={col.key}
-                  role="option"
-                  aria-selected={checked}
                   tabIndex={0}
                   draggable
                   onDragStart={(e) => { setDraggedKey(col.key); e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', col.key); }}

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -460,7 +460,7 @@ function SampleRowsTable({ rows, tagColumns, totalRowCount, hasEnabledRules, loa
                 className="accent-accent"
                 checked={hideExcluded}
                 onChange={e => { setHideExcluded(e.target.checked); }}
-              />
+              />{' '}
               Hide excluded
             </label>
           )}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -114,7 +114,7 @@ function buildDiscoverOptions(
   const isAccountDim = dim.field === 'account_id';
   const isAnyRegionDim = dim.field === 'region';
   return {
-    ...(normalize !== undefined ? { normalize } : {}),
+    ...(normalize === undefined ? {} : { normalize }),
     ...(isAccountDim ? {
       useOrgAccounts: true,
       nameStripPatterns: stripPatternList,
@@ -1327,7 +1327,7 @@ export function DimensionsView() {
     );
   }
 
-  const orderedRows = config !== null ? resolveOrderedRows(config) : [];
+  const orderedRows = config === null ? [] : resolveOrderedRows(config);
 
 
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -1140,7 +1140,7 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
               </button>
             </span>
           </div>
-          <div className="max-h-96 overflow-y-auto py-1" role="listbox">
+          <div className="max-h-96 overflow-y-auto py-1">
             {allColumns.map(col => {
               const checked = !hiddenSet.has(col.key);
               const autoHidden = autoHiddenKeys.has(col.key);
@@ -1149,8 +1149,6 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
               return (
                 <div
                   key={col.key}
-                  role="option"
-                  aria-selected={checked}
                   tabIndex={0}
                   draggable
                   onDragStart={(e) => {


### PR DESCRIPTION
## Summary
- Remove `role="listbox"` / `role="option"` from custom column visibility panels (S6819)
- Flip 3 remaining negated conditions (S7735)
- Refactor `syncDateGroup` and `buildFreshSource` to options objects (S107)
- Flatten nesting in coin-rain-loader and App.tsx (S2004)
- Fix ambiguous JSX spacing in cost-scope (S6772)
- Extract `parseRegionEntries` to reduce `getRegionMap` complexity (S3776)