### PR TITLE
Remove tabIndex from non-interactive column items

### DIFF
--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -169,7 +169,6 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               return (
                 <div
                   key={col.key}
-                  tabIndex={0}
                   draggable
                   onDragStart={(e) => { setDraggedKey(col.key); e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', col.key); }}
                   onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; if (dragOverKey !== col.key) setDragOverKey(col.key); }}

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -1149,7 +1149,6 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
               return (
                 <div
                   key={col.key}
-                  tabIndex={0}
                   draggable
                   onDragStart={(e) => {
                     setDraggedKey(col.key);


### PR DESCRIPTION
## Summary
- Remove redundant `tabIndex={0}` from draggable column visibility divs (S6845/S6848)
- The contained checkbox already provides keyboard accessibility