### PR TITLE
Fix nesting depth and use semantic label for draggable items

### DIFF
--- a/packages/ui/src/components/coin-rain-loader.tsx
+++ b/packages/ui/src/components/coin-rain-loader.tsx
@@ -53,6 +53,10 @@ function updateCoin(c: Coin, containerWidth: number, containerHeight: number): C
   return { ...c, x, y, vx, vy, rotation, rotationSpeed, scale };
 }
 
+function advanceCoins(prev: Coin[], w: number, h: number): Coin[] {
+  return prev.map(c => updateCoin(c, w, h));
+}
+
 export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: number; count?: number }>) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [coins, setCoins] = useState<Coin[]>([]);
@@ -71,7 +75,7 @@ export function CoinRainLoader({ height = 120, count = 5 }: Readonly<{ height?: 
 
     const w = el.offsetWidth;
     function tick() {
-      setCoins(prev => prev.map(c => updateCoin(c, w, height)));
+      setCoins(prev => advanceCoins(prev, w, height));
       frameRef.current = requestAnimationFrame(tick);
     }
 

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -167,7 +167,7 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
               const isDragging = draggedKey === col.key;
               const isDropTarget = dragOverKey === col.key && draggedKey !== null && draggedKey !== col.key;
               return (
-                <div
+                <label
                   key={col.key}
                   draggable
                   onDragStart={(e) => { setDraggedKey(col.key); e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', col.key); }}
@@ -176,7 +176,7 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
                   onDrop={(e) => { e.preventDefault(); handleDrop(col.key); setDragOverKey(null); setDraggedKey(null); }}
                   onDragEnd={() => { setDragOverKey(null); setDraggedKey(null); }}
                   className={[
-                    'flex items-center gap-2 px-2 py-1.5 text-xs select-none',
+                    'flex items-center gap-2 px-2 py-1.5 text-xs select-none cursor-default',
                     isDragging ? 'opacity-40' : '',
                     isDropTarget ? 'border-t-2 border-t-accent' : 'border-t-2 border-t-transparent',
                     'hover:bg-bg-tertiary',
@@ -187,7 +187,7 @@ export function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onCha
                   <span className={['truncate flex-1', !checked || autoHidden ? 'text-text-muted' : 'text-text-primary'].join(' ')}>{col.label}</span>
                   {autoHidden && <span className="text-[10px] text-text-muted uppercase tracking-wider shrink-0" title="Hidden because this column is pinned to a single filter value">filtered</span>}
                   {!autoHidden && col.dimId !== null && col.dimId.startsWith('tag_') && <span className="text-[10px] text-text-muted uppercase tracking-wider shrink-0">tag</span>}
-                </div>
+                </label>
               );
             })}
           </div>

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -1147,15 +1147,12 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
               const isDragging = draggedKey === col.key;
               const isDropTarget = dragOverKey === col.key && draggedKey !== null && draggedKey !== col.key;
               return (
-                <div
+                <label
                   key={col.key}
                   draggable
                   onDragStart={(e) => {
                     setDraggedKey(col.key);
                     e.dataTransfer.effectAllowed = 'move';
-                    // Firefox needs dataTransfer.setData or the drag never
-                    // starts. The payload itself is irrelevant — we drive
-                    // the logic off component state.
                     e.dataTransfer.setData('text/plain', col.key);
                   }}
                   onDragOver={(e) => {
@@ -1177,7 +1174,7 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
                     setDraggedKey(null);
                   }}
                   className={[
-                    'flex items-center gap-2 px-2 py-1.5 text-xs select-none',
+                    'flex items-center gap-2 px-2 py-1.5 text-xs select-none cursor-default',
                     isDragging ? 'opacity-40' : '',
                     isDropTarget ? 'border-t-2 border-t-accent' : 'border-t-2 border-t-transparent',
                     'hover:bg-bg-tertiary',
@@ -1207,7 +1204,7 @@ function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, on
                   {!autoHidden && col.dimId !== null && col.dimId.startsWith('tag_') && (
                     <span className="text-[10px] text-text-muted uppercase tracking-wider shrink-0">tag</span>
                   )}
-                </div>
+                </label>
               );
             })}
           </div>


### PR DESCRIPTION
## Summary
- Extract `advanceCoins` to module level in coin-rain-loader to fix S2004 nesting depth
- Replace `<div>` with `<label>` for draggable column visibility items (S6848) — label is a native interactive element wrapping the checkbox