### PR TITLE
Reduce code duplication across widgets, clients, and panels

### DIFF
--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -1,5 +1,5 @@
-import { Worker } from 'node:worker_threads';
 import { logger } from '@costgoblin/core';
+import { initWorkerLifecycle } from './worker-lifecycle.js';
 
 export type RawRow = Readonly<Record<string, unknown>>;
 
@@ -35,29 +35,16 @@ interface PendingQuery {
 }
 
 export async function createDuckDBClient(workerPath: string): Promise<DuckDBClient> {
-  const worker = new Worker(workerPath);
-  const pending = new Map<number, PendingQuery>();
-  let nextId = 0;
-  let fatalError: Error | null = null;
-
-  const ready = new Promise<void>((resolve, reject) => {
-    const onMessage = (msg: unknown): void => {
-      if (!isWorkerResponse(msg)) return;
-      if (msg.kind === 'ready') {
-        worker.off('message', onMessage);
-        resolve();
-        return;
-      }
-      if (msg.kind === 'error' && msg.id === -1) {
-        worker.off('message', onMessage);
-        const err = new Error(msg.message);
-        fatalError = err;
-        reject(err);
-      }
-    };
-    worker.on('message', onMessage);
-    worker.once('error', (err) => { fatalError = err; reject(err); });
-  });
+  const lifecycle = await initWorkerLifecycle<PendingQuery>(
+    workerPath,
+    (msg) => isWorkerResponse(msg) && msg.kind === 'ready',
+    (msg) => {
+      if (!isWorkerResponse(msg)) return null;
+      if (msg.kind === 'error' && msg.id === -1) return msg.message;
+      return null;
+    },
+  );
+  const { worker, pending } = lifecycle;
 
   worker.on('message', (msg: unknown) => {
     if (!isWorkerResponse(msg)) return;
@@ -74,89 +61,54 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
     else entry.reject(new Error(msg.message));
   });
 
-  worker.on('error', (err) => {
-    fatalError = err;
-    for (const entry of pending.values()) entry.reject(err);
-    pending.clear();
-  });
-
-  worker.on('exit', (code) => {
-    if (code !== 0) {
-      const err = new Error(`DuckDB worker exited unexpectedly with code ${String(code)}`);
-      fatalError ??= err;
-      for (const entry of pending.values()) entry.reject(err);
-      pending.clear();
-    }
-  });
-
-  await ready;
+  function submitQuery(
+    kind: string,
+    sql: string,
+    logTag: string,
+    extraPayload: Record<string, unknown>,
+    extraLogFields: Record<string, unknown>,
+    onStarted?: () => void,
+  ): Promise<RawRow[]> {
+    if (lifecycle.fatalError !== null) return Promise.reject(lifecycle.fatalError);
+    const id = lifecycle.nextId++;
+    const startedAt = Date.now();
+    const startedAtIso = new Date(startedAt).toISOString();
+    return new Promise<RawRow[]>((resolve, reject) => {
+      pending.set(id, {
+        onStarted,
+        resolve: (rows) => {
+          logger.debug(logTag, {
+            id,
+            startedAt: startedAtIso,
+            durationMs: Date.now() - startedAt,
+            rows: rows.length,
+            sql,
+            ...extraLogFields,
+          });
+          resolve(rows);
+        },
+        reject: (err) => {
+          logger.debug(`${logTag}-failed`, {
+            id,
+            startedAt: startedAtIso,
+            durationMs: Date.now() - startedAt,
+            error: err.message,
+            sql,
+            ...extraLogFields,
+          });
+          reject(err);
+        },
+      });
+      worker.postMessage({ kind, id, sql, ...extraPayload });
+    });
+  }
 
   return {
     runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]> {
-      if (fatalError !== null) return Promise.reject(fatalError);
-      const id = nextId++;
-      const startedAt = Date.now();
-      const startedAtIso = new Date(startedAt).toISOString();
-      return new Promise<RawRow[]>((resolve, reject) => {
-        pending.set(id, {
-          onStarted,
-          resolve: (rows) => {
-            logger.debug('duckdb:query', {
-              id,
-              startedAt: startedAtIso,
-              durationMs: Date.now() - startedAt,
-              rows: rows.length,
-              sql,
-            });
-            resolve(rows);
-          },
-          reject: (err) => {
-            logger.debug('duckdb:query-failed', {
-              id,
-              startedAt: startedAtIso,
-              durationMs: Date.now() - startedAt,
-              error: err.message,
-              sql,
-            });
-            reject(err);
-          },
-        });
-        worker.postMessage({ kind: 'query', id, sql });
-      });
+      return submitQuery('query', sql, 'duckdb:query', {}, {}, onStarted);
     },
     runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]> {
-      if (fatalError !== null) return Promise.reject(fatalError);
-      const id = nextId++;
-      const startedAt = Date.now();
-      const startedAtIso = new Date(startedAt).toISOString();
-      return new Promise<RawRow[]>((resolve, reject) => {
-        pending.set(id, {
-          onStarted,
-          resolve: (rows) => {
-            logger.debug('duckdb:prepared-query', {
-              id,
-              startedAt: startedAtIso,
-              durationMs: Date.now() - startedAt,
-              rows: rows.length,
-              sql,
-              paramCount: params.length,
-            });
-            resolve(rows);
-          },
-          reject: (err) => {
-            logger.debug('duckdb:prepared-query-failed', {
-              id,
-              startedAt: startedAtIso,
-              durationMs: Date.now() - startedAt,
-              error: err.message,
-              sql,
-              paramCount: params.length,
-            });
-            reject(err);
-          },
-        });
-        worker.postMessage({ kind: 'prepared-query', id, sql, params });
-      });
+      return submitQuery('prepared-query', sql, 'duckdb:prepared-query', { params }, { paramCount: params.length }, onStarted);
     },
     cancelPendingQueries(): void {
       worker.postMessage({ kind: 'cancel-pending' });

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,14 +1,14 @@
 import { parentPort } from 'node:worker_threads';
 import { cpus } from 'node:os';
-import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
+import type { DuckDBConnection, DuckDBResult } from './duckdb-loader.js';
 import { createResourcePool } from './connection-pool.js';
 import type { ResourcePool } from './connection-pool.js';
 
 interface DuckDBModule {
-  DuckDBInstance: { create: () => Promise<DuckDBInstance> };
+  DuckDBInstance: { create: () => Promise<import('./duckdb-loader.js').DuckDBInstance> };
 }
 
-async function createDuckDB(): Promise<DuckDBInstance> {
+async function createDuckDB(): Promise<import('./duckdb-loader.js').DuckDBInstance> {
   const duckdb = (await import('@duckdb/node-api')) as unknown as DuckDBModule;
   return duckdb.DuckDBInstance.create();
 }
@@ -50,16 +50,23 @@ const cancelledIds = new Set<number>();
 const queuedIds = new Set<number>();  // waiting for pool.acquire()
 const runningIds = new Set<number>(); // executing in DuckDB
 
-async function fetchAllRows(
-  conn: DuckDBConnection,
-  sql: string,
+function collectChunkRows(
+  result: DuckDBResult,
   isCancelled: () => boolean,
 ): Promise<Readonly<Record<string, unknown>>[]> {
-  const result = await conn.run(sql);
   const cols = result.columnCount;
   const names: string[] = [];
   for (let i = 0; i < cols; i++) names.push(result.columnName(i));
 
+  return readChunks(result, names, cols, isCancelled);
+}
+
+async function readChunks(
+  result: DuckDBResult,
+  names: string[],
+  cols: number,
+  isCancelled: () => boolean,
+): Promise<Record<string, unknown>[]> {
   const rows: Record<string, unknown>[] = [];
   let chunk = await result.fetchChunk();
   while (chunk !== null && chunk.rowCount > 0) {
@@ -75,6 +82,15 @@ async function fetchAllRows(
     chunk = await result.fetchChunk();
   }
   return rows;
+}
+
+async function fetchAllRows(
+  conn: DuckDBConnection,
+  sql: string,
+  isCancelled: () => boolean,
+): Promise<Readonly<Record<string, unknown>>[]> {
+  const result = await conn.run(sql);
+  return collectChunkRows(result, isCancelled);
 }
 
 function bindParams(stmt: import('./duckdb-loader.js').DuckDBPreparedStatement, params: unknown[]): void {
@@ -109,25 +125,7 @@ async function fetchAllRowsPrepared(
   try {
     bindParams(stmt, params);
     const result = await stmt.run();
-    const cols = result.columnCount;
-    const names: string[] = [];
-    for (let i = 0; i < cols; i++) names.push(result.columnName(i));
-
-    const rows: Record<string, unknown>[] = [];
-    let chunk = await result.fetchChunk();
-    while (chunk !== null && chunk.rowCount > 0) {
-      if (isCancelled()) return [];
-      for (let r = 0; r < chunk.rowCount; r++) {
-        const row: Record<string, unknown> = {};
-        for (let c = 0; c < cols; c++) {
-          const name = names[c];
-          if (name !== undefined) row[name] = chunk.getColumnVector(c).getItem(r);
-        }
-        rows.push(row);
-      }
-      chunk = await result.fetchChunk();
-    }
-    return rows;
+    return await collectChunkRows(result, isCancelled);
   } finally {
     stmt.destroySync();
   }
@@ -169,86 +167,53 @@ void getPool().then(() => {
   send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
 });
 
-async function handleRequest(req: { kind: 'query'; id: number; sql: string }): Promise<void> {
-  // Check before acquiring a pool connection
-  if (cancelledIds.has(req.id)) {
-    cancelledIds.delete(req.id);
-    send({ kind: 'rows', id: req.id, rows: [] });
+async function executeWithPool(
+  id: number,
+  execute: (conn: DuckDBConnection) => Promise<Readonly<Record<string, unknown>>[]>,
+): Promise<void> {
+  if (cancelledIds.has(id)) {
+    cancelledIds.delete(id);
+    send({ kind: 'rows', id, rows: [] });
     return;
   }
 
-  queuedIds.add(req.id);
+  queuedIds.add(id);
   const pool = await getPool();
   const conn = await pool.acquire();
-  queuedIds.delete(req.id);
-  send({ kind: 'started', id: req.id });
+  queuedIds.delete(id);
+  send({ kind: 'started', id });
 
   try {
-    // Check after acquiring — cancel may have arrived while queued
-    if (cancelledIds.has(req.id)) {
-      cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
+    if (cancelledIds.has(id)) {
+      cancelledIds.delete(id);
+      send({ kind: 'rows', id, rows: [] });
       return;
     }
 
-    runningIds.add(req.id);
-    const rows = await fetchAllRows(conn, req.sql, () => cancelledIds.has(req.id));
+    runningIds.add(id);
+    const rows = await execute(conn);
 
-    // Skip serialization if cancelled during execution
-    if (cancelledIds.has(req.id)) {
-      cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
+    if (cancelledIds.has(id)) {
+      cancelledIds.delete(id);
+      send({ kind: 'rows', id, rows: [] });
     } else {
-      send({ kind: 'rows', id: req.id, rows });
+      send({ kind: 'rows', id, rows });
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    send({ kind: 'error', id: req.id, message });
+    send({ kind: 'error', id, message });
   } finally {
-    runningIds.delete(req.id);
+    runningIds.delete(id);
     pool.release(conn);
   }
 }
 
-async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; sql: string; params: unknown[] }): Promise<void> {
-  // Check before acquiring a pool connection
-  if (cancelledIds.has(req.id)) {
-    cancelledIds.delete(req.id);
-    send({ kind: 'rows', id: req.id, rows: [] });
-    return;
-  }
+function handleRequest(req: { kind: 'query'; id: number; sql: string }): Promise<void> {
+  return executeWithPool(req.id, (conn) => fetchAllRows(conn, req.sql, () => cancelledIds.has(req.id)));
+}
 
-  queuedIds.add(req.id);
-  const pool = await getPool();
-  const conn = await pool.acquire();
-  queuedIds.delete(req.id);
-  send({ kind: 'started', id: req.id });
-
-  try {
-    // Check after acquiring — cancel may have arrived while queued
-    if (cancelledIds.has(req.id)) {
-      cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
-      return;
-    }
-
-    runningIds.add(req.id);
-    const rows = await fetchAllRowsPrepared(conn, req.sql, req.params, () => cancelledIds.has(req.id));
-
-    // Skip serialization if cancelled during execution
-    if (cancelledIds.has(req.id)) {
-      cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
-    } else {
-      send({ kind: 'rows', id: req.id, rows });
-    }
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    send({ kind: 'error', id: req.id, message });
-  } finally {
-    runningIds.delete(req.id);
-    pool.release(conn);
-  }
+function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; sql: string; params: unknown[] }): Promise<void> {
+  return executeWithPool(req.id, (conn) => fetchAllRowsPrepared(conn, req.sql, req.params, () => cancelledIds.has(req.id)));
 }
 
 function handleCancelPending(): void {

--- a/packages/desktop/src/main/sync-client.ts
+++ b/packages/desktop/src/main/sync-client.ts
@@ -1,6 +1,6 @@
-import { Worker } from 'node:worker_threads';
 import { logger } from '@costgoblin/core';
 import type { ManifestFileEntry, SyncProgress } from '@costgoblin/core';
+import { initWorkerLifecycle } from './worker-lifecycle.js';
 
 export interface SyncOptions {
   readonly bucketPath: string;
@@ -58,29 +58,16 @@ interface PendingSync {
 }
 
 export async function createSyncClient(workerPath: string): Promise<SyncClient> {
-  const worker = new Worker(workerPath);
-  const pending = new Map<number, PendingSync>();
-  let nextId = 0;
-  let fatalError: Error | null = null;
-
-  const ready = new Promise<void>((resolve, reject) => {
-    const onMessage = (msg: unknown): void => {
-      if (!isWorkerResponse(msg)) return;
-      if (msg.kind === 'ready') {
-        worker.off('message', onMessage);
-        resolve();
-        return;
-      }
-      if (msg.kind === 'error' && msg.id === -1) {
-        worker.off('message', onMessage);
-        const err = new Error(msg.message);
-        fatalError = err;
-        reject(err);
-      }
-    };
-    worker.on('message', onMessage);
-    worker.once('error', (err) => { fatalError = err; reject(err); });
-  });
+  const lifecycle = await initWorkerLifecycle<PendingSync>(
+    workerPath,
+    (msg) => isWorkerResponse(msg) && msg.kind === 'ready',
+    (msg) => {
+      if (!isWorkerResponse(msg)) return null;
+      if (msg.kind === 'error' && msg.id === -1) return msg.message;
+      return null;
+    },
+  );
+  const { worker, pending } = lifecycle;
 
   worker.on('message', (msg: unknown) => {
     if (!isWorkerResponse(msg)) return;
@@ -106,27 +93,10 @@ export async function createSyncClient(workerPath: string): Promise<SyncClient> 
     }
   });
 
-  worker.on('error', (err) => {
-    fatalError = err;
-    for (const entry of pending.values()) entry.reject(err);
-    pending.clear();
-  });
-
-  worker.on('exit', (code) => {
-    if (code !== 0) {
-      const err = new Error(`Sync worker exited unexpectedly with code ${String(code)}`);
-      fatalError ??= err;
-      for (const entry of pending.values()) entry.reject(err);
-      pending.clear();
-    }
-  });
-
-  await ready;
-
   return {
     syncPeriods(options: SyncOptions): Promise<SyncResult> {
-      if (fatalError !== null) return Promise.reject(fatalError);
-      const id = nextId++;
+      if (lifecycle.fatalError !== null) return Promise.reject(lifecycle.fatalError);
+      const id = lifecycle.nextId++;
       const startedAt = Date.now();
       const startedAtIso = new Date(startedAt).toISOString();
       return new Promise<SyncResult>((resolve, reject) => {

--- a/packages/desktop/src/main/worker-lifecycle.ts
+++ b/packages/desktop/src/main/worker-lifecycle.ts
@@ -1,0 +1,55 @@
+import { Worker } from 'node:worker_threads';
+
+export interface WorkerLifecycle<P> {
+  readonly worker: Worker;
+  readonly pending: Map<number, P>;
+  nextId: number;
+  fatalError: Error | null;
+}
+
+export async function initWorkerLifecycle<P extends { reject: (err: Error) => void }>(
+  workerPath: string,
+  isReady: (msg: unknown) => boolean,
+  isInitError: (msg: unknown) => string | null,
+): Promise<WorkerLifecycle<P>> {
+  const worker = new Worker(workerPath);
+  const pending = new Map<number, P>();
+  const state: WorkerLifecycle<P> = { worker, pending, nextId: 0, fatalError: null };
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const onMessage = (msg: unknown): void => {
+      if (isReady(msg)) {
+        worker.off('message', onMessage);
+        resolve();
+        return;
+      }
+      const errMsg = isInitError(msg);
+      if (errMsg !== null) {
+        worker.off('message', onMessage);
+        const err = new Error(errMsg);
+        state.fatalError = err;
+        reject(err);
+      }
+    };
+    worker.on('message', onMessage);
+    worker.once('error', (err) => { state.fatalError = err; reject(err); });
+  });
+
+  worker.on('error', (err) => {
+    state.fatalError = err;
+    for (const entry of pending.values()) entry.reject(err);
+    pending.clear();
+  });
+
+  worker.on('exit', (code) => {
+    if (code !== 0) {
+      const err = new Error(`Worker exited unexpectedly with code ${String(code)}`);
+      state.fatalError ??= err;
+      for (const entry of pending.values()) entry.reject(err);
+      pending.clear();
+    }
+  });
+
+  await ready;
+  return state;
+}

--- a/packages/ui/src/hooks/use-widget-query.ts
+++ b/packages/ui/src/hooks/use-widget-query.ts
@@ -1,0 +1,142 @@
+import { useMemo } from 'react';
+import { useCostApi } from './use-cost-api.js';
+import { useQuery } from './use-query.js';
+import type { CostApi } from '@costgoblin/core/browser';
+import type {
+  CostResult,
+  DailyCostsResult,
+  DateRange,
+  DimensionId,
+  FilterMap,
+  Granularity,
+  QueryState,
+} from '@costgoblin/core/browser';
+import { filtersKey, getDimensionFallback, mergeFilters } from '../widgets/widget.js';
+
+interface DailyQueryResult {
+  readonly result: DailyCostsResult;
+  readonly groupBy: DimensionId;
+}
+
+interface CostQueryResult {
+  readonly result: CostResult;
+  readonly groupBy: DimensionId;
+}
+
+async function fetchDailyWithFallback(
+  api: CostApi,
+  specGroupBy: DimensionId,
+  fallbackDim: DimensionId | undefined,
+  dateRange: DateRange,
+  filters: FilterMap,
+  granularity: Granularity,
+): Promise<DailyQueryResult> {
+  if (fallbackDim === undefined) {
+    const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+    return { result, groupBy: specGroupBy };
+  }
+  const [primary, fallback] = await Promise.all([
+    api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+    api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+  ]);
+  if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
+  return { result: fallback, groupBy: fallbackDim };
+}
+
+async function fetchCostsWithFallback(
+  api: CostApi,
+  specGroupBy: DimensionId,
+  fallbackDim: DimensionId | undefined,
+  dateRange: DateRange,
+  filters: FilterMap,
+  granularity: Granularity,
+): Promise<CostQueryResult> {
+  if (fallbackDim === undefined) {
+    const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+    return { result, groupBy: specGroupBy };
+  }
+  const [primary, fallback] = await Promise.all([
+    api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
+    api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
+  ]);
+  if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
+  return { result: fallback, groupBy: fallbackDim };
+}
+
+interface WidgetQueryArgs {
+  readonly specGroupBy: DimensionId | undefined;
+  readonly dateRange: DateRange;
+  readonly granularity: Granularity;
+  readonly globalFilters: FilterMap;
+  readonly specFilters: FilterMap | undefined;
+}
+
+interface DailyWidgetQueryResult {
+  readonly query: QueryState<DailyQueryResult | null>;
+  readonly activeGroupBy: DimensionId | undefined;
+  readonly dailyResult: DailyCostsResult | null;
+  readonly filters: FilterMap;
+}
+
+export function useDailyWidgetQuery({
+  specGroupBy,
+  dateRange,
+  granularity,
+  globalFilters,
+  specFilters,
+}: WidgetQueryArgs): DailyWidgetQueryResult {
+  const api = useCostApi();
+  const filters = mergeFilters(globalFilters, specFilters);
+  const fk = filtersKey(filters);
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
+
+  const query = useQuery<DailyQueryResult | null>(
+    () => specGroupBy === undefined
+      ? Promise.resolve(null)
+      : fetchDailyWithFallback(api, specGroupBy, fallbackDim, dateRange, filters, granularity),
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
+  );
+
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
+  const dailyResult = useMemo(
+    () => (query.status === 'success' && query.data !== null ? query.data.result : null),
+    [query],
+  );
+
+  return { query, activeGroupBy, dailyResult, filters };
+}
+
+interface CostWidgetQueryResult {
+  readonly query: QueryState<CostQueryResult | null>;
+  readonly activeGroupBy: DimensionId | undefined;
+  readonly costResult: CostResult | null;
+  readonly filters: FilterMap;
+}
+
+export function useCostWidgetQuery({
+  specGroupBy,
+  dateRange,
+  granularity,
+  globalFilters,
+  specFilters,
+}: WidgetQueryArgs): CostWidgetQueryResult {
+  const api = useCostApi();
+  const filters = mergeFilters(globalFilters, specFilters);
+  const fk = filtersKey(filters);
+  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
+
+  const query = useQuery<CostQueryResult | null>(
+    () => specGroupBy === undefined
+      ? Promise.resolve(null)
+      : fetchCostsWithFallback(api, specGroupBy, fallbackDim, dateRange, filters, granularity),
+    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
+  );
+
+  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
+  const costResult = useMemo(
+    () => (query.status === 'success' && query.data !== null ? query.data.result : null),
+    [query],
+  );
+
+  return { query, activeGroupBy, costResult, filters };
+}

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -17,6 +17,8 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
 import { formatDollars } from '../components/format.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
+import { ColumnsPicker } from '../components/data-table.js';
+import type { ColumnSpec } from '../components/data-table.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { getDimensionId } from '../lib/dimensions.js';
@@ -39,19 +41,6 @@ interface RowsState {
   data: ExplorerRowsResult | null;
   loading: boolean;
   error: string | null;
-}
-
-/** Columns the user can sort / filter on. Must line up with the server's
- *  SORTABLE_SCALAR_COLUMNS set and with the dim ids the handler emits as
- *  filter predicates. `dimId` is set when the column maps to a filter-able
- *  dimension — clicking a cell's value then adds it to the filter. */
-interface ColumnSpec {
-  readonly key: string;
-  readonly label: string;
-  readonly dimId: string | null;
-  readonly align: 'left' | 'right';
-  readonly mono?: boolean;
-  readonly truncate?: boolean;
 }
 
 const BASE_COLUMNS: readonly ColumnSpec[] = [
@@ -1018,198 +1007,6 @@ function RowsTable({ columns, allColumns, hiddenColumns, autoHiddenKeys, onHidde
           </tbody>
         </table>
       </div>
-    </div>
-  );
-}
-
-interface ColumnsPickerProps {
-  readonly allColumns: readonly ColumnSpec[];
-  readonly hiddenColumns: readonly string[];
-  readonly autoHiddenKeys: ReadonlySet<string>;
-  readonly onChange: (next: readonly string[]) => void;
-  readonly onOrderChange: (next: readonly string[]) => void;
-}
-
-function ColumnsPicker({ allColumns, hiddenColumns, autoHiddenKeys, onChange, onOrderChange }: ColumnsPickerProps): React.JSX.Element {
-  const [open, setOpen] = useState(false);
-  // The row currently being hovered during a drag — we use this to draw a
-  // blue top-border drop indicator. Separate from the dragged key because
-  // browsers don't give us dragover coords relative to the list.
-  const [dragOverKey, setDragOverKey] = useState<string | null>(null);
-  const [draggedKey, setDraggedKey] = useState<string | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const hiddenSet = useMemo(() => new Set(hiddenColumns), [hiddenColumns]);
-  // Picker count reflects what the table ACTUALLY renders — subtracting
-  // both manual hides and auto-hides keeps it honest. Otherwise "5/10
-  // shown" while the table renders 3 columns would be confusing.
-  const visibleCount = allColumns.filter(c => !hiddenSet.has(c.key) && !autoHiddenKeys.has(c.key)).length;
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClickOutside(e: MouseEvent) {
-      if (containerRef.current !== null && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    function handleEsc(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEsc);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEsc);
-    };
-  }, [open]);
-
-  function toggle(key: string) {
-    if (hiddenSet.has(key)) {
-      onChange(hiddenColumns.filter(k => k !== key));
-    } else {
-      onChange([...hiddenColumns, key]);
-    }
-  }
-
-  function showAll() {
-    onChange([]);
-  }
-
-  function hideAll() {
-    onChange(allColumns.map(c => c.key));
-  }
-
-  function resetOrder() {
-    onOrderChange([]);
-  }
-
-  function handleDrop(targetKey: string) {
-    if (draggedKey === null || draggedKey === targetKey) return;
-    const keys = allColumns.map(c => c.key);
-    const from = keys.indexOf(draggedKey);
-    const to = keys.indexOf(targetKey);
-    if (from === -1 || to === -1) return;
-    const next = [...keys];
-    next.splice(from, 1);
-    next.splice(to, 0, draggedKey);
-    onOrderChange(next);
-  }
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => { setOpen(prev => !prev); }}
-        className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border"
-        title="Choose and reorder columns"
-      >
-        <span>Columns</span>
-        <span className="tabular-nums text-text-muted">
-          {String(visibleCount)}/{String(allColumns.length)}
-        </span>
-      </button>
-      {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-80 rounded-lg border border-border bg-bg-secondary shadow-lg">
-          <div className="flex items-center justify-between border-b border-border px-3 py-2 text-[11px]">
-            <span className="text-text-muted">Drag to reorder</span>
-            <span className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={showAll}
-                className="text-text-secondary hover:text-text-primary"
-                disabled={hiddenColumns.length === 0}
-              >
-                Show all
-              </button>
-              <span className="text-text-muted">·</span>
-              <button
-                type="button"
-                onClick={hideAll}
-                className="text-text-secondary hover:text-text-primary"
-                disabled={hiddenColumns.length === allColumns.length}
-              >
-                Hide all
-              </button>
-              <span className="text-text-muted">·</span>
-              <button
-                type="button"
-                onClick={resetOrder}
-                className="text-text-secondary hover:text-text-primary"
-                title="Restore the default column order"
-              >
-                Reset order
-              </button>
-            </span>
-          </div>
-          <div className="max-h-96 overflow-y-auto py-1">
-            {allColumns.map(col => {
-              const checked = !hiddenSet.has(col.key);
-              const autoHidden = autoHiddenKeys.has(col.key);
-              const isDragging = draggedKey === col.key;
-              const isDropTarget = dragOverKey === col.key && draggedKey !== null && draggedKey !== col.key;
-              return (
-                <label
-                  key={col.key}
-                  draggable
-                  onDragStart={(e) => {
-                    setDraggedKey(col.key);
-                    e.dataTransfer.effectAllowed = 'move';
-                    e.dataTransfer.setData('text/plain', col.key);
-                  }}
-                  onDragOver={(e) => {
-                    e.preventDefault();
-                    e.dataTransfer.dropEffect = 'move';
-                    if (dragOverKey !== col.key) setDragOverKey(col.key);
-                  }}
-                  onDragLeave={() => {
-                    if (dragOverKey === col.key) setDragOverKey(null);
-                  }}
-                  onDrop={(e) => {
-                    e.preventDefault();
-                    handleDrop(col.key);
-                    setDragOverKey(null);
-                    setDraggedKey(null);
-                  }}
-                  onDragEnd={() => {
-                    setDragOverKey(null);
-                    setDraggedKey(null);
-                  }}
-                  className={[
-                    'flex items-center gap-2 px-2 py-1.5 text-xs select-none cursor-default',
-                    isDragging ? 'opacity-40' : '',
-                    isDropTarget ? 'border-t-2 border-t-accent' : 'border-t-2 border-t-transparent',
-                    'hover:bg-bg-tertiary',
-                  ].join(' ')}
-                >
-                  <span className="cursor-grab text-text-muted hover:text-text-secondary" title="Drag to reorder">⋮⋮</span>
-                  <input
-                    type="checkbox"
-                    className="accent-accent shrink-0"
-                    checked={checked}
-                    onChange={() => { toggle(col.key); }}
-                  />
-                  <span className={[
-                    'truncate flex-1',
-                    !checked || autoHidden ? 'text-text-muted' : 'text-text-primary',
-                  ].join(' ')}>
-                    {col.label}
-                  </span>
-                  {autoHidden && (
-                    <span
-                      className="text-[10px] text-text-muted uppercase tracking-wider shrink-0"
-                      title="Hidden because this column is pinned to a single filter value — clear or widen the filter to show it"
-                    >
-                      filtered
-                    </span>
-                  )}
-                  {!autoHidden && col.dimId !== null && col.dimId.startsWith('tag_') && (
-                    <span className="text-[10px] text-text-muted uppercase tracking-wider shrink-0">tag</span>
-                  )}
-                </label>
-              );
-            })}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -1,18 +1,12 @@
 import { useMemo } from 'react';
-import { useCostApi } from '../hooks/use-cost-api.js';
-import { useQuery } from '../hooks/use-query.js';
+import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { HeatmapChart } from '../components/heatmap-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { HeatmapCell } from '../components/heatmap-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
+import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
-
-interface DailyQueryResult {
-  readonly result: DailyCostsResult;
-  readonly groupBy: DimensionId;
-}
+import { dimensionLabelFor } from './widget.js';
 
 interface BuiltCells {
   readonly cells: readonly HeatmapCell[];
@@ -53,34 +47,20 @@ export function HeatmapWidget({
   dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
-  const api = useCostApi();
   const specGroupBy = spec.type === 'heatmap' ? spec.groupBy : undefined;
   const topN = spec.type === 'heatmap' ? (spec.topN ?? 12) : 12;
 
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
-  const query = useQuery<DailyQueryResult | null>(
-    async () => {
-      if (specGroupBy === undefined) return null;
-      if (fallbackDim === undefined) {
-        const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-        return { result, groupBy: specGroupBy };
-      }
-      const [primary, fallback] = await Promise.all([
-        api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
-        api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
-      ]);
-      if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
-      return { result: fallback, groupBy: fallbackDim };
-    },
-    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
-  );
+  const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
+    specGroupBy,
+    dateRange,
+    granularity,
+    globalFilters,
+    specFilters: spec.filters,
+  });
 
-  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const { cells, groups, dates } = useMemo(
-    () => buildCells(query.status === 'success' && query.data !== null ? query.data.result : null, topN),
-    [query, topN],
+    () => buildCells(dailyResult, topN),
+    [dailyResult, topN],
   );
 
   if (spec.type !== 'heatmap' || specGroupBy === undefined || activeGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -1,18 +1,12 @@
 import { useMemo } from 'react';
-import { useCostApi } from '../hooks/use-cost-api.js';
-import { useQuery } from '../hooks/use-query.js';
+import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { LineChart } from '../components/line-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { LineSeries } from '../components/line-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
+import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
-
-interface DailyQueryResult {
-  readonly result: DailyCostsResult;
-  readonly groupBy: DimensionId;
-}
+import { dimensionLabelFor } from './widget.js';
 
 function buildSeries(data: DailyCostsResult | null, topN: number): LineSeries[] {
   if (data === null) return [];
@@ -44,34 +38,20 @@ export function LineWidget({
   dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
-  const api = useCostApi();
   const specGroupBy = spec.type === 'line' ? spec.groupBy : undefined;
-
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
-  const query = useQuery<DailyQueryResult | null>(
-    async () => {
-      if (specGroupBy === undefined) return null;
-      if (fallbackDim === undefined) {
-        const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-        return { result, groupBy: specGroupBy };
-      }
-      const [primary, fallback] = await Promise.all([
-        api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
-        api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
-      ]);
-      if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
-      return { result: fallback, groupBy: fallbackDim };
-    },
-    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
-  );
-
-  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const topN = spec.type === 'line' ? (spec.topN ?? 6) : 6;
+
+  const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
+    specGroupBy,
+    dateRange,
+    granularity,
+    globalFilters,
+    specFilters: spec.filters,
+  });
+
   const series = useMemo(
-    () => buildSeries(query.status === 'success' && query.data !== null ? query.data.result : null, topN),
-    [query, topN],
+    () => buildSeries(dailyResult, topN),
+    [dailyResult, topN],
   );
 
   if (spec.type !== 'line' || specGroupBy === undefined || activeGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -1,19 +1,13 @@
 import { useMemo } from 'react';
-import { useCostApi } from '../hooks/use-cost-api.js';
-import { useQuery } from '../hooks/use-query.js';
+import { useCostWidgetQuery } from '../hooks/use-widget-query.js';
 import { PieChart } from '../components/pie-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { PieSlice } from '../components/pie-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult, DimensionId } from '@costgoblin/core/browser';
+import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
-
-interface PieQueryResult {
-  readonly result: CostResult;
-  readonly groupBy: DimensionId;
-}
+import { dimensionLabelFor } from './widget.js';
 
 function rowsToSlices(data: CostResult | null): PieSlice[] {
   if (data === null) return [];
@@ -33,37 +27,22 @@ export function PieWidget({
   dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
-  const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
   const specGroupBy = spec.type === 'pie' ? spec.groupBy : undefined;
   const specTitle = spec.title;
 
-  const baseFilters = mergeFilters(globalFilters, spec.filters);
+  const { query, activeGroupBy, costResult } = useCostWidgetQuery({
+    specGroupBy,
+    dateRange,
+    granularity,
+    globalFilters,
+    specFilters: spec.filters,
+  });
 
-  const fk = filtersKey(baseFilters);
-  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
-  const query = useQuery<PieQueryResult | null>(
-    async () => {
-      if (specGroupBy === undefined) return null;
-      if (fallbackDim === undefined) {
-        const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity });
-        return { result, groupBy: specGroupBy };
-      }
-      const [primary, fallback] = await Promise.all([
-        api.queryCosts({ groupBy: specGroupBy, dateRange, filters: baseFilters, granularity }),
-        api.queryCosts({ groupBy: fallbackDim, dateRange, filters: baseFilters, granularity }),
-      ]);
-      if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
-      return { result: fallback, groupBy: fallbackDim };
-    },
-    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
-  );
-
-  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const slices = useMemo(
-    () => rowsToSlices(query.status === 'success' && query.data !== null ? query.data.result : null),
-    [query],
+    () => rowsToSlices(costResult),
+    [costResult],
   );
 
   if (spec.type !== 'pie' || specGroupBy === undefined || activeGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,17 +1,10 @@
 import { useMemo, useState } from 'react';
 import { daysBetween } from '../lib/dates.js';
-import { useCostApi } from '../hooks/use-cost-api.js';
-import { useQuery } from '../hooks/use-query.js';
+import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { StackedBarChart, type BarDay, type HistogramTab } from '../components/stacked-bar-chart.js';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
-import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
+import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
-
-interface DailyQueryResult {
-  readonly result: DailyCostsResult;
-  readonly groupBy: DimensionId;
-}
 
 function getISOWeekStart(dateStr: string): string {
   const d = new Date(dateStr);
@@ -56,36 +49,23 @@ export function StackedBarWidget({
   granularity,
   globalFilters,
 }: WidgetCommonProps) {
-  const api = useCostApi();
   const focus = useCostFocus();
   const [tab, setTab] = useState<HistogramTab>('service');
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
 
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
-  const query = useQuery<DailyQueryResult | null>(
-    async () => {
-      if (specGroupBy === undefined) return null;
-      if (fallbackDim === undefined) {
-        const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-        return { result, groupBy: specGroupBy };
-      }
-      const [primary, fallback] = await Promise.all([
-        api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
-        api.queryDailyCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
-      ]);
-      if (primary.groups.length > 1) return { result: primary, groupBy: specGroupBy };
-      return { result: fallback, groupBy: fallbackDim };
-    },
-    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
-  );
+  const { query, dailyResult } = useDailyWidgetQuery({
+    specGroupBy,
+    dateRange,
+    granularity,
+    globalFilters,
+    specFilters: spec.filters,
+  });
 
   const periodDays = daysBetween(dateRange.start, dateRange.end);
   const useWeekly = periodDays > 90;
   const barDays = useMemo(
-    () => dailyToBarDays(query.status === 'success' && query.data !== null ? query.data.result : null, useWeekly),
-    [query, useWeekly],
+    () => dailyToBarDays(dailyResult, useWeekly),
+    [dailyResult, useWeekly],
   );
 
   if (spec.type !== 'stackedBar') return null;

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -1,19 +1,13 @@
 import { useMemo } from 'react';
-import { useCostApi } from '../hooks/use-cost-api.js';
-import { useQuery } from '../hooks/use-query.js';
+import { useCostWidgetQuery } from '../hooks/use-widget-query.js';
 import { TopNBarChart } from '../components/top-n-bar-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { TopNBar } from '../components/top-n-bar-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult, DimensionId } from '@costgoblin/core/browser';
+import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
-
-interface CostQueryResult {
-  readonly result: CostResult;
-  readonly groupBy: DimensionId;
-}
+import { dimensionLabelFor } from './widget.js';
 
 function rowsToBars(data: CostResult | null): TopNBar[] {
   if (data === null) return [];
@@ -33,35 +27,21 @@ export function TopNBarWidget({
   dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
-  const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
   const specGroupBy = spec.type === 'topNBar' ? spec.groupBy : undefined;
 
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
-  const query = useQuery<CostQueryResult | null>(
-    async () => {
-      if (specGroupBy === undefined) return null;
-      if (fallbackDim === undefined) {
-        const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-        return { result, groupBy: specGroupBy };
-      }
-      const [primary, fallback] = await Promise.all([
-        api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
-        api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
-      ]);
-      if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
-      return { result: fallback, groupBy: fallbackDim };
-    },
-    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
-  );
+  const { query, activeGroupBy, costResult } = useCostWidgetQuery({
+    specGroupBy,
+    dateRange,
+    granularity,
+    globalFilters,
+    specFilters: spec.filters,
+  });
 
-  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const bars = useMemo(
-    () => rowsToBars(query.status === 'success' && query.data !== null ? query.data.result : null),
-    [query],
+    () => rowsToBars(costResult),
+    [costResult],
   );
 
   if (spec.type !== 'topNBar' || specGroupBy === undefined || activeGroupBy === undefined) return null;

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -1,18 +1,12 @@
 import { useMemo } from 'react';
-import { useCostApi } from '../hooks/use-cost-api.js';
-import { useQuery } from '../hooks/use-query.js';
+import { useCostWidgetQuery } from '../hooks/use-widget-query.js';
 import { TreemapChart } from '../components/treemap-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { TreemapCell } from '../components/treemap-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult, DimensionId } from '@costgoblin/core/browser';
+import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, getDimensionFallback, mergeFilters } from './widget.js';
-
-interface CostQueryResult {
-  readonly result: CostResult;
-  readonly groupBy: DimensionId;
-}
+import { dimensionLabelFor } from './widget.js';
 
 function rowsToCells(data: CostResult | null): TreemapCell[] {
   if (data === null) return [];
@@ -27,33 +21,19 @@ export function TreemapWidget({
   dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
-  const api = useCostApi();
   const specGroupBy = spec.type === 'treemap' ? spec.groupBy : undefined;
 
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
-  const fallbackDim = specGroupBy === undefined ? undefined : getDimensionFallback(specGroupBy);
-  const query = useQuery<CostQueryResult | null>(
-    async () => {
-      if (specGroupBy === undefined) return null;
-      if (fallbackDim === undefined) {
-        const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-        return { result, groupBy: specGroupBy };
-      }
-      const [primary, fallback] = await Promise.all([
-        api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity }),
-        api.queryCosts({ groupBy: fallbackDim, dateRange, filters, granularity }),
-      ]);
-      if (primary.rows.length > 1) return { result: primary, groupBy: specGroupBy };
-      return { result: fallback, groupBy: fallbackDim };
-    },
-    [specGroupBy, fallbackDim, dateRange.start, dateRange.end, fk, granularity, api],
-  );
+  const { query, activeGroupBy, costResult } = useCostWidgetQuery({
+    specGroupBy,
+    dateRange,
+    granularity,
+    globalFilters,
+    specFilters: spec.filters,
+  });
 
-  const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
   const cells = useMemo(
-    () => rowsToCells(query.status === 'success' && query.data !== null ? query.data.result : null),
-    [query],
+    () => rowsToCells(costResult),
+    [costResult],
   );
 
   if (spec.type !== 'treemap' || specGroupBy === undefined || activeGroupBy === undefined) return null;


### PR DESCRIPTION
## Summary
- Extract `useDailyWidgetQuery` and `useCostWidgetQuery` hooks to eliminate repeated query+fallback+memo patterns across 6 widget files (line, heatmap, stacked-bar, treemap, top-n-bar, pie)
- Extract `executeWithPool` and `collectChunkRows` helpers in duckdb-worker.ts to deduplicate the 3 pairs of internally duplicated blocks (handleRequest/handlePreparedRequest, fetchAllRows/fetchAllRowsPrepared chunk loops)
- Extract `initWorkerLifecycle` utility shared by duckdb-client.ts and sync-client.ts to deduplicate worker ready/error/exit lifecycle management (~40 lines each)
- Remove duplicate `ColumnsPicker` component from explorer.tsx, now imports the shared one from data-table.tsx
- Net: -240 lines, 0 behavior changes, all tests pass