### PR TITLE
Replace top-level promise chains with async IIFE

### DIFF
--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -162,12 +162,15 @@ function send(msg: WorkerResponse): void {
   port.postMessage(msg);
 }
 
-void getPool().then(() => {
-  send({ kind: 'ready' });
-}).catch((err: unknown) => {
-  const message = err instanceof Error ? err.message : String(err);
-  send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
-});
+void (async () => {
+  try {
+    await getPool();
+    send({ kind: 'ready' });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
+  }
+})();
 
 async function handleRequest(req: { kind: 'query'; id: number; sql: string }): Promise<void> {
   // Check before acquiring a pool connection

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -186,8 +186,12 @@ app.on('window-all-closed', () => {
   }
 });
 
-void main().catch((err: unknown) => {
-  const message = err instanceof Error ? err.message : String(err);
-  process.stderr.write(`Fatal error: ${message}\n`);
-  process.exit(1);
-});
+void (async () => {
+  try {
+    await main();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Fatal error: ${message}\n`);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Fixes S7785 in main.ts and duckdb-worker.ts by wrapping in async IIFE instead of .then().catch().