### PR TITLE
Use top-level await in main.ts and duckdb-worker

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -5,7 +5,7 @@
   "main": "out/main/main.js",
   "scripts": {
     "build": "electron-vite build --sourcemap && npm run build:worker",
-    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron && esbuild src/main/sync-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/sync-worker.cjs --external:@duckdb/node-api --external:@aws-sdk/client-s3 --external:electron",
+    "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=esm --sourcemap --outfile=out/worker/duckdb-worker.mjs --external:@duckdb/node-api --external:electron && esbuild src/main/sync-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/sync-worker.cjs --external:@duckdb/node-api --external:@aws-sdk/client-s3 --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",
     "dev": "npm run build:worker && electron-vite dev"

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -160,15 +160,13 @@ function send(msg: WorkerResponse): void {
   port.postMessage(msg);
 }
 
-void (async () => {
-  try {
-    await getPool();
-    send({ kind: 'ready' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
-  }
-})();
+try {
+  await getPool();
+  send({ kind: 'ready' });
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
+}
 
 async function executeWithPool(
   id: number,

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
   // Worker bundles are built by `npm run build:worker` (esbuild) into out/worker/
   // — sibling to out/main/ where this file lives. We resolve up one level then
   // into out/worker/ to find them.
-  const duckdbWorkerPath = join(__dirname, '..', 'worker', 'duckdb-worker.cjs');
+  const duckdbWorkerPath = join(__dirname, '..', 'worker', 'duckdb-worker.mjs');
   const db = await createDuckDBClient(duckdbWorkerPath);
   logger.info('DuckDB worker ready');
 
@@ -186,12 +186,10 @@ app.on('window-all-closed', () => {
   }
 });
 
-void (async () => {
-  try {
-    await main();
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`Fatal error: ${message}\n`);
-    process.exit(1);
-  }
-})();
+try {
+  await main();
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`Fatal error: ${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- main.ts: replace async IIFE with top-level await (already ESM via electron-vite)
- duckdb-worker.ts: switch esbuild output from CJS to ESM, enabling top-level await
- sync-worker stays CJS (yaml dependency uses `require()` internally)
- Fixes both remaining S7785 SonarCloud issues