### PR TITLE
Split CI into parallel jobs with merged coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,35 +7,98 @@ on:
     branches: [main]
 
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
-
       - run: npm ci
-
       - name: Type check
         run: |
           npx tsc --noEmit -p packages/core/tsconfig.json
           npx tsc --noEmit -p packages/ui/tsconfig.json
           npx tsc --noEmit -p packages/desktop/tsconfig.json
-
       - name: Lint
         run: npx eslint packages/*/src/
 
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
       - name: Build workers
         run: npm run build:worker --workspace=packages/desktop
-
       - name: Test with coverage
         run: npx vitest run --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage
+      - name: Upload unit coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-unit
+          path: coverage/lcov.info
 
+  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Generate fixtures
+        run: npx tsx packages/core/src/__fixtures__/generate.ts --generate
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Build desktop
+        run: npm run build --workspace=packages/desktop
+      - name: Run E2E tests
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npx playwright test e2e/app.test.ts
+      - name: Collect E2E coverage
+        if: always()
+        run: npx tsx e2e/collect-coverage.ts
+      - name: Upload E2E coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-e2e
+          path: coverage-e2e/lcov.info
+          if-no-files-found: ignore
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+  sonarcloud:
+    runs-on: ubuntu-latest
+    needs: [lint, test-unit, test-e2e]
+    if: always() && needs.lint.result == 'success' && needs.test-unit.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download unit coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit
+          path: coverage
+      - name: Download E2E coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-e2e
+          path: coverage-e2e
+          merge-multiple: true
+        continue-on-error: true
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v5
         env:


### PR DESCRIPTION
## Summary
Rework CI into 4 parallel jobs for faster feedback:

| Job | Purpose | Produces |
|-----|---------|----------|
| **lint** | tsc + eslint | fast gate |
| **test-unit** | vitest with coverage | `coverage/lcov.info` |
| **test-e2e** | Playwright + V8 coverage | `coverage-e2e/lcov.info` |
| **sonarcloud** | download + merge + scan | coverage report |

- Unit and E2E coverage artifacts are uploaded separately, then downloaded and merged by the SonarCloud job
- E2E failures don't block SonarCloud (unit coverage still reported via `continue-on-error`)
- Supersedes #84