### PR TITLE
Fix ReDoS-vulnerable regex patterns

### DIFF
--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -20,7 +20,7 @@ export function applyNormalizationRule(value: string, rule: NormalizationRule): 
         .toLowerCase();
     case 'camelCase':
       return value
-        .replaceAll(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase())
+        .replaceAll(/[-_\s]+([^-_\s])/g, (_, c: string) => c.toUpperCase())
         .replace(/^(.)/, (_, c: string) => c.toLowerCase());
   }
 }

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -151,7 +151,9 @@ export function validateTablePath(tablePath: string): void {
   // Strip read_parquet wrapper if present
   const cleanPath = tablePath
     .replace(/^read_parquet\s*\(\s*/, '')
-    .replace(/\s*\)\s*$/, '')
+    .trimEnd()
+    .replace(/\)$/, '')
+    .trimStart()
     .replace(/^\[/, '')
     .replace(/\]$/, '')
     .replace(/^['"]/, '')
@@ -159,7 +161,7 @@ export function validateTablePath(tablePath: string): void {
 
   // Match the tier and period pattern
   // Pattern: {anything}/aws/raw/{tier}-{period}/*.parquet
-  const tierPattern = /\/aws\/raw\/([a-z-]+)-([^/]+)\/\*\.parquet/;
+  const tierPattern = /\/aws\/raw\/([a-z]+(?:-[a-z]+)*)-([^/]+)\/\*\.parquet/;
   const match = tierPattern.exec(cleanPath);
 
   if (match === null) {

--- a/packages/desktop/src/main/handlers/setup.ts
+++ b/packages/desktop/src/main/handlers/setup.ts
@@ -76,12 +76,16 @@ export function registerSetupHandlers(app: AppContext): void {
       const filePath = path.join(os.homedir(), '.aws', filename);
       try {
         const content = await fs.readFile(filePath, 'utf-8');
-        const profileRegex = /\[(?:profile\s+)?([^\]]+)\]/g;
-        let match = profileRegex.exec(content);
+        const sectionRegex = /\[([^\]]+)\]/g;
+        let match = sectionRegex.exec(content);
         while (match !== null) {
-          const name = match[1];
-          if (name !== undefined) profiles.add(name.trim());
-          match = profileRegex.exec(content);
+          let name = match[1];
+          if (name !== undefined) {
+            name = name.trim();
+            if (name.startsWith('profile ')) name = name.slice('profile '.length).trim();
+            profiles.add(name);
+          }
+          match = sectionRegex.exec(content);
         }
       } catch {
         // file doesn't exist

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -520,7 +520,7 @@ function applyPreviewNormalize(v: string, rule: string): string {
     case 'uppercase': return v.toUpperCase();
     case 'lowercase-kebab': return v.replaceAll(/([a-z])([A-Z])/g, '$1-$2').replaceAll('_', '-').replaceAll(' ', '-').toLowerCase();
     case 'lowercase-underscore': return v.replaceAll(/([a-z])([A-Z])/g, '$1_$2').replaceAll('-', '_').replaceAll(' ', '_').toLowerCase();
-    case 'camelCase': return v.replaceAll(/[-_\s]+(.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, (_, c: string) => c.toLowerCase());
+    case 'camelCase': return v.replaceAll(/[-_\s]+([^-_\s])/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, (_, c: string) => c.toLowerCase());
     default: return v;
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites 5 regexes flagged by SonarCloud (rule S5852) as vulnerable to super-linear runtime due to backtracking
- `normalize.ts` + `dimensions.tsx`: `(.)` → `([^-_\s])` to avoid overlap with `[-_\s]+`
- `identifier-validator.ts`: `\s*\)\s*$` → `trimEnd()` + `/\)$/`; `[a-z-]+` → `[a-z]+(?:-[a-z]+)*`
- `setup.ts`: split AWS profile regex into simple `[^\]]+` capture + `startsWith('profile ')` check