### PR TITLE
Fix CI E2E failures and deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -33,9 +33,9 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload unit coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-unit
           path: coverage/lcov.info
@@ -64,8 +64,8 @@ jobs:
       matrix:
         shard: [views-core, views-config, stress]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -83,14 +83,14 @@ jobs:
         run: npx tsx e2e/collect-coverage.ts
       - name: Upload E2E coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-e2e-${{ matrix.shard }}
           path: coverage-e2e/lcov.info
           if-no-files-found: ignore
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ matrix.shard }}
           path: playwright-report/
@@ -101,16 +101,16 @@ jobs:
     needs: [lint, test-unit, test-e2e]
     if: always() && needs.lint.result == 'success' && needs.test-unit.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Download unit coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-unit
           path: coverage
       - name: Download E2E coverage shards
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-e2e-*
           path: coverage-e2e-shards
@@ -122,6 +122,6 @@ jobs:
           cat coverage-e2e-shards/lcov.info > coverage-e2e/lcov.info 2>/dev/null || true
         continue-on-error: true
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,4 @@
 *
 !.gitkeep
 !.gitignore
+!profile.json

--- a/data/profile.json
+++ b/data/profile.json
@@ -1,0 +1,331 @@
+{
+  "rowCount": 1410240,
+  "dateRange": {
+    "min": "2026-04-01",
+    "max": "2026-05-01"
+  },
+  "services": [
+    {
+      "name": "ComputeSavingsPlans",
+      "costShare": 0.16475459552527583,
+      "avgDailyCost": 463.4399999999998
+    },
+    {
+      "name": "AmazonRDS",
+      "costShare": 0.15609360818179624,
+      "avgDailyCost": 439.0774141694493
+    },
+    {
+      "name": "AmazonCloudWatch",
+      "costShare": 0.07024795393151054,
+      "avgDailyCost": 197.601236349275
+    },
+    {
+      "name": "DatabaseSavingsPlans",
+      "costShare": 0.06325586746105294,
+      "avgDailyCost": 177.93312
+    },
+    {
+      "name": "AWSShield",
+      "costShare": 0.03569365613625859,
+      "avgDailyCost": 100.40307493122344
+    },
+    {
+      "name": "AmazonEC2",
+      "costShare": 0.028690520679278044,
+      "avgDailyCost": 80.70387876716164
+    },
+    {
+      "name": "AmazonVPC",
+      "costShare": 0.021706543616879327,
+      "avgDailyCost": 61.058573460327224
+    },
+    {
+      "name": "AmazonDynamoDB",
+      "costShare": 0.021108979823067125,
+      "avgDailyCost": 59.37767974248345
+    },
+    {
+      "name": "AWSBackup",
+      "costShare": 0.020037694035021356,
+      "avgDailyCost": 56.36424825652673
+    },
+    {
+      "name": "AmazonS3",
+      "costShare": 0.01339578668384199,
+      "avgDailyCost": 37.68115457396943
+    },
+    {
+      "name": "AWSDatabaseMigrationSvc",
+      "costShare": 0.012474521535258583,
+      "avgDailyCost": 35.089717782186625
+    },
+    {
+      "name": "AWSELB",
+      "costShare": 0.011631934493876086,
+      "avgDailyCost": 32.719595496897185
+    },
+    {
+      "name": "AmazonGuardDuty",
+      "costShare": 0.01052287976612826,
+      "avgDailyCost": 29.599923348215906
+    },
+    {
+      "name": "AWSXRay",
+      "costShare": 0.009103327617966683,
+      "avgDailyCost": 25.60684961666665
+    },
+    {
+      "name": "AmazonDetective",
+      "costShare": 0.00883073806496794,
+      "avgDailyCost": 24.840079487803344
+    },
+    {
+      "name": "AWSSecurityHub",
+      "costShare": 0.006146255080452273,
+      "avgDailyCost": 17.28886800033332
+    },
+    {
+      "name": "AmazonElastiCache",
+      "costShare": 0.00603109529686754,
+      "avgDailyCost": 16.96493378815336
+    },
+    {
+      "name": "awskms",
+      "costShare": 0.0054041247422878,
+      "avgDailyCost": 15.201321471980618
+    },
+    {
+      "name": "AmazonConnect",
+      "costShare": 0.005316384741698292,
+      "avgDailyCost": 14.954516666666624
+    },
+    {
+      "name": "AmazonECS",
+      "costShare": 0.005054141978837707,
+      "avgDailyCost": 14.216851136715054
+    }
+  ],
+  "accounts": [
+    {
+      "id": "439916378441",
+      "name": "solarisBank AG",
+      "costShare": 0.5948919302082044
+    },
+    {
+      "id": "890219777283",
+      "name": "Core Banking Default production",
+      "costShare": 0.09760368881115286
+    },
+    {
+      "id": "283567760452",
+      "name": "DiBa Cards RTA production",
+      "costShare": 0.04864716926520932
+    },
+    {
+      "id": "906323275771",
+      "name": "Identity Default production",
+      "costShare": 0.03487216712378947
+    },
+    {
+      "id": "778114978010",
+      "name": "PET Default production",
+      "costShare": 0.03452477974666616
+    },
+    {
+      "id": "739701143176",
+      "name": "Identity AFC production",
+      "costShare": 0.034158717173133485
+    },
+    {
+      "id": "970831335143",
+      "name": "B2C Banking Default production",
+      "costShare": 0.022863710307565167
+    },
+    {
+      "id": "154268422988",
+      "name": "Platform Tools",
+      "costShare": 0.022189325471037653
+    },
+    {
+      "id": "404977151305",
+      "name": "Platform CI",
+      "costShare": 0.021251057571422167
+    },
+    {
+      "id": "803260048317",
+      "name": "Platform Security",
+      "costShare": 0.016505840695565977
+    },
+    {
+      "id": "052243513717",
+      "name": "DiBa Cards Cards production",
+      "costShare": 0.016087654501272662
+    },
+    {
+      "id": "952637769795",
+      "name": "DiBa Cards Dunning production",
+      "costShare": 0.014837839662340098
+    },
+    {
+      "id": "754961608729",
+      "name": "Platform Production",
+      "costShare": 0.014495584295514839
+    },
+    {
+      "id": "361449312040",
+      "name": "Business Ops Default production",
+      "costShare": 0.01421442103920488
+    },
+    {
+      "id": "986752179579",
+      "name": "Platform VPN",
+      "costShare": 0.01285611412792092
+    }
+  ],
+  "regions": [
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "sa-east-1",
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2"
+  ],
+  "tags": {
+    "team": {
+      "values": [
+        "afc-risk-identification",
+        "process-engineering",
+        "BusinessOps",
+        "Productivity",
+        "bizops",
+        "cloud-and-platform-engineering",
+        "angus",
+        "Architecture",
+        "lending",
+        "undine",
+        "payments",
+        "cyber-security",
+        "core-banking",
+        "adac-migration",
+        "infosec",
+        "CPE",
+        "data-platform",
+        "cardano",
+        "sre",
+        "cards-vulcanus",
+        "account-management-and-services",
+        "transaction-processing",
+        "architecture",
+        "accounts",
+        "identity-kyc-b2c",
+        "cpe",
+        "auth",
+        "afc-risk-and-devices",
+        "site-reliability-engineering",
+        "cards-undine",
+        "gemini",
+        "productivity",
+        "identity-kyc-b2b",
+        "Cyber Security",
+        "identity-customer-compliance",
+        "Core-Banking",
+        "ai-taskforce",
+        "Information Security",
+        "cyber-platform",
+        "data-infrastructure",
+        "b2c-banking",
+        "ada",
+        "originators",
+        "credit-risk-tech",
+        "backoffice",
+        "tech-architects",
+        "Cyber-Security"
+      ],
+      "missingPercent": 0
+    },
+    "system": {
+      "values": [
+        "device-monitoring",
+        "person-identification",
+        "access-control-3ds",
+        "sms",
+        "tokenization",
+        "sdd-settlement",
+        "crt-gdpr-trigger",
+        "card-management",
+        "afc-suspicious-activity-report",
+        "sepa-instant-outgoing",
+        "architecture-infrastructure",
+        "webui",
+        "client-vpn",
+        "data-platform-account",
+        "policy",
+        "proxy-auth",
+        "siem",
+        "proxy-xs2a",
+        "decoupled-card-dunning",
+        "afc-cops-cards-monitoring",
+        "account-information",
+        "credit-scorer",
+        "workflow-api",
+        "ai-agents",
+        "sepa-direct-debit",
+        "partner",
+        "okular-orm",
+        "internal-mcp",
+        "partner-monitoring-reporter",
+        "infrastrcuture"
+      ],
+      "missingPercent": 0
+    },
+    "environment": {
+      "values": [
+        "ci",
+        "all",
+        "sandbox",
+        "tools",
+        "staging",
+        "test",
+        "security",
+        "backup",
+        "management",
+        "Staging",
+        "prod",
+        "production",
+        "sun",
+        "Production",
+        "n/a",
+        "testing"
+      ],
+      "missingPercent": 0
+    }
+  },
+  "costDistribution": {
+    "p50": 0.0000048,
+    "p90": 0.012330584020000035,
+    "p99": 0.864
+  },
+  "lineItemTypes": {
+    "Tax": 0.002415900839573406,
+    "SavingsPlanNegation": 0.003722061493079192,
+    "SavingsPlanCoveredUsage": 0.06546899818470615,
+    "SavingsPlanRecurringFee": 0.00008509189925119128,
+    "BundledDiscount": 0.000020563875652371227,
+    "Usage": 0.8114299693669162,
+    "DiscountedUsage": 0.003835517358747447,
+    "RIFee": 0.00008721919673247107,
+    "EdpDiscount": 0.1129346777853415
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "costgoblin",
+      "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
         "packages/ui",
@@ -23,6 +24,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.1",
         "postcss": "^8.5.8",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "v8-to-istanbul": "^9.3.0",
         "vitest": "^3.0.0"
@@ -7353,6 +7355,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -9022,6 +9037,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
@@ -9596,6 +9621,510 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.1",
     "postcss": "^8.5.8",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "v8-to-istanbul": "^9.3.0",
     "vitest": "^3.0.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,12 +2,24 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/*/src/**/*.test.{ts,tsx}'],
-    passWithNoTests: true,
     globalSetup: ['packages/core/src/__fixtures__/setup.ts'],
-    environmentMatchGlobs: [
-      ['packages/ui/src/**/*.test.tsx', 'jsdom'],
+    projects: [
+      {
+        test: {
+          name: 'node',
+          include: ['packages/{core,desktop}/src/**/*.test.ts'],
+          passWithNoTests: true,
+        },
+      },
+      {
+        test: {
+          name: 'ui',
+          include: ['packages/ui/src/**/*.test.tsx'],
+          environment: 'jsdom',
+          setupFiles: ['packages/ui/src/__tests__/setup.ts'],
+          passWithNoTests: true,
+        },
+      },
     ],
-    setupFiles: ['packages/ui/src/__tests__/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- **E2E fix**: Commit `data/profile.json` (statistical profile, no PII) so the fixture generator works in CI — was blocked by `data/.gitignore`
- **Node.js 24**: Bump checkout→v6, setup-node→v6, upload-artifact→v7, download-artifact→v8
- **SonarCloud**: Update sonarqube-scan-action v5→v7 (v5 has a known vulnerability)
- **Vitest**: Migrate deprecated `environmentMatchGlobs` to `test.projects`
- **tsx**: Add as root devDependency to avoid `npx` download warning in CI