### PR TITLE
Enable Electron renderer sandbox and CSP

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,11 +4,12 @@
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {
-    "build": "electron-vite build --sourcemap && npm run build:worker",
+    "build": "electron-vite build --sourcemap && npm run build:worker && npm run build:preload",
     "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron && esbuild src/main/sync-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/sync-worker.cjs --external:@duckdb/node-api --external:@aws-sdk/client-s3 --external:electron",
+    "build:preload": "esbuild src/preload/preload.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/preload/preload.cjs --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",
-    "dev": "npm run build:worker && electron-vite dev"
+    "dev": "npm run build:worker && npm run build:preload && electron-vite dev"
   },
   "dependencies": {
     "@aws-sdk/client-organizations": "^3.1029.0",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "electron-vite build --sourcemap && npm run build:worker && npm run build:preload",
     "build:worker": "esbuild src/main/duckdb-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/duckdb-worker.cjs --external:@duckdb/node-api --external:electron && esbuild src/main/sync-worker.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/sync-worker.cjs --external:@duckdb/node-api --external:@aws-sdk/client-s3 --external:electron",
-    "build:preload": "esbuild src/preload/preload.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/preload/preload.cjs --external:electron",
+    "build:preload": "esbuild src/preload/preload.ts --bundle --platform=node --format=cjs --sourcemap --outfile=out/worker/preload.cjs --external:electron",
     "check": "tsc --noEmit && eslint src/ && vitest run",
     "test": "vitest run",
     "dev": "npm run build:worker && npm run build:preload && electron-vite dev"

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -155,7 +155,7 @@ async function createWindow(db: DuckDBClient, syncClient: SyncClient): Promise<v
     titleBarStyle: 'hiddenInset',
     icon: join(__dirname, '..', '..', 'resources', 'icon.png'),
     webPreferences: {
-      preload: join(__dirname, '..', 'preload', 'preload.cjs'),
+      preload: join(__dirname, '..', 'worker', 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, session, shell } from 'electron';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { Session } from 'node:inspector';
 import { tmpdir } from 'node:os';
@@ -101,6 +101,35 @@ function resolveConfigPath(base: string, name: string): string {
   return typeof env === 'string' && env.length > 0 ? env : join(base, `${name}.yaml`);
 }
 
+function installCSP(): void {
+  const csp = isDev
+    ? [
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: blob:",
+        "font-src 'self' data:",
+        "connect-src 'self' ws:",
+      ].join('; ')
+    : [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: blob:",
+        "font-src 'self' data:",
+        "connect-src 'self'",
+      ].join('; ');
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [csp],
+      },
+    });
+  });
+}
+
 async function createWindow(db: DuckDBClient, syncClient: SyncClient): Promise<void> {
   const userDataPath = app.getPath('userData');
   const dataDir = process.env['COSTGOBLIN_DATA_DIR'] ?? join(userDataPath, 'data');
@@ -126,14 +155,10 @@ async function createWindow(db: DuckDBClient, syncClient: SyncClient): Promise<v
     titleBarStyle: 'hiddenInset',
     icon: join(__dirname, '..', '..', 'resources', 'icon.png'),
     webPreferences: {
-      preload: join(__dirname, '..', 'preload', 'preload.mjs'),
+      preload: join(__dirname, '..', 'preload', 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
-      // sandbox: true is the v1 target but breaks ESM preloads (electron-vite
-      // emits .mjs and the sandboxed loader is CJS-only). contextIsolation +
-      // nodeIntegration: false already prevent the main attack vectors;
-      // sandboxing remains a future hardening task.
-      sandbox: false,
+      sandbox: true,
     },
   });
 
@@ -171,6 +196,7 @@ async function main(): Promise<void> {
   const syncClient = await createSyncClient(syncWorkerPath);
   logger.info('Sync worker ready');
 
+  installCSP();
   await createWindow(db, syncClient);
 
   app.on('activate', () => {

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -212,10 +212,12 @@ app.on('window-all-closed', () => {
   }
 });
 
-try {
-  await main();
-} catch (err: unknown) {
-  const message = err instanceof Error ? err.message : String(err);
-  process.stderr.write(`Fatal error: ${message}\n`);
-  process.exit(1);
-}
+void (async () => {
+  try {
+    await main();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Fatal error: ${message}\n`);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary

- **Sandbox enabled** (`sandbox: true`): sandboxed preloads require CJS, but electron-vite forces ESM for `"type": "module"` packages. Solved by building the preload with esbuild (same pattern as the workers) into `out/worker/preload.cjs`.
- **Content Security Policy**: injected via `session.defaultSession.webRequest.onHeadersReceived`. Production restricts `script-src` to `'self'`; dev mode additionally allows `'unsafe-inline'` and `ws:` for Vite HMR. Both allow `'unsafe-inline'` styles (Radix positioning) and `data:`/`blob:` images.
- **Fix E2E regression from 8abb5a2**: restore async IIFE in main.ts entry point — top-level `await` blocks ESM module loading which prevents Playwright from connecting to the Electron debugger.