### PR TITLE
Upgrade to Electron 41, electron-vite 5, Vite 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
         "@playwright/test": "^1.59.1",
-        "@tailwindcss/postcss": "^4.2.2",
+        "@tailwindcss/postcss": "^4.2.4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/user-event": "^14.6.1",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -309,48 +309,48 @@
       }
     },
     "node_modules/@aws-sdk/client-organizations": {
-      "version": "3.1029.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.1029.0.tgz",
-      "integrity": "sha512-6Ag8ozoVc80+XVNjOwNtR3obCV+Bn3Svc9Ha7T+YApH6HwNUUC9WgnOXfbgXeVBhnaFxGSrf8kWj4XeM4d/tIw==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.1038.0.tgz",
+      "integrity": "sha512-lDk1wpJvvWZqgApd+nwtSN6+CuhZQpHSdSB3/9OQaV7t0w2gizbDKApJ5K+OTjETv3TG7bTDBmDiIgRzj0+Row==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-node": "^3.972.30",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -359,65 +359,65 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1025.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1025.0.tgz",
-      "integrity": "sha512-9Byz2fPnuGRRL8DTTD5bYPl1Iwm+ysLiCMgptffa3lNkVLCiUZc5e5TAaOjk0MvyeXieq+jn35AmQL6cgN2KHQ==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1038.0.tgz",
+      "integrity": "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
-        "@aws-sdk/middleware-expect-continue": "^3.972.8",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-location-constraint": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
-        "@aws-sdk/middleware-ssec": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-blob-browser": "^4.2.13",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/hash-stream-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/md5-js": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.14",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.14",
+        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -425,50 +425,50 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1032.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1032.0.tgz",
-      "integrity": "sha512-IkFS5VbAuLhyDIwfkeWvBsdY6fQpr9adDaA8q1dBVyW4qZEF8qfNB6Oq7s+NkUStWnkquKlBJtHv0qzW81RuNg==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1038.0.tgz",
+      "integrity": "sha512-xP6CqJkTOvX06+IghNmohu1qvzYQBmdszPHPCkCTJi3FKFQXdKpkSsaeAedBLExLW49GnHg0kVPblMGFFhirXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/credential-provider-node": "^3.972.32",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
-        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.17",
-        "@smithy/config-resolver": "^4.4.16",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/hash-node": "^4.2.14",
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/middleware-retry": "^4.5.3",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.47",
-        "@smithy/util-defaults-mode-node": "^4.2.52",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.16",
+        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -476,22 +476,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.1.tgz",
-      "integrity": "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==",
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
+      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.18",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/xml-builder": "^3.972.20",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -500,12 +501,12 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
-      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -513,12 +514,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.27.tgz",
-      "integrity": "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
+      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -529,20 +530,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.29.tgz",
-      "integrity": "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
+      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -550,19 +551,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.31.tgz",
-      "integrity": "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
+      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/credential-provider-env": "^3.972.27",
-        "@aws-sdk/credential-provider-http": "^3.972.29",
-        "@aws-sdk/credential-provider-login": "^3.972.31",
-        "@aws-sdk/credential-provider-process": "^3.972.27",
-        "@aws-sdk/credential-provider-sso": "^3.972.31",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-login": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/nested-clients": "^3.997.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -575,13 +576,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.31.tgz",
-      "integrity": "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
+      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -594,17 +595,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.32.tgz",
-      "integrity": "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
+      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.27",
-        "@aws-sdk/credential-provider-http": "^3.972.29",
-        "@aws-sdk/credential-provider-ini": "^3.972.31",
-        "@aws-sdk/credential-provider-process": "^3.972.27",
-        "@aws-sdk/credential-provider-sso": "^3.972.31",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-ini": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -617,12 +618,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.27.tgz",
-      "integrity": "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
+      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -634,14 +635,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.31.tgz",
-      "integrity": "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
+      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
-        "@aws-sdk/token-providers": "3.1032.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/token-providers": "3.1038.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -653,13 +654,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.31.tgz",
-      "integrity": "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
+      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -671,16 +672,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
-      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -689,14 +690,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
-      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -704,23 +705,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.6.tgz",
-      "integrity": "sha512-YckB8k1ejbyCg/g36gUMFLNzE4W5cERIa4MtsdO+wpTmJEP0+TB7okWIt7d8TDOvnb7SwvxJ21E4TGOBxFpSWQ==",
+      "version": "3.974.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.14.tgz",
+      "integrity": "sha512-mhTO3amGzYv/DQNbbqZo6UkHquBHlEEVRZwXmjeRqLmy1l9z3xCiFzglPL7n9JpVc2DZc9kjaraAn3JQrueZbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/crc64-nvme": "^3.972.5",
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -744,13 +745,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
-      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -788,23 +789,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
-      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
+      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -813,13 +814,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
-      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -827,18 +828,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.31.tgz",
-      "integrity": "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
+      "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.6",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -846,47 +847,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.21.tgz",
-      "integrity": "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==",
+      "version": "3.997.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
+      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.6",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
-        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.17",
-        "@smithy/config-resolver": "^4.4.16",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/hash-node": "^4.2.14",
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/middleware-retry": "^4.5.3",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.47",
-        "@smithy/util-defaults-mode-node": "^4.2.52",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -895,13 +897,13 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
-      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/config-resolver": "^4.4.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -911,16 +913,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
-      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
+      "version": "3.996.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
+      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -928,13 +930,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1032.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1032.0.tgz",
-      "integrity": "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
+      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -971,15 +973,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
-      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1011,12 +1013,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.17.tgz",
-      "integrity": "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==",
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
+      "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -1036,13 +1038,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
+      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1733,32 +1736,32 @@
       }
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.0-r.1.tgz",
-      "integrity": "sha512-VjvjqlCyqUJ22bydG/+9Jj5l0CEvx9QUn1SATBkKFY0+x6n4uHzt0kp/FKwXK9LNduXX6KCKtdF+6v5BcHScfA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.2-r.1.tgz",
+      "integrity": "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-bindings": "1.5.0-r.1"
+        "@duckdb/node-bindings": "1.5.2-r.1"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.0-r.1.tgz",
-      "integrity": "sha512-ViyoHROp0HhQ0ATT8z6h7SV6vEOxNjN8mJcdkst+3rJIU3Rd/gKs8exJO23LxFsjBuAiDpndpEwFihTAdfwJZg==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.2-r.1.tgz",
+      "integrity": "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==",
       "license": "MIT",
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.5.0-r.1",
-        "@duckdb/node-bindings-darwin-x64": "1.5.0-r.1",
-        "@duckdb/node-bindings-linux-arm64": "1.5.0-r.1",
-        "@duckdb/node-bindings-linux-x64": "1.5.0-r.1",
-        "@duckdb/node-bindings-win32-arm64": "1.5.0-r.1",
-        "@duckdb/node-bindings-win32-x64": "1.5.0-r.1"
+        "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.5.2-r.1",
+        "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.5.2-r.1"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.0-r.1.tgz",
-      "integrity": "sha512-s7CB9Y10f3dg2W4jdp6zipogxamq1pPQVt/r+YigZrHqk7HvytUeRH1VOI/3wuGTTlR8mAnIXj2MJIrmMujX4w==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==",
       "cpu": [
         "arm64"
       ],
@@ -1769,9 +1772,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.0-r.1.tgz",
-      "integrity": "sha512-2KxnGvg9o/Y915hwr1Mpb6Cbfrvt/w+/Fv0RZ2VXeQuxqNCMOoJd/7yQ8ffWXJRuOFU/vRmsR88koIjW+yJibA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==",
       "cpu": [
         "x64"
       ],
@@ -1782,9 +1785,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.0-r.1.tgz",
-      "integrity": "sha512-FpmcfJqhKoInjEa1o5dsWPQAFWYgu1eZgJP94nz6d+cKfdXEZKT6vGIwokZRzDqKLG1ZAOBZO2IhxzmW8IbbfA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==",
       "cpu": [
         "arm64"
       ],
@@ -1795,9 +1798,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.0-r.1.tgz",
-      "integrity": "sha512-A4Zgsaq6szEKiMyF1eWkoaHw0OMA0a8Zl8Ev0GcZSRjI4iGHgBQ1f/Zi/w3QKyz7OtjIiZ+pQ1XYyG4QoF6OKA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==",
       "cpu": [
         "x64"
       ],
@@ -1808,9 +1811,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-arm64": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.0-r.1.tgz",
-      "integrity": "sha512-ctCJ2HWpyiN3FNiCQ40RWALZLwKtJ8Aq4Anen2ush1I0a2E52T//jitLzl7DcX0quzew5eci1MQ+H5T1nVhzFA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1821,9 +1824,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.5.0-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.0-r.1.tgz",
-      "integrity": "sha512-725LoefejBlyG/bUcMfqVJkZ8KnZRLa0xOkszw9Q+V5G26iagJY3dgtGJAvwTeVJvXigSEVc5yD9Cj6kWR67vA==",
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==",
       "cpu": [
         "x64"
       ],
@@ -2695,6 +2698,18 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3920,15 +3935,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
-      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
@@ -3937,9 +3952,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.15",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
-      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -3948,7 +3963,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -3974,13 +3989,13 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
-      "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -3989,13 +4004,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
-      "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4003,12 +4018,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
-      "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4016,13 +4031,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
-      "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4030,13 +4045,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
-      "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4060,14 +4075,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.14.tgz",
-      "integrity": "sha512-rtQ5es8r/5v4rav7q5QTsfx9CtCyzrz/g7ZZZBH2xtMmd6G/KQrLOWfSHTvFOUPlVy59RQvxeBYJaLRoybMEyA==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^5.2.2",
         "@smithy/chunked-blob-reader-native": "^4.2.3",
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4090,12 +4105,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.13.tgz",
-      "integrity": "sha512-WdQ7HwUjINXETeh6dqUeob1UHIYx8kAn9PSp1HhM2WWegiZBYVy2WXIs1lB07SZLan/udys9SBnQGt9MQbDpdg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -4129,12 +4144,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.13.tgz",
-      "integrity": "sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -4157,13 +4172,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.30",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
-      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@smithy/types": "^4.14.1",
@@ -4176,19 +4191,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
-      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.6.tgz",
+      "integrity": "sha512-5zhmo2AkstmM/RMKYP0NHfmuYWBR+/umlmSuALgajLxf0X0rLE6d17MfzTxpzkILWVhwvCJkCyPH0AfMlbaucQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -4197,12 +4212,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
-      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -4240,9 +4255,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
-      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -4308,9 +4323,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
-      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1"
@@ -4352,17 +4367,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.11",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
-      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
-        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4459,13 +4474,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.47",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
-      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -4474,16 +4489,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.52",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
-      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/config-resolver": "^4.4.17",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -4492,9 +4507,9 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
-      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
@@ -4531,12 +4546,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
-      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.5.tgz",
+      "integrity": "sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/service-error-classification": "^4.3.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -4545,13 +4560,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
-      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -4589,9 +4604,9 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
-      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -4627,9 +4642,9 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4639,37 +4654,37 @@
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.4"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
       "cpu": [
         "arm64"
       ],
@@ -4684,9 +4699,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
       "cpu": [
         "arm64"
       ],
@@ -4701,9 +4716,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
       "cpu": [
         "x64"
       ],
@@ -4718,9 +4733,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
       "cpu": [
         "x64"
       ],
@@ -4735,9 +4750,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
       "cpu": [
         "arm"
       ],
@@ -4752,9 +4767,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
       "cpu": [
         "arm64"
       ],
@@ -4769,9 +4784,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
       ],
@@ -4786,9 +4801,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
       "cpu": [
         "x64"
       ],
@@ -4803,9 +4818,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
       ],
@@ -4820,9 +4835,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -4850,9 +4865,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
       "cpu": [
         "arm64"
       ],
@@ -4867,9 +4882,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
       "cpu": [
         "x64"
       ],
@@ -4884,29 +4899,29 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
-      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.4"
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
-      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
-        "tailwindcss": "4.2.2"
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -5219,13 +5234,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -6665,15 +6680,15 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "34.5.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-34.5.8.tgz",
-      "integrity": "sha512-vxLD65mabTzYmEVa9KceMHM0+zO+vqgrhcyNVlmTd0IGV5J7XZ8v/qElm0o4YQ4wPeq7olZkUjZkBQQEdr23/g==",
+      "version": "41.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
+      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -6691,28 +6706,28 @@
       "license": "ISC"
     },
     "node_modules/electron-vite": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-3.1.0.tgz",
-      "integrity": "sha512-M7aAzaRvSl5VO+6KN4neJCYLHLpF/iWo5ztchI/+wMxIieDZQqpbCYfaEHHHPH6eupEzfvZdLYdPdmvGqoVe0Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-5.0.0.tgz",
+      "integrity": "sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/plugin-transform-arrow-functions": "^7.25.9",
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
         "cac": "^6.7.14",
-        "esbuild": "^0.25.1",
-        "magic-string": "^0.30.17",
+        "esbuild": "^0.25.11",
+        "magic-string": "^0.30.19",
         "picocolors": "^1.1.1"
       },
       "bin": {
         "electron-vite": "bin/electron-vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "@swc/core": "^1.0.0",
-        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "@swc/core": {
@@ -7175,9 +7190,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -7186,9 +7201,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8275,9 +8291,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.500.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.500.0.tgz",
-      "integrity": "sha512-IyGvnYOSBKiF7rFI3p0tDw4ZI+TKnn1b5LPF2/q3NBmA7zYaDagevs1eMNyPRpKdFXxgma6rEu6+2ylJaaGnJA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9461,9 +9477,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
       "license": "MIT"
     },
@@ -10178,9 +10194,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10294,24 +10310,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -10320,14 +10336,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -10389,6 +10405,490 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vitest": {
@@ -10724,8 +11224,8 @@
       "name": "@costgoblin/core",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1025.0",
-        "@duckdb/node-api": "^1.5.0-r.1",
+        "@aws-sdk/client-s3": "^3.1038.0",
+        "@duckdb/node-api": "^1.5.2-r.1",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
@@ -10737,27 +11237,27 @@
       "name": "@costgoblin/desktop",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-sdk/client-organizations": "^3.1029.0",
-        "@aws-sdk/client-s3": "^3.1025.0",
-        "@aws-sdk/client-ssm": "^3.1032.0",
-        "@costgoblin/core": "*",
-        "@costgoblin/ui": "*",
-        "@duckdb/node-api": "^1.5.0-r.1",
+        "@aws-sdk/client-organizations": "^3.1038.0",
+        "@aws-sdk/client-s3": "^3.1038.0",
+        "@aws-sdk/client-ssm": "^3.1038.0",
+        "@duckdb/node-api": "^1.5.2-r.1",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
-        "@tailwindcss/vite": "^4.0.0",
+        "@costgoblin/core": "*",
+        "@costgoblin/ui": "*",
+        "@tailwindcss/vite": "^4.2.4",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.0.0",
-        "electron": "^34.0.0",
-        "electron-vite": "^3.0.0",
+        "electron": "^41.0.0",
+        "electron-vite": "^5.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwindcss": "^4.0.0",
+        "tailwindcss": "^4.2.4",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0",
+        "vite": "^7.0.0",
         "vitest": "^3.0.0"
       }
     },
@@ -10783,7 +11283,7 @@
         "@visx/tooltip": "^4.0.1-alpha.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
-        "lucide-react": "^0.500.0",
+        "lucide-react": "^1.11.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@playwright/test": "^1.59.1",
-    "@tailwindcss/postcss": "^4.2.2",
+    "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/user-event": "^14.6.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1025.0",
-    "@duckdb/node-api": "^1.5.0-r.1",
+    "@aws-sdk/client-s3": "^3.1038.0",
+    "@duckdb/node-api": "^1.5.2-r.1",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/packages/desktop/electron-vite.config.ts
+++ b/packages/desktop/electron-vite.config.ts
@@ -1,9 +1,8 @@
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { defineConfig } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin({ exclude: ['@costgoblin/core'] })],
     build: {
       outDir: 'out/main',
       commonjsOptions: {
@@ -15,7 +14,6 @@ export default defineConfig({
     },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
     build: {
       outDir: 'out/preload',
       lib: {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,27 +12,27 @@
     "dev": "npm run build:worker && npm run build:preload && electron-vite dev"
   },
   "dependencies": {
-    "@aws-sdk/client-organizations": "^3.1029.0",
-    "@aws-sdk/client-s3": "^3.1025.0",
-    "@aws-sdk/client-ssm": "^3.1032.0",
-    "@costgoblin/core": "*",
-    "@costgoblin/ui": "*",
-    "@duckdb/node-api": "^1.5.0-r.1",
+    "@aws-sdk/client-organizations": "^3.1038.0",
+    "@aws-sdk/client-s3": "^3.1038.0",
+    "@aws-sdk/client-ssm": "^3.1038.0",
+    "@duckdb/node-api": "^1.5.2-r.1",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "yaml": "^2.7.0"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.0.0",
+    "@costgoblin/core": "*",
+    "@costgoblin/ui": "*",
+    "@tailwindcss/vite": "^4.2.4",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "electron": "^34.0.0",
-    "electron-vite": "^3.0.0",
+    "electron": "^41.0.0",
+    "electron-vite": "^5.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.0",
+    "tailwindcss": "^4.2.4",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0",
+    "vite": "^7.0.0",
     "vitest": "^3.0.0"
   }
 }

--- a/packages/desktop/src/__tests__/sync-worker.test.ts
+++ b/packages/desktop/src/__tests__/sync-worker.test.ts
@@ -54,7 +54,10 @@ describe('Sync Worker', () => {
         expect(msg).toEqual({ kind: 'ready' });
         resolve();
       });
-      worker.once('error', (err) => { clearTimeout(timeout); reject(err); });
+      worker.once('error', (e: unknown) => {
+        clearTimeout(timeout);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      });
     });
   });
 

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -367,7 +367,6 @@ export function createAppContext(ctx: IpcContext): AppContext {
     if (cached !== undefined) return cached;
     const fetch = (async (): Promise<ReadonlySet<string>> => {
       try {
-        const { listLocalMonths } = await import('@costgoblin/core');
         const months = await listLocalMonths(ctx.dataDir, tier);
         if (months.length === 0) return new Set<string>();
         // First-month sample is enough — CUR schema is stable across

--- a/packages/desktop/src/main/worker-lifecycle.ts
+++ b/packages/desktop/src/main/worker-lifecycle.ts
@@ -32,10 +32,15 @@ export async function initWorkerLifecycle<P extends { reject: (err: Error) => vo
       }
     };
     worker.on('message', onMessage);
-    worker.once('error', (err) => { state.fatalError = err; reject(err); });
+    worker.once('error', (e: unknown) => {
+      const err = e instanceof Error ? e : new Error(String(e));
+      state.fatalError = err;
+      reject(err);
+    });
   });
 
-  worker.on('error', (err) => {
+  worker.on('error', (e: unknown) => {
+    const err = e instanceof Error ? e : new Error(String(e));
     state.fatalError = err;
     for (const entry of pending.values()) entry.reject(err);
     pending.clear();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,7 +32,7 @@
     "@visx/tooltip": "^4.0.1-alpha.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "lucide-react": "^0.500.0",
+    "lucide-react": "^1.11.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.0",


### PR DESCRIPTION
## Summary

- **Electron** 34 → 41 (Chromium 146, Node 24) — was EOL since Electron 37
- **electron-vite** 3 → 5, **Vite** 6 → 7
- **Tailwind CSS** + plugins → 4.2.4 (Vite 7 compat)
- **lucide-react** 0.500 → 1.11, **@duckdb/node-api** 1.5.0 → 1.5.2
- **AWS SDK** clients unified to 3.1038.0
- Migrated from deprecated `externalizeDepsPlugin` to `build.externalizeDeps` config
- Moved `@costgoblin/core` and `@costgoblin/ui` to devDependencies (electron-vite 5 bundles devDeps, externalizes deps — the standard monorepo pattern)
- Fixed stricter lint errors: typed Worker error handlers as `unknown`
- Removed redundant dynamic `import('@costgoblin/core')` in context.ts