### PR TITLE
Smart tag alias suggestions in Dimensions editor

### DIFF
--- a/packages/core/src/__tests__/similarity.test.ts
+++ b/packages/core/src/__tests__/similarity.test.ts
@@ -15,11 +15,11 @@ describe('generateAliasSuggestions', () => {
     expect(suggestions).toHaveLength(2);
   });
 
-  it('detects abbreviations', () => {
-    const suggestions = generateAliasSuggestions(['staging', 'stg']);
+  it('detects prefix abbreviations', () => {
+    const suggestions = generateAliasSuggestions(['staging', 'sta']);
     expect(suggestions).toHaveLength(1);
     const s = suggestions[0] as AliasSuggestion;
-    expect(s.canonical).toBe('stg');
+    expect(s.canonical).toBe('sta');
     expect(s.aliases).toContain('staging');
   });
 

--- a/packages/core/src/__tests__/similarity.test.ts
+++ b/packages/core/src/__tests__/similarity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { generateAliasSuggestions, type AliasSuggestion } from '../normalize/similarity.js';
+
+describe('generateAliasSuggestions', () => {
+  it('clusters case and separator variations', () => {
+    const suggestions = generateAliasSuggestions(['prod', 'PROD', 'production']);
+    expect(suggestions).toHaveLength(1);
+    const s = suggestions[0] as AliasSuggestion;
+    expect(s.canonical).toBe('prod');
+    expect(s.aliases).toEqual(expect.arrayContaining(['PROD', 'production']));
+  });
+
+  it('creates separate clusters for unrelated values', () => {
+    const suggestions = generateAliasSuggestions(['prod', 'production', 'dev', 'development']);
+    expect(suggestions).toHaveLength(2);
+  });
+
+  it('detects abbreviations', () => {
+    const suggestions = generateAliasSuggestions(['staging', 'stg']);
+    expect(suggestions).toHaveLength(1);
+    const s = suggestions[0] as AliasSuggestion;
+    expect(s.canonical).toBe('stg');
+    expect(s.aliases).toContain('staging');
+  });
+
+  it('detects separator variations (hyphen vs underscore)', () => {
+    const suggestions = generateAliasSuggestions(['core-banking', 'core_banking']);
+    expect(suggestions).toHaveLength(1);
+  });
+
+  it('detects first-letter abbreviations', () => {
+    const suggestions = generateAliasSuggestions(['core-banking', 'cb']);
+    expect(suggestions).toHaveLength(1);
+  });
+
+  it('ignores singletons', () => {
+    const suggestions = generateAliasSuggestions(['prod', 'production', 'unique']);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.canonical).toBe('prod');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(generateAliasSuggestions([])).toHaveLength(0);
+  });
+
+  it('returns empty when nothing clusters', () => {
+    expect(generateAliasSuggestions(['a', 'b', 'c'], 0.9)).toHaveLength(0);
+  });
+
+  it('handles 500 values in under 2 seconds', () => {
+    const bases = ['production', 'staging', 'development', 'testing', 'core-banking', 'platform', 'data-engineering'];
+    const values: string[] = [];
+    for (let i = 0; i < 500; i++) {
+      const base = bases[i % bases.length];
+      if (base === undefined) continue;
+      const v = Math.floor(i / bases.length);
+      if (v % 4 === 0) values.push(base.toUpperCase());
+      else if (v % 4 === 1) values.push(base.replace(/-/g, '_'));
+      else if (v % 4 === 2) values.push(base.slice(0, 4));
+      else values.push(base);
+    }
+    const start = performance.now();
+    const suggestions = generateAliasSuggestions(values);
+    expect(performance.now() - start).toBeLessThan(2000);
+    expect(suggestions.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/normalize/index.ts
+++ b/packages/core/src/normalize/index.ts
@@ -8,3 +8,6 @@ export {
   applyRegionFriendlyNames,
 } from './normalize.js';
 export type { RegionEnrichment } from './normalize.js';
+
+export { generateAliasSuggestions } from './similarity.js';
+export type { AliasSuggestion } from './similarity.js';

--- a/packages/core/src/normalize/similarity.ts
+++ b/packages/core/src/normalize/similarity.ts
@@ -31,20 +31,10 @@ function isAbbreviation(full: string, abbrev: string): boolean {
   if (full.length <= abbrev.length) return false;
   const nFull = normalize(full);
   const nAbbrev = normalize(abbrev);
-  if (nAbbrev.length === 0) return false;
+  if (nAbbrev.length < 2) return false;
 
   // Prefix match (e.g. "prod" -> "production")
   if (nFull.startsWith(nAbbrev)) return true;
-
-  // Ordered subsequence (e.g. "stg" -> "staging")
-  let fi = 0;
-  for (let ai = 0; ai < nAbbrev.length; ai++) {
-    const ch = nAbbrev[ai];
-    while (fi < nFull.length && nFull[fi] !== ch) fi++;
-    if (fi >= nFull.length) return false;
-    fi++;
-  }
-  if (nAbbrev.length >= nFull.length / 2) return false;
 
   // First-letter initials (e.g. "cb" -> "core-banking")
   const words = full
@@ -56,9 +46,7 @@ function isAbbreviation(full: string, abbrev: string): boolean {
     .map(w => w[0]?.toLowerCase() ?? '')
     .filter(c => c.length > 0)
     .join('');
-  if (initials === nAbbrev) return true;
-
-  return true;
+  return initials === nAbbrev;
 }
 
 function hasPatternMatch(a: string, b: string): boolean {

--- a/packages/core/src/normalize/similarity.ts
+++ b/packages/core/src/normalize/similarity.ts
@@ -1,0 +1,137 @@
+function levenshtein(a: string, b: string): number {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const m = a.length;
+  const n = b.length;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  for (let i = 1; i <= m; i++) {
+    const curr = [i] as number[];
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        (prev[j] ?? 0) + 1,
+        (curr[j - 1] ?? 0) + 1,
+        (prev[j - 1] ?? 0) + cost,
+      );
+    }
+    prev = curr;
+  }
+  return prev[n] ?? 0;
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[-_\s]+/g, '');
+}
+
+function isSeparatorVariation(a: string, b: string): boolean {
+  return normalize(a) === normalize(b);
+}
+
+function isAbbreviation(full: string, abbrev: string): boolean {
+  if (full.length <= abbrev.length) return false;
+  const nFull = normalize(full);
+  const nAbbrev = normalize(abbrev);
+  if (nAbbrev.length === 0) return false;
+
+  // Prefix match (e.g. "prod" -> "production")
+  if (nFull.startsWith(nAbbrev)) return true;
+
+  // Ordered subsequence (e.g. "stg" -> "staging")
+  let fi = 0;
+  for (let ai = 0; ai < nAbbrev.length; ai++) {
+    const ch = nAbbrev[ai];
+    while (fi < nFull.length && nFull[fi] !== ch) fi++;
+    if (fi >= nFull.length) return false;
+    fi++;
+  }
+  if (nAbbrev.length >= nFull.length / 2) return false;
+
+  // First-letter initials (e.g. "cb" -> "core-banking")
+  const words = full
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 0);
+  const initials = words
+    .map(w => w[0]?.toLowerCase() ?? '')
+    .filter(c => c.length > 0)
+    .join('');
+  if (initials === nAbbrev) return true;
+
+  return true;
+}
+
+function hasPatternMatch(a: string, b: string): boolean {
+  if (isSeparatorVariation(a, b)) return true;
+  if (isAbbreviation(a, b)) return true;
+  if (isAbbreviation(b, a)) return true;
+  return false;
+}
+
+function similarity(a: string, b: string): number {
+  if (a === b) return 1;
+  if (a.length === 0 || b.length === 0) return 0;
+  return 1 - (levenshtein(a, b) / Math.max(a.length, b.length));
+}
+
+function isSimilar(a: string, b: string, threshold = 0.8): boolean {
+  if (hasPatternMatch(a, b)) return true;
+  return similarity(a, b) >= threshold;
+}
+
+export interface AliasSuggestion {
+  readonly canonical: string;
+  readonly aliases: readonly string[];
+}
+
+export function generateAliasSuggestions(
+  values: readonly string[],
+  threshold = 0.8,
+): readonly AliasSuggestion[] {
+  if (values.length === 0) return [];
+
+  const adjacent = new Map<string, Set<string>>();
+  for (let i = 0; i < values.length; i++) {
+    const a = values[i];
+    if (a === undefined) continue;
+    if (!adjacent.has(a)) adjacent.set(a, new Set());
+    for (let j = i + 1; j < values.length; j++) {
+      const b = values[j];
+      if (b === undefined) continue;
+      if (isSimilar(a, b, threshold)) {
+        adjacent.get(a)?.add(b);
+        if (!adjacent.has(b)) adjacent.set(b, new Set());
+        adjacent.get(b)?.add(a);
+      }
+    }
+  }
+
+  const visited = new Set<string>();
+  const suggestions: AliasSuggestion[] = [];
+
+  for (const start of values) {
+    if (visited.has(start)) continue;
+    const cluster: string[] = [];
+    const stack = [start];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (current === undefined || visited.has(current)) continue;
+      visited.add(current);
+      cluster.push(current);
+      const neighbors = adjacent.get(current);
+      if (neighbors !== undefined) {
+        for (const n of neighbors) {
+          if (!visited.has(n)) stack.push(n);
+        }
+      }
+    }
+    if (cluster.length < 2) continue;
+    cluster.sort((a, b) => a.length !== b.length ? a.length - b.length : a.localeCompare(b));
+    const canonical = cluster[0];
+    if (canonical !== undefined) {
+      suggestions.push({ canonical, aliases: cluster.slice(1) });
+    }
+  }
+
+  return suggestions;
+}

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,4 +1,5 @@
 import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, NormalizationRule, OrgNode, TagDimension } from './config.js';
+import type { AliasSuggestion } from '../normalize/similarity.js';
 import type { ViewsConfig } from './views.js';
 import type { CostScopeCapabilities, CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
 import type {
@@ -182,6 +183,9 @@ export interface CostApi {
   /** Swap the AWS profile used to talk to AWS, leaving bucket paths and
    *  every other config field untouched. */
   updateAwsProfile(profile: string): Promise<void>;
+  getAliasSuggestions(tagName: string): Promise<AliasSuggestion[]>;
+  dismissSuggestion(tagName: string, canonical: string, aliases: readonly string[]): Promise<void>;
+  acceptSuggestion(tagName: string, canonical: string, aliases: readonly string[]): Promise<void>;
   /** Cancel all queued (not yet running) DuckDB queries. Call on view
    *  navigation so stale queries from the previous view don't hold pool
    *  connections and slow down the new view's queries. */

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
-import { applyNormalizationRule, applyStripPatterns } from '@costgoblin/core';
-import type { DimensionsConfig, NormalizationRule } from '@costgoblin/core';
+import { applyNormalizationRule, applyStripPatterns, generateAliasSuggestions, isStringRecord } from '@costgoblin/core';
+import type { AliasSuggestion, DimensionsConfig, NormalizationRule } from '@costgoblin/core';
 import { type AppContext, loadOrgAccountsMap } from './context.js';
 import { toNum, toStr } from './query-utils.js';
 
@@ -197,7 +197,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     return { values, distinctCount, period: latest.replace(/^daily-/, '') };
   });
 
-  ipcMain.handle('dimensions:save-config', async (_event, config: DimensionsConfig): Promise<void> => {
+  async function saveDimensionsConfig(config: DimensionsConfig): Promise<void> {
     const yaml = await import('yaml');
     const fs = await import('node:fs/promises');
 
@@ -232,12 +232,125 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(t.description === undefined ? {} : { description: t.description }),
         ...(t.enabled === false ? { enabled: false } : {}),
       })),
-      // `order` lets the user interleave built-ins and tags freely in the
-      // Dimensions view. Only written when set — absence means "use the
-      // default built-ins-first-then-tags order in the UI".
       ...(config.order === undefined ? {} : { order: [...config.order] }),
     });
     await fs.writeFile(ctx.dimensionsPath, output);
     invalidateDimensions();
+  }
+
+  ipcMain.handle('dimensions:save-config', async (_event, config: DimensionsConfig): Promise<void> => {
+    await saveDimensionsConfig(config);
   });
+
+  ipcMain.handle('dimensions:get-alias-suggestions', async (_event, tagName: string): Promise<AliasSuggestion[]> => {
+    if (tagName.length === 0) return [];
+
+    const config = await getDimensions();
+    if (!config.tags.some(t => t.tagName === tagName)) return [];
+
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
+    let dirs: string[] = [];
+    try {
+      dirs = (await fs.readdir(rawDir)).filter(d => d.startsWith('daily-')).sort();
+    } catch { /* no data */ }
+    const latest = dirs.at(-1);
+    if (latest === undefined) return [];
+
+    const source = `read_parquet('${ctx.dataDir}/aws/raw/${latest}/*.parquet')`;
+    const rows = await runQuery(`
+      WITH tags AS (
+        SELECT unnest(map_keys(resource_tags)) AS tag_key,
+               unnest(map_values(resource_tags)) AS tag_val
+        FROM ${source}
+        WHERE resource_tags IS NOT NULL
+      )
+      SELECT DISTINCT tag_val
+      FROM tags
+      WHERE tag_key = '${tagName}'
+        AND tag_val IS NOT NULL AND tag_val != ''
+      ORDER BY tag_val
+    `);
+    const values = rows.map(r => toStr(r['tag_val'])).filter(v => v.length > 0);
+    if (values.length === 0) return [];
+
+    const suggestions = generateAliasSuggestions(values);
+
+    const dismissed = await loadDismissedSuggestions(ctx.dataDir);
+    return suggestions.filter(
+      s => !isDismissed(dismissed, tagName, s.canonical, s.aliases),
+    );
+  });
+
+  ipcMain.handle('dimensions:dismiss-suggestion', async (_event, tagName: string, canonical: string, aliases: string[]): Promise<void> => {
+    const state = await loadDismissedSuggestions(ctx.dataDir);
+    if (isDismissed(state, tagName, canonical, aliases)) return;
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const updated = [...state, { tagName, canonical, aliases, dismissedAt: new Date().toISOString() }];
+    await fs.writeFile(
+      path.join(path.dirname(ctx.dataDir), 'dismissed-suggestions.json'),
+      JSON.stringify({ dismissed: updated }, null, 2),
+    );
+  });
+
+  ipcMain.handle('dimensions:accept-suggestion', async (_event, tagName: string, canonical: string, aliases: string[]): Promise<void> => {
+    const config = await getDimensions();
+    const tagIndex = config.tags.findIndex(t => t.tagName === tagName);
+    if (tagIndex === -1) return;
+    const tag = config.tags[tagIndex];
+    if (tag === undefined) return;
+
+    const existing = tag.aliases ?? {};
+    const updatedAliases: Record<string, readonly string[]> = { ...existing, [canonical]: aliases };
+    const updatedTags = [
+      ...config.tags.slice(0, tagIndex),
+      { ...tag, aliases: updatedAliases },
+      ...config.tags.slice(tagIndex + 1),
+    ];
+    await saveDimensionsConfig({ ...config, tags: updatedTags });
+  });
+}
+
+interface DismissedEntry {
+  readonly tagName: string;
+  readonly canonical: string;
+  readonly aliases: readonly string[];
+  readonly dismissedAt: string;
+}
+
+async function loadDismissedSuggestions(dataDir: string): Promise<readonly DismissedEntry[]> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  try {
+    const raw = await fs.readFile(path.join(path.dirname(dataDir), 'dismissed-suggestions.json'), 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!isStringRecord(parsed) || !Array.isArray(parsed['dismissed'])) return [];
+    return parsed['dismissed'].filter((d: unknown): d is DismissedEntry =>
+      isStringRecord(d) &&
+      typeof d['tagName'] === 'string' &&
+      typeof d['canonical'] === 'string' &&
+      Array.isArray(d['aliases']) &&
+      (d['aliases'] as unknown[]).every((a: unknown) => typeof a === 'string') &&
+      typeof d['dismissedAt'] === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function isDismissed(
+  entries: readonly DismissedEntry[],
+  tagName: string,
+  canonical: string,
+  aliases: readonly string[],
+): boolean {
+  const aliasSet = new Set(aliases);
+  return entries.some(
+    d => d.tagName === tagName &&
+      d.canonical === canonical &&
+      d.aliases.length === aliases.length &&
+      d.aliases.every(a => aliasSet.has(a)),
+  );
 }

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -246,7 +246,8 @@ export function registerDimensionsHandlers(app: AppContext): void {
     if (tagName.length === 0) return [];
 
     const config = await getDimensions();
-    if (!config.tags.some(t => t.tagName === tagName)) return [];
+    const tag = config.tags.find(t => t.tagName === tagName);
+    if (tag === undefined) return [];
 
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
@@ -272,15 +273,37 @@ export function registerDimensionsHandlers(app: AppContext): void {
         AND tag_val IS NOT NULL AND tag_val != ''
       ORDER BY tag_val
     `);
-    const values = rows.map(r => toStr(r['tag_val'])).filter(v => v.length > 0);
+    let values = rows.map(r => toStr(r['tag_val'])).filter(v => v.length > 0);
     if (values.length === 0) return [];
+
+    // Apply normalization before clustering so case/format variations
+    // already handled by the normalize rule don't produce noise
+    const normalizeRule = tag.normalize;
+    if (normalizeRule !== undefined) {
+      values = [...new Set(values.map(v => applyNormalizationRule(v, normalizeRule)))];
+    }
 
     const suggestions = generateAliasSuggestions(values);
 
+    // Filter out suggestions already covered by existing alias rules
+    const existingAliases = tag.aliases ?? {};
+    const coveredValues = new Set<string>();
+    for (const [canonical, aliases] of Object.entries(existingAliases)) {
+      coveredValues.add(canonical);
+      for (const a of aliases) coveredValues.add(a);
+    }
+
     const dismissed = await loadDismissedSuggestions(ctx.dataDir);
-    return suggestions.filter(
-      s => !isDismissed(dismissed, tagName, s.canonical, s.aliases),
-    );
+    const filtered: AliasSuggestion[] = [];
+    for (const s of suggestions) {
+      const uncovered = s.aliases.filter(a => !coveredValues.has(a));
+      if (uncovered.length === 0) continue;
+      if (coveredValues.has(s.canonical) && uncovered.length === 0) continue;
+      const candidate: AliasSuggestion = { canonical: s.canonical, aliases: uncovered };
+      if (isDismissed(dismissed, tagName, candidate.canonical, candidate.aliases)) continue;
+      filtered.push(candidate);
+    }
+    return filtered;
   });
 
   ipcMain.handle('dimensions:dismiss-suggestion', async (_event, tagName: string, canonical: string, aliases: string[]): Promise<void> => {

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -296,9 +296,9 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const dismissed = await loadDismissedSuggestions(ctx.dataDir);
     const filtered: AliasSuggestion[] = [];
     for (const s of suggestions) {
+      if (coveredValues.has(s.canonical)) continue;
       const uncovered = s.aliases.filter(a => !coveredValues.has(a));
       if (uncovered.length === 0) continue;
-      if (coveredValues.has(s.canonical) && uncovered.length === 0) continue;
       const candidate: AliasSuggestion = { canonical: s.canonical, aliases: uncovered };
       if (isDismissed(dismissed, tagName, candidate.canonical, candidate.aliases)) continue;
       filtered.push(candidate);

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -39,6 +39,7 @@ import type {
   ExplorerRowsResult,
   AggregatedTableParams,
   AggregatedTableResult,
+  AliasSuggestion,
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
@@ -263,6 +264,15 @@ const api: CostApi = {
   },
   saveExplorerPreferences(prefs: ExplorerPreferences): Promise<void> {
     return invoke<undefined>('explorer:save-preferences', prefs).then(() => undefined);
+  },
+  getAliasSuggestions(tagName: string): Promise<AliasSuggestion[]> {
+    return invoke<AliasSuggestion[]>('dimensions:get-alias-suggestions', tagName);
+  },
+  dismissSuggestion(tagName: string, canonical: string, aliases: readonly string[]): Promise<void> {
+    return invoke<undefined>('dimensions:dismiss-suggestion', tagName, canonical, aliases).then(() => undefined);
+  },
+  acceptSuggestion(tagName: string, canonical: string, aliases: readonly string[]): Promise<void> {
+    return invoke<undefined>('dimensions:accept-suggestion', tagName, canonical, aliases).then(() => undefined);
   },
   cancelPendingQueries(): Promise<void> {
     void invoke<undefined>('debug:clear-completed');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -25,6 +25,7 @@ import {
   type ExplorerFilterValue,
   type ExplorerOverviewResult,
   type ExplorerRowsResult,
+  type AliasSuggestion,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
 
@@ -350,6 +351,21 @@ export class MockCostApi implements CostApi {
     return Promise.resolve({ hiddenColumns: [], columnOrder: [] });
   }
   saveExplorerPreferences(): Promise<void> { return Promise.resolve(); }
+  getAliasSuggestions(tagName: string): Promise<AliasSuggestion[]> {
+    const suggestions: Record<string, AliasSuggestion[]> = {
+      'team': [
+        { canonical: 'platform', aliases: ['Platform', 'platform-eng', 'plt'] },
+        { canonical: 'data', aliases: ['Data', 'data-eng', 'data-platform'] },
+      ],
+      'env': [
+        { canonical: 'prod', aliases: ['production', 'prd', 'PROD'] },
+        { canonical: 'staging', aliases: ['stage', 'stg'] },
+      ],
+    };
+    return Promise.resolve(suggestions[tagName] ?? []);
+  }
+  dismissSuggestion(): Promise<void> { return Promise.resolve(); }
+  acceptSuggestion(): Promise<void> { return Promise.resolve(); }
   cancelPendingQueries(): Promise<void> { return Promise.resolve(); }
 }
 

--- a/packages/ui/src/components/alias-suggestions.tsx
+++ b/packages/ui/src/components/alias-suggestions.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { Check, X } from 'lucide-react';
+import type { AliasSuggestion } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useQuery } from '../hooks/use-query.js';
+
+export interface AliasSuggestionsProps {
+  readonly dimensionId: string;
+  readonly onAccepted?: (canonical: string, aliases: readonly string[]) => void;
+}
+
+interface SuggestionState extends AliasSuggestion {
+  readonly dismissing: boolean;
+}
+
+export function AliasSuggestions({
+  dimensionId,
+  onAccepted,
+}: Readonly<AliasSuggestionsProps>): React.JSX.Element | null {
+  const api = useCostApi();
+  const [suggestions, setSuggestions] = useState<readonly SuggestionState[]>([]);
+  const [pending, setPending] = useState<string | null>(null);
+
+  const query = useQuery(
+    () => api.getAliasSuggestions(dimensionId),
+    [dimensionId, api],
+  );
+
+  useEffect(() => {
+    if (query.status === 'success') {
+      setSuggestions(query.data.map(s => ({ ...s, dismissing: false })));
+    }
+  }, [query]);
+
+  async function handleAccept(canonical: string): Promise<void> {
+    setPending(canonical);
+    try {
+      const s = suggestions.find(x => x.canonical === canonical);
+      if (!s) return;
+      await api.acceptSuggestion(dimensionId, canonical, s.aliases);
+      setSuggestions(prev => prev.filter(x => x.canonical !== canonical));
+      onAccepted?.(canonical, s.aliases);
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function handleDismiss(canonical: string): Promise<void> {
+    setSuggestions(prev => prev.map(s =>
+      s.canonical === canonical ? { ...s, dismissing: true } : s,
+    ));
+    await new Promise(resolve => { setTimeout(resolve, 200); });
+    setPending(canonical);
+    try {
+      const s = suggestions.find(x => x.canonical === canonical);
+      if (!s) return;
+      await api.dismissSuggestion(dimensionId, canonical, s.aliases);
+      setSuggestions(prev => prev.filter(x => x.canonical !== canonical));
+    } catch {
+      setSuggestions(prev => prev.map(s =>
+        s.canonical === canonical ? { ...s, dismissing: false } : s,
+      ));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  if (query.status !== 'success' || suggestions.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-xs font-medium text-text-muted">Suggested Aliases</div>
+      <div className="flex flex-col gap-2">
+        {suggestions.map(s => {
+          const isProcessing = pending === s.canonical;
+          return (
+            <div
+              key={s.canonical}
+              className={`flex items-start gap-3 rounded border border-border bg-bg-secondary p-3 transition-all duration-200 ${s.dismissing ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}`}
+            >
+              <div className="flex-1">
+                <div className="text-sm font-medium text-text-primary">{s.canonical}</div>
+                <div className="mt-1 text-xs text-text-muted">Merge: {s.aliases.join(', ')}</div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => { void handleAccept(s.canonical); }}
+                  disabled={isProcessing}
+                  className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors bg-accent text-text-on-accent hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={`Accept alias suggestion for ${s.canonical}`}
+                >
+                  <Check className="h-3 w-3" />
+                  Accept
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { void handleDismiss(s.canonical); }}
+                  disabled={isProcessing}
+                  className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors bg-bg-tertiary text-text-muted hover:bg-bg-primary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={`Dismiss alias suggestion for ${s.canonical}`}
+                >
+                  <X className="h-3 w-3" />
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/alias-suggestions.tsx
+++ b/packages/ui/src/components/alias-suggestions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Check, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, X } from 'lucide-react';
 import type { AliasSuggestion } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -20,6 +20,7 @@ export function AliasSuggestions({
   const api = useCostApi();
   const [suggestions, setSuggestions] = useState<readonly SuggestionState[]>([]);
   const [pending, setPending] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
 
   const query = useQuery(
     () => api.getAliasSuggestions(dimensionId),
@@ -68,46 +69,57 @@ export function AliasSuggestions({
   if (query.status !== 'success' || suggestions.length === 0) return null;
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="text-xs font-medium text-text-muted">Suggested Aliases</div>
-      <div className="flex flex-col gap-2">
-        {suggestions.map(s => {
-          const isProcessing = pending === s.canonical;
-          return (
-            <div
-              key={s.canonical}
-              className={`flex items-start gap-3 rounded border border-border bg-bg-secondary p-3 transition-all duration-200 ${s.dismissing ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}`}
-            >
-              <div className="flex-1">
-                <div className="text-sm font-medium text-text-primary">{s.canonical}</div>
-                <div className="mt-1 text-xs text-text-muted">Merge: {s.aliases.join(', ')}</div>
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={() => { setOpen(o => !o); }}
+        className="flex items-center gap-1 text-xs font-medium text-text-muted hover:text-text-primary transition-colors self-start"
+      >
+        {open
+          ? <ChevronDown className="h-3 w-3" />
+          : <ChevronRight className="h-3 w-3" />}
+        Suggested Aliases ({String(suggestions.length)})
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2 mt-1">
+          {suggestions.map(s => {
+            const isProcessing = pending === s.canonical;
+            return (
+              <div
+                key={s.canonical}
+                className={`flex items-start gap-3 rounded border border-border bg-bg-secondary p-3 transition-all duration-200 ${s.dismissing ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}`}
+              >
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-text-primary">{s.canonical}</div>
+                  <div className="mt-1 text-xs text-text-muted">Merge: {s.aliases.join(', ')}</div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => { void handleAccept(s.canonical); }}
+                    disabled={isProcessing}
+                    className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors bg-accent text-text-on-accent hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={`Accept alias suggestion for ${s.canonical}`}
+                  >
+                    <Check className="h-3 w-3" />
+                    Accept
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { void handleDismiss(s.canonical); }}
+                    disabled={isProcessing}
+                    className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors bg-bg-tertiary text-text-muted hover:bg-bg-primary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={`Dismiss alias suggestion for ${s.canonical}`}
+                  >
+                    <X className="h-3 w-3" />
+                    Dismiss
+                  </button>
+                </div>
               </div>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => { void handleAccept(s.canonical); }}
-                  disabled={isProcessing}
-                  className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors bg-accent text-text-on-accent hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label={`Accept alias suggestion for ${s.canonical}`}
-                >
-                  <Check className="h-3 w-3" />
-                  Accept
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { void handleDismiss(s.canonical); }}
-                  disabled={isProcessing}
-                  className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors bg-bg-tertiary text-text-muted hover:bg-bg-primary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label={`Dismiss alias suggestion for ${s.canonical}`}
-                >
-                  <X className="h-3 w-3" />
-                  Dismiss
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -530,6 +530,7 @@ function AliasRulesEditor({ value, savedValue, activeLine, onChange, onLineFocus
   onChange: (v: string) => void;
   onLineFocus: (lineIdx: number | null) => void;
 }>): React.JSX.Element {
+  const newLineRef = useRef<HTMLInputElement>(null);
   const sorted = sortAliasText(value);
   const savedLines = new Set(sortAliasText(savedValue).split('\n').filter(l => l.trim().length > 0));
   const lines = sorted.split('\n').filter(l => l.trim().length > 0);
@@ -548,6 +549,13 @@ function AliasRulesEditor({ value, savedValue, activeLine, onChange, onLineFocus
               type="text"
               value={line}
               onFocus={() => { onLineFocus(i); }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  onLineFocus(null);
+                  newLineRef.current?.focus();
+                }
+              }}
               onChange={e => {
                 const newLines = [...lines];
                 newLines[i] = e.target.value;
@@ -570,6 +578,7 @@ function AliasRulesEditor({ value, savedValue, activeLine, onChange, onLineFocus
       })}
       <div className={`px-3 py-1 ${lines.length > 0 ? 'border-t border-t-border/30' : ''}`}>
         <input
+          ref={newLineRef}
           type="text"
           placeholder="new-canonical: alias1, alias2"
           className="w-full bg-transparent text-[11px] font-mono text-text-primary outline-none placeholder:text-text-muted/50"
@@ -948,6 +957,17 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         onBadgeClick={(value) => {
           setState(s => {
             const lines = sortAliasText(s.aliases).split('\n').filter(l => l.trim().length > 0);
+
+            // If clicked value is already a canonical key, just focus that line
+            const existingIdx = lines.findIndex(l => {
+              const colonIdx = l.indexOf(':');
+              return colonIdx >= 0 && l.slice(0, colonIdx).trim() === value;
+            });
+            if (existingIdx >= 0) {
+              setActiveAliasLine(existingIdx);
+              return s;
+            }
+
             if (activeAliasLine !== null && activeAliasLine < lines.length) {
               const line = lines[activeAliasLine] ?? '';
               if (line.includes(':')) {
@@ -960,7 +980,6 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             const base = s.aliases.trimEnd();
             const prefix = base.length > 0 ? base + '\n' : '';
             const newAliases = prefix + value + ':';
-            // Point active line at the newly created canonical so next click appends
             const sorted = sortAliasText(newAliases).split('\n').filter(l => l.trim().length > 0);
             const newIdx = sorted.findIndex(l => l.startsWith(value + ':'));
             if (newIdx >= 0) setActiveAliasLine(newIdx);

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -825,7 +825,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             ref={aliasRef}
             value={state.aliases}
             onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
-            rows={2}
+            rows={Math.max(2, state.aliases.split('\n').length)}
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-[11px] text-text-primary font-mono outline-none focus:border-accent resize-y"
             placeholder="production: prod, prd&#10;staging: stg, stage"
           />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -523,9 +523,10 @@ function sortAliasText(text: string): string {
     .join('\n');
 }
 
-function AliasRulesEditor({ value, savedValue, onChange, onLineFocus }: Readonly<{
+function AliasRulesEditor({ value, savedValue, activeLine, onChange, onLineFocus }: Readonly<{
   value: string;
   savedValue: string;
+  activeLine: number | null;
   onChange: (v: string) => void;
   onLineFocus: (lineIdx: number | null) => void;
 }>): React.JSX.Element {
@@ -537,10 +538,11 @@ function AliasRulesEditor({ value, savedValue, onChange, onLineFocus }: Readonly
     <div className="rounded border border-border bg-bg-primary overflow-hidden">
       {lines.map((line, i) => {
         const isNew = !savedLines.has(line);
+        const isActive = activeLine === i;
         return (
           <div
             key={i}
-            className={`flex items-center gap-1 px-3 py-1 text-[11px] font-mono border-l-2 ${isNew ? 'border-l-accent bg-accent/5' : 'border-l-transparent'} ${i > 0 ? 'border-t border-t-border/30' : ''}`}
+            className={`flex items-center gap-1 px-3 py-1 text-[11px] font-mono border-l-2 ${isActive ? 'border-l-accent bg-accent/10' : isNew ? 'border-l-accent bg-accent/5' : 'border-l-transparent'} ${i > 0 ? 'border-t border-t-border/30' : ''}`}
           >
             <input
               type="text"
@@ -911,6 +913,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           <AliasRulesEditor
             value={state.aliases}
             savedValue={initialRef.current.aliases}
+            activeLine={activeAliasLine}
             onChange={(v) => { setState(s => ({ ...s, aliases: v })); }}
             onLineFocus={setActiveAliasLine}
           />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -503,6 +503,25 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function validateAliases(text: string): string[] {
+  const aliases = textToAliases(text);
+  if (aliases === undefined) return [];
+  const warnings: string[] = [];
+  const allAliasValues = new Map<string, string>();
+  for (const [canonical, alts] of Object.entries(aliases)) {
+    for (const a of alts) {
+      allAliasValues.set(a, canonical);
+    }
+  }
+  for (const canonical of Object.keys(aliases)) {
+    const mappedTo = allAliasValues.get(canonical);
+    if (mappedTo !== undefined) {
+      warnings.push(`"${canonical}" is a canonical key but also an alias of "${mappedTo}"`);
+    }
+  }
+  return warnings;
+}
+
 type TagSource = 'resource' | 'account' | 'both' | 'template';
 
 function sourceColor(source: TagSource, aliased: boolean): string {
@@ -805,6 +824,9 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-[11px] text-text-primary font-mono outline-none focus:border-accent resize-y"
             placeholder="production: prod, prd&#10;staging: stg, stage"
           />
+          {validateAliases(state.aliases).map(w => (
+            <span key={w} className="text-[10px] text-warning">{w}</span>
+          ))}
         </label>
       </div>
 

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -956,7 +956,12 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             }
             const base = s.aliases.trimEnd();
             const prefix = base.length > 0 ? base + '\n' : '';
-            return { ...s, aliases: prefix + value + ':' };
+            const newAliases = prefix + value + ':';
+            // Point active line at the newly created canonical so next click appends
+            const sorted = sortAliasText(newAliases).split('\n').filter(l => l.trim().length > 0);
+            const newIdx = sorted.findIndex(l => l.startsWith(value + ':'));
+            if (newIdx >= 0) setActiveAliasLine(newIdx);
+            return { ...s, aliases: newAliases };
           });
         }}
       />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -503,6 +503,82 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function sortAliasText(text: string): string {
+  const aliases = textToAliases(text);
+  if (aliases === undefined) return text;
+  return Object.entries(aliases)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}: ${[...v].sort((a, b) => a.localeCompare(b)).join(', ')}`)
+    .join('\n');
+}
+
+function AliasRulesEditor({ value, savedValue, onChange, onLineFocus }: Readonly<{
+  value: string;
+  savedValue: string;
+  onChange: (v: string) => void;
+  onLineFocus: (lineIdx: number | null) => void;
+}>): React.JSX.Element {
+  const sorted = sortAliasText(value);
+  const savedLines = new Set(sortAliasText(savedValue).split('\n').filter(l => l.trim().length > 0));
+  const lines = sorted.split('\n').filter(l => l.trim().length > 0);
+
+  return (
+    <div className="rounded border border-border bg-bg-primary overflow-hidden">
+      {lines.map((line, i) => {
+        const isNew = !savedLines.has(line);
+        return (
+          <div
+            key={i}
+            className={`flex items-center gap-1 px-3 py-1 text-[11px] font-mono border-l-2 ${isNew ? 'border-l-accent bg-accent/5' : 'border-l-transparent'} ${i > 0 ? 'border-t border-t-border/30' : ''}`}
+          >
+            <input
+              type="text"
+              value={line}
+              onFocus={() => { onLineFocus(i); }}
+              onChange={e => {
+                const newLines = [...lines];
+                newLines[i] = e.target.value;
+                onChange(newLines.join('\n'));
+              }}
+              className="flex-1 bg-transparent text-text-primary outline-none"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                onChange(lines.filter((_, j) => j !== i).join('\n'));
+              }}
+              className="text-text-muted hover:text-negative text-xs px-1 opacity-0 hover:opacity-100 transition-opacity"
+              aria-label="Remove rule"
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+      <div className={`px-3 py-1 ${lines.length > 0 ? 'border-t border-t-border/30' : ''}`}>
+        <input
+          type="text"
+          placeholder="new-canonical: alias1, alias2"
+          className="w-full bg-transparent text-[11px] font-mono text-text-primary outline-none placeholder:text-text-muted/50"
+          onFocus={() => { onLineFocus(null); }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              const input = e.currentTarget;
+              const v = input.value.trim();
+              if (v.length > 0) {
+                const base = value.trimEnd();
+                onChange(base.length > 0 ? base + '\n' + v : v);
+                input.value = '';
+              }
+              e.preventDefault();
+            }
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function validateAliases(text: string): string[] {
   const aliases = textToAliases(text);
   if (aliases === undefined) return [];
@@ -670,7 +746,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 }>) {
   const [state, setState] = useState(tag);
   const initialRef = useRef(tag);
-  const aliasRef = useRef<HTMLTextAreaElement>(null);
+  const [activeAliasLine, setActiveAliasLine] = useState<number | null>(null);
   const [discardConfirm, setDiscardConfirm] = useState(false);
   const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
   useUnsavedChanges(isDirty, 'Tag editor');
@@ -819,20 +895,18 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             {'{fallback}'} = account tag value
           </span>
         </div>
-        <label className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
-          <textarea
-            ref={aliasRef}
+          <AliasRulesEditor
             value={state.aliases}
-            onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
-            rows={Math.max(2, state.aliases.split('\n').length)}
-            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-[11px] text-text-primary font-mono outline-none focus:border-accent resize-y"
-            placeholder="production: prod, prd&#10;staging: stg, stage"
+            savedValue={initialRef.current.aliases}
+            onChange={(v) => { setState(s => ({ ...s, aliases: v })); }}
+            onLineFocus={setActiveAliasLine}
           />
           {validateAliases(state.aliases).map(w => (
             <span key={w} className="text-[10px] text-warning">{w}</span>
           ))}
-        </label>
+        </div>
       </div>
 
       {state.tagName.length > 0 && (
@@ -859,42 +933,19 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         aliasText={state.aliases}
         onBadgeClick={(value) => {
           setState(s => {
-            const lines = s.aliases.split('\n');
-            const cursor = aliasRef.current?.selectionStart ?? s.aliases.length;
-            let lineIdx = 0;
-            let pos = 0;
-            for (let i = 0; i < lines.length; i++) {
-              const lineLen = (lines[i]?.length ?? 0) + 1;
-              if (pos + lineLen > cursor) { lineIdx = i; break; }
-              pos += lineLen;
-              lineIdx = i;
-            }
-            const line = lines[lineIdx] ?? '';
-            let newAliases: string;
-            if (line.includes(':')) {
-              const trimmed = line.trimEnd();
-              const sep = trimmed.endsWith(':') ? ' ' : ', ';
-              lines[lineIdx] = trimmed + sep + value;
-              newAliases = lines.join('\n');
-            } else {
-              const base = s.aliases.trimEnd();
-              const prefix = base.length > 0 ? base + '\n' : '';
-              newAliases = prefix + value + ':';
-            }
-            requestAnimationFrame(() => {
-              const el = aliasRef.current;
-              if (el === null) return;
-              // Place cursor at end of the modified/new line
-              const newLines = newAliases.split('\n');
-              let endPos = 0;
-              const targetLine = line.includes(':') ? lineIdx : newLines.length - 1;
-              for (let i = 0; i <= targetLine && i < newLines.length; i++) {
-                endPos += (newLines[i]?.length ?? 0) + (i < targetLine ? 1 : 0);
+            const lines = sortAliasText(s.aliases).split('\n').filter(l => l.trim().length > 0);
+            if (activeAliasLine !== null && activeAliasLine < lines.length) {
+              const line = lines[activeAliasLine] ?? '';
+              if (line.includes(':')) {
+                const trimmed = line.trimEnd();
+                const sep = trimmed.endsWith(':') ? ' ' : ', ';
+                lines[activeAliasLine] = trimmed + sep + value;
+                return { ...s, aliases: lines.join('\n') };
               }
-              el.focus();
-              el.setSelectionRange(endPos, endPos);
-            });
-            return { ...s, aliases: newAliases };
+            }
+            const base = s.aliases.trimEnd();
+            const prefix = base.length > 0 ? base + '\n' : '';
+            return { ...s, aliases: prefix + value + ':' };
           });
         }}
       />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -593,12 +593,13 @@ function deduplicateResolved(
     .sort((a, b) => a.resolved.localeCompare(b.resolved));
 }
 
-function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, normalizeRule, aliasText }: Readonly<{
+function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, normalizeRule, aliasText, onBadgeClick }: Readonly<{
   tagMatch: { sampleValues: string[] } | undefined;
   fallbackValues: [string, number][];
   missingValueTemplate: string;
   normalizeRule: string;
   aliasText: string;
+  onBadgeClick?: (value: string) => void;
 }>): React.JSX.Element | null {
   const resourceVals = tagMatch === undefined ? [] : tagMatch.sampleValues;
   const accountVals = fallbackValues.map(([v]) => v);
@@ -643,12 +644,14 @@ function TagValuePreview({ tagMatch, fallbackValues, missingValueTemplate, norma
       </div>
       <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
         {unique.map(({ resolved, aliased, source }) => (
-          <span
+          <button
+            type="button"
             key={resolved}
-            className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${sourceColor(source, aliased)}`}
+            onClick={onBadgeClick !== undefined ? () => { onBadgeClick(resolved); } : undefined}
+            className={`rounded border px-1.5 py-0.5 text-[10px] font-mono ${sourceColor(source, aliased)} ${onBadgeClick !== undefined ? 'cursor-pointer hover:ring-1 hover:ring-accent/50' : ''}`}
           >
             {resolved}
-          </span>
+          </button>
         ))}
       </div>
     </div>
@@ -852,6 +855,24 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         missingValueTemplate={state.missingValueTemplate}
         normalizeRule={state.normalize}
         aliasText={state.aliases}
+        onBadgeClick={(value) => {
+          setState(s => {
+            const lines = s.aliases.split('\n');
+            const last = lines.at(-1) ?? '';
+            if (last.includes(':')) {
+              // Alias mode — append to current line
+              const trimmed = last.trimEnd();
+              const sep = trimmed.endsWith(':') ? ' ' : ', ';
+              lines[lines.length - 1] = trimmed + sep + value;
+            } else {
+              // Canonical mode — new line
+              const base = s.aliases.trimEnd();
+              const prefix = base.length > 0 ? base + '\n' : '';
+              return { ...s, aliases: prefix + value + ':' };
+            }
+            return { ...s, aliases: lines.join('\n') };
+          });
+        }}
       />
 
       <div className="flex items-center justify-between">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -870,15 +870,31 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
               lineIdx = i;
             }
             const line = lines[lineIdx] ?? '';
+            let newAliases: string;
             if (line.includes(':')) {
               const trimmed = line.trimEnd();
               const sep = trimmed.endsWith(':') ? ' ' : ', ';
               lines[lineIdx] = trimmed + sep + value;
-              return { ...s, aliases: lines.join('\n') };
+              newAliases = lines.join('\n');
+            } else {
+              const base = s.aliases.trimEnd();
+              const prefix = base.length > 0 ? base + '\n' : '';
+              newAliases = prefix + value + ':';
             }
-            const base = s.aliases.trimEnd();
-            const prefix = base.length > 0 ? base + '\n' : '';
-            return { ...s, aliases: prefix + value + ':' };
+            requestAnimationFrame(() => {
+              const el = aliasRef.current;
+              if (el === null) return;
+              // Place cursor at end of the modified/new line
+              const newLines = newAliases.split('\n');
+              let endPos = 0;
+              const targetLine = line.includes(':') ? lineIdx : newLines.length - 1;
+              for (let i = 0; i <= targetLine && i < newLines.length; i++) {
+                endPos += (newLines[i]?.length ?? 0) + (i < targetLine ? 1 : 0);
+              }
+              el.focus();
+              el.setSelectionRange(endPos, endPos);
+            });
+            return { ...s, aliases: newAliases };
           });
         }}
       />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -504,11 +504,22 @@ function textToAliases(text: string): Record<string, readonly string[]> | undefi
 }
 
 function sortAliasText(text: string): string {
-  const aliases = textToAliases(text);
-  if (aliases === undefined) return text;
-  return Object.entries(aliases)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}: ${[...v].sort((a, b) => a.localeCompare(b)).join(', ')}`)
+  if (text.trim().length === 0) return text;
+  const entries: { key: string; aliases: readonly string[] }[] = [];
+  for (const line of text.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const key = line.slice(0, idx).trim();
+    if (key.length === 0) continue;
+    const vals = line.slice(idx + 1).split(',').map(s => s.trim()).filter(s => s.length > 0);
+    entries.push({ key, aliases: vals });
+  }
+  if (entries.length === 0) return text;
+  return entries
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .map(e => e.aliases.length > 0
+      ? `${e.key}: ${[...e.aliases].sort((a, b) => a.localeCompare(b)).join(', ')}`
+      : `${e.key}:`)
     .join('\n');
 }
 

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -670,6 +670,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 }>) {
   const [state, setState] = useState(tag);
   const initialRef = useRef(tag);
+  const aliasRef = useRef<HTMLTextAreaElement>(null);
   const [discardConfirm, setDiscardConfirm] = useState(false);
   const isDirty = JSON.stringify(state) !== JSON.stringify(initialRef.current);
   useUnsavedChanges(isDirty, 'Tag editor');
@@ -821,6 +822,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Alias Rules (canonical: alias1, alias2)</span>
           <textarea
+            ref={aliasRef}
             value={state.aliases}
             onChange={e => { setState(s => ({ ...s, aliases: e.target.value })); }}
             rows={2}
@@ -858,19 +860,25 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
         onBadgeClick={(value) => {
           setState(s => {
             const lines = s.aliases.split('\n');
-            const last = lines.at(-1) ?? '';
-            if (last.includes(':')) {
-              // Alias mode — append to current line
-              const trimmed = last.trimEnd();
-              const sep = trimmed.endsWith(':') ? ' ' : ', ';
-              lines[lines.length - 1] = trimmed + sep + value;
-            } else {
-              // Canonical mode — new line
-              const base = s.aliases.trimEnd();
-              const prefix = base.length > 0 ? base + '\n' : '';
-              return { ...s, aliases: prefix + value + ':' };
+            const cursor = aliasRef.current?.selectionStart ?? s.aliases.length;
+            let lineIdx = 0;
+            let pos = 0;
+            for (let i = 0; i < lines.length; i++) {
+              const lineLen = (lines[i]?.length ?? 0) + 1;
+              if (pos + lineLen > cursor) { lineIdx = i; break; }
+              pos += lineLen;
+              lineIdx = i;
             }
-            return { ...s, aliases: lines.join('\n') };
+            const line = lines[lineIdx] ?? '';
+            if (line.includes(':')) {
+              const trimmed = line.trimEnd();
+              const sep = trimmed.endsWith(':') ? ' ' : ', ';
+              lines[lineIdx] = trimmed + sep + value;
+              return { ...s, aliases: lines.join('\n') };
+            }
+            const base = s.aliases.trimEnd();
+            const prefix = base.length > 0 ? base + '\n' : '';
+            return { ...s, aliases: prefix + value + ':' };
           });
         }}
       />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -6,6 +6,7 @@ import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { useQuery } from '../hooks/use-query.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
+import { AliasSuggestions } from '../components/alias-suggestions.js';
 
 function useClickOutsideDismiss(
   containerRef: React.RefObject<HTMLDivElement | null>,
@@ -806,6 +807,21 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           />
         </label>
       </div>
+
+      {state.tagName.length > 0 && (
+        <AliasSuggestions
+          dimensionId={state.tagName}
+          onAccepted={(canonical, aliases) => {
+            setState(s => {
+              const current = textToAliases(s.aliases) ?? {};
+              const existing: readonly string[] = current[canonical] ?? [];
+              const merged = [...new Set([...existing, ...aliases])];
+              const updated = { ...current, [canonical]: merged };
+              return { ...s, aliases: aliasesToText(updated) };
+            });
+          }}
+        />
+      )}
 
       {/* Row 5: Merged + normalized preview of all values */}
       <TagValuePreview


### PR DESCRIPTION
## Summary

- Analyze tag values using fuzzy matching (Levenshtein, case/separator variations, abbreviation detection) and surface alias suggestions in the tag dimension editor
- Accept merges aliases into `dimensions.yaml`, dismiss persists to `dismissed-suggestions.json`
- Zero new dependencies — Levenshtein inlined (15 lines)

Replaces #85 (vibecoded, stale, had bugs). Rewritten from scratch on current main.