### PR TITLE
Add sandbox regression guard

### DIFF
--- a/e2e/sandbox-verification.test.ts
+++ b/e2e/sandbox-verification.test.ts
@@ -1,0 +1,23 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { launchApp } from './helpers.js';
+
+let app: ElectronApplication;
+let page: Page;
+
+test.beforeAll(async () => {
+  app = await launchApp();
+  page = await app.firstWindow();
+  await expect(page).toHaveTitle('CostGoblin');
+});
+
+test.afterAll(async () => {
+  await app.close();
+});
+
+test('renderer is sandboxed', async () => {
+  const sandboxed = await page.evaluate(() => {
+    const debug = (window as { costgoblinDebug?: { isSandboxed: () => boolean } }).costgoblinDebug;
+    return debug?.isSandboxed() ?? false;
+  });
+  expect(sandboxed).toBe(true);
+});

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -155,9 +155,15 @@ async function createWindow(db: DuckDBClient, syncClient: SyncClient): Promise<v
     titleBarStyle: 'hiddenInset',
     icon: join(__dirname, '..', '..', 'resources', 'icon.png'),
     webPreferences: {
+      // Preload script built as CJS (preload.cjs) using esbuild (build:preload)
+      // instead of electron-vite because sandbox: true requires CommonJS format.
       preload: join(__dirname, '..', 'worker', 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
+      // sandbox: true is defense-in-depth on top of contextIsolation and
+      // nodeIntegration: false. Prevents a compromised renderer from accessing
+      // Node.js APIs even if contextBridge is bypassed. Critical for handling
+      // sensitive billing data in a local-first app.
       sandbox: true,
     },
   });

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -283,7 +283,7 @@ const api: CostApi = {
 contextBridge.exposeInMainWorld('costgoblin', api);
 
 contextBridge.exposeInMainWorld('costgoblinDebug', {
-  isSandboxed(): boolean { return process.sandboxed === true; },
+  isSandboxed(): boolean { return process.sandboxed; },
   getInFlightCount(): number { return inFlightCount; },
   getQueryLog(): Promise<DebugQueryLogEntry[]> {
     return invoke<DebugQueryLogEntry[]>('debug:get-query-log');

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -283,6 +283,7 @@ const api: CostApi = {
 contextBridge.exposeInMainWorld('costgoblin', api);
 
 contextBridge.exposeInMainWorld('costgoblinDebug', {
+  isSandboxed(): boolean { return process.sandboxed === true; },
   getInFlightCount(): number { return inFlightCount; },
   getQueryLog(): Promise<DebugQueryLogEntry[]> {
     return invoke<DebugQueryLogEntry[]>('debug:get-query-log');


### PR DESCRIPTION
## Summary

- Expose `process.sandboxed` via the debug API so E2E tests can verify the renderer is actually sandboxed (not just context-isolated)
- Add a single E2E test that catches silent regressions if `sandbox: true` is accidentally removed
- Inline comments in `main.ts` explaining why sandbox is enabled and why the preload must be CJS

Reworked from the original PR which had redundant tests that only verified `contextIsolation` behavior, a fragile build-artifact unit test, and auto-generated commit messages.