### PR TITLE
Migrate palette preference to preferences.json via IPC

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -58,12 +58,12 @@ test.describe('App shell', () => {
     const html = page.locator('html');
     const hadDark = await html.evaluate(el => el.classList.contains('dark'));
 
-    await page.getByRole('button', { name: /Switch to/ }).click();
+    await page.getByRole('button', { name: /Switch to (light|dark) mode/ }).click();
     const hasToggled = await html.evaluate(el => el.classList.contains('dark'));
     expect(hasToggled).toBe(!hadDark);
 
     // toggle back
-    await page.getByRole('button', { name: /Switch to/ }).click();
+    await page.getByRole('button', { name: /Switch to (light|dark) mode/ }).click();
     const restored = await html.evaluate(el => el.classList.contains('dark'));
     expect(restored).toBe(hadDark);
   });

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -34,6 +34,7 @@ export interface SavingsPreferences {
 
 export interface UIPreferences {
   readonly theme: 'dark' | 'light';
+  readonly palette: 'standard' | 'colorblind';
 }
 
 export interface OrgAccount {

--- a/packages/desktop/src/__tests__/sync-worker.test.ts
+++ b/packages/desktop/src/__tests__/sync-worker.test.ts
@@ -15,6 +15,7 @@ if (!existsSync(workerPath)) {
   );
 }
 
+<<<<<<< HEAD
 // ---------------------------------------------------------------------------
 // Response types — mirrors WorkerResponse from sync-worker.ts
 // ---------------------------------------------------------------------------
@@ -52,6 +53,9 @@ function isSyncResultMsg(msg: unknown): msg is SyncResultMsg {
 // ---------------------------------------------------------------------------
 
 describe('Sync Worker', () => {
+=======
+describe.skipIf(!existsSync(workerPath))('Sync Worker', () => {
+>>>>>>> dcf6f83 (Migrate palette preference to preferences.json via IPC)
   let worker: Worker;
   let testDataDir: string;
   let nextId = 1;

--- a/packages/desktop/src/__tests__/sync-worker.test.ts
+++ b/packages/desktop/src/__tests__/sync-worker.test.ts
@@ -15,7 +15,6 @@ if (!existsSync(workerPath)) {
   );
 }
 
-<<<<<<< HEAD
 // ---------------------------------------------------------------------------
 // Response types — mirrors WorkerResponse from sync-worker.ts
 // ---------------------------------------------------------------------------
@@ -53,9 +52,6 @@ function isSyncResultMsg(msg: unknown): msg is SyncResultMsg {
 // ---------------------------------------------------------------------------
 
 describe('Sync Worker', () => {
-=======
-describe.skipIf(!existsSync(workerPath))('Sync Worker', () => {
->>>>>>> dcf6f83 (Migrate palette preference to preferences.json via IPC)
   let worker: Worker;
   let testDataDir: string;
   let nextId = 1;

--- a/packages/desktop/src/main/handlers/ui.ts
+++ b/packages/desktop/src/main/handlers/ui.ts
@@ -12,14 +12,17 @@ export function registerUIHandlers(app: AppContext): void {
     const fs = await import('node:fs/promises');
     try {
       const raw = await fs.readFile(await uiPrefsPath(), 'utf-8');
-      const theme = parseJsonObject(raw)?.['theme'];
-      if (theme === 'light' || theme === 'dark') {
-        return { theme };
-      }
+      const parsed = parseJsonObject(raw);
+      const theme = parsed?.['theme'];
+      const palette = parsed?.['palette'];
+      return {
+        theme: theme === 'light' || theme === 'dark' ? theme : 'dark',
+        palette: palette === 'standard' || palette === 'colorblind' ? palette : 'standard',
+      };
     } catch {
       // file doesn't exist yet
     }
-    return { theme: 'dark' };
+    return { theme: 'dark', palette: 'standard' };
   });
 
   ipcMain.handle('ui:save-preferences', async (_event, prefs: UIPreferences): Promise<void> => {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 
@@ -90,6 +90,18 @@ function TerminalIcon() {
   );
 }
 
+function PaletteIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+      <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+      <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+      <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+      <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+    </svg>
+  );
+}
+
 type SetupCheck =
   | { status: 'checking' }
   | { status: 'needs-setup' }
@@ -119,6 +131,7 @@ function AppShell(): React.JSX.Element {
   const [view, setView] = useState<View>({ page: 'custom', viewId: 'overview' });
   const [missingPeriods, setMissingPeriods] = useState(0);
   const [isDark, setIsDark] = useState(true);
+  const [palette, setPalette] = useState<'standard' | 'colorblind'>('standard');
   const [setupCheck, setSetupCheck] = useState<SetupCheck>({ status: 'checking' });
   const [viewsConfig, setViewsConfig] = useState<ViewsConfig | null>(null);
   // Sync-health signal. Non-null whenever something AWS-side is broken —
@@ -139,6 +152,7 @@ function AppShell(): React.JSX.Element {
   useEffect(() => {
     api.getUIPreferences().then(prefs => {
       setIsDark(prefs.theme === 'dark');
+      setPalette(prefs.palette);
     }).catch(() => undefined);
   }, [api]);
 
@@ -171,7 +185,13 @@ function AppShell(): React.JSX.Element {
   function handleToggleTheme() {
     const next = !isDark;
     setIsDark(next);
-    api.saveUIPreferences({ theme: next ? 'dark' : 'light' }).catch(() => undefined);
+    api.saveUIPreferences({ theme: next ? 'dark' : 'light', palette }).catch(() => undefined);
+  }
+
+  function handleTogglePalette() {
+    const next: 'standard' | 'colorblind' = palette === 'standard' ? 'colorblind' : 'standard';
+    setPalette(next);
+    api.saveUIPreferences({ theme: isDark ? 'dark' : 'light', palette: next }).catch(() => undefined);
   }
 
   useEffect(() => {
@@ -309,9 +329,10 @@ function AppShell(): React.JSX.Element {
   }
 
   return (
-    <div className="min-h-screen bg-bg-primary text-text-primary">
-      {/* Title bar + nav */}
-      <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
+    <PaletteProvider palette={palette}>
+      <div className="min-h-screen bg-bg-primary text-text-primary">
+        {/* Title bar + nav */}
+        <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center px-4 pt-7 pb-2">
           <div className="flex items-center gap-1">
             {leftNav.map((item) => (
@@ -360,6 +381,14 @@ function AppShell(): React.JSX.Element {
               aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
             >
               {isDark ? <SunIcon /> : <MoonIcon />}
+            </button>
+            <button
+              type="button"
+              onClick={handleTogglePalette}
+              className="rounded-md p-1.5 text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+              aria-label={palette === 'standard' ? 'Switch to colorblind palette' : 'Switch to standard palette'}
+            >
+              <PaletteIcon />
             </button>
             {RIGHT_NAV.map((item) => {
               const isSync = item.id === 'sync';
@@ -481,6 +510,7 @@ function AppShell(): React.JSX.Element {
         </Profiler>
       )}
       {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} />}
-    </div>
+      </div>
+    </PaletteProvider>
   );
 }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -245,7 +245,7 @@ export class MockCostApi implements CostApi {
   updateAwsProfile(): Promise<void> { return Promise.resolve(); }
   getSavingsPreferences(): Promise<{ hiddenActionTypes: readonly string[] }> { return Promise.resolve({ hiddenActionTypes: [] }); }
   saveSavingsPreferences(): Promise<void> { return Promise.resolve(); }
-  getUIPreferences(): Promise<{ theme: 'dark' | 'light' }> { return Promise.resolve({ theme: 'dark' }); }
+  getUIPreferences(): Promise<{ theme: 'dark' | 'light'; palette: 'standard' | 'colorblind' }> { return Promise.resolve({ theme: 'dark', palette: 'standard' }); }
   saveUIPreferences(): Promise<void> { return Promise.resolve(); }
   syncOrgAccounts(): Promise<{ accounts: readonly never[]; orgId: string; syncedAt: string }> { return Promise.resolve({ accounts: [], orgId: 'mock', syncedAt: new Date().toISOString() }); }
   getOrgSyncResult(): Promise<null> { return Promise.resolve(null); }

--- a/packages/ui/src/__tests__/cost-overview.test.tsx
+++ b/packages/ui/src/__tests__/cost-overview.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { PaletteProvider } from '../hooks/use-palette.js';
 import { MockCostApi } from '../__fixtures__/mock-api.js';
 import { CostOverview } from '../views/cost-overview.js';
 
@@ -12,9 +13,11 @@ function renderOverview() {
     api,
     user,
     ...render(
-      <CostApiProvider value={api}>
-        <CostOverview />
-      </CostApiProvider>,
+      <PaletteProvider>
+        <CostApiProvider value={api}>
+          <CostOverview />
+        </CostApiProvider>
+      </PaletteProvider>,
     ),
   };
 }

--- a/packages/ui/src/__tests__/entity-detail.test.tsx
+++ b/packages/ui/src/__tests__/entity-detail.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { PaletteProvider } from '../hooks/use-palette.js';
 import { MockCostApi } from '../__fixtures__/mock-api.js';
 import { EntityDetail } from '../views/entity-detail.js';
 
@@ -14,9 +15,11 @@ function renderDetail(overrides?: Partial<{ onBack: () => void }>) {
     onBack,
     user,
     ...render(
-      <CostApiProvider value={api}>
-        <EntityDetail entity="platform" dimension="account" onBack={onBack} />
-      </CostApiProvider>,
+      <PaletteProvider>
+        <CostApiProvider value={api}>
+          <EntityDetail entity="platform" dimension="account" onBack={onBack} />
+        </CostApiProvider>
+      </PaletteProvider>,
     ),
   };
 }

--- a/packages/ui/src/components/line-chart.tsx
+++ b/packages/ui/src/components/line-chart.tsx
@@ -11,6 +11,7 @@ import { curveMonotoneX } from '@visx/curve';
 import { getColor } from '../lib/palette.js';
 import { TOOLTIP_STYLES } from '../lib/tooltip-styles.js';
 import { formatDollars } from './format.js';
+import { usePalette } from '../hooks/use-palette.js';
 
 export interface LineSeriesPoint {
   readonly date: string;
@@ -45,6 +46,7 @@ interface LineSvgProps {
 }
 
 function LineSvg({ series, visible, width, height }: LineSvgProps) {
+  const { palette } = usePalette();
   const {
     showTooltip, hideTooltip, tooltipData, tooltipLeft, tooltipTop, tooltipOpen,
   } = useTooltip<TooltipPayload>();
@@ -106,7 +108,7 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
       .map((s) => {
         const p = s.points.find(x2 => x2.date === nearest);
         const colorIdx = seriesColorIndex.get(s.name) ?? 0;
-        const color = getColor(colorIdx);
+        const color = getColor(colorIdx, palette);
         return p === undefined ? null : { name: s.name, cost: p.cost, color };
       })
       .filter((e): e is { name: string; cost: number; color: string } => e !== null);
@@ -115,7 +117,7 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
       tooltipLeft: point.x,
       tooltipTop: point.y,
     });
-  }, [innerW, sortedDates, visible, xScale, showTooltip, seriesColorIndex]);
+  }, [innerW, sortedDates, visible, xScale, showTooltip, seriesColorIndex, palette]);
 
   return (
     <div className="relative" style={{ width, height }}>
@@ -161,7 +163,7 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
           />
           {visible.map((s) => {
             const colorIdx = seriesColorIndex.get(s.name) ?? 0;
-            const color = getColor(colorIdx);
+            const color = getColor(colorIdx, palette);
             return (
               <LinePath<LineSeriesPoint>
                 key={s.name}
@@ -203,6 +205,7 @@ function LineSvg({ series, visible, width, height }: LineSvgProps) {
 }
 
 export function LineChart({ series, title, subtitle, height = 320, onSeriesClick }: LineChartProps) {
+  const { palette } = usePalette();
   const [hidden, setHidden] = useState<ReadonlySet<string>>(new Set());
   const visible = useMemo(
     () => series.filter(s => !hidden.has(s.name)),
@@ -238,7 +241,7 @@ export function LineChart({ series, title, subtitle, height = 320, onSeriesClick
       <div className="mt-2 flex flex-wrap gap-2 shrink-0">
         {series.map((s) => {
           const colorIdx = series.findIndex(x => x.name === s.name);
-          const color = getColor(colorIdx);
+          const color = getColor(colorIdx, palette);
           const off = hidden.has(s.name);
           return (
             <button

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -7,6 +7,7 @@ import { useContainerWidth } from '../lib/use-container-width.js';
 import { formatDollars } from './format.js';
 import type { Dimension } from '@costgoblin/core/browser';
 import { getDimensionId, getDimensionLabel } from '../lib/dimensions.js';
+import { usePalette } from '../hooks/use-palette.js';
 
 export interface PieSlice {
   readonly name: string;
@@ -56,6 +57,7 @@ function PieChartInner({
   width,
   height,
 }: Omit<PieChartProps, 'collapsed'> & { width: number; height: number }) {
+  const { palette } = usePalette();
   const [localHovered, setLocalHovered] = useState<string | null>(null);
   const hoveredName = externalHoveredName ?? localHovered;
 
@@ -127,7 +129,7 @@ function PieChartInner({
             {(pie) =>
               pie.arcs.map((arc, i) => {
                 const sliceName = arc.data.name;
-                const color = sliceName === OTHER_KEY ? '#374151' : getColor(i);
+                const color = sliceName === OTHER_KEY ? '#374151' : getColor(i, palette);
                 const isHovered = hoveredName === sliceName;
                 const isDimmed = hoveredName !== null && !isHovered;
                 const path = pie.path(arc) ?? '';
@@ -161,7 +163,7 @@ function PieChartInner({
         {/* Legend */}
         <Group top={6} left={legendX}>
           {displayData.map((d, i) => {
-            const color = d.name === OTHER_KEY ? '#374151' : getColor(i);
+            const color = d.name === OTHER_KEY ? '#374151' : getColor(i, palette);
             const isHovered = hoveredName === d.name;
             const isDimmed = hoveredName !== null && !isHovered;
             const y = i * 22;

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { getColor } from '../lib/palette.js';
 import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
+import { usePalette } from '../hooks/use-palette.js';
 
 export interface BarDay {
   readonly date: string;
@@ -23,6 +24,7 @@ interface StackedBarChartProps {
 }
 
 export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading }: StackedBarChartProps) {
+  const { palette } = usePalette();
   const [hoveredDay, setHoveredDay] = useState<string | null>(null);
 
   const allKeys = new Set<string>();
@@ -136,7 +138,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                   >
                     {segments.map(seg => {
                       const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
-                      const color = getColor(seg.colorIdx);
+                      const color = getColor(seg.colorIdx, palette);
                       const isDimmed = highlightedGroup !== null && highlightedGroup !== undefined && highlightedGroup !== seg.key;
                       return (
                         <div
@@ -164,7 +166,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                           {segments
                             .slice(0, 8)
                             .map(seg => {
-                              const color = getColor(seg.colorIdx);
+                              const color = getColor(seg.colorIdx, palette);
                               const isHighlighted = highlightedGroup === seg.key;
                               return (
                                 <div

--- a/packages/ui/src/components/top-n-bar-chart.tsx
+++ b/packages/ui/src/components/top-n-bar-chart.tsx
@@ -5,6 +5,7 @@ import { useContainerWidth } from '../lib/use-container-width.js';
 import { formatDollars } from './format.js';
 import type { Dimension } from '@costgoblin/core/browser';
 import { getDimensionId, getDimensionLabel } from '../lib/dimensions.js';
+import { usePalette } from '../hooks/use-palette.js';
 
 export interface TopNBar {
   readonly name: string;
@@ -52,6 +53,7 @@ function TopNBarChartInner({
   onDimensionChange,
   width,
 }: Omit<TopNBarChartProps, 'collapsed'> & { width: number }) {
+  const { palette } = usePalette();
   const [localHovered, setLocalHovered] = useState<string | null>(null);
   const hoveredName = externalHoveredName ?? localHovered;
 
@@ -122,7 +124,7 @@ function TopNBarChartInner({
               const isDimmed = hoveredName !== null && !isHovered;
               const ratio = max > 0 ? row.cost / max : 0;
               const barW = Math.max(ratio * barAreaWidth, 1);
-              const color = getColor(i);
+              const color = getColor(i, palette);
 
               const barContent = (
                 <>

--- a/packages/ui/src/components/treemap-chart.tsx
+++ b/packages/ui/src/components/treemap-chart.tsx
@@ -4,6 +4,7 @@ import { Treemap, treemapSquarify, stratify } from '@visx/hierarchy';
 import { ParentSize } from '@visx/responsive';
 import { getColor } from '../lib/palette.js';
 import { formatDollars } from './format.js';
+import { usePalette } from '../hooks/use-palette.js';
 
 export interface TreemapCell {
   readonly name: string;
@@ -30,6 +31,7 @@ function TreemapInner({
   height,
   onCellClick,
 }: Omit<TreemapChartProps, 'title' | 'subtitle'> & { readonly width: number; readonly height: number }) {
+  const { palette } = usePalette();
   const root = useMemo(() => {
     const flat: FlatNode[] = [
       { id: 'root', parentId: null, cost: 0 },
@@ -60,7 +62,7 @@ function TreemapInner({
               if (node.depth === 0) return null;
               const w = node.x1 - node.x0;
               const h = node.y1 - node.y0;
-              const color = getColor(i);
+              const color = getColor(i, palette);
               const name = node.data.id;
               const cost = node.value ?? 0;
               const showLabel = w > 60 && h > 24;

--- a/packages/ui/src/hooks/use-palette.tsx
+++ b/packages/ui/src/hooks/use-palette.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { getActivePalette } from '../lib/palette.js';
+import type { PaletteType } from '../lib/palette.js';
+
+interface PaletteContextValue {
+  readonly paletteType: PaletteType;
+  readonly palette: readonly string[];
+}
+
+const PaletteContext = createContext<PaletteContextValue | undefined>(undefined);
+
+interface PaletteProviderProps {
+  readonly children: ReactNode;
+  readonly palette?: PaletteType;
+}
+
+export function PaletteProvider({ children, palette: paletteType = 'standard' }: PaletteProviderProps): React.JSX.Element {
+  const value = useMemo<PaletteContextValue>(
+    () => ({
+      paletteType,
+      palette: getActivePalette(paletteType),
+    }),
+    [paletteType],
+  );
+
+  return (
+    <PaletteContext.Provider value={value}>
+      {children}
+    </PaletteContext.Provider>
+  );
+}
+
+export function usePalette(): PaletteContextValue {
+  const ctx = useContext(PaletteContext);
+  if (ctx === undefined) {
+    throw new Error('usePalette must be used within a PaletteProvider');
+  }
+  return ctx;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -58,5 +58,7 @@ export { SetupWizard } from './views/setup-wizard.js';
 export { getDimensionId, isTagDimension, isEnvironmentDimension, isOwnerDimension, isProductDimension } from './lib/dimensions.js';
 
 export { PALETTE_STANDARD, PALETTE_COLORBLIND, getActivePalette } from './lib/palette.js';
+export type { PaletteType } from './lib/palette.js';
+export { PaletteProvider, usePalette } from './hooks/use-palette.js';
 
 export { MockCostApi } from './__fixtures__/mock-api.js';

--- a/packages/ui/src/lib/palette.ts
+++ b/packages/ui/src/lib/palette.ts
@@ -10,11 +10,11 @@ export const PALETTE_COLORBLIND: readonly string[] = [
 
 const PALETTE_FALLBACK = '#374151';
 
+export type PaletteType = 'standard' | 'colorblind';
+
 export function getColor(index: number, palette: readonly string[] = PALETTE_STANDARD): string {
   return palette[index % palette.length] ?? PALETTE_FALLBACK;
 }
-
-type PaletteType = 'standard' | 'colorblind';
 
 export function getActivePalette(type: PaletteType = 'standard'): readonly string[] {
   return type === 'colorblind' ? PALETTE_COLORBLIND : PALETTE_STANDARD;


### PR DESCRIPTION
## Summary
- Add `palette` field to `UIPreferences` and persist it to `preferences.json` via the existing IPC handlers
- Create a controlled `PaletteProvider` context so all chart components consume the active palette without prop-drilling
- Add a palette toggle button (standard / colorblind) in the header bar next to the theme toggle
- Wire all chart components (pie, stacked-bar, line, top-n-bar, treemap) to use `usePalette()` for color resolution