### PR TITLE
Fix in-flight IPC count accumulating on repeated nav clicks

### DIFF
--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -276,7 +276,8 @@ const api: CostApi = {
   },
   cancelPendingQueries(): Promise<void> {
     void invoke<undefined>('debug:clear-completed');
-    return invoke<undefined>('query:cancel-pending').then(() => undefined);
+    // Use ipcRenderer directly — cancel calls shouldn't inflate the in-flight badge
+    return (ipcRenderer.invoke('query:cancel-pending') as Promise<undefined>).then(() => undefined);
   },
 };
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -253,6 +253,8 @@ function AppShell(): React.JSX.Element {
   }, [api, setupCheck, syncActivity]);
 
   function handleNavClick(id: string) {
+    const alreadyActive = view.page === 'custom' ? view.viewId === id : view.page === id;
+    if (alreadyActive) return;
     confirmLeave(() => {
       api.cancelPendingQueries().catch(() => undefined);
       switch (id) {

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -55,7 +55,10 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
   }, [entry.id]);
 
   return (
-    <div className="border-b border-border/50 last:border-b-0">
+    <div className={[
+      'border-b border-border/50 last:border-b-0',
+      (entry.status === 'running' || entry.status === 'queued') ? 'bg-accent/5 animate-pulse' : '',
+    ].join(' ')}>
       <button
         type="button"
         onClick={() => { setExpanded(!expanded); }}
@@ -128,7 +131,10 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
 
   const runningCount = entries.filter(e => e.status === 'running').length;
   const queuedCount = entries.filter(e => e.status === 'queued').length;
-  const reversed = [...entries].reverse();
+  const sorted = [...entries].reverse().sort((a, b) => {
+    const rank = (s: DebugQueryLogEntry['status']) => s === 'running' ? 0 : s === 'queued' ? 1 : 2;
+    return rank(a.status) - rank(b.status);
+  });
 
   return (
     <div className="fixed top-[4.5rem] right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col">
@@ -197,10 +203,10 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
 
       {/* Query list */}
       <div className="flex-1 overflow-y-auto">
-        {reversed.length === 0 && (
+        {sorted.length === 0 && (
           <p className="text-xs text-text-muted text-center py-8">No queries yet</p>
         )}
-        {reversed.map(entry => (
+        {sorted.map(entry => (
           <QueryRow key={entry.id} entry={entry} />
         ))}
       </div>

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -112,6 +112,7 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
 
 export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): React.JSX.Element {
   const [entries, setEntries] = useState<DebugQueryLogEntry[]>([]);
+  const inFlightCount = useDebugBadge();
 
   useEffect(() => {
     let cancelled = false;
@@ -145,6 +146,11 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
               </span>
             )}
           </span>
+          {inFlightCount > 0 && (
+            <span className="text-xs text-text-muted" title="Total IPC calls in-flight (includes config, sync, and other non-SQL calls)">
+              <span className="text-accent">{String(inFlightCount)}</span> IPC in-flight
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <button


### PR DESCRIPTION
## Summary
- Skip navigation when clicking a nav button that's already active — prevents redundant `cancelPendingQueries` calls and inventory effect re-triggers that were inflating the in-flight badge
- `cancelPendingQueries` now bypasses the in-flight counter (the cancel IPC call itself was being counted)
- Debug panel shows "N IPC in-flight" with a tooltip explaining it includes all API calls, not just SQL queries