### PR TITLE
Date Range Presets and Custom Date Picker

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -122,6 +122,15 @@ export async function navigateToText(page: Page, buttonName: string, visibleText
   await waitForQuerySettle(page);
 }
 
+/** Open the date picker popover and click a preset by label. */
+export async function selectDatePreset(page: Page, presetLabel: string): Promise<void> {
+  // The trigger is a button containing a calendar icon + current label + chevron
+  const trigger = page.locator('button:has(svg.lucide-calendar)');
+  await trigger.click();
+  // Inside the popover, click the preset text
+  await page.getByText(presetLabel, { exact: true }).click();
+}
+
 export function writeCoverage(shardName: string, allCoverage: unknown[]): void {
   if (allCoverage.length > 0) {
     writeFileSync(join(V8_DIR, `coverage-${shardName}.json`), JSON.stringify(allCoverage));

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -125,7 +125,7 @@ export async function navigateToText(page: Page, buttonName: string, visibleText
 /** Open the date picker popover and click a preset by label. */
 export async function selectDatePreset(page: Page, presetLabel: string): Promise<void> {
   // The trigger is a button containing a calendar icon + current label + chevron
-  const trigger = page.locator('button:has(svg.lucide-calendar)');
+  const trigger = page.locator('button:has(svg.lucide-chevron-down)');
   await trigger.click();
   // Inside the popover, click the preset text
   await page.getByText(presetLabel, { exact: true }).click();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -116,6 +116,12 @@ export async function navigateTo(page: Page, buttonName: string, headingName: st
   await waitForQuerySettle(page);
 }
 
+export async function navigateToText(page: Page, buttonName: string, visibleText: string): Promise<void> {
+  await clickNavButton(page, buttonName);
+  await expect(page.getByText(visibleText, { exact: false }).first()).toBeVisible({ timeout: 5000 });
+  await waitForQuerySettle(page);
+}
+
 export function writeCoverage(shardName: string, allCoverage: unknown[]): void {
   if (allCoverage.length > 0) {
     writeFileSync(join(V8_DIR, `coverage-${shardName}.json`), JSON.stringify(allCoverage));

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -123,12 +123,13 @@ test.describe('Cost Overview', () => {
     const trigger = page.locator('button:has(svg.lucide-calendar)');
     await expect(trigger).toBeVisible();
 
-    // Open popover and verify sections
+    // Open popover and verify sections exist inside it
     await trigger.click();
-    await expect(page.getByText('Daily')).toBeVisible();
-    await expect(page.getByText('Hourly')).toBeVisible();
-    await expect(page.getByText('Period')).toBeVisible();
-    await expect(page.getByText('Custom range…')).toBeVisible();
+    const popover = page.locator('[data-radix-popper-content-wrapper]');
+    await expect(popover.getByText('Daily')).toBeVisible();
+    await expect(popover.getByText('Hourly')).toBeVisible();
+    await expect(popover.getByText('Period')).toBeVisible();
+    await expect(popover.getByText('Custom range…')).toBeVisible();
 
     // Close by clicking trigger again
     await trigger.click();
@@ -152,8 +153,9 @@ test.describe('Cost Overview', () => {
     await trigger.click();
     await page.getByText('Custom range…').click();
 
-    await expect(page.getByText('From')).toBeVisible();
-    await expect(page.getByText('To')).toBeVisible();
+    const popover = page.locator('[data-radix-popper-content-wrapper]');
+    await expect(popover.getByText('From')).toBeVisible();
+    await expect(popover.getByText('To')).toBeVisible();
 
     // close popover
     await trigger.click();
@@ -480,8 +482,7 @@ test.describe('Missing Tags', () => {
     await navigateToText(page, 'Missing Tags', 'without the selected allocation tag');
   });
 
-  test('shows heading and subtitle', async () => {
-    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+  test('shows subtitle', async () => {
     await expect(page.getByText(/without the selected allocation tag/i)).toBeVisible();
   });
 

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -8,6 +8,7 @@ import {
   waitForQuerySettle,
   hasVisibleData,
   navigateTo,
+  navigateToText,
   clickNavButton,
   writeCoverage,
   LOAD_TIMEOUT,
@@ -43,7 +44,7 @@ test.describe('App shell', () => {
   });
 
   test('shows all navigation buttons', async () => {
-    for (const label of ['Cost Overview', 'Trends', 'Missing Tags', 'Savings', 'Cost Scope', 'Dimensions', 'Views']) {
+    for (const label of ['Cost Overview', 'Trends', 'Findings', 'Missing Tags', 'Explorer', 'Cost Scope', 'Dimensions', 'Views']) {
       await expect(page.getByRole('button', { name: label })).toBeVisible();
     }
     await expect(page.getByRole('button', { name: /Sync/ }).first()).toBeVisible();
@@ -70,18 +71,22 @@ test.describe('App shell', () => {
 
   test('navigating between all views changes active content', async () => {
     const views = [
-      { button: 'Cost Overview', heading: 'Cost Overview' },
-      { button: 'Trends', heading: 'Cost Trends' },
-      { button: 'Missing Tags', heading: 'Missing Tags' },
-      { button: 'Savings', heading: 'Savings Opportunities' },
-      { button: 'Cost Scope', heading: 'Cost Scope' },
-      { button: 'Dimensions', heading: 'Dimensions' },
-      { button: 'Sync', heading: 'Data Management' },
+      { button: 'Cost Overview', marker: { type: 'heading' as const, text: 'Cost Overview' } },
+      { button: 'Trends', marker: { type: 'text' as const, text: 'Period-over-period comparison' } },
+      { button: 'Missing Tags', marker: { type: 'text' as const, text: 'without the selected allocation tag' } },
+      { button: 'Findings', marker: { type: 'text' as const, text: 'AWS cost optimization recommendations' } },
+      { button: 'Cost Scope', marker: { type: 'heading' as const, text: 'Cost Scope' } },
+      { button: 'Dimensions', marker: { type: 'heading' as const, text: 'Dimensions' } },
+      { button: 'Sync', marker: { type: 'heading' as const, text: 'Data Management' } },
     ];
 
-    for (const { button, heading } of views) {
+    for (const { button, marker } of views) {
       await clickNavButton(page, button);
-      await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible({ timeout: 5000 });
+      if (marker.type === 'heading') {
+        await expect(page.getByRole('heading', { name: marker.text, exact: true })).toBeVisible({ timeout: 5000 });
+      } else {
+        await expect(page.getByText(marker.text, { exact: false }).first()).toBeVisible({ timeout: 5000 });
+      }
       await page.waitForTimeout(500);
       await assertNoReactCrash(page);
     }
@@ -112,24 +117,34 @@ test.describe('Cost Overview', () => {
     await screenshot(page, 'overview-summary');
   });
 
-  test('renders date range picker with daily and hourly presets', async () => {
-    // daily presets
-    for (const preset of ['30 days', '90 days', '365 days']) {
-      await expect(page.getByRole('button', { name: preset }).first()).toBeVisible();
+  test('renders date range picker popover with daily and hourly presets', async () => {
+    // Open the date picker popover
+    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    // daily presets inside the popover
+    for (const preset of ['Last 30 days', 'Last 90 days', 'Last 365 days']) {
+      await expect(page.getByText(preset, { exact: true })).toBeVisible();
     }
 
     // hourly presets
-    for (const preset of ['7 days', '14 days']) {
-      await expect(page.getByRole('button', { name: preset }).first()).toBeVisible();
+    for (const preset of ['Last 7 days', 'Last 14 days']) {
+      await expect(page.getByText(preset, { exact: true })).toBeVisible();
     }
 
-    // Custom button
-    await expect(page.getByRole('button', { name: 'Custom' })).toBeVisible();
+    // Custom range option
+    await expect(page.getByText('Custom range\u2026')).toBeVisible();
+
+    // Close the popover
+    await trigger.click();
   });
 
   test('switching date range preset triggers a reload', async () => {
-    const btn365 = page.getByRole('button', { name: '365 days' }).first();
-    await btn365.click();
+    // Open popover and select 365 days
+    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+    await trigger.click();
+    await page.getByText('Last 365 days', { exact: true }).click();
     await waitForQuerySettle(page);
 
     // After switching, summary card shows either a dollar amount or "—"
@@ -138,20 +153,25 @@ test.describe('Cost Overview', () => {
     expect(text === '—' || (text !== null && text.includes('$'))).toBe(true);
 
     // switch back
-    await page.getByRole('button', { name: '30 days' }).first().click();
+    await trigger.click();
+    await page.getByText('Last 30 days', { exact: true }).click();
     await waitForQuerySettle(page);
   });
 
-  test('custom date range inputs appear when Custom is clicked', async () => {
-    const customBtn = page.getByRole('button', { name: 'Custom' });
-    await customBtn.click();
+  test('custom date range inputs appear when Custom range is clicked', async () => {
+    // Open the date picker popover
+    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+    await trigger.click();
 
-    const dateInputs = page.locator('input[type="date"]');
-    await expect(dateInputs.first()).toBeVisible();
-    expect(await dateInputs.count()).toBeGreaterThanOrEqual(2);
+    // Click "Custom range..." to expand the custom date inputs
+    await page.getByText('Custom range\u2026').click();
 
-    // click Custom again to dismiss
-    await customBtn.click();
+    // From/To date buttons should appear
+    await expect(page.getByText('From', { exact: true })).toBeVisible();
+    await expect(page.getByText('To', { exact: true })).toBeVisible();
+
+    // Close the popover
+    await trigger.click();
   });
 
   test('filter bar shows dimension chips and they are clickable', async () => {
@@ -298,7 +318,9 @@ test.describe('Cost Overview', () => {
 
   test('breakdown table renders when data is available', async () => {
     // switch to 365 days to maximize chance of having data
-    await page.getByRole('button', { name: '365 days' }).first().click();
+    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+    await trigger.click();
+    await page.getByText('Last 365 days', { exact: true }).click();
     await waitForQuerySettle(page);
 
     const tables = page.locator('table');
@@ -318,7 +340,8 @@ test.describe('Cost Overview', () => {
     }
 
     // switch back
-    await page.getByRole('button', { name: '30 days' }).first().click();
+    await trigger.click();
+    await page.getByText('Last 30 days', { exact: true }).click();
     await waitForQuerySettle(page);
   });
 
@@ -338,10 +361,10 @@ test.describe('Cost Overview', () => {
 // ---------------------------------------------------------------------------
 test.describe('Cost Trends', () => {
   test.beforeAll(async () => {
-    await navigateTo(page, 'Trends', 'Cost Trends');
+    await navigateToText(page, 'Trends', 'Period-over-period comparison');
   });
 
-  test('shows heading and subtitle', async () => {
+  test('shows subtitle', async () => {
     await expect(page.getByText('Period-over-period comparison')).toBeVisible();
   });
 
@@ -367,7 +390,7 @@ test.describe('Cost Trends', () => {
   });
 
   test('Increases/Savings toggle is present and clickable', async () => {
-    // These buttons have CSS capitalize. The nav bar also has a "Savings" button,
+    // These buttons have CSS capitalize. The nav bar also has a "Findings" button,
     // so we scope to the toggle container (the bordered pill group).
     const toggleContainer = page.locator('.flex.items-center.gap-1.rounded-lg.border').nth(1);
     const increasesBtn = toggleContainer.getByRole('button', { name: 'increases' });
@@ -475,11 +498,10 @@ test.describe('Cost Trends', () => {
 // ---------------------------------------------------------------------------
 test.describe('Missing Tags', () => {
   test.beforeAll(async () => {
-    await navigateTo(page, 'Missing Tags', 'Missing Tags');
+    await navigateToText(page, 'Missing Tags', 'without the selected allocation tag');
   });
 
-  test('shows heading and subtitle', async () => {
-    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+  test('shows subtitle', async () => {
     await expect(page.getByText(/without the selected allocation tag/i)).toBeVisible();
   });
 
@@ -559,14 +581,14 @@ test.describe('Missing Tags', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Savings Opportunities
+// Findings (cost optimization recommendations)
 // ---------------------------------------------------------------------------
-test.describe('Savings', () => {
+test.describe('Findings', () => {
   test.beforeAll(async () => {
-    await navigateTo(page, 'Savings', 'Savings Opportunities');
+    await navigateToText(page, 'Findings', 'AWS cost optimization recommendations');
   });
 
-  test('shows heading and subtitle', async () => {
+  test('shows subtitle', async () => {
     await expect(page.getByText('AWS cost optimization recommendations')).toBeVisible();
   });
 
@@ -644,7 +666,7 @@ test.describe('Entity Detail', () => {
 
   test.beforeAll(async () => {
     // Reach entity detail via Trends → click first entity link.
-    await navigateTo(page, 'Trends', 'Cost Trends');
+    await navigateToText(page, 'Trends', 'Period-over-period comparison');
 
     const entityLink = page.locator('table button.text-accent').first();
     const exists = await entityLink.isVisible().catch(() => false);
@@ -719,8 +741,9 @@ test.describe('Entity Detail', () => {
 
   test('date range picker works on entity detail', async () => {
     test.skip(!entityReached, 'No entity data available');
-    const btn90 = page.getByRole('button', { name: '90 days' }).first();
-    await btn90.click();
+    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+    await trigger.click();
+    await page.getByText('Last 90 days', { exact: true }).click();
     await waitForQuerySettle(page);
 
     const costValue = page.locator('.text-3xl.tabular-nums');
@@ -750,24 +773,24 @@ test.describe('Full user journey', () => {
     await navigateTo(page, 'Cost Overview', 'Cost Overview');
   });
 
-  test('overview → trends → missing tags → savings → data → overview (full navigation cycle)', async () => {
+  test('overview → trends → missing tags → findings → data → overview (full navigation cycle)', async () => {
     // 1. Overview
     await waitForQuerySettle(page);
     await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible();
 
     // 2. Trends
     await clickNavButton(page, 'Trends');
-    await expect(page.getByRole('heading', { name: 'Cost Trends' })).toBeVisible();
+    await expect(page.getByText('Period-over-period comparison').first()).toBeVisible({ timeout: 5000 });
     await waitForQuerySettle(page);
 
     // 3. Missing Tags
     await clickNavButton(page, 'Missing Tags');
-    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+    await expect(page.getByText('without the selected allocation tag').first()).toBeVisible({ timeout: 5000 });
     await waitForQuerySettle(page);
 
-    // 4. Savings
-    await clickNavButton(page, 'Savings');
-    await expect(page.getByRole('heading', { name: 'Savings Opportunities' })).toBeVisible();
+    // 4. Findings
+    await clickNavButton(page, 'Findings');
+    await expect(page.getByText('AWS cost optimization recommendations').first()).toBeVisible({ timeout: 5000 });
     await waitForQuerySettle(page);
 
     // 5. Dimensions
@@ -786,12 +809,12 @@ test.describe('Full user journey', () => {
   });
 
   test('rapid navigation between views does not crash', async () => {
-    const views = ['Trends', 'Cost Overview', 'Missing Tags', 'Savings', 'Dimensions', 'Sync', 'Cost Overview', 'Trends', 'Missing Tags'];
+    const views = ['Trends', 'Cost Overview', 'Missing Tags', 'Findings', 'Dimensions', 'Sync', 'Cost Overview', 'Trends', 'Missing Tags'];
     for (const view of views) {
       await clickNavButton(page, view);
       await page.waitForTimeout(100);
     }
-    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+    await expect(page.getByText('without the selected allocation tag').first()).toBeVisible({ timeout: 5000 });
     await assertNoReactCrash(page);
   });
 });

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -154,8 +154,8 @@ test.describe('Cost Overview', () => {
     await page.getByText('Custom range…').click();
 
     const popover = page.locator('[data-radix-popper-content-wrapper]');
-    await expect(popover.getByText('From')).toBeVisible();
-    await expect(popover.getByText('To')).toBeVisible();
+    await expect(popover.getByText('From', { exact: true })).toBeVisible();
+    await expect(popover.getByText('To', { exact: true })).toBeVisible();
 
     // close popover
     await trigger.click();

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -120,7 +120,7 @@ test.describe('Cost Overview', () => {
 
   test('renders date range picker popover with presets', async () => {
     // Trigger button shows active preset
-    const trigger = page.locator('button:has(svg.lucide-calendar)');
+    const trigger = page.locator('button:has(svg.lucide-chevron-down)');
     await expect(trigger).toBeVisible();
 
     // Open popover and verify sections exist inside it
@@ -149,7 +149,7 @@ test.describe('Cost Overview', () => {
   });
 
   test('custom date range inputs appear when Custom range is clicked', async () => {
-    const trigger = page.locator('button:has(svg.lucide-calendar)');
+    const trigger = page.locator('button:has(svg.lucide-chevron-down)');
     await trigger.click();
     await page.getByText('Custom range…').click();
 

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -9,6 +9,7 @@ import {
   hasVisibleData,
   navigateTo,
   navigateToText,
+  selectDatePreset,
   clickNavButton,
   writeCoverage,
   LOAD_TIMEOUT,
@@ -44,7 +45,7 @@ test.describe('App shell', () => {
   });
 
   test('shows all navigation buttons', async () => {
-    for (const label of ['Cost Overview', 'Trends', 'Findings', 'Missing Tags', 'Explorer', 'Cost Scope', 'Dimensions', 'Views']) {
+    for (const label of ['Cost Overview', 'Trends', 'Missing Tags', 'Findings', 'Cost Scope', 'Dimensions', 'Views']) {
       await expect(page.getByRole('button', { name: label })).toBeVisible();
     }
     await expect(page.getByRole('button', { name: /Sync/ }).first()).toBeVisible();
@@ -70,20 +71,20 @@ test.describe('App shell', () => {
   });
 
   test('navigating between all views changes active content', async () => {
-    const views = [
-      { button: 'Cost Overview', marker: { type: 'heading' as const, text: 'Cost Overview' } },
-      { button: 'Trends', marker: { type: 'text' as const, text: 'Period-over-period comparison' } },
-      { button: 'Missing Tags', marker: { type: 'text' as const, text: 'without the selected allocation tag' } },
-      { button: 'Findings', marker: { type: 'text' as const, text: 'AWS cost optimization recommendations' } },
-      { button: 'Cost Scope', marker: { type: 'heading' as const, text: 'Cost Scope' } },
-      { button: 'Dimensions', marker: { type: 'heading' as const, text: 'Dimensions' } },
-      { button: 'Sync', marker: { type: 'heading' as const, text: 'Data Management' } },
+    const views: { button: string; marker: { type: 'heading'; name: string } | { type: 'text'; text: string } }[] = [
+      { button: 'Cost Overview', marker: { type: 'heading', name: 'Cost Overview' } },
+      { button: 'Trends', marker: { type: 'text', text: 'Period-over-period comparison' } },
+      { button: 'Missing Tags', marker: { type: 'text', text: 'without the selected allocation tag' } },
+      { button: 'Findings', marker: { type: 'text', text: 'cost optimization recommendations' } },
+      { button: 'Cost Scope', marker: { type: 'heading', name: 'Cost Scope' } },
+      { button: 'Dimensions', marker: { type: 'heading', name: 'Dimensions' } },
+      { button: 'Sync', marker: { type: 'heading', name: 'Data Management' } },
     ];
 
     for (const { button, marker } of views) {
       await clickNavButton(page, button);
       if (marker.type === 'heading') {
-        await expect(page.getByRole('heading', { name: marker.text, exact: true })).toBeVisible({ timeout: 5000 });
+        await expect(page.getByRole('heading', { name: marker.name, exact: true })).toBeVisible({ timeout: 5000 });
       } else {
         await expect(page.getByText(marker.text, { exact: false }).first()).toBeVisible({ timeout: 5000 });
       }
@@ -117,60 +118,44 @@ test.describe('Cost Overview', () => {
     await screenshot(page, 'overview-summary');
   });
 
-  test('renders date range picker popover with daily and hourly presets', async () => {
-    // Open the date picker popover
-    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+  test('renders date range picker popover with presets', async () => {
+    // Trigger button shows active preset
+    const trigger = page.locator('button:has(svg.lucide-calendar)');
     await expect(trigger).toBeVisible();
+
+    // Open popover and verify sections
     await trigger.click();
+    await expect(page.getByText('Daily')).toBeVisible();
+    await expect(page.getByText('Hourly')).toBeVisible();
+    await expect(page.getByText('Period')).toBeVisible();
+    await expect(page.getByText('Custom range…')).toBeVisible();
 
-    // daily presets inside the popover
-    for (const preset of ['Last 30 days', 'Last 90 days', 'Last 365 days']) {
-      await expect(page.getByText(preset, { exact: true })).toBeVisible();
-    }
-
-    // hourly presets
-    for (const preset of ['Last 7 days', 'Last 14 days']) {
-      await expect(page.getByText(preset, { exact: true })).toBeVisible();
-    }
-
-    // Custom range option
-    await expect(page.getByText('Custom range\u2026')).toBeVisible();
-
-    // Close the popover
+    // Close by clicking trigger again
     await trigger.click();
   });
 
   test('switching date range preset triggers a reload', async () => {
-    // Open popover and select 365 days
-    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
-    await trigger.click();
-    await page.getByText('Last 365 days', { exact: true }).click();
+    await selectDatePreset(page, 'Last 90 days');
     await waitForQuerySettle(page);
 
-    // After switching, summary card shows either a dollar amount or "—"
     const costText = page.locator('.tabular-nums').first();
     const text = await costText.textContent();
     expect(text === '—' || (text !== null && text.includes('$'))).toBe(true);
 
     // switch back
-    await trigger.click();
-    await page.getByText('Last 30 days', { exact: true }).click();
+    await selectDatePreset(page, 'Last 30 days');
     await waitForQuerySettle(page);
   });
 
   test('custom date range inputs appear when Custom range is clicked', async () => {
-    // Open the date picker popover
-    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
+    const trigger = page.locator('button:has(svg.lucide-calendar)');
     await trigger.click();
+    await page.getByText('Custom range…').click();
 
-    // Click "Custom range..." to expand the custom date inputs
-    await page.getByText('Custom range\u2026').click();
+    await expect(page.getByText('From')).toBeVisible();
+    await expect(page.getByText('To')).toBeVisible();
 
-    // From/To date buttons should appear
-    await expect(page.getByText('From', { exact: true })).toBeVisible();
-    await expect(page.getByText('To', { exact: true })).toBeVisible();
-
-    // Close the popover
+    // close popover
     await trigger.click();
   });
 
@@ -317,10 +302,7 @@ test.describe('Cost Overview', () => {
   });
 
   test('breakdown table renders when data is available', async () => {
-    // switch to 365 days to maximize chance of having data
-    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
-    await trigger.click();
-    await page.getByText('Last 365 days', { exact: true }).click();
+    await selectDatePreset(page, 'Last 365 days');
     await waitForQuerySettle(page);
 
     const tables = page.locator('table');
@@ -332,16 +314,13 @@ test.describe('Cost Overview', () => {
       const rowCount = await rows.count();
       expect(rowCount).toBeGreaterThan(0);
 
-      // hover a row
       if (rowCount > 0) {
         await rows.first().hover();
         await screenshot(page, 'overview-breakdown-hover');
       }
     }
 
-    // switch back
-    await trigger.click();
-    await page.getByText('Last 30 days', { exact: true }).click();
+    await selectDatePreset(page, 'Last 30 days');
     await waitForQuerySettle(page);
   });
 
@@ -364,7 +343,7 @@ test.describe('Cost Trends', () => {
     await navigateToText(page, 'Trends', 'Period-over-period comparison');
   });
 
-  test('shows subtitle', async () => {
+  test('shows heading and subtitle', async () => {
     await expect(page.getByText('Period-over-period comparison')).toBeVisible();
   });
 
@@ -390,7 +369,7 @@ test.describe('Cost Trends', () => {
   });
 
   test('Increases/Savings toggle is present and clickable', async () => {
-    // These buttons have CSS capitalize. The nav bar also has a "Findings" button,
+    // These buttons have CSS capitalize. The nav bar also has a "Savings" button,
     // so we scope to the toggle container (the bordered pill group).
     const toggleContainer = page.locator('.flex.items-center.gap-1.rounded-lg.border').nth(1);
     const increasesBtn = toggleContainer.getByRole('button', { name: 'increases' });
@@ -501,7 +480,8 @@ test.describe('Missing Tags', () => {
     await navigateToText(page, 'Missing Tags', 'without the selected allocation tag');
   });
 
-  test('shows subtitle', async () => {
+  test('shows heading and subtitle', async () => {
+    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
     await expect(page.getByText(/without the selected allocation tag/i)).toBeVisible();
   });
 
@@ -581,14 +561,14 @@ test.describe('Missing Tags', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Findings (cost optimization recommendations)
+// Savings Opportunities
 // ---------------------------------------------------------------------------
 test.describe('Findings', () => {
   test.beforeAll(async () => {
-    await navigateToText(page, 'Findings', 'AWS cost optimization recommendations');
+    await navigateToText(page, 'Findings', 'cost optimization recommendations');
   });
 
-  test('shows subtitle', async () => {
+  test('shows heading and subtitle', async () => {
     await expect(page.getByText('AWS cost optimization recommendations')).toBeVisible();
   });
 
@@ -741,9 +721,7 @@ test.describe('Entity Detail', () => {
 
   test('date range picker works on entity detail', async () => {
     test.skip(!entityReached, 'No entity data available');
-    const trigger = page.getByRole('button', { name: /Last \d+ days/ }).first();
-    await trigger.click();
-    await page.getByText('Last 90 days', { exact: true }).click();
+    await selectDatePreset(page, 'Last 90 days');
     await waitForQuerySettle(page);
 
     const costValue = page.locator('.text-3xl.tabular-nums');
@@ -773,24 +751,24 @@ test.describe('Full user journey', () => {
     await navigateTo(page, 'Cost Overview', 'Cost Overview');
   });
 
-  test('overview → trends → missing tags → findings → data → overview (full navigation cycle)', async () => {
+  test('overview → trends → missing tags → savings → data → overview (full navigation cycle)', async () => {
     // 1. Overview
     await waitForQuerySettle(page);
     await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible();
 
     // 2. Trends
     await clickNavButton(page, 'Trends');
-    await expect(page.getByText('Period-over-period comparison').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Period-over-period comparison').first()).toBeVisible();
     await waitForQuerySettle(page);
 
     // 3. Missing Tags
     await clickNavButton(page, 'Missing Tags');
-    await expect(page.getByText('without the selected allocation tag').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('without the selected allocation tag').first()).toBeVisible();
     await waitForQuerySettle(page);
 
     // 4. Findings
     await clickNavButton(page, 'Findings');
-    await expect(page.getByText('AWS cost optimization recommendations').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('cost optimization recommendations').first()).toBeVisible();
     await waitForQuerySettle(page);
 
     // 5. Dimensions
@@ -814,7 +792,7 @@ test.describe('Full user journey', () => {
       await clickNavButton(page, view);
       await page.waitForTimeout(100);
     }
-    await expect(page.getByText('without the selected allocation tag').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('without the selected allocation tag').first()).toBeVisible();
     await assertNoReactCrash(page);
   });
 });

--- a/packages/ui/src/__tests__/cost-overview.test.tsx
+++ b/packages/ui/src/__tests__/cost-overview.test.tsx
@@ -54,7 +54,8 @@ describe('CostOverview', () => {
     });
 
     const initialCallCount = queryCostsSpy.mock.calls.length;
-    await user.click(screen.getByText('7 days'));
+    await user.click(screen.getByText('Last 30 days'));
+    await user.click(screen.getByText('Last 90 days'));
 
     await waitFor(() => {
       expect(queryCostsSpy.mock.calls.length).toBeGreaterThan(initialCallCount);

--- a/packages/ui/src/__tests__/date-range-picker.test.tsx
+++ b/packages/ui/src/__tests__/date-range-picker.test.tsx
@@ -24,75 +24,74 @@ function renderPicker(overrides?: Partial<{
 afterEach(cleanup);
 
 describe('DateRangePicker', () => {
-  it('shows daily, period, and hourly rows', () => {
+  it('shows active preset label on trigger button', () => {
     renderPicker();
+    expect(screen.getByText('Last 30 days')).toBeDefined();
+  });
+
+  it('opens popover with preset sections on click', async () => {
+    renderPicker();
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Last 30 days'));
+
     expect(screen.getByText('Daily')).toBeDefined();
     expect(screen.getByText('Period')).toBeDefined();
     expect(screen.getByText('Hourly')).toBeDefined();
   });
 
-  it('shows daily presets (30d, 90d, 365d, Current month, Last month, Quarter, YTD + Custom)', () => {
+  it('shows all presets when open', async () => {
     renderPicker();
-    expect(screen.getByText('30d')).toBeDefined();
-    expect(screen.getByText('90d')).toBeDefined();
-    expect(screen.getByText('365d')).toBeDefined();
-    expect(screen.getByText('Month')).toBeDefined();
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Last 30 days'));
+
+    expect(screen.getByText('Last 90 days')).toBeDefined();
+    expect(screen.getByText('Last 365 days')).toBeDefined();
+    expect(screen.getByText('This month')).toBeDefined();
     expect(screen.getByText('Last month')).toBeDefined();
-    expect(screen.getByText('Quarter')).toBeDefined();
-    expect(screen.getByText('YTD')).toBeDefined();
-    expect(screen.getByText('Custom')).toBeDefined();
+    expect(screen.getByText('This quarter')).toBeDefined();
+    expect(screen.getByText('Last quarter')).toBeDefined();
+    expect(screen.getByText('This year')).toBeDefined();
+    expect(screen.getByText('Last year')).toBeDefined();
+    expect(screen.getByText('Last 7 days')).toBeDefined();
+    expect(screen.getByText('Last 14 days')).toBeDefined();
+    expect(screen.getByText('Last 28 days')).toBeDefined();
+    expect(screen.getByText('Custom range…')).toBeDefined();
   });
 
-  it('shows hourly presets (7, 14, 28 days)', () => {
-    renderPicker();
-    expect(screen.getByText('7 days')).toBeDefined();
-    expect(screen.getByText('14 days')).toBeDefined();
-    expect(screen.getByText('28 days')).toBeDefined();
-  });
-
-  it('30d daily is selected by default', () => {
-    renderPicker();
-    const dailyBtn = screen.getByText('30d');
-    expect(dailyBtn).toBeDefined();
-    expect(dailyBtn.className).toContain('bg-accent');
-  });
-
-  it('clicking hourly 7 days calls onChange with hourly granularity', async () => {
+  it('clicking a preset calls onChange and closes popover', async () => {
     const onChange = vi.fn();
     renderPicker({ onChange });
-
     const user = userEvent.setup();
-    await user.click(screen.getByText('7 days'));
 
-    expect(onChange).toHaveBeenCalledOnce();
-    const granularity = onChange.mock.calls[0]?.[1] as Granularity;
-    expect(granularity).toBe('hourly');
-  });
-
-  it('clicking daily 90d calls onChange with daily granularity', async () => {
-    const onChange = vi.fn();
-    renderPicker({ onChange });
-
-    const user = userEvent.setup();
-    await user.click(screen.getByText('90d'));
+    await user.click(screen.getByText('Last 30 days'));
+    await user.click(screen.getByText('Last 90 days'));
 
     expect(onChange).toHaveBeenCalledOnce();
     const granularity = onChange.mock.calls[0]?.[1] as Granularity;
     expect(granularity).toBe('daily');
   });
 
-  it('clicking Custom shows calendar pickers', async () => {
-    const { container } = renderPicker();
-
-    // No calendar buttons visible initially
-    const initialButtons = container.querySelectorAll('button[class*="justify-start"]');
-    expect(initialButtons.length).toBe(0);
-
+  it('clicking hourly preset calls onChange with hourly granularity', async () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
     const user = userEvent.setup();
-    await user.click(screen.getByText('Custom'));
 
-    // Two calendar picker buttons should now be visible
-    const calendarButtons = container.querySelectorAll('button[class*="justify-start"]');
-    expect(calendarButtons.length).toBe(2);
+    await user.click(screen.getByText('Last 30 days'));
+    await user.click(screen.getByText('Last 7 days'));
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const granularity = onChange.mock.calls[0]?.[1] as Granularity;
+    expect(granularity).toBe('hourly');
+  });
+
+  it('shows custom range inputs when Custom range is clicked', async () => {
+    renderPicker();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText('Last 30 days'));
+    await user.click(screen.getByText('Custom range…'));
+
+    expect(screen.getByText('From')).toBeDefined();
+    expect(screen.getByText('To')).toBeDefined();
   });
 });

--- a/packages/ui/src/__tests__/date-range-picker.test.tsx
+++ b/packages/ui/src/__tests__/date-range-picker.test.tsx
@@ -24,32 +24,35 @@ function renderPicker(overrides?: Partial<{
 afterEach(cleanup);
 
 describe('DateRangePicker', () => {
-  it('shows daily and hourly rows', () => {
+  it('shows daily, period, and hourly rows', () => {
     renderPicker();
     expect(screen.getByText('Daily')).toBeDefined();
+    expect(screen.getByText('Period')).toBeDefined();
     expect(screen.getByText('Hourly')).toBeDefined();
   });
 
-  it('shows daily presets (Last 7d, Last 30d, This month, Last month, Last quarter, YTD + Custom)', () => {
+  it('shows daily presets (30d, 90d, 365d, Current month, Last month, Quarter, YTD + Custom)', () => {
     renderPicker();
-    expect(screen.getByText('Last 7d')).toBeDefined();
-    expect(screen.getByText('Last 30d')).toBeDefined();
-    expect(screen.getByText('This month')).toBeDefined();
+    expect(screen.getByText('30d')).toBeDefined();
+    expect(screen.getByText('90d')).toBeDefined();
+    expect(screen.getByText('365d')).toBeDefined();
+    expect(screen.getByText('Month')).toBeDefined();
     expect(screen.getByText('Last month')).toBeDefined();
-    expect(screen.getByText('Last quarter')).toBeDefined();
+    expect(screen.getByText('Quarter')).toBeDefined();
     expect(screen.getByText('YTD')).toBeDefined();
     expect(screen.getByText('Custom')).toBeDefined();
   });
 
-  it('shows hourly presets (7, 14, 30 days)', () => {
+  it('shows hourly presets (7, 14, 28 days)', () => {
     renderPicker();
     expect(screen.getByText('7 days')).toBeDefined();
     expect(screen.getByText('14 days')).toBeDefined();
+    expect(screen.getByText('28 days')).toBeDefined();
   });
 
-  it('Last 30d daily is selected by default', () => {
+  it('30d daily is selected by default', () => {
     renderPicker();
-    const dailyBtn = screen.getByText('Last 30d');
+    const dailyBtn = screen.getByText('30d');
     expect(dailyBtn).toBeDefined();
     expect(dailyBtn.className).toContain('bg-accent');
   });
@@ -66,12 +69,12 @@ describe('DateRangePicker', () => {
     expect(granularity).toBe('hourly');
   });
 
-  it('clicking daily Last 7d calls onChange with daily granularity', async () => {
+  it('clicking daily 90d calls onChange with daily granularity', async () => {
     const onChange = vi.fn();
     renderPicker({ onChange });
 
     const user = userEvent.setup();
-    await user.click(screen.getByText('Last 7d'));
+    await user.click(screen.getByText('90d'));
 
     expect(onChange).toHaveBeenCalledOnce();
     const granularity = onChange.mock.calls[0]?.[1] as Granularity;

--- a/packages/ui/src/__tests__/dates.test.ts
+++ b/packages/ui/src/__tests__/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { daysBetween, daysAgo, getThisMonth, getLastMonth, getLastQuarter, getYTD } from '../lib/dates.js';
+import { daysBetween, daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getYTD } from '../lib/dates.js';
 
 describe('daysBetween', () => {
   it('calculates inclusive days between dates', () => {
@@ -78,7 +78,7 @@ describe('getLastMonth', () => {
   });
 });
 
-describe('getLastQuarter', () => {
+describe('getCurrentQuarter', () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -87,32 +87,32 @@ describe('getLastQuarter', () => {
     vi.useRealTimers();
   });
 
-  it('returns Q4 when current is Q1', () => {
-    vi.setSystemTime(new Date('2024-01-15'));
-    const { start, end } = getLastQuarter();
-    expect(start).toBe('2023-10-01');
-    expect(end).toBe('2023-12-31');
-  });
-
-  it('returns Q1 when current is Q2', () => {
-    vi.setSystemTime(new Date('2024-05-15'));
-    const { start, end } = getLastQuarter();
+  it('returns Q1 when in Q1', () => {
+    vi.setSystemTime(new Date('2024-02-15'));
+    const { start, end } = getCurrentQuarter();
     expect(start).toBe('2024-01-01');
     expect(end).toBe('2024-03-31');
   });
 
-  it('returns Q2 when current is Q3', () => {
-    vi.setSystemTime(new Date('2024-08-15'));
-    const { start, end } = getLastQuarter();
+  it('returns Q2 when in Q2', () => {
+    vi.setSystemTime(new Date('2024-05-15'));
+    const { start, end } = getCurrentQuarter();
     expect(start).toBe('2024-04-01');
     expect(end).toBe('2024-06-30');
   });
 
-  it('returns Q3 when current is Q4', () => {
-    vi.setSystemTime(new Date('2024-11-15'));
-    const { start, end } = getLastQuarter();
+  it('returns Q3 when in Q3', () => {
+    vi.setSystemTime(new Date('2024-08-15'));
+    const { start, end } = getCurrentQuarter();
     expect(start).toBe('2024-07-01');
     expect(end).toBe('2024-09-30');
+  });
+
+  it('returns Q4 when in Q4', () => {
+    vi.setSystemTime(new Date('2024-11-15'));
+    const { start, end } = getCurrentQuarter();
+    expect(start).toBe('2024-10-01');
+    expect(end).toBe('2024-12-31');
   });
 });
 

--- a/packages/ui/src/__tests__/dates.test.ts
+++ b/packages/ui/src/__tests__/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { daysBetween, daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getYTD } from '../lib/dates.js';
+import { daysBetween, daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getLastQuarter, getYTD } from '../lib/dates.js';
 
 describe('daysBetween', () => {
   it('calculates inclusive days between dates', () => {
@@ -116,6 +116,25 @@ describe('getCurrentQuarter', () => {
   });
 });
 
+describe('getLastQuarter', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('returns Q4 when in Q1', () => {
+    vi.setSystemTime(new Date('2024-02-15'));
+    const { start, end } = getLastQuarter();
+    expect(start).toBe('2023-10-01');
+    expect(end).toBe('2023-12-31');
+  });
+
+  it('returns Q1 when in Q2', () => {
+    vi.setSystemTime(new Date('2024-05-15'));
+    const { start, end } = getLastQuarter();
+    expect(start).toBe('2024-01-01');
+    expect(end).toBe('2024-03-31');
+  });
+});
+
 describe('getYTD', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -125,22 +144,8 @@ describe('getYTD', () => {
     vi.useRealTimers();
   });
 
-  it('returns year start to today', () => {
+  it('returns full current calendar year', () => {
     vi.setSystemTime(new Date('2024-03-15'));
-    const { start, end } = getYTD();
-    expect(start).toBe('2024-01-01');
-    expect(end).toBe('2024-03-15');
-  });
-
-  it('handles first day of year', () => {
-    vi.setSystemTime(new Date('2024-01-01'));
-    const { start, end } = getYTD();
-    expect(start).toBe('2024-01-01');
-    expect(end).toBe('2024-01-01');
-  });
-
-  it('handles last day of year', () => {
-    vi.setSystemTime(new Date('2024-12-31'));
     const { start, end } = getYTD();
     expect(start).toBe('2024-01-01');
     expect(end).toBe('2024-12-31');

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
-import { CalendarIcon } from 'lucide-react';
+import { CalendarIcon, ChevronDown } from 'lucide-react';
 import type { DateString } from '@costgoblin/core/browser';
 import { DEFAULT_LAG_DAYS, asDateString } from '@costgoblin/core/browser';
-import { daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getYTD } from '../lib/dates.js';
+import { daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getLastQuarter, getYTD, getLastYear } from '../lib/dates.js';
 import { Calendar } from './ui/calendar.js';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.js';
-import { Button } from './ui/button.js';
 
 export type Granularity = 'daily' | 'hourly';
 
@@ -13,36 +12,50 @@ type DayPreset = {
   readonly label: string;
   readonly type: 'days';
   readonly days: number;
+  readonly granularity: Granularity;
 };
 
 type CalendarPreset = {
   readonly label: string;
   readonly type: 'calendar';
-  readonly getRange: (lagDays: number) => { start: DateString; end: DateString };
+  readonly getRange: () => { start: DateString; end: DateString };
+  readonly granularity: Granularity;
 };
 
 type Preset = DayPreset | CalendarPreset;
 
-const DAILY_ROLLING: readonly Preset[] = [
-  { label: '30d', type: 'days', days: 30 },
-  { label: '90d', type: 'days', days: 90 },
-  { label: '365d', type: 'days', days: 365 },
+const PRESETS: readonly { section: string; items: readonly Preset[] }[] = [
+  {
+    section: 'Daily',
+    items: [
+      { label: 'Last 30 days', type: 'days', days: 30, granularity: 'daily' },
+      { label: 'Last 90 days', type: 'days', days: 90, granularity: 'daily' },
+      { label: 'Last 180 days', type: 'days', days: 180, granularity: 'daily' },
+      { label: 'Last 365 days', type: 'days', days: 365, granularity: 'daily' },
+    ],
+  },
+  {
+    section: 'Hourly',
+    items: [
+      { label: 'Last 7 days', type: 'days', days: 7, granularity: 'hourly' },
+      { label: 'Last 14 days', type: 'days', days: 14, granularity: 'hourly' },
+      { label: 'Last 28 days', type: 'days', days: 28, granularity: 'hourly' },
+    ],
+  },
+  {
+    section: 'Period',
+    items: [
+      { label: 'This month', type: 'calendar', getRange: () => getThisMonth(), granularity: 'daily' },
+      { label: 'Last month', type: 'calendar', getRange: () => getLastMonth(), granularity: 'daily' },
+      { label: 'This quarter', type: 'calendar', getRange: () => getCurrentQuarter(), granularity: 'daily' },
+      { label: 'Last quarter', type: 'calendar', getRange: () => getLastQuarter(), granularity: 'daily' },
+      { label: 'This year', type: 'calendar', getRange: () => getYTD(), granularity: 'daily' },
+      { label: 'Last year', type: 'calendar', getRange: () => getLastYear(), granularity: 'daily' },
+    ],
+  },
 ];
 
-const DAILY_CALENDAR: readonly Preset[] = [
-  { label: 'Month', type: 'calendar', getRange: () => getThisMonth() },
-  { label: 'Last month', type: 'calendar', getRange: () => getLastMonth() },
-  { label: 'Quarter', type: 'calendar', getRange: () => getCurrentQuarter() },
-  { label: 'YTD', type: 'calendar', getRange: () => getYTD() },
-];
-
-const ALL_DAILY_PRESETS: readonly Preset[] = [...DAILY_ROLLING, ...DAILY_CALENDAR];
-
-const HOURLY_PRESETS = [
-  { label: '7 days', days: 7 },
-  { label: '14 days', days: 14 },
-  { label: '28 days', days: 28 },
-];
+const ALL_PRESETS = PRESETS.flatMap(s => s.items);
 
 export interface DateRange {
   start: DateString;
@@ -53,11 +66,7 @@ interface DateRangePickerProps {
   readonly value: DateRange;
   readonly granularity: Granularity;
   readonly onChange: (range: DateRange, granularity: Granularity) => void;
-  /** Hide the "Hourly" preset row. Used by views that only query the
-   *  daily tier (Explorer), where offering hourly presets would lead to
-   *  empty result sets. */
   readonly hideHourly?: boolean;
-  /** Number of most-recent days excluded from ranges. */
   readonly lagDays?: number;
 }
 
@@ -66,187 +75,155 @@ export function getDefaultDateRange(lagDays: number = DEFAULT_LAG_DAYS): DateRan
 }
 
 export function DateRangePicker({ value, granularity, onChange, hideHourly, lagDays = DEFAULT_LAG_DAYS }: DateRangePickerProps) {
+  const [open, setOpen] = useState(false);
   const [showCustom, setShowCustom] = useState(false);
-  const [startOpen, setStartOpen] = useState(false);
-  const [endOpen, setEndOpen] = useState(false);
   const latestDate = daysAgo(lagDays);
 
   function getPresetRange(preset: Preset): DateRange {
     if (preset.type === 'days') {
       return { start: daysAgo(preset.days + lagDays), end: latestDate };
     }
-    return preset.getRange(lagDays);
+    return preset.getRange();
+  }
+
+  function getActiveLabel(): string {
+    for (const preset of ALL_PRESETS) {
+      const range = getPresetRange(preset);
+      if (value.start === range.start && value.end === range.end && granularity === preset.granularity) {
+        return preset.label;
+      }
+    }
+    return `${value.start} → ${value.end}`;
+  }
+
+  function handlePreset(preset: Preset) {
+    const range = getPresetRange(preset);
+    onChange(range, preset.granularity);
+    setShowCustom(false);
+    setOpen(false);
   }
 
   function isActivePreset(preset: Preset): boolean {
     const range = getPresetRange(preset);
-    return value.start === range.start && value.end === range.end;
+    return value.start === range.start && value.end === range.end && granularity === preset.granularity;
   }
 
-  function isActiveHourly(days: number): boolean {
-    return value.start === daysAgo(days + lagDays) && value.end === latestDate;
-  }
-
-  function handleDailyPreset(preset: Preset) {
-    setShowCustom(false);
-    const range = getPresetRange(preset);
-    onChange(range, 'daily');
-  }
-
-  function handleHourlyPreset(days: number) {
-    setShowCustom(false);
-    onChange({ start: daysAgo(days + lagDays), end: latestDate }, 'hourly');
-  }
-
-  function handleCustomToggle() {
-    setShowCustom(prev => !prev);
-  }
-
-  const isCustom = granularity === 'daily' && !ALL_DAILY_PRESETS.some(p => isActivePreset(p))
-    && !showCustom;
+  const sections = hideHourly === true
+    ? PRESETS.filter(s => s.section !== 'Hourly')
+    : PRESETS;
 
   return (
-    <div className="flex flex-col items-end gap-1">
-      {/* Daily rolling row */}
-      <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-        <span className="text-[10px] text-text-muted px-1.5">Daily</span>
-        {DAILY_ROLLING.map(preset => (
-          <button
-            key={preset.label}
-            type="button"
-            onClick={() => { handleDailyPreset(preset); }}
-            className={[
-              'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
-              granularity === 'daily' && isActivePreset(preset)
-                ? 'bg-accent text-bg-primary shadow-sm'
-                : 'text-text-secondary hover:text-text-primary',
-            ].join(' ')}
-          >
-            {preset.label}
-          </button>
-        ))}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
         <button
           type="button"
-          onClick={handleCustomToggle}
-          className={[
-            'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
-            isCustom || showCustom
-              ? 'bg-accent text-bg-primary shadow-sm'
-              : 'text-text-secondary hover:text-text-primary',
-          ].join(' ')}
+          className="flex items-center gap-1.5 rounded-lg border border-border bg-bg-tertiary/30 px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary/50 transition-colors"
         >
-          Custom
+          <CalendarIcon className="h-3.5 w-3.5 text-text-muted" />
+          <span>{getActiveLabel()}</span>
+          <ChevronDown className="h-3 w-3 text-text-muted" />
         </button>
-      </div>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="end">
+        <div className="flex flex-col">
+          {sections.map(({ section, items }) => (
+            <div key={section}>
+              <div className="px-3 pt-2.5 pb-1">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">{section}</span>
+              </div>
+              {items.map(preset => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => { handlePreset(preset); }}
+                  className={[
+                    'w-full text-left px-3 py-1.5 text-xs transition-colors',
+                    isActivePreset(preset)
+                      ? 'bg-accent/10 text-accent font-medium border-l-2 border-accent'
+                      : 'text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary border-l-2 border-transparent',
+                  ].join(' ')}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          ))}
 
-      {/* Daily calendar row */}
-      <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-        <span className="text-[10px] text-text-muted px-1.5">Period</span>
-        {DAILY_CALENDAR.map(preset => (
-          <button
-            key={preset.label}
-            type="button"
-            onClick={() => { handleDailyPreset(preset); }}
-            className={[
-              'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
-              granularity === 'daily' && isActivePreset(preset)
-                ? 'bg-accent text-bg-primary shadow-sm'
-                : 'text-text-secondary hover:text-text-primary',
-            ].join(' ')}
-          >
-            {preset.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Hourly row */}
-      {hideHourly !== true && (
-      <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-        <span className="text-[10px] text-text-muted px-1.5">Hourly</span>
-        {HOURLY_PRESETS.map(preset => (
-          <button
-            key={preset.days}
-            type="button"
-            onClick={() => { handleHourlyPreset(preset.days); }}
-            className={[
-              'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
-              granularity === 'hourly' && isActiveHourly(preset.days)
-                ? 'bg-accent text-bg-primary shadow-sm'
-                : 'text-text-secondary hover:text-text-primary',
-            ].join(' ')}
-          >
-            {preset.label}
-          </button>
-        ))}
-      </div>
-      )}
-
-      {/* Custom date picker with Calendar */}
-      {showCustom && (
-        <div className="flex items-center gap-1.5">
-          <Popover open={startOpen} onOpenChange={setStartOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="justify-start text-left font-normal"
-              >
-                <CalendarIcon className="mr-2 h-3 w-3" />
-                <span className="text-xs">{value.start}</span>
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="start">
-              <Calendar
-                mode="single"
-                selected={new Date(value.start + 'T00:00:00')}
-                onSelect={(date) => {
-                  if (date) {
-                    const dateStr = asDateString(date.toISOString().slice(0, 10));
-                    onChange({ ...value, start: dateStr }, 'daily');
-                    setStartOpen(false);
-                  }
-                }}
-                disabled={(date) => {
-                  const dateStr = date.toISOString().slice(0, 10);
-                  return dateStr > latestDate;
-                }}
-                autoFocus
-              />
-            </PopoverContent>
-          </Popover>
-          <span className="text-xs text-text-muted">–</span>
-          <Popover open={endOpen} onOpenChange={setEndOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="justify-start text-left font-normal"
-              >
-                <CalendarIcon className="mr-2 h-3 w-3" />
-                <span className="text-xs">{value.end}</span>
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="start">
-              <Calendar
-                mode="single"
-                selected={new Date(value.end + 'T00:00:00')}
-                onSelect={(date) => {
-                  if (date) {
-                    const dateStr = asDateString(date.toISOString().slice(0, 10));
-                    onChange({ ...value, end: dateStr }, 'daily');
-                    setEndOpen(false);
-                  }
-                }}
-                disabled={(date) => {
-                  const dateStr = date.toISOString().slice(0, 10);
-                  return dateStr > latestDate;
-                }}
-                autoFocus
-              />
-            </PopoverContent>
-          </Popover>
+          {/* Custom date range */}
+          <div className="border-t border-border">
+            <button
+              type="button"
+              onClick={() => { setShowCustom(prev => !prev); }}
+              className={[
+                'w-full text-left px-3 py-2 text-xs transition-colors',
+                showCustom
+                  ? 'text-accent font-medium'
+                  : 'text-text-secondary hover:text-text-primary',
+              ].join(' ')}
+            >
+              Custom range…
+            </button>
+            {showCustom && (
+              <div className="px-3 pb-3 flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <span className="text-[10px] text-text-muted">From</span>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex items-center gap-2 rounded border border-border bg-bg-primary px-2 py-1.5 text-xs text-text-primary hover:border-accent transition-colors"
+                      >
+                        <CalendarIcon className="h-3 w-3 text-text-muted" />
+                        {value.start}
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start" side="left">
+                      <Calendar
+                        mode="single"
+                        selected={new Date(value.start + 'T00:00:00')}
+                        onSelect={(date) => {
+                          if (date) {
+                            onChange({ ...value, start: asDateString(date.toISOString().slice(0, 10)) }, 'daily');
+                          }
+                        }}
+                        disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
+                        autoFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-[10px] text-text-muted">To</span>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex items-center gap-2 rounded border border-border bg-bg-primary px-2 py-1.5 text-xs text-text-primary hover:border-accent transition-colors"
+                      >
+                        <CalendarIcon className="h-3 w-3 text-text-muted" />
+                        {value.end}
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start" side="left">
+                      <Calendar
+                        mode="single"
+                        selected={new Date(value.end + 'T00:00:00')}
+                        onSelect={(date) => {
+                          if (date) {
+                            onChange({ ...value, end: asDateString(date.toISOString().slice(0, 10)) }, 'daily');
+                          }
+                        }}
+                        disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
+                        autoFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
-      )}
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { CalendarIcon } from 'lucide-react';
 import type { DateString } from '@costgoblin/core/browser';
 import { DEFAULT_LAG_DAYS, asDateString } from '@costgoblin/core/browser';
-import { daysAgo, getThisMonth, getLastMonth, getLastQuarter, getYTD } from '../lib/dates.js';
+import { daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getYTD } from '../lib/dates.js';
 import { Calendar } from './ui/calendar.js';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.js';
 import { Button } from './ui/button.js';
@@ -23,25 +23,25 @@ type CalendarPreset = {
 
 type Preset = DayPreset | CalendarPreset;
 
-const DAILY_PRESETS: readonly Preset[] = [
-  { label: 'Last 7d', type: 'days', days: 7 },
-  { label: 'Last 30d', type: 'days', days: 30 },
-  { label: 'This month', type: 'calendar', getRange: (lagDays) => {
-    const range = getThisMonth();
-    return { ...range, end: lagDays > 0 ? daysAgo(lagDays) : range.end };
-  }},
-  { label: 'Last month', type: 'calendar', getRange: () => getLastMonth() },
-  { label: 'Last quarter', type: 'calendar', getRange: () => getLastQuarter() },
-  { label: 'YTD', type: 'calendar', getRange: (lagDays) => {
-    const range = getYTD();
-    return { ...range, end: lagDays > 0 ? daysAgo(lagDays) : range.end };
-  }},
+const DAILY_ROLLING: readonly Preset[] = [
+  { label: '30d', type: 'days', days: 30 },
+  { label: '90d', type: 'days', days: 90 },
+  { label: '365d', type: 'days', days: 365 },
 ];
+
+const DAILY_CALENDAR: readonly Preset[] = [
+  { label: 'Month', type: 'calendar', getRange: () => getThisMonth() },
+  { label: 'Last month', type: 'calendar', getRange: () => getLastMonth() },
+  { label: 'Quarter', type: 'calendar', getRange: () => getCurrentQuarter() },
+  { label: 'YTD', type: 'calendar', getRange: () => getYTD() },
+];
+
+const ALL_DAILY_PRESETS: readonly Preset[] = [...DAILY_ROLLING, ...DAILY_CALENDAR];
 
 const HOURLY_PRESETS = [
   { label: '7 days', days: 7 },
   { label: '14 days', days: 14 },
-  { label: '30 days', days: 30 },
+  { label: '28 days', days: 28 },
 ];
 
 export interface DateRange {
@@ -102,15 +102,15 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
     setShowCustom(prev => !prev);
   }
 
-  const isCustom = granularity === 'daily' && !DAILY_PRESETS.some(p => isActivePreset(p))
+  const isCustom = granularity === 'daily' && !ALL_DAILY_PRESETS.some(p => isActivePreset(p))
     && !showCustom;
 
   return (
     <div className="flex flex-col items-end gap-1">
-      {/* Daily row */}
+      {/* Daily rolling row */}
       <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
         <span className="text-[10px] text-text-muted px-1.5">Daily</span>
-        {DAILY_PRESETS.map(preset => (
+        {DAILY_ROLLING.map(preset => (
           <button
             key={preset.label}
             type="button"
@@ -137,6 +137,26 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
         >
           Custom
         </button>
+      </div>
+
+      {/* Daily calendar row */}
+      <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
+        <span className="text-[10px] text-text-muted px-1.5">Period</span>
+        {DAILY_CALENDAR.map(preset => (
+          <button
+            key={preset.label}
+            type="button"
+            onClick={() => { handleDailyPreset(preset); }}
+            className={[
+              'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+              granularity === 'daily' && isActivePreset(preset)
+                ? 'bg-accent text-bg-primary shadow-sm'
+                : 'text-text-secondary hover:text-text-primary',
+            ].join(' ')}
+          >
+            {preset.label}
+          </button>
+        ))}
       </div>
 
       {/* Hourly row */}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -24,6 +24,28 @@ interface StackedBarChartProps {
   readonly onSegmentClick?: ((name: string) => void) | undefined;
 }
 
+export function bucketBars(bars: readonly BarDay[], maxBuckets: number): readonly BarDay[] {
+  if (bars.length <= maxBuckets) return bars;
+  const size = Math.ceil(bars.length / maxBuckets);
+  const result: BarDay[] = [];
+  for (let i = 0; i < bars.length; i += size) {
+    const chunk = bars.slice(i, i + size);
+    const merged: Record<string, number> = {};
+    let total = 0;
+    for (const bar of chunk) {
+      total += bar.total;
+      for (const [key, val] of Object.entries(bar.breakdown)) {
+        merged[key] = (merged[key] ?? 0) + val;
+      }
+    }
+    const first = chunk[0];
+    if (first !== undefined) {
+      result.push({ date: first.date, total, breakdown: merged });
+    }
+  }
+  return result;
+}
+
 export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading, onSegmentClick }: StackedBarChartProps) {
   const { palette } = usePalette();
   const [hoveredDay, setHoveredDay] = useState<string | null>(null);
@@ -177,7 +199,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             );
           })()}
 
-          <div className="absolute left-12 right-0 top-0 bottom-7 flex items-end z-10" style={{ gap: '2px' }}>
+          <div className="absolute left-12 right-0 top-0 bottom-7 flex items-end z-10" style={{ gap: days.length > 100 ? '1px' : '2px' }}>
             {days.map((day) => {
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys

--- a/packages/ui/src/lib/dates.ts
+++ b/packages/ui/src/lib/dates.ts
@@ -67,15 +67,40 @@ export function getCurrentQuarter(): { start: DateString; end: DateString } {
   };
 }
 
-/** Returns start of year to today (Year To Date). */
-export function getYTD(): { start: DateString; end: DateString } {
+/** Returns start and end of previous quarter. */
+export function getLastQuarter(): { start: DateString; end: DateString } {
   const now = new Date();
   const year = now.getUTCFullYear();
+  const currentQuarter = Math.floor(now.getUTCMonth() / 3);
+  const prevQuarter = currentQuarter === 0 ? 3 : currentQuarter - 1;
+  const prevYear = currentQuarter === 0 ? year - 1 : year;
+  const startMonth = prevQuarter * 3;
 
-  const start = new Date(Date.UTC(year, 0, 1)); // January 1st
+  const start = new Date(Date.UTC(prevYear, startMonth, 1));
+  const end = new Date(Date.UTC(prevYear, startMonth + 3, 0));
 
   return {
     start: formatDateUTC(start),
-    end: formatDateUTC(now),
+    end: formatDateUTC(end),
+  };
+}
+
+/** Returns full current calendar year (Jan 1 – Dec 31). */
+export function getYTD(): { start: DateString; end: DateString } {
+  const year = new Date().getUTCFullYear();
+
+  return {
+    start: formatDateUTC(new Date(Date.UTC(year, 0, 1))),
+    end: formatDateUTC(new Date(Date.UTC(year, 11, 31))),
+  };
+}
+
+/** Returns start and end of previous calendar year. */
+export function getLastYear(): { start: DateString; end: DateString } {
+  const year = new Date().getUTCFullYear() - 1;
+
+  return {
+    start: formatDateUTC(new Date(Date.UTC(year, 0, 1))),
+    end: formatDateUTC(new Date(Date.UTC(year, 11, 31))),
   };
 }

--- a/packages/ui/src/lib/dates.ts
+++ b/packages/ui/src/lib/dates.ts
@@ -51,25 +51,15 @@ export function getLastMonth(): { start: DateString; end: DateString } {
   };
 }
 
-/** Returns start and end of previous quarter (Q1: Jan-Mar, Q2: Apr-Jun, Q3: Jul-Sep, Q4: Oct-Dec). */
-export function getLastQuarter(): { start: DateString; end: DateString } {
+/** Returns start and end of current quarter (Q1: Jan-Mar, Q2: Apr-Jun, Q3: Jul-Sep, Q4: Oct-Dec). */
+export function getCurrentQuarter(): { start: DateString; end: DateString } {
   const now = new Date();
   const year = now.getUTCFullYear();
-  const month = now.getUTCMonth(); // 0-11
+  const quarter = Math.floor(now.getUTCMonth() / 3);
+  const startMonth = quarter * 3;
 
-  // Determine current quarter (0-3)
-  const currentQuarter = Math.floor(month / 3);
-
-  // Previous quarter
-  const prevQuarter = currentQuarter === 0 ? 3 : currentQuarter - 1;
-  const prevQuarterYear = currentQuarter === 0 ? year - 1 : year;
-
-  // Start month of previous quarter
-  const startMonth = prevQuarter * 3;
-  const start = new Date(Date.UTC(prevQuarterYear, startMonth, 1));
-
-  // End is last day of third month in quarter
-  const end = new Date(Date.UTC(prevQuarterYear, startMonth + 3, 0));
+  const start = new Date(Date.UTC(year, startMonth, 1));
+  const end = new Date(Date.UTC(year, startMonth + 3, 0));
 
   return {
     start: formatDateUTC(start),

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -2,39 +2,28 @@ import { useState } from 'react';
 import type {
   Dimension,
   DimensionId,
-  DateString,
   TrendResult,
   TrendRow,
   EntityRef,
 } from '@costgoblin/core/browser';
-import { DEFAULT_LAG_DAYS, asDimensionId, asDollars } from '@costgoblin/core/browser';
+import { asDimensionId, asDollars } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
-import { daysAgo } from '../lib/dates.js';
 import { getDimensionId } from '../lib/dimensions.js';
 import { BubbleChart } from '../components/bubble-chart.js';
+import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
+import type { DateRange, Granularity } from '../components/date-range-picker.js';
 import { DimensionSelector } from '../components/dimension-selector.js';
 import { formatDollars, formatPercent } from '../components/format.js';
-
-const PERIOD_PRESETS = [
-  { label: '7d', days: 7 },
-  { label: '14d', days: 14 },
-  { label: '30d', days: 30 },
-  { label: '90d', days: 90 },
-  { label: '180d', days: 180 },
-] as const;
-
-function getDateRange(days: number, lagDays: number = DEFAULT_LAG_DAYS): { start: DateString; end: DateString } {
-  return { start: daysAgo(days + lagDays), end: daysAgo(lagDays) };
-}
 
 type Direction = 'increases' | 'savings';
 
 interface TrendsState {
   selectedDimensionId: DimensionId | null;
   direction: Direction;
-  periodDays: number;
+  dateRange: DateRange;
+  granularity: Granularity;
   deltaThreshold: number;
   percentThreshold: number;
 }
@@ -77,13 +66,14 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
   const lagDays = useLagDays();
   const dimensionsQuery = useQuery(() => api.getDimensions(), []);
 
-  const [state, setState] = useState<TrendsState>({
+  const [state, setState] = useState<TrendsState>(() => ({
     selectedDimensionId: null,
     direction: 'increases',
-    periodDays: 30,
+    dateRange: getDefaultDateRange(lagDays),
+    granularity: 'daily' satisfies Granularity,
     deltaThreshold: 10,
     percentThreshold: 1,
-  });
+  }));
 
   const dimensions: Dimension[] =
     dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
@@ -98,13 +88,13 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
       if (activeDimensionId === null) return Promise.resolve(null);
       return api.queryTrends({
         groupBy: activeDimensionId,
-        dateRange: getDateRange(state.periodDays, lagDays),
+        dateRange: state.dateRange,
         filters: {},
         deltaThreshold: asDollars(state.deltaThreshold),
         percentThreshold: state.percentThreshold,
       });
     },
-    [activeDimensionId, state.periodDays, state.deltaThreshold, state.percentThreshold, lagDays, api],
+    [activeDimensionId, state.dateRange.start, state.dateRange.end, state.deltaThreshold, state.percentThreshold, api],
   );
 
   const trendData: TrendResult | null =
@@ -132,23 +122,13 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
     <div className="flex flex-col gap-6 p-6">
       <div className="flex items-center justify-between">
         <p className="text-base font-medium text-text-secondary">Period-over-period comparison</p>
-        <div className="flex items-center gap-0.5 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-          {PERIOD_PRESETS.map(p => (
-            <button
-              key={p.days}
-              type="button"
-              onClick={() => { setState(s => ({ ...s, periodDays: p.days })); }}
-              className={[
-                'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
-                state.periodDays === p.days
-                  ? 'bg-accent text-bg-primary shadow-sm'
-                  : 'text-text-secondary hover:text-text-primary',
-              ].join(' ')}
-            >
-              {p.label}
-            </button>
-          ))}
-        </div>
+        <DateRangePicker
+          value={state.dateRange}
+          granularity={state.granularity}
+          onChange={(range, g) => { setState(s => ({ ...s, dateRange: range, granularity: g })); }}
+          hideHourly
+          lagDays={lagDays}
+        />
       </div>
 
       {dimensions.length > 0 && (

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -16,7 +16,7 @@ import { DateRangePicker, getDefaultDateRange } from '../components/date-range-p
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
 import { PieChart } from '../components/pie-chart.js';
 import type { PieSlice } from '../components/pie-chart.js';
-import { StackedBarChart } from '../components/stacked-bar-chart.js';
+import { StackedBarChart, bucketBars } from '../components/stacked-bar-chart.js';
 import type { BarDay, HistogramTab } from '../components/stacked-bar-chart.js';
 import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension } from '../lib/dimensions.js';
 
@@ -197,7 +197,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
     () => api.queryDailyCosts({ groupBy: histogramDimId, dateRange, filters: entityFilter, granularity }),
     [histogramDimId, dateRangeKey, filterKey, granularity, api],
   );
-  const barDays = dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null);
+  const barDays = bucketBars(dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null), 170);
 
   const totalCost = data === null ? 0 : data.totalCost;
   const isIncrease = data !== null && data.percentChange > 0;

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,47 +1,36 @@
 import { useMemo } from 'react';
-import { daysBetween } from '../lib/dates.js';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
-import { StackedBarChart, type BarDay } from '../components/stacked-bar-chart.js';
+import { StackedBarChart, bucketBars, type BarDay } from '../components/stacked-bar-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 
-function getISOWeekStart(dateStr: string): string {
-  const d = new Date(dateStr);
-  const day = d.getUTCDay();
-  const diff = (day === 0 ? -6 : 1) - day;
-  d.setUTCDate(d.getUTCDate() + diff);
-  return d.toISOString().slice(0, 10);
-}
+const MAX_BARS = 170;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-function aggregateToWeekly(days: BarDay[]): BarDay[] {
-  const weeks = new Map<string, { total: number; breakdown: Record<string, number> }>();
-  for (const day of days) {
-    const weekStart = getISOWeekStart(day.date);
-    let week = weeks.get(weekStart);
-    if (week === undefined) {
-      week = { total: 0, breakdown: {} };
-      weeks.set(weekStart, week);
+function fillDateRange(bars: BarDay[], start: string, end: string): BarDay[] {
+  const existing = new Set(bars.map(b => b.date));
+  const result = [...bars];
+  const current = new Date(start + 'T00:00:00Z');
+  const last = new Date(end + 'T00:00:00Z');
+  while (current <= last) {
+    const dateStr = current.toISOString().slice(0, 10);
+    if (!existing.has(dateStr)) {
+      result.push({ date: dateStr, total: 0, breakdown: {} });
     }
-    week.total += day.total;
-    for (const [key, val] of Object.entries(day.breakdown)) {
-      week.breakdown[key] = (week.breakdown[key] ?? 0) + val;
-    }
+    current.setTime(current.getTime() + DAY_MS);
   }
-  return [...weeks.entries()]
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([date, data]) => ({ date, total: data.total, breakdown: data.breakdown }));
+  return result.sort((a, b) => a.date.localeCompare(b.date));
 }
 
-function dailyToBarDays(data: DailyCostsResult | null, useWeekly: boolean): BarDay[] {
+function dailyToBarDays(data: DailyCostsResult | null): BarDay[] {
   if (data === null) return [];
-  const daily = data.days.map(d => ({
+  return data.days.map(d => ({
     date: d.date,
     total: d.total,
     breakdown: { ...d.breakdown },
   }));
-  return useWeekly ? aggregateToWeekly(daily) : daily;
 }
 
 export function StackedBarWidget({
@@ -62,20 +51,20 @@ export function StackedBarWidget({
     specFilters: spec.filters,
   });
 
-  const periodDays = daysBetween(dateRange.start, dateRange.end);
-  const useWeekly = periodDays > 90;
   const barDays = useMemo(
-    () => dailyToBarDays(dailyResult, useWeekly),
-    [dailyResult, useWeekly],
+    () => {
+      const raw = dailyToBarDays(dailyResult);
+      const filled = granularity === 'daily' ? fillDateRange(raw, dateRange.start, dateRange.end) : raw;
+      return bucketBars(filled, MAX_BARS);
+    },
+    [dailyResult, granularity, dateRange.start, dateRange.end],
   );
 
   if (spec.type !== 'stackedBar') return null;
 
   const loading = query.status === 'loading';
 
-  let defaultTitle = 'Daily Costs';
-  if (granularity === 'hourly') defaultTitle = 'Hourly Costs';
-  else if (useWeekly) defaultTitle = 'Weekly Costs';
+  const defaultTitle = granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs';
   const title = spec.title ?? defaultTitle;
 
   return (

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -1,5 +1,6 @@
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
+import { daysBetween } from '../lib/dates.js';
 import { SummaryCard } from '../components/summary-card.js';
 import { asDimensionId } from '@costgoblin/core/browser';
 import type { CostResult } from '@costgoblin/core/browser';
@@ -31,10 +32,21 @@ export function SummaryWidget({
 
   if (!isSummary) return null;
 
-  // `null` means "still loading / errored" — SummaryCard renders a dash
-  // placeholder rather than briefly showing $0.00.
   const totalCost = cur.status === 'success' && cur.data !== null ? cur.data.totalCost : null;
-  const previousCost = prev.status === 'success' && prev.data !== null ? prev.data.totalCost : null;
+
+  // Hide comparison when either period has incomplete data (< 80% coverage).
+  // Incomplete current period: forward-looking range (e.g. "This quarter")
+  //   where we only have data through today.
+  // Incomplete previous period: not enough historical data to cover the range.
+  function hasSufficientCoverage(result: CostResult, requested: { start: string; end: string }): boolean {
+    const requestedDays = daysBetween(requested.start, requested.end);
+    const actualDays = daysBetween(result.dateRange.start, result.dateRange.end);
+    return actualDays >= requestedDays * 0.8;
+  }
+
+  const prevData = prev.status === 'success' ? prev.data : null;
+  const previousComplete = prevData !== null && hasSufficientCoverage(prevData, previousDateRange);
+  const previousCost = previousComplete ? prevData.totalCost : null;
 
   return (
     <SummaryCard totalCost={totalCost} previousCost={previousCost} dateRange={dateRange} />


### PR DESCRIPTION
Add quick-select date range presets (Last 7 days, Last 30 days, This month, Last month, Last quarter, This year, YTD) and a full custom date range picker with calendar UI. Persist the last-used date range in preferences.json. Show the selected range prominently in the top bar.