### PR TITLE
Keyboard-Driven Navigation and Shortcuts

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, useKeyboardShortcuts, CommandPalette } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, useKeyboardShortcuts, CommandPalette, KeyboardShortcutsOverlay } from '@costgoblin/ui';
 import type { CommandPaletteAction } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
@@ -143,6 +143,7 @@ function AppShell(): React.JSX.Element {
   const [syncFilesRemaining, setSyncFilesRemaining] = useState(0);
   const [debugOpen, setDebugOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [shortcutsOverlayOpen, setShortcutsOverlayOpen] = useState(false);
   const inFlightCount = useDebugBadge();
 
   useEffect(() => {
@@ -333,6 +334,9 @@ function AppShell(): React.JSX.Element {
     // Cmd/Ctrl+K opens command palette
     map['mod+k'] = () => { setCommandPaletteOpen(true); };
 
+    // Cmd/Ctrl+? opens keyboard shortcuts overlay
+    map['mod+/'] = () => { setShortcutsOverlayOpen(true); };
+
     // Escape closes debug panel if open
     if (debugOpen) {
       map['Escape'] = () => { setDebugOpen(false); };
@@ -369,6 +373,24 @@ function AppShell(): React.JSX.Element {
 
     return actions;
   }, [leftNav]);
+
+  // Build keyboard shortcuts configuration for the help overlay
+  const shortcutsConfig = useMemo(() => [
+    {
+      category: 'Navigation',
+      items: [
+        { keys: ['1', '2', '3', '...', '9'], description: 'Switch between views' },
+        { keys: ['mod+k'], description: 'Open command palette' },
+      ],
+    },
+    {
+      category: 'General',
+      items: [
+        { keys: ['Escape'], description: 'Close panels and dialogs' },
+        { keys: ['mod+/'], description: 'Show keyboard shortcuts' },
+      ],
+    },
+  ], []);
 
   function activeNavId(): string | null {
     if (view.page === 'custom') return view.viewId;
@@ -576,6 +598,11 @@ function AppShell(): React.JSX.Element {
         open={commandPaletteOpen}
         onOpenChange={setCommandPaletteOpen}
         actions={commandPaletteActions}
+      />
+      <KeyboardShortcutsOverlay
+        open={shortcutsOverlayOpen}
+        onOpenChange={setShortcutsOverlayOpen}
+        shortcuts={shortcutsConfig}
       />
       </div>
     </PaletteProvider>

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -417,7 +417,7 @@ function AppShell(): React.JSX.Element {
         <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center px-4 pt-7 pb-2">
           <div className="flex items-center gap-1" role="navigation" aria-label="Analytical views">
-            {leftNav.map((item) => (
+            {leftNav.map((item, index) => (
               <button
                 key={item.id}
                 type="button"
@@ -429,6 +429,7 @@ function AppShell(): React.JSX.Element {
                     : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50',
                 ].join(' ')}
                 aria-current={active === item.id ? 'page' : undefined}
+                title={index < 9 ? `${item.label} (${String(index + 1)})` : item.label}
               >
                 {item.label}
               </button>
@@ -491,7 +492,7 @@ function AppShell(): React.JSX.Element {
                     showError ? 'ring-1 ring-negative/60' : '',
                     showActive ? 'animate-sync-blink' : '',
                   ].join(' ')}
-                  title={syncError === null ? undefined : `Sync error — ${syncError}`}
+                  title={syncError === null ? item.label : `Sync error — ${syncError}`}
                   aria-current={active === item.id ? 'page' : undefined}
                 >
                   {showError && (

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, useKeyboardShortcuts } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, useKeyboardShortcuts, CommandPalette } from '@costgoblin/ui';
+import type { CommandPaletteAction } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 
@@ -141,6 +142,7 @@ function AppShell(): React.JSX.Element {
   const [syncActivity, setSyncActivity] = useState<'idle' | 'syncing' | 'downloading'>('idle');
   const [syncFilesRemaining, setSyncFilesRemaining] = useState(0);
   const [debugOpen, setDebugOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const inFlightCount = useDebugBadge();
 
   useEffect(() => {
@@ -315,7 +317,7 @@ function AppShell(): React.JSX.Element {
   // Register global keyboard shortcuts for navigation and panel controls.
   // Number keys 1-9 navigate to the first 9 left-nav items, respecting
   // unsaved-changes guards via handleNavClick. Escape closes the debug
-  // panel when open.
+  // panel when open. Cmd/Ctrl+K opens the command palette.
   const shortcuts = useMemo(() => {
     const map: Record<string, () => void> = {};
 
@@ -328,6 +330,9 @@ function AppShell(): React.JSX.Element {
       }
     }
 
+    // Cmd/Ctrl+K opens command palette
+    map['mod+k'] = () => { setCommandPaletteOpen(true); };
+
     // Escape closes debug panel if open
     if (debugOpen) {
       map['Escape'] = () => { setDebugOpen(false); };
@@ -337,6 +342,33 @@ function AppShell(): React.JSX.Element {
   }, [leftNav, debugOpen]);
 
   useKeyboardShortcuts(shortcuts);
+
+  // Build command palette actions from all navigation items
+  const commandPaletteActions = useMemo(() => {
+    const actions: CommandPaletteAction[] = [];
+
+    // Add left nav items (custom views + static views)
+    for (const item of leftNav) {
+      actions.push({
+        id: item.id,
+        label: item.label,
+        onSelect: () => { handleNavClick(item.id); },
+        keywords: ['view', 'navigate'],
+      });
+    }
+
+    // Add right nav items (settings/utilities)
+    for (const item of RIGHT_NAV) {
+      actions.push({
+        id: item.id,
+        label: item.label,
+        onSelect: () => { handleNavClick(item.id); },
+        keywords: ['settings', 'configure'],
+      });
+    }
+
+    return actions;
+  }, [leftNav]);
 
   function activeNavId(): string | null {
     if (view.page === 'custom') return view.viewId;
@@ -540,6 +572,11 @@ function AppShell(): React.JSX.Element {
         </Profiler>
       )}
       {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} />}
+      <CommandPalette
+        open={commandPaletteOpen}
+        onOpenChange={setCommandPaletteOpen}
+        actions={commandPaletteActions}
+      />
       </div>
     </PaletteProvider>
   );

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider } from '@costgoblin/ui';
+import { useState, useEffect, useCallback, useMemo, Profiler } from 'react';
+import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, useKeyboardShortcuts } from '@costgoblin/ui';
 import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 
@@ -311,6 +311,32 @@ function AppShell(): React.JSX.Element {
   // views (Trends / Missing Tags / Savings).
   const customNav: { id: string; label: string }[] = views.views.map(v => ({ id: v.id, label: v.name }));
   const leftNav = [...customNav, ...STATIC_LEFT_NAV];
+
+  // Register global keyboard shortcuts for navigation and panel controls.
+  // Number keys 1-9 navigate to the first 9 left-nav items, respecting
+  // unsaved-changes guards via handleNavClick. Escape closes the debug
+  // panel when open.
+  const shortcuts = useMemo(() => {
+    const map: Record<string, () => void> = {};
+
+    // Number keys 1-9 for view navigation
+    for (let i = 0; i < Math.min(9, leftNav.length); i++) {
+      const navItem = leftNav[i];
+      if (navItem !== undefined) {
+        const key = String(i + 1);
+        map[key] = () => { handleNavClick(navItem.id); };
+      }
+    }
+
+    // Escape closes debug panel if open
+    if (debugOpen) {
+      map['Escape'] = () => { setDebugOpen(false); };
+    }
+
+    return map;
+  }, [leftNav, debugOpen]);
+
+  useKeyboardShortcuts(shortcuts);
 
   function activeNavId(): string | null {
     if (view.page === 'custom') return view.viewId;

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -255,7 +255,7 @@ function AppShell(): React.JSX.Element {
     return () => { cancelled = true; clearInterval(timer); };
   }, [api, setupCheck, syncActivity]);
 
-  function handleNavClick(id: string) {
+  const handleNavClick = useCallback((id: string) => {
     const alreadyActive = view.page === 'custom' ? view.viewId === id : view.page === id;
     if (alreadyActive) return;
     confirmLeave(() => {
@@ -270,12 +270,10 @@ function AppShell(): React.JSX.Element {
         case 'views-editor': setView({ page: 'views-editor' }); break;
         case 'sync': setView({ page: 'sync' }); break;
         default:
-          // Anything else is a custom view id (every left-nav entry that
-          // isn't one of the well-known static pages above).
           setView({ page: 'custom', viewId: id });
       }
     });
-  }
+  }, [view, confirmLeave, api]);
 
   function handleEntityClick(entity: string, dimension: string) {
     confirmLeave(() => {
@@ -315,14 +313,9 @@ function AppShell(): React.JSX.Element {
   const customNav: { id: string; label: string }[] = views.views.map(v => ({ id: v.id, label: v.name }));
   const leftNav = [...customNav, ...STATIC_LEFT_NAV];
 
-  // Register global keyboard shortcuts for navigation and panel controls.
-  // Number keys 1-9 navigate to the first 9 left-nav items, respecting
-  // unsaved-changes guards via handleNavClick. Escape closes the debug
-  // panel when open. Cmd/Ctrl+K opens the command palette.
   const shortcuts = useMemo(() => {
     const map: Record<string, () => void> = {};
 
-    // Number keys 1-9 for view navigation
     for (let i = 0; i < Math.min(9, leftNav.length); i++) {
       const navItem = leftNav[i];
       if (navItem !== undefined) {
@@ -331,27 +324,21 @@ function AppShell(): React.JSX.Element {
       }
     }
 
-    // Cmd/Ctrl+K opens command palette
     map['mod+k'] = () => { setCommandPaletteOpen(true); };
-
-    // Cmd/Ctrl+? opens keyboard shortcuts overlay
     map['mod+/'] = () => { setShortcutsOverlayOpen(true); };
 
-    // Escape closes debug panel if open
     if (debugOpen) {
       map['Escape'] = () => { setDebugOpen(false); };
     }
 
     return map;
-  }, [leftNav, debugOpen]);
+  }, [leftNav, debugOpen, handleNavClick]);
 
   useKeyboardShortcuts(shortcuts);
 
-  // Build command palette actions from all navigation items
   const commandPaletteActions = useMemo(() => {
     const actions: CommandPaletteAction[] = [];
 
-    // Add left nav items (custom views + static views)
     for (const item of leftNav) {
       actions.push({
         id: item.id,
@@ -361,7 +348,6 @@ function AppShell(): React.JSX.Element {
       });
     }
 
-    // Add right nav items (settings/utilities)
     for (const item of RIGHT_NAV) {
       actions.push({
         id: item.id,
@@ -372,7 +358,7 @@ function AppShell(): React.JSX.Element {
     }
 
     return actions;
-  }, [leftNav]);
+  }, [leftNav, handleNavClick]);
 
   // Build keyboard shortcuts configuration for the help overlay
   const shortcutsConfig = useMemo(() => [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit && eslint src/ && vitest run",
-    "test": "vitest run"
+    "check": "tsc --noEmit && eslint src/ && cd ../.. && npx vitest run --project ui",
+    "test": "cd ../.. && npx vitest run --project ui"
   },
   "dependencies": {
     "@costgoblin/core": "*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit && eslint src/ && cd ../.. && npx vitest run --project ui",
-    "test": "cd ../.. && npx vitest run --project ui"
+    "check": "tsc --noEmit && eslint src/ && vitest run",
+    "test": "vitest run"
   },
   "dependencies": {
     "@costgoblin/core": "*",

--- a/packages/ui/src/components/command-palette.tsx
+++ b/packages/ui/src/components/command-palette.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+} from './ui/dialog.js';
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from './ui/command.js';
+
+export interface CommandPaletteAction {
+  id: string;
+  label: string;
+  onSelect: () => void;
+  keywords?: string[];
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  actions: CommandPaletteAction[];
+}
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  actions,
+}: Readonly<CommandPaletteProps>) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [search, setSearch] = useState('');
+
+  // Focus input when dialog opens and reset search
+  useEffect(() => {
+    if (open) {
+      setSearch('');
+      // Use setTimeout to ensure the dialog is fully rendered
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [open]);
+
+  // Filter actions based on search query
+  const filteredActions = actions.filter((action) => {
+    if (search === '') return true;
+
+    const searchLower = search.toLowerCase();
+    const labelMatch = action.label.toLowerCase().includes(searchLower);
+    const keywordsMatch =
+      action.keywords !== undefined &&
+      action.keywords.some((keyword) =>
+        keyword.toLowerCase().includes(searchLower),
+      );
+    return labelMatch || keywordsMatch;
+  });
+
+  const handleSelect = (action: CommandPaletteAction) => {
+    action.onSelect();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 shadow-2xl max-w-2xl">
+        <Command>
+          <CommandInput
+            ref={inputRef}
+            placeholder="Type a command or search..."
+            className="h-12"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+            }}
+          />
+          <CommandList>
+            {filteredActions.length === 0 ? (
+              <CommandEmpty>No results found.</CommandEmpty>
+            ) : (
+              <CommandGroup>
+                {filteredActions.map((action) => (
+                  <CommandItem
+                    key={action.id}
+                    value={action.id}
+                    onSelect={() => {
+                      handleSelect(action);
+                    }}
+                  >
+                    {action.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -105,6 +105,12 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     onFilterChange(withoutFilter(dimId));
   }
 
+  function handleChipKeyDown(dimId: DimensionId, e: React.KeyboardEvent) {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    handleChipClick(dimId);
+  }
+
   function handleApply(dimId: DimensionId) {
     if (draft.length === 0) {
       onFilterChange(withoutFilter(dimId));
@@ -172,6 +178,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
               <button
                 type="button"
                 onClick={() => { handleChipClick(dimId); }}
+                onKeyDown={(e) => { handleChipKeyDown(dimId, e); }}
                 className="bg-transparent border-none p-0 text-inherit font-inherit cursor-pointer"
               >
                 {chipLabel(dim, activeValues)}

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -32,7 +32,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
-  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const itemRefs = useRef<Record<string, HTMLElement | null>>({});
 
   const hasActiveFilters = Object.keys(filters).length > 0;
 
@@ -83,6 +83,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     setSearch('');
     setDraft([...(filters[dimId] ?? [])]);
     setHighlightedIndex(-1);
+    itemRefs.current = {};
     setDropdown({ status: 'loading' });
 
     const filtersWithoutThis = withoutFilter(dimId);
@@ -295,7 +296,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     return (
                       <label
                         key={item.value}
-                        ref={(el: HTMLLabelElement | null) => { itemRefs.current[item.value] = el as unknown as HTMLButtonElement | null; }}
+                        ref={(el: HTMLLabelElement | null) => { itemRefs.current[item.value] = el; }}
                         className={[
                           'group flex items-center justify-between gap-2 px-3 py-1.5 text-xs cursor-pointer select-none',
                           checked ? 'bg-accent-muted/50 text-text-primary' : 'text-text-secondary hover:bg-bg-tertiary',

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -29,8 +29,10 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
   const [search, setSearch] = useState('');
   const [draft, setDraft] = useState<readonly string[]>([]);
   const [labelMap, setLabelMap] = useState<Record<string, string>>({});
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
+  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
   const hasActiveFilters = Object.keys(filters).length > 0;
 
@@ -40,11 +42,22 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
         setOpenDimId(null);
         setDropdown({ status: 'closed' });
         setSearch('');
+        setHighlightedIndex(-1);
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => { document.removeEventListener('mousedown', handleClickOutside); };
   }, []);
+
+  useEffect(() => {
+    if (highlightedIndex < 0) return;
+    const highlightedKey = Object.keys(itemRefs.current)[highlightedIndex];
+    if (highlightedKey === undefined) return;
+    const element = itemRefs.current[highlightedKey];
+    if (element !== null && element !== undefined) {
+      element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [highlightedIndex]);
 
   function withoutFilter(dimId: DimensionId): FilterMap {
     const next: Partial<Record<DimensionId, readonly TagValue[]>> = {};
@@ -62,12 +75,14 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
       setOpenDimId(null);
       setDropdown({ status: 'closed' });
       setSearch('');
+      setHighlightedIndex(-1);
       return;
     }
 
     setOpenDimId(dimId);
     setSearch('');
     setDraft([...(filters[dimId] ?? [])]);
+    setHighlightedIndex(-1);
     setDropdown({ status: 'loading' });
 
     const filtersWithoutThis = withoutFilter(dimId);
@@ -120,6 +135,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     setOpenDimId(null);
     setDropdown({ status: 'closed' });
     setSearch('');
+    setHighlightedIndex(-1);
   }
 
   function handleClose() {
@@ -138,6 +154,46 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
 
   function handleClearAll() {
     onFilterChange({});
+  }
+
+  function handleSearchKeyDown(dimId: DimensionId, filteredValues: FilterValue[], e: React.KeyboardEvent) {
+    if (e.key === 'Escape') {
+      setOpenDimId(null);
+      setDropdown({ status: 'closed' });
+      setSearch('');
+      setHighlightedIndex(-1);
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => {
+        const next = prev + 1;
+        return next >= filteredValues.length ? 0 : next;
+      });
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => {
+        const next = prev - 1;
+        return next < 0 ? filteredValues.length - 1 : next;
+      });
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < filteredValues.length) {
+        const item = filteredValues[highlightedIndex];
+        if (item !== undefined) {
+          toggleValue(item.value);
+        }
+      } else {
+        handleApply(dimId);
+      }
+    }
   }
 
   function chipLabel(dim: Dimension, active: readonly TagValue[] | undefined): string {
@@ -204,11 +260,11 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     type="text"
                     value={search}
                     placeholder={`Search ${dim.label}…`}
-                    onChange={(e) => { setSearch(e.target.value); }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Escape') handleClose();
-                      if (e.key === 'Enter') handleApply(dimId);
+                    onChange={(e) => {
+                      setSearch(e.target.value);
+                      setHighlightedIndex(-1);
                     }}
+                    onKeyDown={(e) => { handleSearchKeyDown(dimId, filteredValues, e); }}
                     className="w-full rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
                   />
                 </div>
@@ -233,14 +289,17 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     </div>
                   )}
 
-                  {dropdown.status === 'ready' && filteredValues.map((item) => {
+                  {dropdown.status === 'ready' && filteredValues.map((item, index) => {
                     const checked = draft.includes(item.value);
+                    const isHighlighted = index === highlightedIndex;
                     return (
                       <label
                         key={item.value}
+                        ref={(el: HTMLLabelElement | null) => { itemRefs.current[item.value] = el as unknown as HTMLButtonElement | null; }}
                         className={[
                           'group flex items-center justify-between gap-2 px-3 py-1.5 text-xs cursor-pointer select-none',
                           checked ? 'bg-accent-muted/50 text-text-primary' : 'text-text-secondary hover:bg-bg-tertiary',
+                          isHighlighted ? 'ring-1 ring-accent' : '',
                         ].join(' ')}
                       >
                         <span className="flex items-center gap-2 min-w-0 flex-1">

--- a/packages/ui/src/components/keyboard-shortcuts-overlay.tsx
+++ b/packages/ui/src/components/keyboard-shortcuts-overlay.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -29,23 +28,6 @@ export function KeyboardShortcutsOverlay({
   onOpenChange,
   shortcuts,
 }: Readonly<KeyboardShortcutsOverlayProps>) {
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        onOpenChange(false);
-      }
-    }
-
-    if (open) {
-      document.addEventListener('keydown', handleKey);
-      return () => {
-        document.removeEventListener('keydown', handleKey);
-      };
-    }
-
-    return undefined;
-  }, [open, onOpenChange]);
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">

--- a/packages/ui/src/components/keyboard-shortcuts-overlay.tsx
+++ b/packages/ui/src/components/keyboard-shortcuts-overlay.tsx
@@ -1,0 +1,99 @@
+import { useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from './ui/dialog.js';
+import { formatShortcut } from '../lib/keyboard-utils.js';
+
+interface ShortcutItem {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutCategory {
+  category: string;
+  items: ShortcutItem[];
+}
+
+interface KeyboardShortcutsOverlayProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  shortcuts: ShortcutCategory[];
+}
+
+export function KeyboardShortcutsOverlay({
+  open,
+  onOpenChange,
+  shortcuts,
+}: Readonly<KeyboardShortcutsOverlayProps>) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onOpenChange(false);
+      }
+    }
+
+    if (open) {
+      document.addEventListener('keydown', handleKey);
+      return () => {
+        document.removeEventListener('keydown', handleKey);
+      };
+    }
+
+    return undefined;
+  }, [open, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+          <DialogDescription>
+            Use these shortcuts to navigate CostGoblin faster
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 mt-4">
+          {shortcuts.map((section) => (
+            <div key={section.category}>
+              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3">
+                {section.category}
+              </h4>
+              <div className="space-y-2">
+                {section.items.map((item, index) => (
+                  <div
+                    key={`${section.category}-${index.toString()}`}
+                    className="flex items-center justify-between py-2 px-3 rounded-md hover:bg-bg-tertiary transition-colors"
+                  >
+                    <span className="text-sm text-text-primary">
+                      {item.description}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {item.keys.map((key, keyIndex) => (
+                        <kbd
+                          key={`${section.category}-${index.toString()}-${keyIndex.toString()}`}
+                          className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-2 text-xs font-mono font-medium text-text-primary bg-bg-primary border border-border rounded shadow-sm"
+                        >
+                          {formatShortcut([key])}
+                        </kbd>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 pt-4 border-t border-border">
+          <p className="text-xs text-text-tertiary text-center">
+            Press <kbd className="inline-flex items-center justify-center min-w-[1.75rem] h-5 px-1.5 text-xs font-mono font-medium text-text-primary bg-bg-primary border border-border rounded">Esc</kbd> to close
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -173,7 +173,7 @@ export interface CommandItemProps
 
 export const CommandItem = React.forwardRef<HTMLDivElement, CommandItemProps>(
   ({ className, value, onSelect, disabled = false, children, ...props }, ref) => {
-    const { selectedIndex, setItemCount } = useCommandContext();
+    const { selectedIndex, setItemCount, search } = useCommandContext();
     const itemRef = React.useRef<HTMLDivElement>(null);
     const [itemIndex, setItemIndex] = React.useState(-1);
 
@@ -188,7 +188,7 @@ export const CommandItem = React.forwardRef<HTMLDivElement, CommandItemProps>(
       const index = items.indexOf(currentRef);
       setItemIndex(index);
       setItemCount(items.length);
-    }, [setItemCount]);
+    }, [setItemCount, search]);
 
     React.useEffect(() => {
       if (itemIndex === selectedIndex && itemRef.current !== null) {

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -1,0 +1,265 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils.js';
+
+type CommandContextValue = {
+  search: string;
+  setSearch: (search: string) => void;
+  selectedIndex: number;
+  setSelectedIndex: (index: number) => void;
+  itemCount: number;
+  setItemCount: (count: number) => void;
+};
+
+const CommandContext = React.createContext<CommandContextValue | null>(null);
+
+function useCommandContext(): CommandContextValue {
+  const ctx = React.useContext(CommandContext);
+  if (ctx === null) {
+    throw new Error('Command components must be used within Command');
+  }
+  return ctx;
+}
+
+export const Command = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, children, ...props }, ref) => {
+    const [search, setSearch] = React.useState('');
+    const [selectedIndex, setSelectedIndex] = React.useState(0);
+    const [itemCount, setItemCount] = React.useState(0);
+
+    const value = React.useMemo<CommandContextValue>(
+      () => ({
+        search,
+        setSearch,
+        selectedIndex,
+        setSelectedIndex,
+        itemCount,
+        setItemCount,
+      }),
+      [search, selectedIndex, itemCount],
+    );
+
+    return (
+      <CommandContext.Provider value={value}>
+        <div
+          ref={ref}
+          className={cn(
+            'flex h-full w-full flex-col overflow-hidden rounded-lg bg-bg-secondary text-text-primary',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </CommandContext.Provider>
+    );
+  },
+);
+Command.displayName = 'Command';
+
+export const CommandInput = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, ref) => {
+  const { search, setSearch, setSelectedIndex } = useCommandContext();
+
+  return (
+    <div className="flex items-center border-b border-border px-3">
+      <input
+        ref={ref}
+        type="text"
+        value={search}
+        onChange={(e) => {
+          setSearch(e.target.value);
+          setSelectedIndex(0);
+        }}
+        className={cn(
+          'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-text-muted disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CommandInput.displayName = 'CommandInput';
+
+export interface CommandListProps extends React.HTMLAttributes<HTMLDivElement> {
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+}
+
+export const CommandList = React.forwardRef<HTMLDivElement, CommandListProps>(
+  ({ className, children, onKeyDown, ...props }, ref) => {
+    const { selectedIndex, setSelectedIndex, itemCount } = useCommandContext();
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setSelectedIndex(Math.min(selectedIndex + 1, itemCount - 1));
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setSelectedIndex(Math.max(selectedIndex - 1, 0));
+        }
+        onKeyDown?.(e);
+      },
+      [selectedIndex, setSelectedIndex, itemCount, onKeyDown],
+    );
+
+    return (
+      <div
+        ref={ref}
+        role="listbox"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+CommandList.displayName = 'CommandList';
+
+export const CommandEmpty = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('py-6 text-center text-sm text-text-muted', className)}
+        {...props}
+      />
+    );
+  },
+);
+CommandEmpty.displayName = 'CommandEmpty';
+
+export interface CommandGroupProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  heading?: string;
+}
+
+export const CommandGroup = React.forwardRef<HTMLDivElement, CommandGroupProps>(
+  ({ className, heading, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role="group"
+        className={cn('overflow-hidden p-1', className)}
+        {...props}
+      >
+        {heading !== undefined && (
+          <div className="px-2 py-1.5 text-xs font-medium text-text-muted">
+            {heading}
+          </div>
+        )}
+        {children}
+      </div>
+    );
+  },
+);
+CommandGroup.displayName = 'CommandGroup';
+
+export interface CommandItemProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  value?: string;
+  onSelect?: (value: string) => void;
+  disabled?: boolean;
+}
+
+export const CommandItem = React.forwardRef<HTMLDivElement, CommandItemProps>(
+  ({ className, value, onSelect, disabled = false, children, ...props }, ref) => {
+    const { selectedIndex, setItemCount } = useCommandContext();
+    const itemRef = React.useRef<HTMLDivElement>(null);
+    const [itemIndex, setItemIndex] = React.useState(-1);
+
+    React.useEffect(() => {
+      const currentRef = itemRef.current;
+      if (currentRef === null) return;
+
+      const parent = currentRef.parentElement;
+      if (parent === null) return;
+
+      const items = Array.from(parent.querySelectorAll('[role="option"]'));
+      const index = items.indexOf(currentRef);
+      setItemIndex(index);
+      setItemCount(items.length);
+    }, [setItemCount]);
+
+    React.useEffect(() => {
+      if (itemIndex === selectedIndex && itemRef.current !== null) {
+        itemRef.current.scrollIntoView({ block: 'nearest' });
+      }
+    }, [itemIndex, selectedIndex]);
+
+    const isSelected = itemIndex === selectedIndex;
+
+    const handleClick = React.useCallback(() => {
+      if (disabled) return;
+      if (value !== undefined && onSelect !== undefined) {
+        onSelect(value);
+      }
+    }, [disabled, value, onSelect]);
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter' && isSelected && !disabled) {
+          e.preventDefault();
+          if (value !== undefined && onSelect !== undefined) {
+            onSelect(value);
+          }
+        }
+      },
+      [isSelected, disabled, value, onSelect],
+    );
+
+    return (
+      <div
+        ref={(node) => {
+          itemRef.current = node;
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref !== null) {
+            ref.current = node;
+          }
+        }}
+        role="option"
+        aria-selected={isSelected}
+        aria-disabled={disabled}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors',
+          isSelected && !disabled
+            ? 'bg-accent-muted text-accent'
+            : 'hover:bg-bg-tertiary hover:text-text-primary',
+          disabled && 'pointer-events-none opacity-50',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+CommandItem.displayName = 'CommandItem';
+
+export const CommandSeparator = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      role="separator"
+      className={cn('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+});
+CommandSeparator.displayName = 'CommandSeparator';

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '../../lib/utils.js';
+
+export const Dialog = DialogPrimitive.Root;
+
+export const DialogTrigger = DialogPrimitive.Trigger;
+
+export const DialogPortal = DialogPrimitive.Portal;
+
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-bg-secondary p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-xl',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export function DialogHeader({
+  className,
+  ...props
+}: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col space-y-1.5 text-center sm:text-left',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DialogFooter({
+  className,
+  ...props
+}: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-sm font-semibold text-text-primary leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-text-secondary', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;

--- a/packages/ui/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/ui/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { matchesShortcut } from '../lib/keyboard-utils.js';
+
+/**
+ * Register keyboard shortcuts that trigger callbacks when pressed.
+ * Shortcuts are checked against keyboard events globally and the first
+ * matching shortcut's handler is invoked. The default browser behavior
+ * for matched shortcuts is prevented.
+ *
+ * @param shortcuts - Map of shortcut strings to handler functions.
+ *   Keys use '+' to separate modifiers and the final key (e.g., 'Mod+k', 'Shift+Enter', 'Escape').
+ *   Use 'Mod' for the platform-specific primary modifier (Cmd on macOS, Ctrl elsewhere).
+ * @param enabled - Whether the shortcuts are active (default: true).
+ *   When false, the event listener is not attached.
+ *
+ * @example
+ * useKeyboardShortcuts({
+ *   'Mod+k': () => setCommandPaletteOpen(true),
+ *   'Escape': () => closePanel(),
+ *   '1': () => navigateToView('overview'),
+ *   'Shift+?': () => setShortcutsOverlayOpen(true),
+ * });
+ *
+ * @example
+ * // Disable shortcuts conditionally
+ * useKeyboardShortcuts(
+ *   { 'Mod+s': saveDocument },
+ *   !isModalOpen // Only active when modal is closed
+ * );
+ */
+export function useKeyboardShortcuts(
+  shortcuts: Readonly<Record<string, () => void>>,
+  enabled = true
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      // Check each shortcut in order until we find a match
+      for (const [shortcutString, handler] of Object.entries(shortcuts)) {
+        const keys = shortcutString.split('+');
+        if (matchesShortcut(event, keys)) {
+          event.preventDefault();
+          handler();
+          break; // Only trigger the first matching shortcut
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => { document.removeEventListener('keydown', handleKeyDown); };
+  }, [shortcuts, enabled]);
+}

--- a/packages/ui/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/ui/src/hooks/use-keyboard-shortcuts.ts
@@ -1,33 +1,6 @@
 import { useEffect } from 'react';
 import { matchesShortcut } from '../lib/keyboard-utils.js';
 
-/**
- * Register keyboard shortcuts that trigger callbacks when pressed.
- * Shortcuts are checked against keyboard events globally and the first
- * matching shortcut's handler is invoked. The default browser behavior
- * for matched shortcuts is prevented.
- *
- * @param shortcuts - Map of shortcut strings to handler functions.
- *   Keys use '+' to separate modifiers and the final key (e.g., 'Mod+k', 'Shift+Enter', 'Escape').
- *   Use 'Mod' for the platform-specific primary modifier (Cmd on macOS, Ctrl elsewhere).
- * @param enabled - Whether the shortcuts are active (default: true).
- *   When false, the event listener is not attached.
- *
- * @example
- * useKeyboardShortcuts({
- *   'Mod+k': () => setCommandPaletteOpen(true),
- *   'Escape': () => closePanel(),
- *   '1': () => navigateToView('overview'),
- *   'Shift+?': () => setShortcutsOverlayOpen(true),
- * });
- *
- * @example
- * // Disable shortcuts conditionally
- * useKeyboardShortcuts(
- *   { 'Mod+s': saveDocument },
- *   !isModalOpen // Only active when modal is closed
- * );
- */
 export function useKeyboardShortcuts(
   shortcuts: Readonly<Record<string, () => void>>,
   enabled = true
@@ -36,13 +9,12 @@ export function useKeyboardShortcuts(
     if (!enabled) return;
 
     function handleKeyDown(event: KeyboardEvent): void {
-      // Check each shortcut in order until we find a match
       for (const [shortcutString, handler] of Object.entries(shortcuts)) {
         const keys = shortcutString.split('+');
         if (matchesShortcut(event, keys)) {
           event.preventDefault();
           handler();
-          break; // Only trigger the first matching shortcut
+          break;
         }
       }
     }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,7 @@ export { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts.js';
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './components/ui/card.js';
 export { Button, buttonVariants } from './components/ui/button.js';
 export type { ButtonProps } from './components/ui/button.js';
+export { Dialog, DialogTrigger, DialogPortal, DialogClose, DialogOverlay, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription } from './components/ui/dialog.js';
 
 export { ErrorBoundary } from './components/error-boundary.js';
 export { BubbleChart } from './components/bubble-chart.js';
@@ -36,6 +37,8 @@ export { TreemapChart } from './components/treemap-chart.js';
 export { HeatmapChart } from './components/heatmap-chart.js';
 export { FilterActiveBanner } from './components/filter-active-banner.js';
 export { CoinRainLoader } from './components/coin-rain-loader.js';
+export { CommandPalette } from './components/command-palette.js';
+export type { CommandPaletteAction } from './components/command-palette.js';
 export { useCostFocus, useCostFocusDispatch, useCostFocusReducer, CostFocusProvider, CostFocusDispatchProvider } from './hooks/use-cost-focus.js';
 
 export { WIDGET_REGISTRY, WIDGET_CATALOG } from './widgets/registry.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,10 +4,12 @@ export type {
 } from './api/CostApi.js';
 
 export { cn } from './lib/utils.js';
+export { isMac, getModifierKey, formatShortcut, matchesShortcut } from './lib/keyboard-utils.js';
 
 export { useCostApi, CostApiProvider } from './hooks/use-cost-api.js';
 export { useQuery } from './hooks/use-query.js';
 export { UnsavedChangesProvider, useUnsavedChanges, useConfirmLeave } from './hooks/use-unsaved-changes.js';
+export { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts.js';
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './components/ui/card.js';
 export { Button, buttonVariants } from './components/ui/button.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -39,6 +39,7 @@ export { FilterActiveBanner } from './components/filter-active-banner.js';
 export { CoinRainLoader } from './components/coin-rain-loader.js';
 export { CommandPalette } from './components/command-palette.js';
 export type { CommandPaletteAction } from './components/command-palette.js';
+export { KeyboardShortcutsOverlay } from './components/keyboard-shortcuts-overlay.js';
 export { useCostFocus, useCostFocusDispatch, useCostFocusReducer, CostFocusProvider, CostFocusDispatchProvider } from './hooks/use-cost-focus.js';
 
 export { WIDGET_REGISTRY, WIDGET_CATALOG } from './widgets/registry.js';

--- a/packages/ui/src/lib/keyboard-utils.ts
+++ b/packages/ui/src/lib/keyboard-utils.ts
@@ -1,41 +1,15 @@
-/**
- * Keyboard utility functions for cross-platform keyboard shortcut handling.
- * Handles differences between macOS (Cmd) and Windows/Linux (Ctrl).
- */
-
-/**
- * Detects if the current platform is macOS.
- * Uses navigator.userAgent for platform detection.
- */
 export function isMac(): boolean {
   if (typeof navigator === 'undefined') {
     return false;
   }
 
-  // Use userAgent for platform detection
   return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 }
 
-/**
- * Returns the primary modifier key for the current platform.
- * @returns 'Cmd' on macOS, 'Ctrl' on Windows/Linux
- */
 export function getModifierKey(): 'Cmd' | 'Ctrl' {
   return isMac() ? 'Cmd' : 'Ctrl';
 }
 
-/**
- * Formats an array of key names into a human-readable shortcut string.
- * Automatically uses the correct modifier key for the platform.
- *
- * @param keys - Array of key names (e.g., ['Mod', 'K'] or ['Shift', 'Enter'])
- * @returns Formatted shortcut string (e.g., 'Cmd+K' on Mac, 'Ctrl+K' on Windows)
- *
- * @example
- * formatShortcut(['Mod', 'K']) // 'Cmd+K' on Mac, 'Ctrl+K' on Windows
- * formatShortcut(['Shift', 'Enter']) // 'Shift+Enter'
- * formatShortcut(['Escape']) // 'Escape'
- */
 export function formatShortcut(keys: readonly string[]): string {
   if (keys.length === 0) {
     return '';
@@ -43,7 +17,6 @@ export function formatShortcut(keys: readonly string[]): string {
 
   return keys
     .map((key) => {
-      // Replace 'Mod' with platform-specific modifier
       if (key === 'Mod') {
         return getModifierKey();
       }
@@ -52,19 +25,6 @@ export function formatShortcut(keys: readonly string[]): string {
     .join('+');
 }
 
-/**
- * Checks if a keyboard event matches a shortcut definition.
- * Supports platform-agnostic 'Mod' key (Cmd on Mac, Ctrl elsewhere).
- *
- * @param event - Keyboard event to check
- * @param shortcut - Array of key names defining the shortcut
- * @returns true if the event matches the shortcut
- *
- * @example
- * matchesShortcut(event, ['Mod', 'k']) // Matches Cmd+K on Mac, Ctrl+K on Windows
- * matchesShortcut(event, ['Escape']) // Matches Escape key
- * matchesShortcut(event, ['Shift', 'Enter']) // Matches Shift+Enter
- */
 export function matchesShortcut(
   event: KeyboardEvent,
   shortcut: readonly string[]
@@ -73,7 +33,6 @@ export function matchesShortcut(
     return false;
   }
 
-  // Extract the actual key (last element) and modifiers
   const modifiers = shortcut.slice(0, -1);
   const key = shortcut[shortcut.length - 1];
 
@@ -81,7 +40,6 @@ export function matchesShortcut(
     return false;
   }
 
-  // Check if the key matches (case-insensitive)
   const eventKey = event.key.toLowerCase();
   const targetKey = key.toLowerCase();
 
@@ -89,12 +47,10 @@ export function matchesShortcut(
     return false;
   }
 
-  // Check each modifier
   for (const modifier of modifiers) {
     const normalizedModifier = modifier.toLowerCase();
 
     if (normalizedModifier === 'mod') {
-      // 'Mod' means metaKey on Mac, ctrlKey elsewhere
       const modPressed = isMac() ? event.metaKey : event.ctrlKey;
       if (!modPressed) {
         return false;
@@ -118,7 +74,6 @@ export function matchesShortcut(
     }
   }
 
-  // Ensure no extra modifiers are pressed (unless they're specified)
   const hasCtrl = modifiers.some((m) => m.toLowerCase() === 'ctrl' || (m.toLowerCase() === 'mod' && !isMac()));
   const hasMeta = modifiers.some((m) => m.toLowerCase() === 'meta' || m.toLowerCase() === 'cmd' || (m.toLowerCase() === 'mod' && isMac()));
   const hasAlt = modifiers.some((m) => m.toLowerCase() === 'alt');

--- a/packages/ui/src/lib/keyboard-utils.ts
+++ b/packages/ui/src/lib/keyboard-utils.ts
@@ -1,0 +1,146 @@
+/**
+ * Keyboard utility functions for cross-platform keyboard shortcut handling.
+ * Handles differences between macOS (Cmd) and Windows/Linux (Ctrl).
+ */
+
+/**
+ * Detects if the current platform is macOS.
+ * Checks navigator.platform and navigator.userAgent for compatibility.
+ */
+export function isMac(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  // Check platform first (more reliable when available)
+  if (navigator.platform) {
+    return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+  }
+
+  // Fallback to userAgent
+  return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
+/**
+ * Returns the primary modifier key for the current platform.
+ * @returns 'Cmd' on macOS, 'Ctrl' on Windows/Linux
+ */
+export function getModifierKey(): 'Cmd' | 'Ctrl' {
+  return isMac() ? 'Cmd' : 'Ctrl';
+}
+
+/**
+ * Formats an array of key names into a human-readable shortcut string.
+ * Automatically uses the correct modifier key for the platform.
+ *
+ * @param keys - Array of key names (e.g., ['Mod', 'K'] or ['Shift', 'Enter'])
+ * @returns Formatted shortcut string (e.g., 'Cmd+K' on Mac, 'Ctrl+K' on Windows)
+ *
+ * @example
+ * formatShortcut(['Mod', 'K']) // 'Cmd+K' on Mac, 'Ctrl+K' on Windows
+ * formatShortcut(['Shift', 'Enter']) // 'Shift+Enter'
+ * formatShortcut(['Escape']) // 'Escape'
+ */
+export function formatShortcut(keys: readonly string[]): string {
+  if (keys.length === 0) {
+    return '';
+  }
+
+  return keys
+    .map((key) => {
+      // Replace 'Mod' with platform-specific modifier
+      if (key === 'Mod') {
+        return getModifierKey();
+      }
+      return key;
+    })
+    .join('+');
+}
+
+/**
+ * Checks if a keyboard event matches a shortcut definition.
+ * Supports platform-agnostic 'Mod' key (Cmd on Mac, Ctrl elsewhere).
+ *
+ * @param event - Keyboard event to check
+ * @param shortcut - Array of key names defining the shortcut
+ * @returns true if the event matches the shortcut
+ *
+ * @example
+ * matchesShortcut(event, ['Mod', 'k']) // Matches Cmd+K on Mac, Ctrl+K on Windows
+ * matchesShortcut(event, ['Escape']) // Matches Escape key
+ * matchesShortcut(event, ['Shift', 'Enter']) // Matches Shift+Enter
+ */
+export function matchesShortcut(
+  event: KeyboardEvent,
+  shortcut: readonly string[]
+): boolean {
+  if (shortcut.length === 0) {
+    return false;
+  }
+
+  // Extract the actual key (last element) and modifiers
+  const modifiers = shortcut.slice(0, -1);
+  const key = shortcut[shortcut.length - 1];
+
+  if (!key) {
+    return false;
+  }
+
+  // Check if the key matches (case-insensitive)
+  const eventKey = event.key.toLowerCase();
+  const targetKey = key.toLowerCase();
+
+  if (eventKey !== targetKey) {
+    return false;
+  }
+
+  // Check each modifier
+  for (const modifier of modifiers) {
+    const normalizedModifier = modifier.toLowerCase();
+
+    if (normalizedModifier === 'mod') {
+      // 'Mod' means metaKey on Mac, ctrlKey elsewhere
+      const modPressed = isMac() ? event.metaKey : event.ctrlKey;
+      if (!modPressed) {
+        return false;
+      }
+    } else if (normalizedModifier === 'ctrl') {
+      if (!event.ctrlKey) {
+        return false;
+      }
+    } else if (normalizedModifier === 'alt') {
+      if (!event.altKey) {
+        return false;
+      }
+    } else if (normalizedModifier === 'shift') {
+      if (!event.shiftKey) {
+        return false;
+      }
+    } else if (normalizedModifier === 'meta' || normalizedModifier === 'cmd') {
+      if (!event.metaKey) {
+        return false;
+      }
+    }
+  }
+
+  // Ensure no extra modifiers are pressed (unless they're specified)
+  const hasCtrl = modifiers.some((m) => m.toLowerCase() === 'ctrl' || (m.toLowerCase() === 'mod' && !isMac()));
+  const hasMeta = modifiers.some((m) => m.toLowerCase() === 'meta' || m.toLowerCase() === 'cmd' || (m.toLowerCase() === 'mod' && isMac()));
+  const hasAlt = modifiers.some((m) => m.toLowerCase() === 'alt');
+  const hasShift = modifiers.some((m) => m.toLowerCase() === 'shift');
+
+  if (event.ctrlKey && !hasCtrl) {
+    return false;
+  }
+  if (event.metaKey && !hasMeta) {
+    return false;
+  }
+  if (event.altKey && !hasAlt) {
+    return false;
+  }
+  if (event.shiftKey && !hasShift) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/ui/src/lib/keyboard-utils.ts
+++ b/packages/ui/src/lib/keyboard-utils.ts
@@ -5,19 +5,14 @@
 
 /**
  * Detects if the current platform is macOS.
- * Checks navigator.platform and navigator.userAgent for compatibility.
+ * Uses navigator.userAgent for platform detection.
  */
 export function isMac(): boolean {
   if (typeof navigator === 'undefined') {
     return false;
   }
 
-  // Check platform first (more reliable when available)
-  if (navigator.platform) {
-    return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-  }
-
-  // Fallback to userAgent
+  // Use userAgent for platform detection
   return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 }
 


### PR DESCRIPTION
Add comprehensive keyboard shortcuts for power-user navigation: Cmd/Ctrl+K for command palette, number keys for view switching, Escape to close panels, Tab through filters, Enter to drill down, and customizable keybindings. Display shortcut hints in tooltips and a dedicated keyboard shortcut overlay (Cmd/Ctrl+?).