### PR TITLE
Smart Alias Suggestions via Fuzzy Matching

### DIFF
--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -370,6 +370,20 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
           {aliasField}
         </div>
       ) : aliasField}
+
+      <AliasSuggestions
+        dimensionId={dim.name}
+        onAccepted={(canonical, aliases) => {
+          setState(s => {
+            const current = textToAliases(s.aliases) ?? {};
+            const existing: readonly string[] = current[canonical] ?? [];
+            const merged = [...new Set([...existing, ...aliases])];
+            const updated = { ...current, [canonical]: merged };
+            return { ...s, aliases: aliasesToText(updated) };
+          });
+        }}
+      />
+
       {preview !== null && (
         <div className="flex flex-col gap-2">
           <span className="text-xs text-text-muted">


### PR DESCRIPTION
On first sync or when new tag values appear, automatically detect potential alias groups using fuzzy string matching (Levenshtein distance, case normalization, separator normalization). Present suggestions in the Dimensions Editor — e.g., 'prod', 'prd', 'production' → suggest grouping as 'production'. User approves or dismisses each suggestion.