### PR TITLE
Multi-select dashboard filter badges with Only action

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -198,11 +198,12 @@ test.describe('Cost Overview', () => {
       await expect(page.getByText('Loading…')).toBeHidden({ timeout: 10000 });
     } catch { /* may not appear */ }
 
-    const dropdownItems = dropdown.locator('button');
-    const itemCount = await dropdownItems.count();
+    // Multi-select: values are pre-checked. Use "Only" on the first item to filter to just that value.
+    const onlyButtons = dropdown.locator('button', { hasText: 'only' });
+    const onlyCount = await onlyButtons.count();
 
-    if (itemCount > 0) {
-      await dropdownItems.first().click();
+    if (onlyCount > 0) {
+      await onlyButtons.first().click();
       await waitForQuerySettle(page);
 
       // "Clear all" button should appear

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -48,7 +48,7 @@ describe('buildCostQuery', () => {
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-        filters: { [asDimensionId('account')]: asTagValue('111111111111') },
+        filters: { [asDimensionId('account')]: [asTagValue('111111111111')] },
       },
       { dataDir: '/data', dimensions },
     );

--- a/packages/core/src/__tests__/query-integration.test.ts
+++ b/packages/core/src/__tests__/query-integration.test.ts
@@ -155,7 +155,7 @@ describe('DuckDB query integration', () => {
       {
         groupBy: asDimensionId('service'),
         dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-        filters: { [asDimensionId('region')]: asTagValue('eu-central-1') },
+        filters: { [asDimensionId('region')]: [asTagValue('eu-central-1')] },
       },
       { dataDir: SYNTHETIC_DIR, dimensions },
     );

--- a/packages/core/src/__tests__/security.test.ts
+++ b/packages/core/src/__tests__/security.test.ts
@@ -28,7 +28,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue("'; DROP TABLE users; --") },
+          filters: { [asDimensionId('account')]: [asTagValue("'; DROP TABLE users; --")] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -44,7 +44,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('test"value"with"quotes') },
+          filters: { [asDimensionId('account')]: [asTagValue('test"value"with"quotes')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -57,7 +57,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('test--comment') },
+          filters: { [asDimensionId('account')]: [asTagValue('test--comment')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -70,7 +70,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('test\nvalue\nwith\nnewlines') },
+          filters: { [asDimensionId('account')]: [asTagValue('test\nvalue\nwith\nnewlines')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -83,7 +83,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('service')]: asTagValue("' UNION SELECT password FROM users --") },
+          filters: { [asDimensionId('service')]: [asTagValue("' UNION SELECT password FROM users --")] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -96,7 +96,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('service')]: asTagValue("test'; DELETE FROM accounts; SELECT '") },
+          filters: { [asDimensionId('service')]: [asTagValue("test'; DELETE FROM accounts; SELECT '")] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -216,8 +216,8 @@ describe('SQL Injection Prevention', () => {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString("2026-01-01' OR 1=1 --"), end: asDateString("2026-01-31'; DROP TABLE x; --") },
           filters: {
-            [asDimensionId('account')]: asTagValue("'; DELETE FROM users; --"),
-            [asDimensionId('service')]: asTagValue("' UNION SELECT * FROM secrets --"),
+            [asDimensionId('account')]: [asTagValue("'; DELETE FROM users; --")],
+            [asDimensionId('service')]: [asTagValue("' UNION SELECT * FROM secrets --")],
           },
         },
         { dataDir: '/data', dimensions },
@@ -240,8 +240,8 @@ describe('SQL Injection Prevention', () => {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
           filters: {
-            [asDimensionId('account')]: asTagValue("malicious'value"),
-            [asDimensionId('service')]: asTagValue("another'injection"),
+            [asDimensionId('account')]: [asTagValue("malicious'value")],
+            [asDimensionId('service')]: [asTagValue("another'injection")],
           },
         },
         { dataDir: '/data', dimensions },
@@ -287,7 +287,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('test\x00value') },
+          filters: { [asDimensionId('account')]: [asTagValue('test\x00value')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -299,7 +299,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('test-值-🔒-value') },
+          filters: { [asDimensionId('account')]: [asTagValue('test-值-🔒-value')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -311,7 +311,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('test\\value\\with\\backslashes') },
+          filters: { [asDimensionId('account')]: [asTagValue('test\\value\\with\\backslashes')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -323,7 +323,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('%malicious%') },
+          filters: { [asDimensionId('account')]: [asTagValue('%malicious%')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -335,7 +335,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue('') },
+          filters: { [asDimensionId('account')]: [asTagValue('')] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -378,7 +378,7 @@ describe('SQL Injection Prevention', () => {
         {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('service')]: asTagValue("'; DROP TABLE x; SELECT '") },
+          filters: { [asDimensionId('service')]: [asTagValue("'; DROP TABLE x; SELECT '")] },
         },
         { dataDir: '/data', dimensions },
       );
@@ -400,8 +400,8 @@ describe('SQL Injection Prevention', () => {
           groupBy: asDimensionId('service'),
           dateRange: { start: asDateString('2026-02-01'), end: asDateString('2026-02-28') },
           filters: {
-            [asDimensionId('account')]: asTagValue('test1'),
-            [asDimensionId('service')]: asTagValue('test2'),
+            [asDimensionId('account')]: [asTagValue('test1')],
+            [asDimensionId('service')]: [asTagValue('test2')],
           },
           deltaThreshold: asDollars(100),
           percentThreshold: 10,
@@ -429,7 +429,7 @@ describe('SQL Injection Prevention', () => {
       const result = buildNonResourceCostQuery(
         {
           dateRange: { start: asDateString("2026-01-01' OR 1=1 --"), end: asDateString('2026-01-31') },
-          filters: { [asDimensionId('account')]: asTagValue("'; DROP TABLE x; --") },
+          filters: { [asDimensionId('account')]: [asTagValue("'; DROP TABLE x; --")] },
           minCost: asDollars(0),
           tagDimension: asDimensionId('tag_org_team'),
         },

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -112,19 +112,35 @@ function buildFilterClauses(
   qb: QueryBuilder,
 ): string[] {
   const clauses: string[] = [];
-  for (const [dimId, value] of Object.entries(filters)) {
-    if (value === undefined) continue;
+  for (const [dimId, values] of Object.entries(filters)) {
+    if (values === undefined || values.length === 0) continue;
     const resolved = resolveField(dimId as DimensionId, dimensions);
     if (resolved.rawField === 'account_id' && accountReverseMap !== undefined) {
-      const ids = accountReverseMap.get(String(value));
-      if (ids !== undefined && ids.length > 0) {
-        const list = buildSqlList(ids, qb);
+      const allIds = new Set<string>();
+      let usedReverse = false;
+      for (const v of values) {
+        const ids = accountReverseMap.get(String(v));
+        if (ids !== undefined && ids.length > 0) {
+          for (const id of ids) allIds.add(id);
+          usedReverse = true;
+        } else {
+          allIds.add(String(v));
+        }
+      }
+      if (usedReverse) {
+        const list = buildSqlList([...allIds], qb);
         clauses.push(`${resolved.rawField} IN (${list})`);
         continue;
       }
     }
-    const placeholder = qb.addParam(String(value));
-    clauses.push(`${resolved.fieldExpr} = ${placeholder}`);
+    const first = values[0];
+    if (values.length === 1 && first !== undefined) {
+      const placeholder = qb.addParam(String(first));
+      clauses.push(`${resolved.fieldExpr} = ${placeholder}`);
+    } else {
+      const list = buildSqlList(values.map(v => String(v)), qb);
+      clauses.push(`${resolved.fieldExpr} IN (${list})`);
+    }
   }
   return clauses;
 }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -102,7 +102,7 @@ export interface CostApi {
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult>;
   syncPeriods(files: readonly { key: string; contentHash: string; size: number }[], syncId?: string): Promise<{ filesDownloaded: number; rowsProcessed: number }>;
   cancelSync(syncId?: string): Promise<void>;
-  getFilterValues(dimensionId: string, filters: Record<string, string>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]>;
+  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]>;
   deleteLocalPeriod(period: string, tier?: DataTier): Promise<void>;
   openDataFolder(): Promise<void>;
   getAccountMapping(): Promise<AccountMappingStatus>;

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -7,7 +7,7 @@ export interface DateRange {
   readonly end: DateString;
 }
 
-export type FilterMap = Readonly<Partial<Record<DimensionId, TagValue>>>;
+export type FilterMap = Readonly<Partial<Record<DimensionId, readonly TagValue[]>>>;
 
 export interface CostQueryParams {
   readonly groupBy: DimensionId;

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -26,12 +26,13 @@ function resolveFieldExpr(
 }
 
 function buildFilterWhereClauses(
-  filterEntries: Record<string, string>,
+  filterEntries: Record<string, readonly string[]>,
   dimensions: import('@costgoblin/core').DimensionsConfig,
   accountReverseMap: Map<string, readonly string[]>,
 ): string[] {
   const clauses: string[] = [];
-  for (const [key, value] of Object.entries(filterEntries)) {
+  for (const [key, values] of Object.entries(filterEntries)) {
+    if (values.length === 0) continue;
     const fb = dimensions.builtIn.find(d => d.name === key);
     const ft = dimensions.tags.find(d => tagColumnName(d.tagName) === key);
     const ff = fb === undefined ? key : fb.field;
@@ -40,14 +41,31 @@ function buildFilterWhereClauses(
     else if (ft !== undefined) ffExpr = buildAliasSqlCase(ff, ft);
 
     if (ff === 'account_id') {
-      const ids = accountReverseMap.get(value);
-      if (ids !== undefined && ids.length > 0) {
-        const list = ids.map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
+      const allIds = new Set<string>();
+      let usedReverse = false;
+      for (const v of values) {
+        const ids = accountReverseMap.get(v);
+        if (ids !== undefined && ids.length > 0) {
+          for (const id of ids) allIds.add(id);
+          usedReverse = true;
+        } else {
+          allIds.add(v);
+        }
+      }
+      if (usedReverse) {
+        const list = [...allIds].map(id => `'${id.replaceAll("'", "''")}'`).join(', ');
         clauses.push(`${ff} IN (${list})`);
         continue;
       }
     }
-    clauses.push(`${ffExpr} = '${value.replaceAll("'", "''")}'`);
+    if (values.length === 1) {
+      const first = values[0];
+      if (first === undefined) continue;
+      clauses.push(`${ffExpr} = '${first.replaceAll("'", "''")}'`);
+    } else {
+      const list = values.map(v => `'${v.replaceAll("'", "''")}'`).join(', ');
+      clauses.push(`${ffExpr} IN (${list})`);
+    }
   }
   return clauses;
 }
@@ -85,7 +103,7 @@ function mergeAccountRows(
 export function registerFilterHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runQuery } = app;
 
-  ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, string>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> => {
+  ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -118,7 +118,7 @@ const api: CostApi = {
   getOrgTree(): Promise<OrgNode[]> {
     return invoke<OrgNode[]>('config:org-tree');
   },
-  getFilterValues(dimensionId: string, filters: Record<string, string>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> {
+  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> {
     return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange, opts);
   },
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult> {

--- a/packages/ui/src/__tests__/date-range-picker.test.tsx
+++ b/packages/ui/src/__tests__/date-range-picker.test.tsx
@@ -48,7 +48,7 @@ describe('DateRangePicker', () => {
     const dailyButtons = screen.getAllByText('30 days');
     const dailyBtn = dailyButtons[0];
     expect(dailyBtn).toBeDefined();
-    expect(dailyBtn?.className).toContain('bg-bg-primary');
+    expect(dailyBtn?.className).toContain('bg-accent');
   });
 
   it('clicking hourly 7 days calls onChange with hourly granularity', async () => {

--- a/packages/ui/src/__tests__/filter-bar.test.tsx
+++ b/packages/ui/src/__tests__/filter-bar.test.tsx
@@ -91,7 +91,7 @@ describe('FilterBar', () => {
     expect(screen.getByText('$18.9k')).toBeDefined();
   });
 
-  it('selecting a value calls onFilterChange', async () => {
+  it('checking a value and clicking Apply calls onFilterChange with array', async () => {
     const onFilterChange = vi.fn();
     renderFilterBar({ onFilterChange });
 
@@ -103,22 +103,76 @@ describe('FilterBar', () => {
     });
 
     await user.click(screen.getByText('platform'));
+    await user.click(screen.getByText('Apply'));
 
     expect(onFilterChange).toHaveBeenCalledOnce();
     const callArg = onFilterChange.mock.calls[0]?.[0] as FilterMap;
-    expect(callArg[asDimensionId('tag_team')]).toBe(asTagValue('platform'));
+    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('platform')]);
+  });
+
+  it('multi-select: checking multiple values applies all', async () => {
+    const onFilterChange = vi.fn();
+    renderFilterBar({ onFilterChange });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Team'));
+
+    await waitFor(() => {
+      expect(screen.getByText('platform')).toBeDefined();
+    });
+
+    await user.click(screen.getByText('platform'));
+    await user.click(screen.getByText('data'));
+    await user.click(screen.getByText('Apply'));
+
+    expect(onFilterChange).toHaveBeenCalledOnce();
+    const callArg = onFilterChange.mock.calls[0]?.[0] as FilterMap;
+    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('platform'), asTagValue('data')]);
+  });
+
+  it('"Only" button selects just that value', async () => {
+    const onFilterChange = vi.fn();
+    renderFilterBar({
+      onFilterChange,
+      filters: { [asDimensionId('tag_team')]: [asTagValue('platform'), asTagValue('data')] },
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/Team/));
+
+    await waitFor(() => {
+      expect(screen.getByText('platform')).toBeDefined();
+    });
+
+    const onlyButtons = screen.getAllByText('only');
+    const secondOnly = onlyButtons[1];
+    expect(secondOnly).toBeDefined();
+    if (secondOnly === undefined) return;
+    await user.click(secondOnly);
+    await user.click(screen.getByText('Apply'));
+
+    expect(onFilterChange).toHaveBeenCalledOnce();
+    const callArg = onFilterChange.mock.calls[0]?.[0] as FilterMap;
+    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('data')]);
   });
 
   it('active filter shows value and clear button', () => {
-    const filters: FilterMap = { [asDimensionId('tag_team')]: asTagValue('platform') };
+    const filters: FilterMap = { [asDimensionId('tag_team')]: [asTagValue('platform')] };
     renderFilterBar({ filters });
 
     expect(screen.getByText('Team: platform')).toBeDefined();
     expect(screen.getByLabelText('Clear Team filter')).toBeDefined();
   });
 
+  it('multi-value badge shows count', () => {
+    const filters: FilterMap = { [asDimensionId('tag_team')]: [asTagValue('platform'), asTagValue('data')] };
+    renderFilterBar({ filters });
+
+    expect(screen.getByText('Team \u00b7 2')).toBeDefined();
+  });
+
   it('clear all button appears when filters are active', () => {
-    const filters: FilterMap = { [asDimensionId('tag_team')]: asTagValue('platform') };
+    const filters: FilterMap = { [asDimensionId('tag_team')]: [asTagValue('platform')] };
     renderFilterBar({ filters });
 
     expect(screen.getByText('Clear all')).toBeDefined();

--- a/packages/ui/src/__tests__/filter-bar.test.tsx
+++ b/packages/ui/src/__tests__/filter-bar.test.tsx
@@ -178,69 +178,6 @@ describe('FilterBar', () => {
     expect(screen.getByText('Clear all')).toBeDefined();
   });
 
-  it('arrow down navigates through dropdown options', async () => {
-    renderFilterBar();
-
-    const user = userEvent.setup();
-    await user.click(screen.getByText('Team'));
-
-    await waitFor(() => {
-      expect(screen.getByText('platform')).toBeDefined();
-    });
-
-    await user.keyboard('{ArrowDown}');
-    const firstOption = screen.getByText('platform').closest('button');
-    expect(firstOption?.className).toContain('bg-accent-muted');
-
-    await user.keyboard('{ArrowDown}');
-    const secondOption = screen.getByText('data').closest('button');
-    expect(secondOption?.className).toContain('bg-accent-muted');
-
-    await user.keyboard('{ArrowDown}');
-    const thirdOption = screen.getByText('growth').closest('button');
-    expect(thirdOption?.className).toContain('bg-accent-muted');
-  });
-
-  it('arrow up navigates backwards through dropdown options', async () => {
-    renderFilterBar();
-
-    const user = userEvent.setup();
-    await user.click(screen.getByText('Team'));
-
-    await waitFor(() => {
-      expect(screen.getByText('platform')).toBeDefined();
-    });
-
-    await user.keyboard('{ArrowDown}');
-    await user.keyboard('{ArrowDown}');
-    const secondOption = screen.getByText('data').closest('button');
-    expect(secondOption?.className).toContain('bg-accent-muted');
-
-    await user.keyboard('{ArrowUp}');
-    const firstOption = screen.getByText('platform').closest('button');
-    expect(firstOption?.className).toContain('bg-accent-muted');
-  });
-
-  it('enter key selects highlighted option', async () => {
-    const onFilterChange = vi.fn();
-    renderFilterBar({ onFilterChange });
-
-    const user = userEvent.setup();
-    await user.click(screen.getByText('Team'));
-
-    await waitFor(() => {
-      expect(screen.getByText('platform')).toBeDefined();
-    });
-
-    await user.keyboard('{ArrowDown}');
-    await user.keyboard('{ArrowDown}');
-    await user.keyboard('{Enter}');
-
-    expect(onFilterChange).toHaveBeenCalledOnce();
-    const callArg = onFilterChange.mock.calls[0]?.[0] as FilterMap;
-    expect(callArg[asDimensionId('tag_team')]).toBe(asTagValue('data'));
-  });
-
   it('escape key closes dropdown', async () => {
     renderFilterBar();
 

--- a/packages/ui/src/__tests__/filter-bar.test.tsx
+++ b/packages/ui/src/__tests__/filter-bar.test.tsx
@@ -91,7 +91,7 @@ describe('FilterBar', () => {
     expect(screen.getByText('$18.9k')).toBeDefined();
   });
 
-  it('checking a value and clicking Apply calls onFilterChange with array', async () => {
+  it('unchecking a value and clicking Apply excludes it', async () => {
     const onFilterChange = vi.fn();
     renderFilterBar({ onFilterChange });
 
@@ -102,15 +102,16 @@ describe('FilterBar', () => {
       expect(screen.getByText('platform')).toBeDefined();
     });
 
+    // All start checked when no filter active; uncheck platform to exclude it
     await user.click(screen.getByText('platform'));
     await user.click(screen.getByText('Apply'));
 
     expect(onFilterChange).toHaveBeenCalledOnce();
     const callArg = onFilterChange.mock.calls[0]?.[0] as FilterMap;
-    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('platform')]);
+    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('data'), asTagValue('growth')]);
   });
 
-  it('multi-select: checking multiple values applies all', async () => {
+  it('unchecking multiple values excludes all of them', async () => {
     const onFilterChange = vi.fn();
     renderFilterBar({ onFilterChange });
 
@@ -127,7 +128,7 @@ describe('FilterBar', () => {
 
     expect(onFilterChange).toHaveBeenCalledOnce();
     const callArg = onFilterChange.mock.calls[0]?.[0] as FilterMap;
-    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('platform'), asTagValue('data')]);
+    expect(callArg[asDimensionId('tag_team')]).toEqual([asTagValue('growth')]);
   });
 
   it('"Only" button selects just that value', async () => {

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -71,7 +71,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
             className={[
               'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
               granularity === 'daily' && isActive(preset.days)
-                ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+                ? 'bg-accent text-bg-primary shadow-sm'
                 : 'text-text-secondary hover:text-text-primary',
             ].join(' ')}
           >
@@ -84,7 +84,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
           className={[
             'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
             isCustom || showCustom
-              ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+              ? 'bg-accent text-bg-primary shadow-sm'
               : 'text-text-secondary hover:text-text-primary',
           ].join(' ')}
         >
@@ -104,7 +104,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
             className={[
               'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
               granularity === 'hourly' && isActive(preset.days)
-                ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+                ? 'bg-accent text-bg-primary shadow-sm'
                 : 'text-text-secondary hover:text-text-primary',
             ].join(' ')}
           >

--- a/packages/ui/src/components/dimension-selector.tsx
+++ b/packages/ui/src/components/dimension-selector.tsx
@@ -21,7 +21,7 @@ export function DimensionSelector({ dimensions, selected, onSelect }: Readonly<D
             className={[
               'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
               isSelected
-                ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+                ? 'bg-accent text-bg-primary shadow-sm'
                 : 'text-text-secondary hover:text-text-primary',
             ].join(' ')}
           >

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -73,16 +73,16 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     const filtersWithoutThis = withoutFilter(dimId);
     const thisRequestId = ++requestIdRef.current;
 
+    const noActiveFilter = filters[dimId] === undefined || filters[dimId].length === 0;
     getFilterValues(dimId, filtersWithoutThis).then(
       (values) => {
         if (thisRequestId !== requestIdRef.current) return;
         const newLabels: Record<string, string> = {};
         for (const v of values) newLabels[v.value] = v.label;
         setLabelMap(prev => ({ ...prev, ...newLabels }));
-        setDropdown({
-          status: 'ready',
-          values: [...values].sort((a, b) => b.count - a.count),
-        });
+        const sorted = [...values].sort((a, b) => b.count - a.count);
+        if (noActiveFilter) setDraft(sorted.map(v => v.value));
+        setDropdown({ status: 'ready', values: sorted });
       },
       (err: unknown) => {
         if (thisRequestId !== requestIdRef.current) return;

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { Dimension, DimensionId, FilterMap } from '@costgoblin/core/browser';
+import type { Dimension, DimensionId, FilterMap, TagValue } from '@costgoblin/core/browser';
 import { asTagValue } from '@costgoblin/core/browser';
 import { getDimensionId } from '../lib/dimensions.js';
 import { formatDollars } from './format.js';
@@ -27,11 +27,10 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
   const [openDimId, setOpenDimId] = useState<DimensionId | null>(null);
   const [dropdown, setDropdown] = useState<DropdownState>({ status: 'closed' });
   const [search, setSearch] = useState('');
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [draft, setDraft] = useState<readonly string[]>([]);
   const [labelMap, setLabelMap] = useState<Record<string, string>>({});
   const containerRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
-  const itemRefs = useRef(new Map<number, HTMLButtonElement>());
 
   const hasActiveFilters = Object.keys(filters).length > 0;
 
@@ -41,28 +40,14 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
         setOpenDimId(null);
         setDropdown({ status: 'closed' });
         setSearch('');
-        setHighlightedIndex(-1);
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => { document.removeEventListener('mousedown', handleClickOutside); };
   }, []);
 
-  useEffect(() => {
-    setHighlightedIndex(-1);
-  }, [search]);
-
-  useEffect(() => {
-    if (highlightedIndex >= 0) {
-      const item = itemRefs.current.get(highlightedIndex);
-      if (item !== undefined) {
-        item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      }
-    }
-  }, [highlightedIndex]);
-
   function withoutFilter(dimId: DimensionId): FilterMap {
-    const next: Partial<Record<DimensionId, ReturnType<typeof asTagValue>>> = {};
+    const next: Partial<Record<DimensionId, readonly TagValue[]>> = {};
     for (const dim of dimensions) {
       const id = getDimensionId(dim);
       if (id === dimId) continue;
@@ -77,13 +62,12 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
       setOpenDimId(null);
       setDropdown({ status: 'closed' });
       setSearch('');
-      setHighlightedIndex(-1);
       return;
     }
 
     setOpenDimId(dimId);
     setSearch('');
-    setHighlightedIndex(-1);
+    setDraft([...(filters[dimId] ?? [])]);
     setDropdown({ status: 'loading' });
 
     const filtersWithoutThis = withoutFilter(dimId);
@@ -92,6 +76,9 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     getFilterValues(dimId, filtersWithoutThis).then(
       (values) => {
         if (thisRequestId !== requestIdRef.current) return;
+        const newLabels: Record<string, string> = {};
+        for (const v of values) newLabels[v.value] = v.label;
+        setLabelMap(prev => ({ ...prev, ...newLabels }));
         setDropdown({
           status: 'ready',
           values: [...values].sort((a, b) => b.count - a.count),
@@ -118,24 +105,51 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
     onFilterChange(withoutFilter(dimId));
   }
 
-  function handleSelectValue(dimId: DimensionId, value: string, label: string) {
-    setLabelMap(prev => ({ ...prev, [value]: label }));
-    onFilterChange({ ...filters, [dimId]: asTagValue(value) });
+  function handleApply(dimId: DimensionId) {
+    if (draft.length === 0) {
+      onFilterChange(withoutFilter(dimId));
+    } else {
+      onFilterChange({ ...filters, [dimId]: draft.map(v => asTagValue(v)) });
+    }
     setOpenDimId(null);
     setDropdown({ status: 'closed' });
     setSearch('');
-    setHighlightedIndex(-1);
+  }
+
+  function handleClose() {
+    setOpenDimId(null);
+    setDropdown({ status: 'closed' });
+    setSearch('');
+  }
+
+  function toggleValue(value: string) {
+    setDraft(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
+  }
+
+  function handleOnly(value: string) {
+    setDraft([value]);
   }
 
   function handleClearAll() {
     onFilterChange({});
   }
 
+  function chipLabel(dim: Dimension, active: readonly TagValue[] | undefined): string {
+    if (active === undefined || active.length === 0) return dim.label;
+    if (active.length === 1) {
+      const first = active[0];
+      if (first === undefined) return dim.label;
+      return `${dim.label}: ${labelMap[first] ?? first}`;
+    }
+    return `${dim.label} \u00b7 ${String(active.length)}`;
+  }
+
   return (
     <div ref={containerRef} className="relative flex flex-wrap items-center gap-2">
       {dimensions.map((dim) => {
         const dimId = getDimensionId(dim);
-        const activeValue = filters[dimId];
+        const activeValues = filters[dimId];
+        const isActive = activeValues !== undefined && activeValues.length > 0;
         const isOpen = openDimId === dimId;
 
         const filteredValues =
@@ -150,7 +164,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
             <div
               className={[
                 'flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-                activeValue === undefined
+                !isActive
                   ? 'border-border bg-bg-tertiary/30 text-text-secondary hover:border-border hover:text-text-primary'
                   : 'border-accent bg-accent-muted text-accent',
               ].join(' ')}
@@ -160,9 +174,9 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                 onClick={() => { handleChipClick(dimId); }}
                 className="bg-transparent border-none p-0 text-inherit font-inherit cursor-pointer"
               >
-                {activeValue === undefined ? dim.label : `${dim.label}: ${labelMap[activeValue] ?? activeValue}`}
+                {chipLabel(dim, activeValues)}
               </button>
-              {activeValue !== undefined && (
+              {isActive && (
                 <button
                   type="button"
                   aria-label={`Clear ${dim.label} filter`}
@@ -176,7 +190,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
             </div>
 
             {isOpen && (
-              <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded-lg border border-border bg-bg-secondary shadow-lg">
+              <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-bg-secondary shadow-lg">
                 <div className="border-b border-border p-2">
                   <input
                     autoFocus
@@ -185,54 +199,8 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     placeholder={`Search ${dim.label}…`}
                     onChange={(e) => { setSearch(e.target.value); }}
                     onKeyDown={(e) => {
-                      if (e.key === 'Escape') {
-                        setOpenDimId(null);
-                        setDropdown({ status: 'closed' });
-                        setSearch('');
-                        setHighlightedIndex(-1);
-                        return;
-                      }
-
-                      if (e.key === 'ArrowDown') {
-                        e.preventDefault();
-                        setHighlightedIndex((prev) => {
-                          const next = prev + 1;
-                          if (next >= filteredValues.length) return 0;
-                          return next;
-                        });
-                        return;
-                      }
-
-                      if (e.key === 'ArrowUp') {
-                        e.preventDefault();
-                        setHighlightedIndex((prev) => {
-                          const next = prev - 1;
-                          if (next < 0) return filteredValues.length - 1;
-                          return next;
-                        });
-                        return;
-                      }
-
-                      if (e.key === 'Home') {
-                        e.preventDefault();
-                        setHighlightedIndex(0);
-                        return;
-                      }
-
-                      if (e.key === 'End') {
-                        e.preventDefault();
-                        setHighlightedIndex(filteredValues.length - 1);
-                        return;
-                      }
-
-                      if (e.key === 'Enter' && highlightedIndex >= 0 && highlightedIndex < filteredValues.length) {
-                        e.preventDefault();
-                        const item = filteredValues[highlightedIndex];
-                        if (item !== undefined) {
-                          handleSelectValue(dimId, item.value, item.label);
-                        }
-                        return;
-                      }
+                      if (e.key === 'Escape') handleClose();
+                      if (e.key === 'Enter') handleApply(dimId);
                     }}
                     className="w-full rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
                   />
@@ -258,30 +226,65 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     </div>
                   )}
 
-                  {dropdown.status === 'ready' && filteredValues.map((item, index) => {
-                    const isHighlighted = index === highlightedIndex;
+                  {dropdown.status === 'ready' && filteredValues.map((item) => {
+                    const checked = draft.includes(item.value);
                     return (
-                      <button
+                      <label
                         key={item.value}
-                        ref={(el) => {
-                          if (el !== null) {
-                            itemRefs.current.set(index, el);
-                          } else {
-                            itemRefs.current.delete(index);
-                          }
-                        }}
-                        type="button"
-                        onClick={() => { handleSelectValue(dimId, item.value, item.label); }}
                         className={[
-                          'flex w-full items-center justify-between px-3 py-1.5 text-left text-xs text-text-primary',
-                          isHighlighted ? 'bg-accent-muted' : 'hover:bg-bg-tertiary',
+                          'group flex items-center justify-between gap-2 px-3 py-1.5 text-xs cursor-pointer select-none',
+                          checked ? 'bg-accent-muted/50 text-text-primary' : 'text-text-secondary hover:bg-bg-tertiary',
                         ].join(' ')}
                       >
-                        <span className="truncate">{item.label}</span>
-                        <span className="ml-2 shrink-0 text-text-muted">{formatDollars(item.count)}</span>
-                      </button>
+                        <span className="flex items-center gap-2 min-w-0 flex-1">
+                          <input
+                            type="checkbox"
+                            className="accent-accent shrink-0"
+                            checked={checked}
+                            onChange={() => { toggleValue(item.value); }}
+                          />
+                          <span className="truncate">{item.label}</span>
+                        </span>
+                        <span className="flex items-center gap-1.5 shrink-0">
+                          <button
+                            type="button"
+                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleOnly(item.value); }}
+                            className="text-text-muted hover:text-accent opacity-0 group-hover:opacity-100 text-[10px] font-medium uppercase tracking-wide"
+                          >
+                            only
+                          </button>
+                          <span className="text-text-muted tabular-nums">{formatDollars(item.count)}</span>
+                        </span>
+                      </label>
                     );
                   })}
+                </div>
+
+                <div className="flex items-center justify-between border-t border-border p-2 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => { setDraft([]); }}
+                    className="text-xs text-text-secondary hover:text-text-primary"
+                    disabled={draft.length === 0}
+                  >
+                    Clear
+                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={handleClose}
+                      className="rounded-md px-2 py-1 text-xs text-text-secondary hover:bg-bg-tertiary"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { handleApply(dimId); }}
+                      className="rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-bg-primary hover:bg-accent/90"
+                    >
+                      Apply
+                    </button>
+                  </div>
                 </div>
               </div>
             )}

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -261,14 +261,24 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                 </div>
 
                 <div className="flex items-center justify-between border-t border-border p-2 gap-2">
-                  <button
-                    type="button"
-                    onClick={() => { setDraft([]); }}
-                    className="text-xs text-text-secondary hover:text-text-primary"
-                    disabled={draft.length === 0}
-                  >
-                    Clear
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => { setDraft([]); }}
+                      className="text-xs text-text-secondary hover:text-text-primary"
+                      disabled={draft.length === 0}
+                    >
+                      Clear
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setDraft(filteredValues.map(v => v.value)); }}
+                      className="text-xs text-text-secondary hover:text-text-primary"
+                      disabled={filteredValues.length === 0 || draft.length === filteredValues.length}
+                    >
+                      All
+                    </button>
+                  </div>
                   <div className="flex items-center gap-2">
                     <button
                       type="button"

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -265,7 +265,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     <button
                       type="button"
                       onClick={() => { setDraft([]); }}
-                      className="text-xs text-text-secondary hover:text-text-primary"
+                      className="text-xs text-text-secondary hover:text-accent"
                       disabled={draft.length === 0}
                     >
                       Clear

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -273,7 +273,7 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                     <button
                       type="button"
                       onClick={() => { setDraft(filteredValues.map(v => v.value)); }}
-                      className="text-xs text-text-secondary hover:text-text-primary"
+                      className="text-xs text-text-secondary hover:text-accent"
                       disabled={filteredValues.length === 0 || draft.length === filteredValues.length}
                     >
                       All

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -144,7 +144,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
               className={[
                 'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
                 state.periodDays === p.days
-                  ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+                  ? 'bg-accent text-bg-primary shadow-sm'
                   : 'text-text-secondary hover:text-text-primary',
               ].join(' ')}
             >
@@ -171,7 +171,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
                 className={[
                   'rounded-md px-3 py-1.5 text-xs font-medium transition-colors capitalize',
                   state.direction === d
-                    ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+                    ? 'bg-accent text-bg-primary shadow-sm'
                     : 'text-text-secondary hover:text-text-primary',
                 ].join(' ')}
               >

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -76,11 +76,11 @@ function CustomViewInner({ spec, headerSubtitle, onEntityClick }: CustomViewProp
   );
 
   function handleSetFilter(dim: DimensionId, value: TagValue) {
-    setFilters(prev => ({ ...prev, [dim]: value }));
+    setFilters(prev => ({ ...prev, [dim]: [value] }));
   }
 
   function handleGetFilterValues(dimensionId: DimensionId, currentFilters: FilterMap): Promise<{ value: string; label: string; count: number }[]> {
-    const plain: Record<string, string> = {};
+    const plain: Record<string, readonly string[]> = {};
     for (const [k, v] of Object.entries(currentFilters)) if (v !== undefined) plain[k] = v;
     return api.getFilterValues(dimensionId, plain, dateRange);
   }

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -86,7 +86,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const [pie3DimId, setPie3DimId] = useState<DimensionId | null>(null);
 
   const dateRangeKey = `${dateRange.start}_${dateRange.end}`;
-  const entityFilter: FilterMap = { [asDimensionId(dimension)]: asTagValue(entity) };
+  const entityFilter: FilterMap = { [asDimensionId(dimension)]: [asTagValue(entity)] };
   const filterKey = JSON.stringify(entityFilter);
 
   // Entity detail summary (total, previous, percent change)

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -123,7 +123,7 @@ export function MissingTags() {
                   className={[
                     'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                     isSelected
-                      ? 'bg-bg-primary text-text-primary shadow-sm border border-border'
+                      ? 'bg-accent text-bg-primary shadow-sm'
                       : 'text-text-secondary hover:text-text-primary',
                   ].join(' ')}
                 >

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -73,7 +73,7 @@ export function TableWidget({
   const explorerFilters = useMemo<ExplorerFilterMap>(() => {
     const map: Record<string, readonly string[]> = {};
     for (const [k, v] of Object.entries(widgetFilters)) {
-      if (v !== undefined) map[k] = [v];
+      if (v !== undefined) map[k] = v;
     }
     return map;
   }, [widgetFilters]);

--- a/packages/ui/src/widgets/widget.ts
+++ b/packages/ui/src/widgets/widget.ts
@@ -61,7 +61,12 @@ export function widgetFlexBasis(size: WidgetSize): string {
  *  conflict so a widget can pin a specific dimension while the FilterBar
  *  remains the user's primary control. */
 export function mergeFilters(global: FilterMap, overlay?: WidgetFilterOverlay): FilterMap {
-  return overlay === undefined ? global : { ...global, ...overlay };
+  if (overlay === undefined) return global;
+  const merged = { ...global };
+  for (const [k, v] of Object.entries(overlay)) {
+    if (v !== undefined) (merged as Record<string, readonly TagValue[]>)[k] = [v];
+  }
+  return merged;
 }
 
 /** Stable key for a FilterMap. Used as a useQuery dep so widgets refetch on


### PR DESCRIPTION
## Summary

- **FilterMap** changed from single-value (`TagValue`) to multi-value (`readonly TagValue[]`) per dimension, enabling OR-within-dimension, AND-across-dimensions filtering on dashboards
- **FilterBar** rewritten with checkboxes, Apply/Cancel flow, and a Grafana-style **"Only"** button on each row that selects just that value
- Badge labels adapt: `"Label"` → `"Label: value"` → `"Label · N"`
- Query builders (`buildFilterClauses`, `buildFilterWhereClauses`) generate `IN (...)` clauses for multi-value filters
- All downstream consumers updated: widget props, entity-detail, table-widget ExplorerFilterMap conversion, getFilterValues API signature