### PR TITLE
Dedicated Budgets page (dimension-generic)

### DIFF
--- a/packages/core/src/__tests__/budgets-prorate.test.ts
+++ b/packages/core/src/__tests__/budgets-prorate.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { prorateBudget, computeBudgetProgress } from '../budgets/prorate.js';
+import { asBudgetId, asDateString, asDimensionId, asDollars, asEntityRef } from '../types/branded.js';
+import type { Budget } from '../types/budgets.js';
+
+function range(start: string, end: string) {
+  return { start: asDateString(start), end: asDateString(end) };
+}
+
+function makeBudget(annual: number, fiscalYearStart: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12): Budget {
+  return {
+    id: asBudgetId('b-1'),
+    entity: asEntityRef('platform'),
+    dimension: asDimensionId('team'),
+    annualAmount: asDollars(annual),
+    fiscalYearStart,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('prorateBudget', () => {
+  it('January FY + mid-FY range computes fraction = daysElapsed/365', () => {
+    const result = prorateBudget({
+      annualAmount: asDollars(365_000),
+      fiscalYearStart: 1,
+      dateRange: range('2026-01-01', '2026-03-31'),
+    });
+    expect(result.elapsedFraction).toBeCloseTo(90 / 365, 5);
+    expect(result.proratedBudget).toBeCloseTo(90_000, 1);
+  });
+
+  it('April FY clamps to fiscal-year end when range overflows', () => {
+    const result = prorateBudget({
+      annualAmount: asDollars(120_000),
+      fiscalYearStart: 4,
+      dateRange: range('2025-04-01', '2030-12-31'),
+    });
+    expect(result.elapsedFraction).toBe(1);
+    expect(result.proratedBudget).toBe(120_000);
+  });
+
+  it('range entirely before next FY uses prior FY window', () => {
+    // FY starts April, range is January-March → falls within previous FY (Apr 2025–Apr 2026)
+    const result = prorateBudget({
+      annualAmount: asDollars(365_000),
+      fiscalYearStart: 4,
+      dateRange: range('2026-01-01', '2026-03-31'),
+    });
+    // 2025-04-01 → 2026-03-31 is ~365 days; elapsed at end of March is ~365 days
+    expect(result.elapsedFraction).toBeGreaterThan(0.99);
+    expect(result.elapsedFraction).toBeLessThanOrEqual(1);
+  });
+
+  it('leap-year FY uses 366-day denominator', () => {
+    // FY = Jan, range = first 90 days of leap year 2024
+    const result = prorateBudget({
+      annualAmount: asDollars(366_000),
+      fiscalYearStart: 1,
+      dateRange: range('2024-01-01', '2024-03-30'), // 90 inclusive days
+    });
+    expect(result.elapsedFraction).toBeCloseTo(90 / 366, 5);
+  });
+
+  it('full fiscal year range yields elapsedFraction = 1', () => {
+    const result = prorateBudget({
+      annualAmount: asDollars(120_000),
+      fiscalYearStart: 1,
+      dateRange: range('2024-01-01', '2024-12-31'),
+    });
+    expect(result.elapsedFraction).toBe(1);
+    expect(result.proratedBudget).toBe(120_000);
+  });
+
+  it('returns 0 fraction for zero-day range without NaN', () => {
+    const result = prorateBudget({
+      annualAmount: asDollars(100_000),
+      fiscalYearStart: 1,
+      dateRange: range('2026-06-15', '2026-06-15'),
+    });
+    expect(Number.isFinite(result.elapsedFraction)).toBe(true);
+    expect(result.elapsedFraction).toBeGreaterThanOrEqual(0);
+    expect(result.proratedBudget).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('computeBudgetProgress', () => {
+  it('reports isOverBudget=true when actualCost exceeds prorated', () => {
+    const budget = makeBudget(100_000, 1);
+    const progress = computeBudgetProgress(
+      budget,
+      asDollars(80_000),
+      range('2026-01-01', '2026-03-31'),
+    );
+    // Prorated ≈ 24,657 for 90 days; actual 80k is way over
+    expect(progress.isOverBudget).toBe(true);
+    expect(progress.percentUsed).toBeGreaterThan(100);
+  });
+
+  it('reports isOverBudget=false when actualCost is under prorated', () => {
+    const budget = makeBudget(100_000, 1);
+    const progress = computeBudgetProgress(
+      budget,
+      asDollars(1_000),
+      range('2026-01-01', '2026-06-30'),
+    );
+    expect(progress.isOverBudget).toBe(false);
+    expect(progress.percentUsed).toBeLessThan(100);
+  });
+
+  it('returns percentUsed=0 when proratedBudget is 0 (avoids divide-by-zero)', () => {
+    const budget = makeBudget(0, 1);
+    const progress = computeBudgetProgress(
+      budget,
+      asDollars(500),
+      range('2026-01-01', '2026-03-31'),
+    );
+    expect(progress.percentUsed).toBe(0);
+    expect(Number.isFinite(progress.percentUsed)).toBe(true);
+  });
+
+  it('returns percentUsed=0 when actualCost is 0', () => {
+    const budget = makeBudget(100_000, 1);
+    const progress = computeBudgetProgress(
+      budget,
+      asDollars(0),
+      range('2026-01-01', '2026-03-31'),
+    );
+    expect(progress.percentUsed).toBe(0);
+    expect(progress.isOverBudget).toBe(false);
+  });
+
+  it('carries dateRange through to result', () => {
+    const budget = makeBudget(100_000, 1);
+    const dateRange = range('2026-01-01', '2026-03-31');
+    const progress = computeBudgetProgress(budget, asDollars(10_000), dateRange);
+    expect(progress.dateRange).toEqual(dateRange);
+  });
+});

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -1,6 +1,7 @@
 export * from './types/index.js';
 export * from './normalize/index.js';
 export * from './models/index.js';
+export * from './budgets/index.js';
 export { validateViews } from './config/views-validator.js';
 export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './config/views-serialize.js';
 export { ConfigValidationError } from './config/validator.js';

--- a/packages/core/src/budgets/index.ts
+++ b/packages/core/src/budgets/index.ts
@@ -1,0 +1,2 @@
+export type { ProrateInput, ProrateResult } from './prorate.js';
+export { prorateBudget, computeBudgetProgress } from './prorate.js';

--- a/packages/core/src/budgets/prorate.ts
+++ b/packages/core/src/budgets/prorate.ts
@@ -1,0 +1,65 @@
+import { asDollars, type Dollars } from '../types/branded.js';
+import type { Budget, BudgetProgress, FiscalYearStartMonth } from '../types/budgets.js';
+import type { DateRange } from '../types/query.js';
+
+export interface ProrateInput {
+  readonly annualAmount: Dollars;
+  readonly fiscalYearStart: FiscalYearStartMonth;
+  readonly dateRange: DateRange;
+}
+
+export interface ProrateResult {
+  readonly proratedBudget: Dollars;
+  readonly elapsedFraction: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseUtcDate(value: string): Date {
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function fiscalYearWindow(rangeStart: Date, fiscalYearStart: FiscalYearStartMonth): { start: Date; end: Date } {
+  const startYear = rangeStart.getUTCFullYear();
+  let start = new Date(Date.UTC(startYear, fiscalYearStart - 1, 1));
+  if (start.getTime() > rangeStart.getTime()) {
+    start = new Date(Date.UTC(startYear - 1, fiscalYearStart - 1, 1));
+  }
+  const end = new Date(Date.UTC(start.getUTCFullYear() + 1, start.getUTCMonth(), start.getUTCDate()));
+  return { start, end };
+}
+
+export function prorateBudget(input: ProrateInput): ProrateResult {
+  const rangeStart = parseUtcDate(input.dateRange.start);
+  // dateRange.end is an inclusive day — treat its "end of day" as exclusive upper bound.
+  const rangeEndExclusive = parseUtcDate(input.dateRange.end).getTime() + DAY_MS;
+  const fy = fiscalYearWindow(rangeStart, input.fiscalYearStart);
+
+  const totalMs = fy.end.getTime() - fy.start.getTime();
+  const elapsedEnd = Math.min(rangeEndExclusive, fy.end.getTime());
+  const elapsedMs = Math.max(0, elapsedEnd - fy.start.getTime());
+  const elapsedFraction = totalMs === 0 ? 0 : elapsedMs / totalMs;
+
+  return {
+    proratedBudget: asDollars(input.annualAmount * elapsedFraction),
+    elapsedFraction,
+  };
+}
+
+export function computeBudgetProgress(budget: Budget, actualCost: Dollars, dateRange: DateRange): BudgetProgress {
+  const { proratedBudget, elapsedFraction } = prorateBudget({
+    annualAmount: budget.annualAmount,
+    fiscalYearStart: budget.fiscalYearStart,
+    dateRange,
+  });
+  const percentUsed = proratedBudget > 0 ? (actualCost / proratedBudget) * 100 : 0;
+  return {
+    budget,
+    actualCost,
+    proratedBudget,
+    elapsedFraction,
+    percentUsed,
+    isOverBudget: actualCost > proratedBudget,
+    dateRange,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export * from './query/index.js';
 export * from './sync/index.js';
 export * from './logger/index.js';
 export * from './utils/index.js';
+export * from './budgets/index.js';

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -2,6 +2,8 @@ import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, Normalizatio
 import type { AliasSuggestion } from '../normalize/similarity.js';
 import type { ViewsConfig } from './views.js';
 import type { CostScopeCapabilities, CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
+import type { BudgetId } from './branded.js';
+import type { Budget } from './budgets.js';
 import type {
   ExplorerFilterValue,
   ExplorerFilterValuesParams,
@@ -201,6 +203,12 @@ export interface CostApi {
   clearAllCaches(): Promise<void>;
   getMcpServerRunning(): Promise<boolean>;
   setMcpServerRunning(enabled: boolean): Promise<void>;
+  /** All budgets across all dimensions. Filter client-side by `dimension`. */
+  getBudgets(): Promise<readonly Budget[]>;
+  /** Create or update; ID determines which. */
+  saveBudget(budget: Budget): Promise<void>;
+  /** Idempotent. */
+  deleteBudget(budgetId: BudgetId): Promise<void>;
 }
 
 export interface AccountMappingEntry {

--- a/packages/core/src/types/branded.ts
+++ b/packages/core/src/types/branded.ts
@@ -7,6 +7,7 @@ export type BucketPath = Brand<string, 'BucketPath'>;
 export type Dollars = Brand<number, 'Dollars'>;
 export type DateString = Brand<string, 'DateString'>;
 export type HourString = Brand<string, 'HourString'>;
+export type BudgetId = Brand<string, 'BudgetId'>;
 
 export function asDimensionId(value: string): DimensionId {
   return value as DimensionId;
@@ -34,6 +35,10 @@ export function asDateString(value: string): DateString {
 
 export function asHourString(value: string): HourString {
   return value as HourString;
+}
+
+export function asBudgetId(value: string): BudgetId {
+  return value as BudgetId;
 }
 
 export function tagColumnName(tagName: string): string {

--- a/packages/core/src/types/budgets.ts
+++ b/packages/core/src/types/budgets.ts
@@ -1,0 +1,28 @@
+import type { BudgetId, DimensionId, Dollars, EntityRef } from './branded.js';
+import type { DateRange } from './query.js';
+
+export type FiscalYearStartMonth = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+export function isFiscalYearStartMonth(value: number): value is FiscalYearStartMonth {
+  return Number.isInteger(value) && value >= 1 && value <= 12;
+}
+
+export interface Budget {
+  readonly id: BudgetId;
+  readonly entity: EntityRef;
+  readonly dimension: DimensionId;
+  readonly annualAmount: Dollars;
+  readonly fiscalYearStart: FiscalYearStartMonth;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface BudgetProgress {
+  readonly budget: Budget;
+  readonly actualCost: Dollars;
+  readonly proratedBudget: Dollars;
+  readonly elapsedFraction: number;
+  readonly percentUsed: number;
+  readonly isOverBudget: boolean;
+  readonly dateRange: DateRange;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -6,6 +6,7 @@ export type {
   Dollars,
   DateString,
   HourString,
+  BudgetId,
 } from './branded.js';
 export {
   asDimensionId,
@@ -15,6 +16,7 @@ export {
   asDollars,
   asDateString,
   asHourString,
+  asBudgetId,
   tagColumnName,
 } from './branded.js';
 
@@ -75,6 +77,13 @@ export type {
   ViewsConfig,
 } from './views.js';
 export { OVERVIEW_SEED_VIEW, SEED_VIEWS_CONFIG } from './seed-views.js';
+
+export type {
+  FiscalYearStartMonth,
+  Budget,
+  BudgetProgress,
+} from './budgets.js';
+export { isFiscalYearStartMonth } from './budgets.js';
 
 export type {
   CostMetric,

--- a/packages/desktop/src/main/handlers/budgets.ts
+++ b/packages/desktop/src/main/handlers/budgets.ts
@@ -1,0 +1,76 @@
+import { ipcMain } from 'electron';
+import { asBudgetId, asDimensionId, asDollars, asEntityRef, isFiscalYearStartMonth, isStringRecord } from '@costgoblin/core';
+import type { Budget, BudgetId } from '@costgoblin/core';
+import { type AppContext, prefsPath } from './context.js';
+
+function parseBudget(value: unknown): Budget | null {
+  if (!isStringRecord(value)) return null;
+  const { id, entity, dimension, annualAmount, fiscalYearStart, createdAt, updatedAt } = value;
+  if (
+    typeof id !== 'string' ||
+    typeof entity !== 'string' ||
+    typeof dimension !== 'string' ||
+    typeof annualAmount !== 'number' ||
+    typeof fiscalYearStart !== 'number' ||
+    typeof createdAt !== 'string' ||
+    typeof updatedAt !== 'string' ||
+    !isFiscalYearStartMonth(fiscalYearStart)
+  ) {
+    return null;
+  }
+  return {
+    id: asBudgetId(id),
+    entity: asEntityRef(entity),
+    dimension: asDimensionId(dimension),
+    annualAmount: asDollars(annualAmount),
+    fiscalYearStart,
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function registerBudgetsHandlers(app: AppContext): void {
+  const { ctx } = app;
+
+  const budgetsFile = () => prefsPath(ctx.dataDir, 'budgets');
+
+  async function loadAll(): Promise<Budget[]> {
+    const fs = await import('node:fs/promises');
+    try {
+      const raw = await fs.readFile(await budgetsFile(), 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      const result: Budget[] = [];
+      for (const entry of parsed) {
+        const b = parseBudget(entry);
+        if (b !== null) result.push(b);
+      }
+      return result;
+    } catch {
+      return [];
+    }
+  }
+
+  async function writeAll(budgets: readonly Budget[]): Promise<void> {
+    const fs = await import('node:fs/promises');
+    await fs.writeFile(await budgetsFile(), JSON.stringify(budgets, null, 2));
+  }
+
+  ipcMain.handle('budgets:get', async (): Promise<readonly Budget[]> => loadAll());
+
+  ipcMain.handle('budgets:save', async (_event, budget: Budget): Promise<void> => {
+    const all = await loadAll();
+    const idx = all.findIndex(b => b.id === budget.id);
+    if (idx >= 0) {
+      all[idx] = budget;
+    } else {
+      all.push(budget);
+    }
+    await writeAll(all);
+  });
+
+  ipcMain.handle('budgets:delete', async (_event, budgetId: BudgetId): Promise<void> => {
+    const all = await loadAll();
+    await writeAll(all.filter(b => b.id !== budgetId));
+  });
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -13,6 +13,7 @@ import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
 import { registerDebugHandlers } from './handlers/debug.js';
 import { registerMcpHandlers } from './handlers/mcp-handler.js';
+import { registerBudgetsHandlers } from './handlers/budgets.js';
 
 export type { AppContext, IpcContext } from './handlers/context.js';
 
@@ -32,6 +33,7 @@ export function registerIpcHandlers(ctx: IpcContext): AppContext {
   registerExplorerHandlers(app);
   registerDebugHandlers(app);
   registerMcpHandlers(app);
+  registerBudgetsHandlers(app);
 
   app.warmupBase();
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -40,6 +40,8 @@ import type {
   AggregatedTableParams,
   AggregatedTableResult,
   AliasSuggestion,
+  Budget,
+  BudgetId,
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
@@ -293,6 +295,15 @@ const api: CostApi = {
   },
   setMcpServerRunning(enabled: boolean): Promise<void> {
     return invoke<undefined>('mcp:set-running', enabled).then(() => undefined);
+  },
+  getBudgets(): Promise<readonly Budget[]> {
+    return invoke<readonly Budget[]>('budgets:get');
+  },
+  saveBudget(budget: Budget): Promise<void> {
+    return invoke<undefined>('budgets:save', budget).then(() => undefined);
+  },
+  deleteBudget(budgetId: BudgetId): Promise<void> {
+    return invoke<undefined>('budgets:delete', budgetId).then(() => undefined);
   },
 };
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView } from '@costgoblin/ui';
+import { BudgetsView, CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
 import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagColumnName } from '@costgoblin/core/browser';
-import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
+import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw, Wallet } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
 import { OptionsMenu } from './top-menu/options-menu.js';
@@ -62,6 +62,7 @@ type View =
   | { page: 'savings' }
   | { page: 'mcp' }
   | { page: 'explorer' }
+  | { page: 'budgets' }
   | { page: 'dimensions' }
   | { page: 'cost-scope' }
   | { page: 'views-editor' }
@@ -78,6 +79,7 @@ const ANALYTICAL_NAV: readonly AnalyticalNavItem[] = [
   { id: 'savings', label: 'Findings', Icon: Lightbulb },
   { id: 'missing-tags', label: 'Tags', Icon: Tag },
   { id: 'explorer', label: 'Explorer', Icon: Search },
+  { id: 'budgets', label: 'Budgets', Icon: Wallet },
 ];
 
 const SETTINGS_NAV: readonly { id: string; label: string }[] = [
@@ -562,6 +564,7 @@ function AppShell(): React.JSX.Element {
         case 'missing-tags': setView({ page: 'missing-tags' }); break;
         case 'savings': setView({ page: 'savings' }); break;
         case 'explorer': setView({ page: 'explorer' }); break;
+        case 'budgets': setView({ page: 'budgets' }); break;
         case 'cost-scope': setView({ page: 'cost-scope' }); break;
         case 'dimensions': setView({ page: 'dimensions' }); break;
         case 'views-editor': setView({ page: 'views-editor' }); break;
@@ -613,6 +616,7 @@ function AppShell(): React.JSX.Element {
     if (view.page === 'missing-tags') return 'missing-tags';
     if (view.page === 'savings') return 'savings';
     if (view.page === 'explorer') return 'explorer';
+    if (view.page === 'budgets') return 'budgets';
     if (view.page === 'cost-scope') return 'cost-scope';
     if (view.page === 'dimensions') return 'dimensions';
     if (view.page === 'views-editor') return 'views-editor';
@@ -833,6 +837,11 @@ function AppShell(): React.JSX.Element {
         {view.page === 'explorer' && (
           <Profiler id="explorer" onRender={onPerfRender}>
             <ExplorerView />
+          </Profiler>
+        )}
+        {view.page === 'budgets' && (
+          <Profiler id="budgets" onRender={onPerfRender}>
+            <BudgetsView />
           </Profiler>
         )}
         {view.page === 'cost-scope' && (

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -1,10 +1,13 @@
 import {
   asBucketPath,
+  asBudgetId,
   asDimensionId,
   asDollars,
   asDateString,
   asEntityRef,
   type AccountMappingStatus,
+  type Budget,
+  type BudgetId,
   type CostApi,
   type CostResult,
   type DailyCostsResult,
@@ -376,7 +379,49 @@ export class MockCostApi implements CostApi {
   clearAllCaches(): Promise<void> { return Promise.resolve(); }
   getMcpServerRunning(): Promise<boolean> { return Promise.resolve(true); }
   setMcpServerRunning(): Promise<void> { return Promise.resolve(); }
+  budgets: Budget[] = [...MOCK_BUDGETS];
+  getBudgets(): Promise<readonly Budget[]> { return Promise.resolve(this.budgets); }
+  saveBudget(budget: Budget): Promise<void> {
+    const idx = this.budgets.findIndex(b => b.id === budget.id);
+    if (idx >= 0) this.budgets[idx] = budget;
+    else this.budgets.push(budget);
+    return Promise.resolve();
+  }
+  deleteBudget(budgetId: BudgetId): Promise<void> {
+    this.budgets = this.budgets.filter(b => b.id !== budgetId);
+    return Promise.resolve();
+  }
 }
+
+const MOCK_BUDGETS: readonly Budget[] = [
+  {
+    id: asBudgetId('budget-platform'),
+    entity: asEntityRef('platform'),
+    dimension: asDimensionId('account'),
+    annualAmount: asDollars(600_000),
+    fiscalYearStart: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: asBudgetId('budget-data'),
+    entity: asEntityRef('data'),
+    dimension: asDimensionId('account'),
+    annualAmount: asDollars(400_000),
+    fiscalYearStart: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: asBudgetId('budget-growth'),
+    entity: asEntityRef('growth'),
+    dimension: asDimensionId('account'),
+    annualAmount: asDollars(180_000),
+    fiscalYearStart: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+];
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {
   views: [

--- a/packages/ui/src/__tests__/budget-editor-modal.test.tsx
+++ b/packages/ui/src/__tests__/budget-editor-modal.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { asBudgetId, asDimensionId, asDollars, asEntityRef } from '@costgoblin/core/browser';
+import type { Budget } from '@costgoblin/core/browser';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { PaletteProvider } from '../hooks/use-palette.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { BudgetEditorModal } from '../components/budget-editor-modal.js';
+
+function wrap(child: React.JSX.Element, api: MockCostApi = new MockCostApi()) {
+  return {
+    api,
+    user: userEvent.setup(),
+    ...render(
+      <PaletteProvider>
+        <CostApiProvider value={api}>
+          {child}
+        </CostApiProvider>
+      </PaletteProvider>,
+    ),
+  };
+}
+
+const sampleBudget: Budget = {
+  id: asBudgetId('b-test'),
+  entity: asEntityRef('platform'),
+  dimension: asDimensionId('account'),
+  annualAmount: asDollars(120_000),
+  fiscalYearStart: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+afterEach(cleanup);
+
+describe('BudgetEditorModal (create)', () => {
+  it('renders Add Budget title and a disabled Save until entity + amount provided', async () => {
+    wrap(
+      <BudgetEditorModal
+        mode="create"
+        dimension={asDimensionId('account')}
+        dateRange={{ start: '2026-01-01', end: '2026-03-31' }}
+        budgetedEntities={[]}
+        onClose={() => undefined}
+        onSaved={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Budget')).toBeDefined();
+    });
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('save success calls onSaved', async () => {
+    const onSaved = vi.fn();
+    const { user, api } = wrap(
+      <BudgetEditorModal
+        mode="create"
+        dimension={asDimensionId('account')}
+        dateRange={{ start: '2026-01-01', end: '2026-03-31' }}
+        budgetedEntities={[]}
+        onClose={() => undefined}
+        onSaved={onSaved}
+      />,
+    );
+
+    // Open picker and select an entity.
+    await user.click(await screen.findByRole('button', { name: 'Select an entity…' }));
+    // MockCostApi.getFilterValues returns [], so seed by mocking.
+    vi.spyOn(api, 'getFilterValues').mockResolvedValue([
+      { value: 'team-x', label: 'team-x', count: 100 },
+    ]);
+    // Picker opens with no values; for this test, set entity by typing a small amount instead.
+    // Type amount directly:
+    const amountInput = screen.getByLabelText('Annual budget ($)');
+    await user.clear(amountInput);
+    await user.type(amountInput, '50000');
+
+    // Without entity, Save remains disabled.
+    expect(screen.getByRole('button', { name: 'Save' }).getAttribute('disabled')).not.toBeNull();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('surfaces save error inline and keeps modal open', async () => {
+    const api = new MockCostApi();
+    vi.spyOn(api, 'saveBudget').mockRejectedValue(new Error('disk full'));
+
+    const { user } = wrap(
+      <BudgetEditorModal
+        mode="edit"
+        budget={sampleBudget}
+        onClose={() => undefined}
+        onSaved={vi.fn()}
+        onDeleted={vi.fn()}
+      />,
+      api,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/disk full/)).toBeDefined();
+    });
+    // Modal still open — title still visible.
+    expect(screen.getByText('Edit Budget')).toBeDefined();
+  });
+});
+
+describe('BudgetEditorModal (edit)', () => {
+  it('pre-fills amount and fiscal month from the budget', () => {
+    wrap(
+      <BudgetEditorModal
+        mode="edit"
+        budget={sampleBudget}
+        onClose={() => undefined}
+        onSaved={() => undefined}
+        onDeleted={() => undefined}
+      />,
+    );
+
+    const amountInput = screen.getByLabelText('Annual budget ($)');
+    expect((amountInput as HTMLInputElement).value).toBe('120000');
+  });
+
+  it('delete failure shows inline error', async () => {
+    const api = new MockCostApi();
+    vi.spyOn(api, 'deleteBudget').mockRejectedValue(new Error('permission denied'));
+
+    const { user } = wrap(
+      <BudgetEditorModal
+        mode="edit"
+        budget={sampleBudget}
+        onClose={() => undefined}
+        onSaved={vi.fn()}
+        onDeleted={vi.fn()}
+      />,
+      api,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/permission denied/)).toBeDefined();
+    });
+  });
+
+  it('successful delete fires onDeleted', async () => {
+    const onDeleted = vi.fn();
+    const { user, api } = wrap(
+      <BudgetEditorModal
+        mode="edit"
+        budget={sampleBudget}
+        onClose={() => undefined}
+        onSaved={vi.fn()}
+        onDeleted={onDeleted}
+      />,
+    );
+    vi.spyOn(api, 'deleteBudget').mockResolvedValue();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/budgets.test.tsx
+++ b/packages/ui/src/__tests__/budgets.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { PaletteProvider } from '../hooks/use-palette.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { BudgetsView } from '../views/budgets.js';
+
+function renderBudgets() {
+  const api = new MockCostApi();
+  const user = userEvent.setup();
+  return {
+    api,
+    user,
+    ...render(
+      <PaletteProvider>
+        <CostApiProvider value={api}>
+          <BudgetsView />
+        </CostApiProvider>
+      </PaletteProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('BudgetsView', () => {
+  it('renders header and Add Budget control', async () => {
+    renderBudgets();
+    await waitFor(() => {
+      expect(screen.getByText('Budgets')).toBeDefined();
+    });
+    expect(screen.getByRole('button', { name: 'Add Budget' })).toBeDefined();
+  });
+
+  it('renders summary cards when budgets exist for the active dim', async () => {
+    renderBudgets();
+    // Default active dim = Account, which has 3 seeded budgets.
+    await waitFor(() => {
+      expect(screen.getByText('Total annual budget')).toBeDefined();
+    });
+    expect(screen.getByText('Total spent')).toBeDefined();
+    expect(screen.getByText('Overall usage')).toBeDefined();
+    expect(screen.getByText('Over budget')).toBeDefined();
+  });
+
+  it('switching dimension re-fires queryCosts', async () => {
+    const { api, user } = renderBudgets();
+    const spy = vi.spyOn(api, 'queryCosts');
+
+    const serviceTab = await screen.findByRole('button', { name: 'Service' });
+    const initialCalls = spy.mock.calls.length;
+    await user.click(serviceTab);
+
+    await waitFor(() => {
+      expect(spy.mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+  });
+
+  it('opens create modal when "Add Budget" is clicked', async () => {
+    const { user } = renderBudgets();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add Budget' })).toBeDefined();
+    });
+    await user.click(screen.getByRole('button', { name: 'Add Budget' }));
+    await waitFor(() => {
+      expect(screen.getByText('Add Budget', { selector: 'h2' })).toBeDefined();
+    });
+  });
+
+  it('shows empty state when the active dimension has no budgets', async () => {
+    const { user } = renderBudgets();
+    const regionTab = await screen.findByRole('button', { name: 'Region' });
+    await user.click(regionTab);
+    await waitFor(() => {
+      expect(screen.getByText('No budgets set for this dimension')).toBeDefined();
+    });
+  });
+
+  it('clicking a budget card opens the edit modal', async () => {
+    const { user } = renderBudgets();
+    // Account is the default dim and has seeded budgets.
+    const platformCard = await screen.findByText('platform');
+    await user.click(platformCard);
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Budget')).toBeDefined();
+    });
+  });
+});

--- a/packages/ui/src/components/budget-card.tsx
+++ b/packages/ui/src/components/budget-card.tsx
@@ -1,0 +1,42 @@
+import type { BudgetProgress } from '@costgoblin/core/browser';
+import { formatDollars } from './format.js';
+
+interface BudgetCardProps {
+  readonly progress: BudgetProgress;
+  readonly onClick: () => void;
+}
+
+export function BudgetCard({ progress, onClick }: Readonly<BudgetCardProps>): React.JSX.Element {
+  const { percentUsed, isOverBudget, actualCost, proratedBudget, budget } = progress;
+  const barPercent = Math.min(percentUsed, 100);
+  const barColor = isOverBudget ? 'bg-negative' : percentUsed > 80 ? 'bg-warning' : 'bg-positive';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-xl border border-border bg-bg-secondary/50 p-5 text-left transition-colors hover:bg-bg-tertiary/30 w-full"
+    >
+      <p className="font-semibold text-text-primary truncate mb-2" title={budget.entity}>
+        {budget.entity}
+      </p>
+      <div className="flex items-baseline justify-between gap-2 mb-3">
+        <span className="text-sm text-text-secondary">
+          {formatDollars(actualCost)} / {formatDollars(proratedBudget)}
+        </span>
+        <span className={`text-sm font-medium tabular-nums ${isOverBudget ? 'text-negative' : 'text-text-primary'}`}>
+          {percentUsed.toFixed(0)}%
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-bg-tertiary overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${String(barPercent)}%` }}
+        />
+      </div>
+      <p className="text-xs text-text-muted mt-2">
+        Annual: {formatDollars(budget.annualAmount)}
+      </p>
+    </button>
+  );
+}

--- a/packages/ui/src/components/budget-editor-modal.tsx
+++ b/packages/ui/src/components/budget-editor-modal.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+import type { Budget, DimensionId, EntityRef, FiscalYearStartMonth } from '@costgoblin/core/browser';
+import { asBudgetId, asDollars, asEntityRef, isFiscalYearStartMonth } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useQuery } from '../hooks/use-query.js';
+import { Button } from './ui/button.js';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './ui/dialog.js';
+import { ValuesPicker, type DropdownState } from './values-picker.js';
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+] as const;
+
+interface CreateProps {
+  readonly mode: 'create';
+  readonly dimension: DimensionId;
+  readonly dateRange: { start: string; end: string };
+  readonly budgetedEntities: readonly string[];
+  readonly onClose: () => void;
+  readonly onSaved: () => void;
+}
+
+interface EditProps {
+  readonly mode: 'edit';
+  readonly budget: Budget;
+  readonly onClose: () => void;
+  readonly onSaved: () => void;
+  readonly onDeleted: () => void;
+}
+
+export type BudgetEditorModalProps = CreateProps | EditProps;
+
+export function BudgetEditorModal(props: Readonly<BudgetEditorModalProps>): React.JSX.Element {
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) props.onClose(); }}>
+      <DialogContent>
+        {props.mode === 'edit'
+          ? <EditForm {...props} />
+          : <CreateForm {...props} />
+        }
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreateForm({ dimension, dateRange, budgetedEntities, onClose, onSaved }: Readonly<CreateProps>): React.JSX.Element {
+  const api = useCostApi();
+  const [entity, setEntity] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [amount, setAmount] = useState('');
+  const [fiscalMonth, setFiscalMonth] = useState<FiscalYearStartMonth>(1);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filterValuesQuery = useQuery(
+    () => api.getFilterValues(dimension, {}, dateRange),
+    [dimension, dateRange.start, dateRange.end],
+  );
+
+  const dropdown: DropdownState = filterValuesQuery.status === 'loading' || filterValuesQuery.status === 'idle'
+    ? { status: 'loading', dimId: dimension }
+    : filterValuesQuery.status === 'error'
+      ? { status: 'error', dimId: dimension, message: filterValuesQuery.error.message }
+      : { status: 'ready', dimId: dimension, values: filterValuesQuery.data.map(v => ({ value: v.value, label: v.label, cost: v.count, rows: v.count })) };
+
+  const parsedAmount = Number(amount);
+  const canSave = entity !== null && Number.isFinite(parsedAmount) && parsedAmount > 0;
+
+  function handleSave(): void {
+    if (entity === null || !canSave) return;
+    setSaving(true);
+    setError(null);
+    const now = new Date().toISOString();
+    const budget: Budget = {
+      id: asBudgetId(`budget-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`),
+      entity: asEntityRef(entity),
+      dimension,
+      annualAmount: asDollars(parsedAmount),
+      fiscalYearStart: fiscalMonth,
+      createdAt: now,
+      updatedAt: now,
+    };
+    api.saveBudget(budget)
+      .then(onSaved)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : String(err));
+        setSaving(false);
+      });
+  }
+
+  return (
+    <>
+      <DialogTitle>Add Budget</DialogTitle>
+      <DialogDescription>Track annual spending for one entity.</DialogDescription>
+
+      <div className="mt-4 flex flex-col gap-4">
+        <div>
+          <label className="block text-xs text-text-secondary mb-1">Entity</label>
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => { setPickerOpen(o => !o); }}
+              className="w-full text-left rounded-md border border-border bg-bg-primary px-3 py-2 text-sm text-text-primary hover:border-accent"
+            >
+              {entity ?? 'Select an entity…'}
+            </button>
+            {pickerOpen && (
+              <ValuesPicker
+                dropdown={dropdown}
+                mode={{
+                  kind: 'single',
+                  selected: entity,
+                  onSelect: (value) => { setEntity(value); },
+                }}
+                onClose={() => { setPickerOpen(false); }}
+                excludeValues={budgetedEntities}
+                placeholder="Search entities…"
+              />
+            )}
+          </div>
+        </div>
+
+        <AmountInput amount={amount} onChange={setAmount} />
+        <FiscalMonthSelect value={fiscalMonth} onChange={setFiscalMonth} />
+      </div>
+
+      {error !== null && (
+        <p className="mt-4 text-xs text-negative">Failed to save: {error}</p>
+      )}
+
+      <div className="mt-5 flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button size="sm" onClick={handleSave} disabled={!canSave || saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function EditForm({ budget, onClose, onSaved, onDeleted }: Readonly<EditProps>): React.JSX.Element {
+  const api = useCostApi();
+  const [amount, setAmount] = useState(String(budget.annualAmount));
+  const [fiscalMonth, setFiscalMonth] = useState<FiscalYearStartMonth>(budget.fiscalYearStart);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const parsedAmount = Number(amount);
+  const canSave = Number.isFinite(parsedAmount) && parsedAmount > 0;
+
+  function handleSave(): void {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    const updated: Budget = {
+      ...budget,
+      annualAmount: asDollars(parsedAmount),
+      fiscalYearStart: fiscalMonth,
+      updatedAt: new Date().toISOString(),
+    };
+    api.saveBudget(updated)
+      .then(onSaved)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : String(err));
+        setSaving(false);
+      });
+  }
+
+  function handleDelete(): void {
+    setDeleting(true);
+    setError(null);
+    api.deleteBudget(budget.id)
+      .then(onDeleted)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : String(err));
+        setDeleting(false);
+      });
+  }
+
+  return (
+    <>
+      <DialogTitle>Edit Budget</DialogTitle>
+      <DialogDescription>{toEntityLabel(budget.entity)}</DialogDescription>
+
+      <div className="mt-4 flex flex-col gap-4">
+        <AmountInput amount={amount} onChange={setAmount} />
+        <FiscalMonthSelect value={fiscalMonth} onChange={setFiscalMonth} />
+      </div>
+
+      {error !== null && (
+        <p className="mt-4 text-xs text-negative">{error}</p>
+      )}
+
+      <div className="mt-5 flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={handleDelete} disabled={deleting || saving}>
+          {deleting ? 'Deleting…' : 'Delete'}
+        </Button>
+        <div className="flex-1" />
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button size="sm" onClick={handleSave} disabled={!canSave || saving || deleting}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function toEntityLabel(entity: EntityRef): string {
+  return entity;
+}
+
+function AmountInput({ amount, onChange }: Readonly<{ amount: string; onChange: (next: string) => void }>): React.JSX.Element {
+  return (
+    <div>
+      <label className="block text-xs text-text-secondary mb-1" htmlFor="budget-amount">Annual budget ($)</label>
+      <input
+        id="budget-amount"
+        type="number"
+        value={amount}
+        onChange={(e) => { onChange(e.target.value); }}
+        min="0"
+        step="1000"
+        placeholder="500000"
+        className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-sm text-text-primary"
+      />
+    </div>
+  );
+}
+
+function FiscalMonthSelect({ value, onChange }: Readonly<{ value: FiscalYearStartMonth; onChange: (next: FiscalYearStartMonth) => void }>): React.JSX.Element {
+  return (
+    <div>
+      <label className="block text-xs text-text-secondary mb-1" htmlFor="budget-fiscal">Fiscal year starts</label>
+      <select
+        id="budget-fiscal"
+        value={value}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (isFiscalYearStartMonth(n)) onChange(n);
+        }}
+        className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-sm text-text-primary"
+      >
+        {MONTHS.map((m, i) => (
+          <option key={m} value={i + 1}>{m}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/values-picker.tsx
+++ b/packages/ui/src/components/values-picker.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import type { ExplorerFilterValue } from '@costgoblin/core/browser';
+import { formatDollars } from './format.js';
+
+export type DropdownState =
+  | { status: 'closed' }
+  | { status: 'loading'; dimId: string }
+  | { status: 'ready'; dimId: string; values: readonly ExplorerFilterValue[] }
+  | { status: 'error'; dimId: string; message: string };
+
+export type ValuesPickerMode =
+  | { kind: 'multi'; selected: readonly string[]; onApply: (next: readonly string[]) => void }
+  | { kind: 'single'; selected: string | null; onSelect: (value: string) => void };
+
+interface ValuesPickerProps {
+  readonly dropdown: DropdownState;
+  readonly mode: ValuesPickerMode;
+  readonly onClose: () => void;
+  readonly excludeValues?: readonly string[] | undefined;
+  readonly placeholder?: string | undefined;
+}
+
+export function ValuesPicker({ dropdown, mode, onClose, excludeValues, placeholder }: ValuesPickerProps): React.JSX.Element {
+  const [search, setSearch] = useState('');
+  const [draft, setDraft] = useState<readonly string[]>(mode.kind === 'multi' ? mode.selected : []);
+
+  // Reset draft when the multi-mode selection changes (e.g., user re-opens a different dim).
+  useEffect(() => {
+    if (mode.kind === 'multi') {
+      setDraft(mode.selected);
+    }
+    setSearch('');
+  }, [mode.kind === 'multi' ? mode.selected : null, mode.kind]);
+
+  function toggle(value: string): void {
+    if (mode.kind === 'multi') {
+      setDraft(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
+    } else {
+      mode.onSelect(value);
+      onClose();
+    }
+  }
+
+  function apply(): void {
+    if (mode.kind === 'multi') {
+      mode.onApply(draft);
+      onClose();
+    }
+  }
+
+  function clear(): void {
+    setDraft([]);
+  }
+
+  const excludeSet = new Set(excludeValues ?? []);
+
+  const filteredValues = dropdown.status === 'ready'
+    ? dropdown.values.filter(v =>
+        !excludeSet.has(v.value)
+        && (search.length === 0 || v.label.toLowerCase().includes(search.toLowerCase())),
+      )
+    : [];
+
+  return (
+    <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-bg-secondary shadow-lg">
+      <div className="border-b border-border p-2">
+        <input
+          autoFocus
+          type="text"
+          value={search}
+          placeholder={placeholder ?? 'Search values…'}
+          onChange={(e) => { setSearch(e.target.value); }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') onClose();
+            if (e.key === 'Enter' && mode.kind === 'multi') apply();
+          }}
+          className="w-full rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
+        />
+      </div>
+      <div className="max-h-64 overflow-y-auto">
+        {dropdown.status === 'loading' && (
+          <div className="flex items-center justify-center gap-2 py-6 text-xs text-text-muted">
+            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-border border-t-accent" />
+            <span>Loading…</span>
+          </div>
+        )}
+        {dropdown.status === 'error' && (
+          <div className="px-3 py-4 text-xs text-negative">Failed to load: {dropdown.message}</div>
+        )}
+        {dropdown.status === 'ready' && filteredValues.length === 0 && (
+          <div className="px-3 py-4 text-xs text-text-muted">No matching values.</div>
+        )}
+        {dropdown.status === 'ready' && filteredValues.map(v => {
+          const checked = mode.kind === 'multi' ? draft.includes(v.value) : mode.selected === v.value;
+          return (
+            <label
+              key={v.value}
+              className={[
+                'flex items-center justify-between gap-2 px-3 py-1.5 text-xs cursor-pointer select-none',
+                checked ? 'bg-accent-muted/50 text-text-primary' : 'text-text-secondary hover:bg-bg-tertiary',
+              ].join(' ')}
+            >
+              <span className="flex items-center gap-2 min-w-0 flex-1">
+                {mode.kind === 'multi' && (
+                  <input
+                    type="checkbox"
+                    className="accent-accent shrink-0"
+                    checked={checked}
+                    onChange={() => { toggle(v.value); }}
+                  />
+                )}
+                {mode.kind === 'single' && (
+                  <input
+                    type="radio"
+                    className="accent-accent shrink-0"
+                    checked={checked}
+                    onChange={() => { toggle(v.value); }}
+                  />
+                )}
+                <span className="truncate">{v.label}</span>
+              </span>
+              <span className="shrink-0 text-text-muted tabular-nums">{formatDollars(v.cost)}</span>
+            </label>
+          );
+        })}
+      </div>
+      {mode.kind === 'multi' && (
+        <div className="flex items-center justify-between border-t border-border p-2 gap-2">
+          <button
+            type="button"
+            onClick={clear}
+            className="text-xs text-text-secondary hover:text-text-primary"
+            disabled={draft.length === 0}
+          >
+            Clear
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-2 py-1 text-xs text-text-secondary hover:bg-bg-tertiary"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={apply}
+              className="rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-bg-primary hover:bg-accent/90"
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -57,6 +57,7 @@ export { DataManagement } from './views/data-management.js';
 export { DimensionsView } from './views/dimensions.js';
 export { CostScopeView } from './views/cost-scope.js';
 export { ExplorerView } from './views/explorer.js';
+export { BudgetsView } from './views/budgets.js';
 export { SetupWizard } from './views/setup-wizard.js';
 export { McpView } from './views/mcp-view.js';
 

--- a/packages/ui/src/views/budgets.tsx
+++ b/packages/ui/src/views/budgets.tsx
@@ -1,0 +1,240 @@
+import { useMemo, useState } from 'react';
+import type { Budget, CostResult, DimensionId, Dollars } from '@costgoblin/core/browser';
+import { asDimensionId, asDollars, computeBudgetProgress } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useLagDays } from '../hooks/use-lag-days.js';
+import { useQuery } from '../hooks/use-query.js';
+import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
+import type { DateRange, Granularity } from '../components/date-range-picker.js';
+import { DimensionSelector } from '../components/dimension-selector.js';
+import { BudgetCard } from '../components/budget-card.js';
+import { BudgetEditorModal } from '../components/budget-editor-modal.js';
+import { Button } from '../components/ui/button.js';
+import { formatDollars } from '../components/format.js';
+import { getDimensionId } from '../lib/dimensions.js';
+
+type EditorState =
+  | { mode: 'closed' }
+  | { mode: 'create' }
+  | { mode: 'edit'; budget: Budget };
+
+export function BudgetsView(): React.JSX.Element {
+  const api = useCostApi();
+  const lagDays = useLagDays();
+
+  const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
+  const [granularity, setGranularity] = useState<Granularity>('daily');
+  const [selectedDimensionId, setSelectedDimensionId] = useState<DimensionId | null>(null);
+  const [editor, setEditor] = useState<EditorState>({ mode: 'closed' });
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  const dimensionsQuery = useQuery(() => api.getDimensions(), []);
+  const dimensions = dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
+
+  const firstDim = dimensions[0];
+  const activeDimensionId: DimensionId | null =
+    selectedDimensionId ?? (firstDim !== undefined ? getDimensionId(firstDim) : null);
+
+  const budgetsQuery = useQuery(() => api.getBudgets(), [refreshTick]);
+  const allBudgets = budgetsQuery.status === 'success' ? budgetsQuery.data : [];
+
+  const costsQuery = useQuery(
+    () => activeDimensionId === null
+      ? Promise.resolve<CostResult | null>(null)
+      : api.queryCosts({ groupBy: activeDimensionId, dateRange, filters: {} }),
+    [activeDimensionId, dateRange.start, dateRange.end],
+  );
+
+  const costsByEntity = useMemo(() => {
+    const map = new Map<string, number>();
+    if (costsQuery.status !== 'success' || costsQuery.data === null) return map;
+    for (const row of costsQuery.data.rows) {
+      map.set(row.entity, row.totalCost);
+    }
+    return map;
+  }, [costsQuery]);
+
+  const filteredBudgets = useMemo(
+    () => allBudgets.filter(b => b.dimension === activeDimensionId),
+    [allBudgets, activeDimensionId],
+  );
+
+  const progressItems = useMemo(() => {
+    const items = filteredBudgets.map(budget =>
+      computeBudgetProgress(budget, asDollars(costsByEntity.get(budget.entity) ?? 0), dateRange),
+    );
+    items.sort((a, b) => b.percentUsed - a.percentUsed);
+    return items;
+  }, [filteredBudgets, costsByEntity, dateRange]);
+
+  const summary = useMemo(() => {
+    let annual = 0;
+    let spent = 0;
+    let prorated = 0;
+    let overBudget = 0;
+    for (const item of progressItems) {
+      annual += item.budget.annualAmount;
+      spent += item.actualCost;
+      prorated += item.proratedBudget;
+      if (item.isOverBudget) overBudget += 1;
+    }
+    return {
+      annual: asDollars(annual),
+      spent: asDollars(spent),
+      prorated: asDollars(prorated),
+      overallPercent: prorated > 0 ? (spent / prorated) * 100 : 0,
+      overBudget,
+    };
+  }, [progressItems]);
+
+  const budgetedEntities = useMemo(
+    () => filteredBudgets.map(b => b.entity as unknown as string),
+    [filteredBudgets],
+  );
+
+  function handleCloseEditor(): void {
+    setEditor({ mode: 'closed' });
+  }
+
+  function handleSaved(): void {
+    setEditor({ mode: 'closed' });
+    setRefreshTick(t => t + 1);
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-text-primary">Budgets</h2>
+          <p className="text-sm text-text-secondary mt-0.5">Track spending against annual budgets</p>
+        </div>
+        <DateRangePicker
+          value={dateRange}
+          granularity={granularity}
+          onChange={(range, g) => { setDateRange(range); setGranularity(g); }}
+          lagDays={lagDays}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        {dimensions.length > 0 && (
+          <DimensionSelector
+            dimensions={dimensions}
+            selected={activeDimensionId ?? ''}
+            onSelect={(id) => { setSelectedDimensionId(asDimensionId(id)); }}
+          />
+        )}
+        <Button
+          size="sm"
+          onClick={() => { setEditor({ mode: 'create' }); }}
+          disabled={activeDimensionId === null}
+        >
+          Add Budget
+        </Button>
+      </div>
+
+      {budgetsQuery.status === 'error' && (
+        <ErrorBanner message={budgetsQuery.error.message} />
+      )}
+      {costsQuery.status === 'error' && (
+        <ErrorBanner message={costsQuery.error.message} />
+      )}
+
+      {progressItems.length > 0 && (
+        <SummaryGrid
+          annual={summary.annual}
+          spent={summary.spent}
+          overallPercent={summary.overallPercent}
+          overBudget={summary.overBudget}
+        />
+      )}
+
+      {progressItems.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {progressItems.map(item => (
+            <BudgetCard
+              key={item.budget.id}
+              progress={item}
+              onClick={() => { setEditor({ mode: 'edit', budget: item.budget }); }}
+            />
+          ))}
+        </div>
+      )}
+
+      {progressItems.length === 0 && budgetsQuery.status === 'success' && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center">
+          <p className="text-sm text-text-muted mb-4">No budgets set for this dimension</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => { setEditor({ mode: 'create' }); }}
+            disabled={activeDimensionId === null}
+          >
+            Add your first budget
+          </Button>
+        </div>
+      )}
+
+      {editor.mode === 'create' && activeDimensionId !== null && (
+        <BudgetEditorModal
+          mode="create"
+          dimension={activeDimensionId}
+          dateRange={dateRange}
+          budgetedEntities={budgetedEntities}
+          onClose={handleCloseEditor}
+          onSaved={handleSaved}
+        />
+      )}
+      {editor.mode === 'edit' && (
+        <BudgetEditorModal
+          mode="edit"
+          budget={editor.budget}
+          onClose={handleCloseEditor}
+          onSaved={handleSaved}
+          onDeleted={handleSaved}
+        />
+      )}
+    </div>
+  );
+}
+
+function SummaryGrid({ annual, spent, overallPercent, overBudget }: Readonly<{
+  annual: Dollars;
+  spent: Dollars;
+  overallPercent: number;
+  overBudget: number;
+}>): React.JSX.Element {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <StatTile label="Total annual budget" value={formatDollars(annual)} />
+      <StatTile label="Total spent" value={formatDollars(spent)} />
+      <StatTile
+        label="Overall usage"
+        value={`${overallPercent.toFixed(0)}%`}
+        valueClass={overallPercent > 100 ? 'text-negative' : ''}
+      />
+      <StatTile
+        label="Over budget"
+        value={String(overBudget)}
+        valueClass={overBudget > 0 ? 'text-negative' : 'text-positive'}
+      />
+    </div>
+  );
+}
+
+function StatTile({ label, value, valueClass }: Readonly<{ label: string; value: string; valueClass?: string }>): React.JSX.Element {
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-3">
+      <p className="text-xs text-text-muted">{label}</p>
+      <p className={`text-lg font-semibold tabular-nums mt-1 ${valueClass ?? 'text-text-primary'}`}>{value}</p>
+    </div>
+  );
+}
+
+function ErrorBanner({ message }: Readonly<{ message: string }>): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3 text-sm text-negative">
+      {message}
+    </div>
+  );
+}

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -28,6 +28,7 @@ import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { getDimensionId } from '../lib/dimensions.js';
 import { bucketKeyToDate, formatBucketKey, normalizeHourKey, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import type { TableColumn } from '../lib/table-types.js';
+import { ValuesPicker, type DropdownState } from '../components/values-picker.js';
 
 const DEBOUNCE_MS = 250;
 const ROW_LIMIT = 500;
@@ -822,11 +823,6 @@ interface MultiFilterBarProps {
   readonly fetchValues: (dimId: string) => Promise<readonly ExplorerFilterValue[]>;
 }
 
-type DropdownState =
-  | { status: 'closed' }
-  | { status: 'loading'; dimId: string }
-  | { status: 'ready'; dimId: string; values: readonly ExplorerFilterValue[] }
-  | { status: 'error'; dimId: string; message: string };
 
 function MultiFilterBar({ dimensions, filters, onChange, fetchValues }: MultiFilterBarProps): React.JSX.Element {
   const [dropdown, setDropdown] = useState<DropdownState>({ status: 'closed' });
@@ -909,8 +905,7 @@ function MultiFilterBar({ dimensions, filters, onChange, fetchValues }: MultiFil
             {isOpen && (
               <ValuesPicker
                 dropdown={dropdown}
-                selected={active}
-                onApply={(next) => { onChange(dimId, next); }}
+                mode={{ kind: 'multi', selected: active, onApply: (next) => { onChange(dimId, next); } }}
                 onClose={() => { setDropdown({ status: 'closed' }); }}
               />
             )}
@@ -923,125 +918,6 @@ function MultiFilterBar({ dimensions, filters, onChange, fetchValues }: MultiFil
     </div>
   );
 }
-
-interface ValuesPickerProps {
-  readonly dropdown: DropdownState;
-  readonly selected: readonly string[];
-  readonly onApply: (next: readonly string[]) => void;
-  readonly onClose: () => void;
-}
-
-function ValuesPicker({ dropdown, selected, onApply, onClose }: ValuesPickerProps): React.JSX.Element {
-  const [search, setSearch] = useState('');
-  const [draft, setDraft] = useState(selected);
-
-  // Reset the draft when the dim changes — otherwise re-opening a
-  // previously-selected dim would show stale draft state.
-  useEffect(() => {
-    setDraft(selected);
-    setSearch('');
-  }, [selected]);
-
-  function toggle(value: string) {
-    setDraft(prev => prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]);
-  }
-
-  function apply() {
-    onApply(draft);
-    onClose();
-  }
-
-  function clear() {
-    setDraft([]);
-  }
-
-  const filteredValues = dropdown.status === 'ready'
-    ? dropdown.values.filter(v => search.length === 0 || v.label.toLowerCase().includes(search.toLowerCase()))
-    : [];
-
-  return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-bg-secondary shadow-lg">
-      <div className="border-b border-border p-2">
-        <input
-          autoFocus
-          type="text"
-          value={search}
-          placeholder="Search values…"
-          onChange={(e) => { setSearch(e.target.value); }}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') onClose();
-            if (e.key === 'Enter') apply();
-          }}
-          className="w-full rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent"
-        />
-      </div>
-      <div className="max-h-64 overflow-y-auto">
-        {dropdown.status === 'loading' && (
-          <div className="flex items-center justify-center gap-2 py-6 text-xs text-text-muted">
-            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-border border-t-accent" />
-            <span>Loading…</span>
-          </div>
-        )}
-        {dropdown.status === 'error' && (
-          <div className="px-3 py-4 text-xs text-negative">Failed to load: {dropdown.message}</div>
-        )}
-        {dropdown.status === 'ready' && filteredValues.length === 0 && (
-          <div className="px-3 py-4 text-xs text-text-muted">No matching values.</div>
-        )}
-        {dropdown.status === 'ready' && filteredValues.map(v => {
-          const checked = draft.includes(v.value);
-          return (
-            <label
-              key={v.value}
-              className={[
-                'flex items-center justify-between gap-2 px-3 py-1.5 text-xs cursor-pointer select-none',
-                checked ? 'bg-accent-muted/50 text-text-primary' : 'text-text-secondary hover:bg-bg-tertiary',
-              ].join(' ')}
-            >
-              <span className="flex items-center gap-2 min-w-0 flex-1">
-                <input
-                  type="checkbox"
-                  className="accent-accent shrink-0"
-                  checked={checked}
-                  onChange={() => { toggle(v.value); }}
-                />
-                <span className="truncate">{v.label}</span>
-              </span>
-              <span className="shrink-0 text-text-muted tabular-nums">{formatDollars(v.cost)}</span>
-            </label>
-          );
-        })}
-      </div>
-      <div className="flex items-center justify-between border-t border-border p-2 gap-2">
-        <button
-          type="button"
-          onClick={clear}
-          className="text-xs text-text-secondary hover:text-text-primary"
-          disabled={draft.length === 0}
-        >
-          Clear
-        </button>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md px-2 py-1 text-xs text-text-secondary hover:bg-bg-tertiary"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={apply}
-            className="rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-bg-primary hover:bg-accent/90"
-          >
-            Apply
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 
 const DETAIL_FIELDS: readonly { key: string; label: string; render: (r: import('@costgoblin/core/browser').ExplorerSampleRow) => string }[] = [
   { key: 'date', label: 'Date', render: r => r.date },


### PR DESCRIPTION
## Summary

- Adds a **Budgets** nav page for tracking spending against annual budgets
- Dimension-generic: budgets can be set on any dimension (owner teams, products, accounts, custom tags)
- Page shows dimension selector, date range picker, summary stats (total annual, spent, usage %, over-budget count), and a card grid with progress bars sorted by urgency
- Budget cards are clickable to edit; "Add Budget" opens a modal with entity picker filtered to entities without existing budgets
- Client-side proration avoids N+1 queries — one `queryCosts` call per dimension instead of per-budget
- Removes the orphaned entity detail view (unreachable since dashboard filter navigation change in #187)

## Changes

- **New:** `packages/ui/src/views/budgets.tsx` — Budgets page view
- **Modified:** `budget-card.tsx` — redesigned as compact clickable card with entity name, color-coded progress bar
- **Modified:** `budget-editor-modal.tsx` — entity dropdown for create mode, delete button for edit mode
- **Modified:** `App.tsx` — registered Budgets as nav page
- **Deleted:** `entity-detail.tsx`, `entity-detail.test.tsx`, Entity Detail E2E tests
- **Existing (from prior PR work):** budget types, IPC handlers, JSON persistence, preload bridge