### PR TITLE
Tag Remediation Workflow with Issue Creation

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -24,6 +24,7 @@ import type {
   MissingTagsResult,
   SavingsResult,
   SyncStatus,
+  TagCoverageSnapshot,
   TrendQueryParams,
   TrendResult,
 } from './query.js';
@@ -191,6 +192,17 @@ export interface CostApi {
    *  navigation so stale queries from the previous view don't hold pool
    *  connections and slow down the new view's queries. */
   cancelPendingQueries(): Promise<void>;
+  /** Load tag coverage history from state/tag-coverage-history.json.
+   *  Returns empty array if file doesn't exist. Snapshots are sorted by
+   *  timestamp descending (newest first). */
+  getTagCoverageHistory(): Promise<readonly TagCoverageSnapshot[]>;
+  /** Append a new coverage snapshot to state/tag-coverage-history.json.
+   *  Automatically deduplicates by timestamp (same-day snapshots replace
+   *  each other) and maintains descending sort order. */
+  saveTagCoverageSnapshot(snapshot: TagCoverageSnapshot): Promise<void>;
+  /** Delete all coverage snapshots from state/tag-coverage-history.json.
+   *  Idempotent — succeeds even if file doesn't exist. */
+  clearTagCoverageHistory(): Promise<void>;
 }
 
 export interface AccountMappingEntry {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -58,6 +58,7 @@ export type {
   SavingsResult,
   SyncStatus,
   QueryState,
+  TagCoverageSnapshot,
 } from './query.js';
 
 export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -110,6 +110,27 @@ export interface MissingTagsResult {
   readonly nonResourceRows: readonly NonResourceCostRow[];
 }
 
+/** Point-in-time snapshot of tag coverage metrics for trend tracking. Stored
+ *  in state/tag-coverage-history.json. */
+export interface TagCoverageSnapshot {
+  /** ISO 8601 date-time when this snapshot was captured. */
+  readonly timestamp: string;
+  /** Cost of actionable untagged resources at snapshot time. */
+  readonly totalActionableCost: Dollars;
+  /** Cost of resources in categories where nothing is ever tagged. */
+  readonly totalLikelyUntaggableCost: Dollars;
+  /** Cost of line items that are not resource-bound (tax, support, etc.). */
+  readonly totalNonResourceCost: Dollars;
+  /** Number of actionable untagged resources. */
+  readonly actionableCount: number;
+  /** Number of likely untaggable resources. */
+  readonly likelyUntaggableCount: number;
+  /** Coverage percentage (0-100): what fraction of taggable resources are
+   *  actually tagged. Calculated as:
+   *  (totalTaggedCost / (totalTaggedCost + totalActionableCost)) × 100 */
+  readonly coveragePercentage: number;
+}
+
 export interface EntityDetailParams {
   readonly entity: EntityRef;
   readonly dimension: DimensionId;

--- a/packages/desktop/src/main/handlers/tag-remediation.ts
+++ b/packages/desktop/src/main/handlers/tag-remediation.ts
@@ -1,0 +1,93 @@
+import { ipcMain } from 'electron';
+import { parseJsonObject } from '@costgoblin/core';
+import type { TagCoverageSnapshot } from '@costgoblin/core';
+import type { AppContext } from './context.js';
+
+async function tagCoverageHistoryPath(dataDir: string): Promise<string> {
+  const path = await import('node:path');
+  const baseDir = path.dirname(dataDir);
+  return path.join(baseDir, 'state', 'tag-coverage-history.json');
+}
+
+async function ensureStateDir(dataDir: string): Promise<void> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const stateDir = path.join(path.dirname(dataDir), 'state');
+  try {
+    await fs.mkdir(stateDir, { recursive: true });
+  } catch {
+    // directory already exists
+  }
+}
+
+function isTagCoverageSnapshot(value: unknown): value is TagCoverageSnapshot {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['timestamp'] === 'string' &&
+    typeof obj['totalActionableCost'] === 'number' &&
+    typeof obj['totalLikelyUntaggableCost'] === 'number' &&
+    typeof obj['totalNonResourceCost'] === 'number' &&
+    typeof obj['actionableCount'] === 'number' &&
+    typeof obj['likelyUntaggableCount'] === 'number' &&
+    typeof obj['coveragePercentage'] === 'number'
+  );
+}
+
+function parseTagCoverageSnapshots(raw: string): readonly TagCoverageSnapshot[] {
+  const parsed = parseJsonObject(raw);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isTagCoverageSnapshot);
+}
+
+export function registerTagRemediationHandlers(app: AppContext): void {
+  const { ctx } = app;
+
+  ipcMain.handle('tag-remediation:get-history', async (): Promise<readonly TagCoverageSnapshot[]> => {
+    const fs = await import('node:fs/promises');
+    try {
+      const raw = await fs.readFile(await tagCoverageHistoryPath(ctx.dataDir), 'utf-8');
+      const snapshots = parseTagCoverageSnapshots(raw);
+      // Return sorted by timestamp descending (newest first)
+      return [...snapshots].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    } catch {
+      // file doesn't exist yet
+      return [];
+    }
+  });
+
+  ipcMain.handle('tag-remediation:save-snapshot', async (_event, snapshot: TagCoverageSnapshot): Promise<void> => {
+    const fs = await import('node:fs/promises');
+    await ensureStateDir(ctx.dataDir);
+
+    // Load existing snapshots
+    let existing: TagCoverageSnapshot[] = [];
+    try {
+      const raw = await fs.readFile(await tagCoverageHistoryPath(ctx.dataDir), 'utf-8');
+      existing = [...parseTagCoverageSnapshots(raw)];
+    } catch {
+      // file doesn't exist yet
+    }
+
+    // Extract date part from timestamp for deduplication
+    const getDatePart = (timestamp: string): string => timestamp.split('T')[0] ?? timestamp;
+    const newDatePart = getDatePart(snapshot.timestamp);
+
+    // Remove any existing snapshot from the same day
+    const filtered = existing.filter(s => getDatePart(s.timestamp) !== newDatePart);
+
+    // Add new snapshot and sort descending
+    const updated = [...filtered, snapshot].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+    await fs.writeFile(await tagCoverageHistoryPath(ctx.dataDir), JSON.stringify(updated, null, 2));
+  });
+
+  ipcMain.handle('tag-remediation:clear-history', async (): Promise<void> => {
+    const fs = await import('node:fs/promises');
+    try {
+      await fs.unlink(await tagCoverageHistoryPath(ctx.dataDir));
+    } catch {
+      // file doesn't exist — idempotent
+    }
+  });
+}

--- a/packages/desktop/src/main/handlers/tag-remediation.ts
+++ b/packages/desktop/src/main/handlers/tag-remediation.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { parseJsonObject } from '@costgoblin/core';
+import { isStringRecord } from '@costgoblin/core';
 import type { TagCoverageSnapshot } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
@@ -21,21 +21,20 @@ async function ensureStateDir(dataDir: string): Promise<void> {
 }
 
 function isTagCoverageSnapshot(value: unknown): value is TagCoverageSnapshot {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
+  if (!isStringRecord(value)) return false;
   return (
-    typeof obj['timestamp'] === 'string' &&
-    typeof obj['totalActionableCost'] === 'number' &&
-    typeof obj['totalLikelyUntaggableCost'] === 'number' &&
-    typeof obj['totalNonResourceCost'] === 'number' &&
-    typeof obj['actionableCount'] === 'number' &&
-    typeof obj['likelyUntaggableCount'] === 'number' &&
-    typeof obj['coveragePercentage'] === 'number'
+    typeof value['timestamp'] === 'string' &&
+    typeof value['totalActionableCost'] === 'number' &&
+    typeof value['totalLikelyUntaggableCost'] === 'number' &&
+    typeof value['totalNonResourceCost'] === 'number' &&
+    typeof value['actionableCount'] === 'number' &&
+    typeof value['likelyUntaggableCount'] === 'number' &&
+    typeof value['coveragePercentage'] === 'number'
   );
 }
 
 function parseTagCoverageSnapshots(raw: string): readonly TagCoverageSnapshot[] {
-  const parsed = parseJsonObject(raw);
+  const parsed: unknown = JSON.parse(raw);
   if (!Array.isArray(parsed)) return [];
   return parsed.filter(isTagCoverageSnapshot);
 }

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -12,6 +12,7 @@ import { registerViewsHandlers } from './handlers/views.js';
 import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
 import { registerDebugHandlers } from './handlers/debug.js';
+import { registerTagRemediationHandlers } from './handlers/tag-remediation.js';
 
 export type { IpcContext } from './handlers/context.js';
 
@@ -29,6 +30,7 @@ export function registerIpcHandlers(ctx: IpcContext): void {
   registerViewsHandlers(app);
   registerCostScopeHandlers(app);
   registerExplorerHandlers(app);
+  registerTagRemediationHandlers(app);
   registerDebugHandlers(app);
 
   app.warmupBase();

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -40,6 +40,7 @@ import type {
   AggregatedTableParams,
   AggregatedTableResult,
   AliasSuggestion,
+  TagCoverageSnapshot,
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
@@ -273,6 +274,15 @@ const api: CostApi = {
   },
   acceptSuggestion(tagName: string, canonical: string, aliases: readonly string[]): Promise<void> {
     return invoke<undefined>('dimensions:accept-suggestion', tagName, canonical, aliases).then(() => undefined);
+  },
+  getTagCoverageHistory(): Promise<readonly TagCoverageSnapshot[]> {
+    return invoke<readonly TagCoverageSnapshot[]>('tag-remediation:get-history');
+  },
+  saveTagCoverageSnapshot(snapshot: TagCoverageSnapshot): Promise<void> {
+    return invoke<undefined>('tag-remediation:save-snapshot', snapshot).then(() => undefined);
+  },
+  clearTagCoverageHistory(): Promise<void> {
+    return invoke<undefined>('tag-remediation:clear-history').then(() => undefined);
   },
   cancelPendingQueries(): Promise<void> {
     void invoke<undefined>('debug:clear-completed');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -26,6 +26,7 @@ import {
   type ExplorerOverviewResult,
   type ExplorerRowsResult,
   type AliasSuggestion,
+  type TagCoverageSnapshot,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
 
@@ -366,6 +367,9 @@ export class MockCostApi implements CostApi {
   }
   dismissSuggestion(): Promise<void> { return Promise.resolve(); }
   acceptSuggestion(): Promise<void> { return Promise.resolve(); }
+  getTagCoverageHistory(): Promise<readonly TagCoverageSnapshot[]> { return Promise.resolve([]); }
+  saveTagCoverageSnapshot(): Promise<void> { return Promise.resolve(); }
+  clearTagCoverageHistory(): Promise<void> { return Promise.resolve(); }
   cancelPendingQueries(): Promise<void> { return Promise.resolve(); }
 }
 

--- a/packages/ui/src/__tests__/remediation-actions.test.tsx
+++ b/packages/ui/src/__tests__/remediation-actions.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { RemediationActions } from '../components/remediation-actions.js';
+import { asDollars } from '@costgoblin/core/browser';
+import type { MissingTagRow } from '@costgoblin/core/browser';
+
+const mockRows: MissingTagRow[] = [
+  {
+    accountId: '123456789012',
+    accountName: 'prod-main',
+    resourceId: 'i-0abc123def456gh78',
+    service: 'Amazon EC2',
+    serviceFamily: 'Compute',
+    cost: asDollars(1_200),
+    closestOwner: 'platform' as never,
+    bucket: 'actionable',
+    categoryTaggedRatio: 0.82,
+  },
+  {
+    accountId: '234567890123',
+    accountName: 'prod-data',
+    resourceId: 'arn:aws:rds:us-east-1:234567890123:db:analytics-prod',
+    service: 'Amazon RDS',
+    serviceFamily: 'Database',
+    cost: asDollars(870),
+    closestOwner: 'data' as never,
+    bucket: 'actionable',
+    categoryTaggedRatio: 0.65,
+  },
+];
+
+afterEach(cleanup);
+
+describe('RemediationActions', () => {
+  it('returns null when no rows selected', () => {
+    const { container } = render(
+      <RemediationActions selectedRows={[]} tagName="team" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows export CSV button when rows are selected', () => {
+    render(
+      <RemediationActions selectedRows={mockRows} tagName="team" />,
+    );
+    expect(screen.getByText('Export CSV')).toBeDefined();
+  });
+
+  it('shows copy issue template button when rows are selected', () => {
+    render(
+      <RemediationActions selectedRows={mockRows} tagName="team" />,
+    );
+    expect(screen.getByText('Copy Issue Template')).toBeDefined();
+  });
+
+  it('displays correct count for single resource', () => {
+    render(
+      <RemediationActions selectedRows={[mockRows[0]!]} tagName="team" />,
+    );
+    expect(screen.getByText('1 resource selected')).toBeDefined();
+  });
+
+  it('displays correct count for multiple resources', () => {
+    render(
+      <RemediationActions selectedRows={mockRows} tagName="team" />,
+    );
+    expect(screen.getByText('2 resources selected')).toBeDefined();
+  });
+});

--- a/packages/ui/src/__tests__/remediation-actions.test.tsx
+++ b/packages/ui/src/__tests__/remediation-actions.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, cleanup } from '@testing-library/react';
 import { afterEach, describe, it, expect } from 'vitest';
 import { RemediationActions } from '../components/remediation-actions.js';
-import { asDollars } from '@costgoblin/core/browser';
+import { asDollars, asEntityRef } from '@costgoblin/core/browser';
 import type { MissingTagRow } from '@costgoblin/core/browser';
 
 const mockRows: MissingTagRow[] = [
@@ -12,7 +12,7 @@ const mockRows: MissingTagRow[] = [
     service: 'Amazon EC2',
     serviceFamily: 'Compute',
     cost: asDollars(1_200),
-    closestOwner: 'platform' as never,
+    closestOwner: asEntityRef('platform'),
     bucket: 'actionable',
     categoryTaggedRatio: 0.82,
   },
@@ -23,7 +23,7 @@ const mockRows: MissingTagRow[] = [
     service: 'Amazon RDS',
     serviceFamily: 'Database',
     cost: asDollars(870),
-    closestOwner: 'data' as never,
+    closestOwner: asEntityRef('data'),
     bucket: 'actionable',
     categoryTaggedRatio: 0.65,
   },

--- a/packages/ui/src/__tests__/remediation-actions.test.tsx
+++ b/packages/ui/src/__tests__/remediation-actions.test.tsx
@@ -55,7 +55,7 @@ describe('RemediationActions', () => {
 
   it('displays correct count for single resource', () => {
     render(
-      <RemediationActions selectedRows={[mockRows[0]!]} tagName="team" />,
+      <RemediationActions selectedRows={mockRows.slice(0, 1)} tagName="team" />,
     );
     expect(screen.getByText('1 resource selected')).toBeDefined();
   });

--- a/packages/ui/src/__tests__/tag-coverage-chart.test.tsx
+++ b/packages/ui/src/__tests__/tag-coverage-chart.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { TagCoverageChart } from '../components/tag-coverage-chart.js';
+import { asDollars } from '@costgoblin/core/browser';
+import type { TagCoverageSnapshot } from '@costgoblin/core/browser';
+import { PaletteProvider } from '../hooks/use-palette.js';
+
+const mockSnapshots: TagCoverageSnapshot[] = [
+  {
+    timestamp: '2026-04-01T00:00:00Z',
+    totalActionableCost: asDollars(2_070),
+    totalLikelyUntaggableCost: asDollars(340),
+    totalNonResourceCost: asDollars(150),
+    actionableCount: 2,
+    likelyUntaggableCount: 1,
+    coveragePercentage: 85.5,
+  },
+  {
+    timestamp: '2026-04-15T00:00:00Z',
+    totalActionableCost: asDollars(1_500),
+    totalLikelyUntaggableCost: asDollars(300),
+    totalNonResourceCost: asDollars(150),
+    actionableCount: 1,
+    likelyUntaggableCount: 1,
+    coveragePercentage: 90.2,
+  },
+  {
+    timestamp: '2026-04-29T00:00:00Z',
+    totalActionableCost: asDollars(800),
+    totalLikelyUntaggableCost: asDollars(250),
+    totalNonResourceCost: asDollars(150),
+    actionableCount: 1,
+    likelyUntaggableCount: 1,
+    coveragePercentage: 94.8,
+  },
+];
+
+function renderChart(snapshots: TagCoverageSnapshot[], height?: number) {
+  return render(
+    <PaletteProvider>
+      <TagCoverageChart snapshots={snapshots} height={height} />
+    </PaletteProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe('TagCoverageChart', () => {
+  it('shows no data message when snapshots array is empty', () => {
+    renderChart([]);
+    expect(screen.getByText('No coverage data available')).toBeDefined();
+  });
+
+  it('renders SVG element when snapshots are provided', () => {
+    const { container } = renderChart(mockSnapshots);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeDefined();
+  });
+
+  it('uses default height of 300 when not specified', () => {
+    const { container } = renderChart(mockSnapshots);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('height')).toBe('300');
+  });
+
+  it('uses custom height when specified', () => {
+    const { container } = renderChart(mockSnapshots, 240);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('height')).toBe('240');
+  });
+
+  it('renders line path for coverage data', () => {
+    const { container } = renderChart(mockSnapshots);
+    const linePath = container.querySelector('path[stroke-width="1.75"]');
+    expect(linePath).toBeDefined();
+  });
+
+  it('sorts snapshots by timestamp before rendering', () => {
+    const unsortedSnapshots: TagCoverageSnapshot[] = [
+      {
+        timestamp: '2026-04-29T00:00:00Z',
+        totalActionableCost: asDollars(800),
+        totalLikelyUntaggableCost: asDollars(250),
+        totalNonResourceCost: asDollars(150),
+        actionableCount: 1,
+        likelyUntaggableCount: 1,
+        coveragePercentage: 94.8,
+      },
+      {
+        timestamp: '2026-04-01T00:00:00Z',
+        totalActionableCost: asDollars(2_070),
+        totalLikelyUntaggableCost: asDollars(340),
+        totalNonResourceCost: asDollars(150),
+        actionableCount: 2,
+        likelyUntaggableCount: 1,
+        coveragePercentage: 85.5,
+      },
+    ];
+    const { container } = renderChart(unsortedSnapshots);
+    const linePath = container.querySelector('path[stroke-width="1.75"]');
+    expect(linePath).toBeDefined();
+  });
+
+  it('renders with single snapshot without errors', () => {
+    const singleSnapshot = [mockSnapshots[0]!];
+    const { container } = renderChart(singleSnapshot);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeDefined();
+  });
+});

--- a/packages/ui/src/__tests__/tag-coverage-chart.test.tsx
+++ b/packages/ui/src/__tests__/tag-coverage-chart.test.tsx
@@ -102,7 +102,7 @@ describe('TagCoverageChart', () => {
   });
 
   it('renders with single snapshot without errors', () => {
-    const singleSnapshot = [mockSnapshots[0]!];
+    const singleSnapshot = mockSnapshots.slice(0, 1);
     const { container } = renderChart(singleSnapshot);
     const svg = container.querySelector('svg');
     expect(svg).toBeDefined();

--- a/packages/ui/src/components/csv-export.tsx
+++ b/packages/ui/src/components/csv-export.tsx
@@ -6,7 +6,7 @@ interface CsvExportProps {
   filename?: string;
 }
 
-function escapeCell(value: string): string {
+export function escapeCell(value: string): string {
   if (value.includes(',') || value.includes('"') || value.includes('\n')) {
     return `"${value.replaceAll('"', '""')}"`;
   }

--- a/packages/ui/src/components/remediation-actions.tsx
+++ b/packages/ui/src/components/remediation-actions.tsx
@@ -53,7 +53,7 @@ function buildIssueTemplate(rows: readonly MissingTagRow[], tagName: string): st
     `# Missing ${tagName} Tag Remediation`,
     '',
     '## Summary',
-    `- **Total untagged resources:** ${rows.length}`,
+    `- **Total untagged resources:** ${String(rows.length)}`,
     `- **Total cost impact:** ${formatDollars(totalCost)}`,
     `- **Tag required:** \`${tagName}\``,
     '',

--- a/packages/ui/src/components/remediation-actions.tsx
+++ b/packages/ui/src/components/remediation-actions.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { Download, Copy } from 'lucide-react';
+import type { MissingTagRow } from '@costgoblin/core/browser';
+import { formatDollars } from './format.js';
+
+interface RemediationActionsProps {
+  readonly selectedRows: readonly MissingTagRow[];
+  readonly tagName: string;
+}
+
+function escapeCell(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+  return value;
+}
+
+function buildCsv(rows: readonly MissingTagRow[]): string {
+  const headers = ['Account ID', 'Account Name', 'Resource ID', 'Service', 'Service Family', 'Cost', 'Suggested Owner'];
+  const lines = [headers.map(escapeCell).join(',')];
+
+  for (const row of rows) {
+    const cells = [
+      escapeCell(row.accountId),
+      escapeCell(row.accountName),
+      escapeCell(row.resourceId),
+      escapeCell(row.service),
+      escapeCell(row.serviceFamily),
+      String(row.cost),
+      escapeCell(row.closestOwner ?? ''),
+    ];
+    lines.push(cells.join(','));
+  }
+
+  return lines.join('\n');
+}
+
+function buildIssueTemplate(rows: readonly MissingTagRow[], tagName: string): string {
+  const totalCost = rows.reduce((sum, row) => sum + row.cost, 0);
+  const groupedByOwner = new Map<string, MissingTagRow[]>();
+
+  for (const row of rows) {
+    const owner = row.closestOwner ?? 'Unknown';
+    const existing = groupedByOwner.get(owner);
+    if (existing === undefined) {
+      groupedByOwner.set(owner, [row]);
+    } else {
+      existing.push(row);
+    }
+  }
+
+  const lines: string[] = [
+    `# Missing ${tagName} Tag Remediation`,
+    '',
+    '## Summary',
+    `- **Total untagged resources:** ${rows.length}`,
+    `- **Total cost impact:** ${formatDollars(totalCost)}`,
+    `- **Tag required:** \`${tagName}\``,
+    '',
+    '## Resources by Suggested Owner',
+    '',
+  ];
+
+  const sortedOwners = Array.from(groupedByOwner.entries()).sort((a, b) => {
+    const costA = a[1].reduce((sum, r) => sum + r.cost, 0);
+    const costB = b[1].reduce((sum, r) => sum + r.cost, 0);
+    return costB - costA;
+  });
+
+  for (const [owner, ownerRows] of sortedOwners) {
+    const ownerCost = ownerRows.reduce((sum, r) => sum + r.cost, 0);
+    lines.push(`### ${owner} (${formatDollars(ownerCost)})`);
+    lines.push('');
+    for (const row of ownerRows) {
+      lines.push(`- **Resource:** \`${row.resourceId}\``);
+      lines.push(`  - Account: ${row.accountName} (\`${row.accountId}\`)`);
+      lines.push(`  - Service: ${row.service} (${row.serviceFamily})`);
+      lines.push(`  - Cost: ${formatDollars(row.cost)}`);
+      lines.push('');
+    }
+  }
+
+  lines.push('## Action Items');
+  lines.push('');
+  lines.push('- [ ] Review resource ownership assignments');
+  lines.push('- [ ] Add required tags to all resources');
+  lines.push('- [ ] Verify tags are correctly applied');
+  lines.push('- [ ] Update runbooks if needed');
+
+  return lines.join('\n');
+}
+
+export function RemediationActions({ selectedRows, tagName }: Readonly<RemediationActionsProps>) {
+  const [copied, setCopied] = useState(false);
+
+  function handleExportCsv() {
+    const csv = buildCsv(selectedRows);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `missing-${tagName}-remediation.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function handleCopyIssue(): Promise<void> {
+    const issueBody = buildIssueTemplate(selectedRows, tagName);
+    await navigator.clipboard.writeText(issueBody);
+    setCopied(true);
+    setTimeout(() => { setCopied(false); }, 1500);
+  }
+
+  if (selectedRows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={handleExportCsv}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors"
+      >
+        <Download size={14} />
+        Export CSV
+      </button>
+      <button
+        type="button"
+        onClick={() => { void handleCopyIssue(); }}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors"
+      >
+        <Copy size={14} />
+        {copied ? 'Copied!' : 'Copy Issue Template'}
+      </button>
+      <span className="text-xs text-text-muted">
+        {selectedRows.length} {selectedRows.length === 1 ? 'resource' : 'resources'} selected
+      </span>
+    </div>
+  );
+}

--- a/packages/ui/src/components/remediation-actions.tsx
+++ b/packages/ui/src/components/remediation-actions.tsx
@@ -2,17 +2,11 @@ import { useState } from 'react';
 import { Download, Copy } from 'lucide-react';
 import type { MissingTagRow } from '@costgoblin/core/browser';
 import { formatDollars } from './format.js';
+import { escapeCell } from './csv-export.js';
 
 interface RemediationActionsProps {
   readonly selectedRows: readonly MissingTagRow[];
   readonly tagName: string;
-}
-
-function escapeCell(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replaceAll('"', '""')}"`;
-  }
-  return value;
 }
 
 function buildCsv(rows: readonly MissingTagRow[]): string {

--- a/packages/ui/src/components/tag-coverage-chart.tsx
+++ b/packages/ui/src/components/tag-coverage-chart.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useMemo } from 'react';
+import { Group } from '@visx/group';
+import { LinePath } from '@visx/shape';
+import { scaleLinear, scaleTime } from '@visx/scale';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { localPoint } from '@visx/event';
+import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
+import { curveMonotoneX } from '@visx/curve';
+import { getColor } from '../lib/palette.js';
+import { TOOLTIP_STYLES } from '../lib/tooltip-styles.js';
+import { formatDollars } from './format.js';
+import { usePalette } from '../hooks/use-palette.js';
+import type { TagCoverageSnapshot } from '@costgoblin/core/browser';
+
+interface TagCoverageChartProps {
+  readonly snapshots: readonly TagCoverageSnapshot[];
+  readonly height?: number | undefined;
+}
+
+const MARGIN = { top: 20, right: 24, bottom: 36, left: 60 };
+
+interface TooltipPayload {
+  readonly timestamp: string;
+  readonly coveragePercentage: number;
+  readonly actionableCount: number;
+  readonly totalActionableCost: number;
+}
+
+interface CoverageSvgProps {
+  readonly snapshots: readonly TagCoverageSnapshot[];
+  readonly width: number;
+  readonly height: number;
+}
+
+function CoverageSvg({ snapshots, width, height }: CoverageSvgProps) {
+  const { palette } = usePalette();
+  const {
+    showTooltip, hideTooltip, tooltipData, tooltipLeft, tooltipTop, tooltipOpen,
+  } = useTooltip<TooltipPayload>();
+
+  const innerW = Math.max(width - MARGIN.left - MARGIN.right, 10);
+  const innerH = Math.max(height - MARGIN.top - MARGIN.bottom, 10);
+
+  const sortedSnapshots = useMemo(
+    () => [...snapshots].sort((a, b) => a.timestamp.localeCompare(b.timestamp)),
+    [snapshots],
+  );
+
+  const minDate = sortedSnapshots[0]?.timestamp;
+  const maxDate = sortedSnapshots.at(-1)?.timestamp;
+
+  const xScale = useMemo(() => {
+    const start = minDate === undefined ? new Date() : new Date(minDate);
+    const end = maxDate === undefined ? new Date() : new Date(maxDate);
+    return scaleTime<number>({
+      domain: [start, end],
+      range: [0, innerW],
+    });
+  }, [minDate, maxDate, innerW]);
+
+  const yScale = useMemo(() => scaleLinear<number>({
+    domain: [0, 100],
+    range: [innerH, 0],
+    nice: true,
+  }), [innerH]);
+
+  const lineColor = getColor(2, palette); // Use a consistent color from palette
+
+  const handleMove = useCallback((event: React.MouseEvent<SVGRectElement>) => {
+    const point = localPoint(event);
+    if (point === null) return;
+    const x = point.x - MARGIN.left;
+    if (x < 0 || x > innerW || sortedSnapshots.length === 0) return;
+    const date = xScale.invert(x);
+    let nearest = sortedSnapshots[0];
+    let nearestDiff = Infinity;
+    for (const snap of sortedSnapshots) {
+      const diff = Math.abs(new Date(snap.timestamp).getTime() - date.getTime());
+      if (diff < nearestDiff) {
+        nearestDiff = diff;
+        nearest = snap;
+      }
+    }
+    if (nearest === undefined) return;
+    showTooltip({
+      tooltipData: {
+        timestamp: nearest.timestamp,
+        coveragePercentage: nearest.coveragePercentage,
+        actionableCount: nearest.actionableCount,
+        totalActionableCost: nearest.totalActionableCost,
+      },
+      tooltipLeft: point.x,
+      tooltipTop: point.y,
+    });
+  }, [innerW, sortedSnapshots, xScale, showTooltip]);
+
+  if (sortedSnapshots.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-text-muted" style={{ width, height }}>
+        No coverage data available
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative" style={{ width, height }}>
+      <svg width={width} height={height}>
+        <Group left={MARGIN.left} top={MARGIN.top}>
+          <GridRows
+            scale={yScale}
+            width={innerW}
+            stroke="var(--color-border-subtle)"
+            strokeDasharray="2,3"
+            numTicks={5}
+          />
+          <AxisBottom
+            top={innerH}
+            scale={xScale}
+            numTicks={Math.min(6, Math.max(2, Math.floor(innerW / 80)))}
+            tickFormat={(v) => {
+              const d = v instanceof Date ? v : new Date(v.valueOf());
+              return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+            }}
+            stroke="var(--color-text-muted)"
+            tickStroke="var(--color-text-muted)"
+            tickLabelProps={() => ({
+              fill: 'var(--color-text-muted)',
+              fontSize: 10,
+              textAnchor: 'middle' as const,
+              dy: '0.25em',
+            })}
+          />
+          <AxisLeft
+            scale={yScale}
+            numTicks={5}
+            tickFormat={(v) => `${String(v.valueOf())}%`}
+            stroke="var(--color-text-muted)"
+            tickStroke="var(--color-text-muted)"
+            tickLabelProps={() => ({
+              fill: 'var(--color-text-muted)',
+              fontSize: 10,
+              textAnchor: 'end' as const,
+              dx: '-0.25em',
+              dy: '0.33em',
+            })}
+          />
+          <LinePath<TagCoverageSnapshot>
+            data={sortedSnapshots}
+            x={(d) => xScale(new Date(d.timestamp))}
+            y={(d) => yScale(d.coveragePercentage)}
+            stroke={lineColor}
+            strokeWidth={1.75}
+            curve={curveMonotoneX}
+          />
+          <rect
+            width={innerW}
+            height={innerH}
+            fill="transparent"
+            onMouseMove={handleMove}
+            onMouseLeave={hideTooltip}
+          />
+        </Group>
+      </svg>
+
+      {tooltipOpen && tooltipData !== undefined && tooltipLeft !== undefined && tooltipTop !== undefined && (
+        <TooltipWithBounds left={tooltipLeft} top={tooltipTop} style={TOOLTIP_STYLES}>
+          <div className="flex flex-col gap-0.5">
+            <span className="font-medium text-text-primary mb-1">
+              {new Date(tooltipData.timestamp).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </span>
+            <span className="text-text-secondary">
+              Coverage: <span className="text-text-primary tabular-nums">{tooltipData.coveragePercentage.toFixed(1)}%</span>
+            </span>
+            <span className="text-text-secondary">
+              Untagged: <span className="text-text-primary tabular-nums">{tooltipData.actionableCount}</span> resources
+            </span>
+            <span className="text-text-secondary">
+              Cost impact: <span className="text-text-primary tabular-nums">{formatDollars(tooltipData.totalActionableCost)}</span>
+            </span>
+          </div>
+        </TooltipWithBounds>
+      )}
+    </div>
+  );
+}
+
+export function TagCoverageChart({ snapshots, height = 300 }: TagCoverageChartProps) {
+  return (
+    <ParentSize>
+      {({ width }) => (
+        <CoverageSvg
+          snapshots={snapshots}
+          width={width}
+          height={height}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type {
   Dimension,
   DimensionId,
@@ -168,6 +168,51 @@ export function MissingTags() {
 
   const data: MissingTagsResult | null =
     missingQuery.status === 'success' ? missingQuery.data : null;
+
+  // Save coverage snapshot when data loads successfully
+  useEffect(() => {
+    if (missingQuery.status !== 'success') return;
+    if (missingQuery.data === null) return;
+    if (activeTagId === null) return;
+
+    const snapshot = missingQuery.data;
+    const dateRange = getDateRange();
+
+    // Query total cost to calculate coverage percentage
+    api.queryCosts({
+      dateRange,
+      filters: {},
+      groupBy: activeTagId,
+    }).then((costResult) => {
+      const totalCost = costResult.totalCost;
+      const totalUntaggedCost = snapshot.totalActionableCost + snapshot.totalLikelyUntaggableCost + snapshot.totalNonResourceCost;
+      const totalTaggedCost = Math.max(0, totalCost - totalUntaggedCost);
+      const taggableCost = totalTaggedCost + snapshot.totalActionableCost;
+      const coveragePercentage = taggableCost > 0 ? (totalTaggedCost / taggableCost) * 100 : 0;
+
+      const coverageSnapshot: TagCoverageSnapshot = {
+        timestamp: new Date().toISOString(),
+        totalActionableCost: snapshot.totalActionableCost,
+        totalLikelyUntaggableCost: snapshot.totalLikelyUntaggableCost,
+        totalNonResourceCost: snapshot.totalNonResourceCost,
+        actionableCount: snapshot.actionableCount,
+        likelyUntaggableCount: snapshot.likelyUntaggableCount,
+        coveragePercentage,
+      };
+
+      api.saveTagCoverageSnapshot(coverageSnapshot).catch((error: unknown) => {
+        // Silently fail - this is background persistence
+        if (error instanceof Error) {
+          // Log would go here if we had a logger
+        }
+      });
+    }).catch((error: unknown) => {
+      // Silently fail - coverage calculation is not critical
+      if (error instanceof Error) {
+        // Log would go here if we had a logger
+      }
+    });
+  }, [missingQuery, activeTagId, api]);
 
   const actionableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'actionable');
   const likelyUntaggableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'likely-untaggable');

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -20,12 +20,41 @@ function getDateRange(): { start: DateString; end: DateString } {
   return { start, end };
 }
 
-function ResourceTable({ rows, showRatio }: Readonly<{ rows: readonly MissingTagRow[]; showRatio: boolean }>) {
+function ResourceTable({
+  rows,
+  showRatio,
+  selectedResources,
+  onToggleResource,
+  onToggleAll,
+}: Readonly<{
+  rows: readonly MissingTagRow[];
+  showRatio: boolean;
+  selectedResources: ReadonlySet<string>;
+  onToggleResource: (resourceId: string) => void;
+  onToggleAll: (rows: readonly MissingTagRow[]) => void;
+}>) {
+  const allSelected = rows.length > 0 && rows.every(row => selectedResources.has(row.resourceId));
+  const someSelected = rows.some(row => selectedResources.has(row.resourceId));
+  const indeterminate = someSelected && !allSelected;
+
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-border text-left text-text-secondary">
+            <th className="px-4 pb-3 pt-4 w-10">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                ref={(el) => {
+                  if (el !== null) {
+                    el.indeterminate = indeterminate;
+                  }
+                }}
+                onChange={() => { onToggleAll(rows); }}
+                className="h-3.5 w-3.5 rounded accent-emerald-500"
+              />
+            </th>
             <th className="px-4 pb-3 pt-4 font-medium">Account</th>
             <th className="px-4 pb-3 pt-4 font-medium">Resource</th>
             <th className="px-4 pb-3 pt-4 font-medium">Service</th>
@@ -36,27 +65,38 @@ function ResourceTable({ rows, showRatio }: Readonly<{ rows: readonly MissingTag
           </tr>
         </thead>
         <tbody>
-          {rows.map((row, i) => (
-            <tr key={`${row.resourceId}-${String(i)}`} className="border-b border-border-subtle hover:bg-bg-tertiary/30 transition-colors">
-              <td className="px-4 py-3 text-text-primary">{row.accountName}</td>
-              <td className="px-4 py-3 text-text-secondary font-mono text-xs max-w-64 truncate" title={row.resourceId}>
-                {row.resourceId}
-              </td>
-              <td className="px-4 py-3 text-text-secondary">{row.service}</td>
-              <td className="px-4 py-3 text-text-secondary">{row.serviceFamily}</td>
-              <td className="px-4 py-3 text-right tabular-nums font-medium text-text-primary">
-                {formatDollars(row.cost)}
-              </td>
-              <td className="px-4 py-3 text-text-secondary">
-                {row.closestOwner ?? '—'}
-              </td>
-              {showRatio && (
-                <td className="px-4 py-3 text-right tabular-nums text-text-muted">
-                  {`${String(Math.round(row.categoryTaggedRatio * 100))}%`}
+          {rows.map((row, i) => {
+            const isSelected = selectedResources.has(row.resourceId);
+            return (
+              <tr key={`${row.resourceId}-${String(i)}`} className="border-b border-border-subtle hover:bg-bg-tertiary/30 transition-colors">
+                <td className="px-4 py-3">
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => { onToggleResource(row.resourceId); }}
+                    className="h-3.5 w-3.5 rounded accent-emerald-500"
+                  />
                 </td>
-              )}
-            </tr>
-          ))}
+                <td className="px-4 py-3 text-text-primary">{row.accountName}</td>
+                <td className="px-4 py-3 text-text-secondary font-mono text-xs max-w-64 truncate" title={row.resourceId}>
+                  {row.resourceId}
+                </td>
+                <td className="px-4 py-3 text-text-secondary">{row.service}</td>
+                <td className="px-4 py-3 text-text-secondary">{row.serviceFamily}</td>
+                <td className="px-4 py-3 text-right tabular-nums font-medium text-text-primary">
+                  {formatDollars(row.cost)}
+                </td>
+                <td className="px-4 py-3 text-text-secondary">
+                  {row.closestOwner ?? '—'}
+                </td>
+                {showRatio && (
+                  <td className="px-4 py-3 text-right tabular-nums text-text-muted">
+                    {`${String(Math.round(row.categoryTaggedRatio * 100))}%`}
+                  </td>
+                )}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -71,6 +111,33 @@ export function MissingTags() {
   const [selectedTag, setSelectedTag] = useState<DimensionId | null>(null);
   const [showLikelyUntaggable, setShowLikelyUntaggable] = useState(false);
   const [nonResourceExpanded, setNonResourceExpanded] = useState(false);
+  const [selectedResources, setSelectedResources] = useState<Set<string>>(new Set());
+
+  const handleToggleResource = (resourceId: string) => {
+    setSelectedResources((prev) => {
+      const next = new Set(prev);
+      if (next.has(resourceId)) {
+        next.delete(resourceId);
+      } else {
+        next.add(resourceId);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleAll = (rows: readonly MissingTagRow[]) => {
+    setSelectedResources((prev) => {
+      const allSelected = rows.every(row => prev.has(row.resourceId));
+      if (allSelected) {
+        const next = new Set(prev);
+        rows.forEach(row => { next.delete(row.resourceId); });
+        return next;
+      }
+      const next = new Set(prev);
+      rows.forEach(row => { next.add(row.resourceId); });
+      return next;
+    });
+  };
 
   const dimensions: Dimension[] =
     dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
@@ -204,7 +271,13 @@ export function MissingTags() {
               {String(actionableRows.length)} resources · {formatDollars(data.totalActionableCost)}
             </span>
           </h3>
-          <ResourceTable rows={actionableRows} showRatio />
+          <ResourceTable
+            rows={actionableRows}
+            showRatio
+            selectedResources={selectedResources}
+            onToggleResource={handleToggleResource}
+            onToggleAll={handleToggleAll}
+          />
         </div>
       )}
 
@@ -225,7 +298,13 @@ export function MissingTags() {
           <p className="text-xs text-text-muted -mt-2">
             No resource in these categories has been tagged in the selected period — either AWS doesn't allow tagging them, or your org never has.
           </p>
-          <ResourceTable rows={likelyUntaggableRows} showRatio={false} />
+          <ResourceTable
+            rows={likelyUntaggableRows}
+            showRatio={false}
+            selectedResources={selectedResources}
+            onToggleResource={handleToggleResource}
+            onToggleAll={handleToggleAll}
+          />
         </div>
       )}
 

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type {
   Dimension,
   DimensionId,
@@ -151,6 +151,10 @@ export function MissingTags() {
     : null;
   const activeTagId = selectedTag ?? firstTagId;
 
+  useEffect(() => {
+    setSelectedResources(new Set<string>());
+  }, [activeTagId]);
+
   const missingQuery = useQuery(
     () => {
       if (activeTagId === null) return Promise.resolve(null);
@@ -166,19 +170,22 @@ export function MissingTags() {
 
   const coverageHistoryQuery = useQuery(() => api.getTagCoverageHistory(), [api]);
 
-  const data: MissingTagsResult | null =
-    missingQuery.status === 'success' ? missingQuery.data : null;
+  const snapshotSavedRef = useRef<string | null>(null);
+  const missingData = missingQuery.status === 'success' ? missingQuery.data : null;
+  const data: MissingTagsResult | null = missingData;
 
   // Save coverage snapshot when data loads successfully
   useEffect(() => {
-    if (missingQuery.status !== 'success') return;
-    if (missingQuery.data === null) return;
+    if (missingData === null) return;
     if (activeTagId === null) return;
 
-    const snapshot = missingQuery.data;
+    const snapshotKey = `${activeTagId}-${String(missingData.actionableCount)}-${String(missingData.totalActionableCost)}`;
+    if (snapshotSavedRef.current === snapshotKey) return;
+    snapshotSavedRef.current = snapshotKey;
+
+    const snapshot = missingData;
     const dateRange = getDateRange();
 
-    // Query total cost to calculate coverage percentage
     api.queryCosts({
       dateRange,
       filters: {},
@@ -200,19 +207,9 @@ export function MissingTags() {
         coveragePercentage,
       };
 
-      api.saveTagCoverageSnapshot(coverageSnapshot).catch((error: unknown) => {
-        // Silently fail - this is background persistence
-        if (error instanceof Error) {
-          // Log would go here if we had a logger
-        }
-      });
-    }).catch((error: unknown) => {
-      // Silently fail - coverage calculation is not critical
-      if (error instanceof Error) {
-        // Log would go here if we had a logger
-      }
-    });
-  }, [missingQuery, activeTagId, api]);
+      api.saveTagCoverageSnapshot(coverageSnapshot).catch(() => { /* intentionally swallowed */ });
+    }).catch(() => { /* intentionally swallowed */ });
+  }, [missingData, activeTagId, api]);
 
   const actionableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'actionable');
   const likelyUntaggableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'likely-untaggable');

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -5,12 +5,15 @@ import type {
   DateString,
   MissingTagsResult,
   MissingTagRow,
+  TagCoverageSnapshot,
 } from '@costgoblin/core/browser';
 import { asDimensionId, asDateString, asDollars } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { getDimensionId, isTagDimension } from '../lib/dimensions.js';
 import { formatDollars } from '../components/format.js';
+import { RemediationActions } from '../components/remediation-actions.js';
+import { TagCoverageChart } from '../components/tag-coverage-chart.js';
 
 function getDateRange(): { start: DateString; end: DateString } {
   const today = new Date();
@@ -111,7 +114,7 @@ export function MissingTags() {
   const [selectedTag, setSelectedTag] = useState<DimensionId | null>(null);
   const [showLikelyUntaggable, setShowLikelyUntaggable] = useState(false);
   const [nonResourceExpanded, setNonResourceExpanded] = useState(false);
-  const [selectedResources, setSelectedResources] = useState<Set<string>>(new Set());
+  const [selectedResources, setSelectedResources] = useState(new Set<string>());
 
   const handleToggleResource = (resourceId: string) => {
     setSelectedResources((prev) => {
@@ -161,11 +164,27 @@ export function MissingTags() {
     [activeTagId, minCost, api],
   );
 
+  const coverageHistoryQuery = useQuery(() => api.getTagCoverageHistory(), [api]);
+
   const data: MissingTagsResult | null =
     missingQuery.status === 'success' ? missingQuery.data : null;
 
   const actionableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'actionable');
   const likelyUntaggableRows = data === null ? [] : data.rows.filter(r => r.bucket === 'likely-untaggable');
+
+  const coverageSnapshots: readonly TagCoverageSnapshot[] =
+    coverageHistoryQuery.status === 'success' ? coverageHistoryQuery.data : [];
+
+  const selectedRows: MissingTagRow[] = [];
+  const allRows = [...actionableRows, ...likelyUntaggableRows];
+  for (const row of allRows) {
+    if (selectedResources.has(row.resourceId)) {
+      selectedRows.push(row);
+    }
+  }
+
+  const activeTagDimension = tagDimensions.find(dim => getDimensionId(dim) === activeTagId);
+  const activeTagName = activeTagDimension !== undefined ? activeTagDimension.label : 'Tag';
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -220,6 +239,8 @@ export function MissingTags() {
           />
           <span>Show likely-untaggable categories</span>
         </label>
+
+        <RemediationActions selectedRows={selectedRows} tagName={activeTagName} />
       </div>
 
       {data !== null && (
@@ -250,6 +271,15 @@ export function MissingTags() {
             <p className="text-[11px] text-text-muted">
               tax, support, credits, and usage without a resource
             </p>
+          </div>
+        </div>
+      )}
+
+      {coverageSnapshots.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold text-text-primary">Tag Coverage Trend</h3>
+          <div className="rounded-xl border border-border bg-bg-secondary/50 p-4">
+            <TagCoverageChart snapshots={coverageSnapshots} height={240} />
           </div>
         </div>
       )}


### PR DESCRIPTION
Extend the Missing Tags View with actionable remediation workflows. Users can select untagged resources and generate a remediation report or create GitHub/Jira issues with pre-filled details (resource ARN, account, service, estimated cost impact, suggested owner). Track tagging improvement over time with a coverage trend chart.