### PR TITLE
LRU result cache for completed DuckDB queries

### DIFF
--- a/packages/desktop/src/__tests__/lru-cache.test.ts
+++ b/packages/desktop/src/__tests__/lru-cache.test.ts
@@ -185,7 +185,7 @@ describe('LRUCache edge cases', () => {
   it('handles large maxSize', () => {
     const cache = new LRUCache<string, number>(1000);
     for (let i = 0; i < 1000; i++) {
-      cache.set(`key${i}`, i);
+      cache.set(`key${String(i)}`, i);
     }
     expect(cache.size).toBe(1000);
     cache.set('overflow', 9999);
@@ -261,7 +261,7 @@ describe('LRUCache stress tests', () => {
   it('handles rapid set/get cycles', () => {
     const cache = new LRUCache<string, number>(10);
     for (let i = 0; i < 100; i++) {
-      cache.set(`key${i % 15}`, i);
+      cache.set(`key${String(i % 15)}`, i);
     }
     expect(cache.size).toBe(10);
   });

--- a/packages/desktop/src/__tests__/lru-cache.test.ts
+++ b/packages/desktop/src/__tests__/lru-cache.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import { LRUCache } from '../main/lru-cache.js';
+
+describe('LRUCache constructor', () => {
+  it('creates cache with positive maxSize', () => {
+    const cache = new LRUCache<string, number>(5);
+    expect(cache.size).toBe(0);
+  });
+
+  it('creates cache with maxSize 0', () => {
+    const cache = new LRUCache<string, number>(0);
+    expect(cache.size).toBe(0);
+  });
+
+  it('throws on negative maxSize', () => {
+    expect(() => new LRUCache<string, number>(-1)).toThrow('LRUCache maxSize must be non-negative');
+  });
+});
+
+describe('LRUCache basic operations', () => {
+  it('stores and retrieves values', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBe(2);
+  });
+
+  it('returns undefined for missing keys', () => {
+    const cache = new LRUCache<string, number>(3);
+    expect(cache.get('nonexistent')).toBeUndefined();
+  });
+
+  it('updates existing keys', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('a', 42);
+    expect(cache.get('a')).toBe(42);
+    expect(cache.size).toBe(1);
+  });
+
+  it('tracks size correctly', () => {
+    const cache = new LRUCache<string, number>(5);
+    expect(cache.size).toBe(0);
+    cache.set('a', 1);
+    expect(cache.size).toBe(1);
+    cache.set('b', 2);
+    expect(cache.size).toBe(2);
+    cache.delete('a');
+    expect(cache.size).toBe(1);
+  });
+});
+
+describe('LRUCache has/delete', () => {
+  it('checks key existence without updating access order', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+  });
+
+  it('deletes entries', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.has('a')).toBe(false);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.delete('nonexistent')).toBe(false);
+  });
+});
+
+describe('LRUCache clear', () => {
+  it('removes all entries', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    expect(cache.size).toBe(3);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBeUndefined();
+  });
+
+  it('works on empty cache', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});
+
+describe('LRUCache eviction', () => {
+  it('evicts oldest entry when full', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    cache.set('d', 4); // should evict 'a'
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+    expect(cache.get('d')).toBe(4);
+    expect(cache.size).toBe(3);
+  });
+
+  it('evicts in correct order after multiple insertions', () => {
+    const cache = new LRUCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3); // evicts 'a'
+    cache.set('d', 4); // evicts 'b'
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+    expect(cache.get('d')).toBe(4);
+  });
+});
+
+describe('LRUCache access order', () => {
+  it('updates access order on get', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    // Access 'a' to make it most recent
+    cache.get('a');
+    // Add 'd', should evict 'b' (oldest)
+    cache.set('d', 4);
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+    expect(cache.get('d')).toBe(4);
+  });
+
+  it('updates access order on set of existing key', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    // Update 'a' to make it most recent
+    cache.set('a', 42);
+    // Add 'd', should evict 'b' (oldest)
+    cache.set('d', 4);
+    expect(cache.get('a')).toBe(42);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+    expect(cache.get('d')).toBe(4);
+  });
+
+  it('preserves LRU order through multiple accesses', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    cache.get('a'); // a is now newest
+    cache.get('b'); // b is now newest, a is middle, c is oldest
+    cache.set('d', 4); // should evict c
+    expect(cache.get('c')).toBeUndefined();
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('d')).toBe(4);
+  });
+});
+
+describe('LRUCache edge cases', () => {
+  it('handles maxSize of 0 (no items stored)', () => {
+    const cache = new LRUCache<string, number>(0);
+    cache.set('a', 1);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it('handles maxSize of 1', () => {
+    const cache = new LRUCache<string, number>(1);
+    cache.set('a', 1);
+    expect(cache.get('a')).toBe(1);
+    cache.set('b', 2);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.size).toBe(1);
+  });
+
+  it('handles large maxSize', () => {
+    const cache = new LRUCache<string, number>(1000);
+    for (let i = 0; i < 1000; i++) {
+      cache.set(`key${i}`, i);
+    }
+    expect(cache.size).toBe(1000);
+    cache.set('overflow', 9999);
+    expect(cache.size).toBe(1000);
+    expect(cache.get('key0')).toBeUndefined(); // oldest evicted
+    expect(cache.get('key1')).toBe(1);
+    expect(cache.get('overflow')).toBe(9999);
+  });
+
+  it('works with different key types', () => {
+    const cache = new LRUCache<number, string>(3);
+    cache.set(1, 'one');
+    cache.set(2, 'two');
+    expect(cache.get(1)).toBe('one');
+    expect(cache.get(2)).toBe('two');
+  });
+
+  it('works with object values', () => {
+    const cache = new LRUCache<string, { value: number }>(3);
+    const obj1 = { value: 1 };
+    const obj2 = { value: 2 };
+    cache.set('a', obj1);
+    cache.set('b', obj2);
+    expect(cache.get('a')).toBe(obj1);
+    expect(cache.get('b')).toBe(obj2);
+  });
+});
+
+describe('LRUCache iterators', () => {
+  it('returns entries in LRU order', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    cache.get('a'); // move 'a' to end
+    const entries = Array.from(cache.entries());
+    expect(entries).toEqual([
+      ['b', 2],
+      ['c', 3],
+      ['a', 1],
+    ]);
+  });
+
+  it('returns keys in LRU order', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    const keys = Array.from(cache.keys());
+    expect(keys).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns values in LRU order', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    const values = Array.from(cache.values());
+    expect(values).toEqual([1, 2, 3]);
+  });
+
+  it('iterators reflect current state after modifications', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.delete('a');
+    const keys = Array.from(cache.keys());
+    expect(keys).toEqual(['b']);
+  });
+});
+
+describe('LRUCache stress tests', () => {
+  it('handles rapid set/get cycles', () => {
+    const cache = new LRUCache<string, number>(10);
+    for (let i = 0; i < 100; i++) {
+      cache.set(`key${i % 15}`, i);
+    }
+    expect(cache.size).toBe(10);
+  });
+
+  it('maintains integrity after mixed operations', () => {
+    const cache = new LRUCache<string, number>(5);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a');
+    cache.delete('b');
+    cache.set('c', 3);
+    cache.set('d', 4);
+    cache.set('e', 5);
+    cache.get('a');
+    cache.set('f', 6);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.size).toBe(5);
+  });
+});

--- a/packages/desktop/src/__tests__/lru-cache.test.ts
+++ b/packages/desktop/src/__tests__/lru-cache.test.ts
@@ -1,284 +1,62 @@
 import { describe, it, expect } from 'vitest';
 import { LRUCache } from '../main/lru-cache.js';
 
-describe('LRUCache constructor', () => {
-  it('creates cache with positive maxSize', () => {
-    const cache = new LRUCache<string, number>(5);
-    expect(cache.size).toBe(0);
-  });
-
-  it('creates cache with maxSize 0', () => {
-    const cache = new LRUCache<string, number>(0);
-    expect(cache.size).toBe(0);
-  });
-
-  it('throws on negative maxSize', () => {
-    expect(() => new LRUCache<string, number>(-1)).toThrow('LRUCache maxSize must be non-negative');
-  });
-});
-
-describe('LRUCache basic operations', () => {
+describe('LRUCache', () => {
   it('stores and retrieves values', () => {
     const cache = new LRUCache<string, number>(3);
     cache.set('a', 1);
     cache.set('b', 2);
     expect(cache.get('a')).toBe(1);
     expect(cache.get('b')).toBe(2);
+    expect(cache.get('missing')).toBeUndefined();
   });
 
-  it('returns undefined for missing keys', () => {
-    const cache = new LRUCache<string, number>(3);
-    expect(cache.get('nonexistent')).toBeUndefined();
-  });
-
-  it('updates existing keys', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('a', 42);
-    expect(cache.get('a')).toBe(42);
-    expect(cache.size).toBe(1);
-  });
-
-  it('tracks size correctly', () => {
-    const cache = new LRUCache<string, number>(5);
-    expect(cache.size).toBe(0);
-    cache.set('a', 1);
-    expect(cache.size).toBe(1);
-    cache.set('b', 2);
-    expect(cache.size).toBe(2);
-    cache.delete('a');
-    expect(cache.size).toBe(1);
-  });
-});
-
-describe('LRUCache has/delete', () => {
-  it('checks key existence without updating access order', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    expect(cache.has('a')).toBe(true);
-    expect(cache.has('b')).toBe(false);
-  });
-
-  it('deletes entries', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    expect(cache.delete('a')).toBe(true);
-    expect(cache.has('a')).toBe(false);
-    expect(cache.get('a')).toBeUndefined();
-    expect(cache.delete('nonexistent')).toBe(false);
-  });
-});
-
-describe('LRUCache clear', () => {
-  it('removes all entries', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.set('c', 3);
-    expect(cache.size).toBe(3);
-    cache.clear();
-    expect(cache.size).toBe(0);
-    expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toBeUndefined();
-    expect(cache.get('c')).toBeUndefined();
-  });
-
-  it('works on empty cache', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.clear();
-    expect(cache.size).toBe(0);
-  });
-});
-
-describe('LRUCache eviction', () => {
   it('evicts oldest entry when full', () => {
     const cache = new LRUCache<string, number>(3);
     cache.set('a', 1);
     cache.set('b', 2);
     cache.set('c', 3);
-    cache.set('d', 4); // should evict 'a'
+    cache.set('d', 4);
     expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toBe(2);
-    expect(cache.get('c')).toBe(3);
     expect(cache.get('d')).toBe(4);
     expect(cache.size).toBe(3);
   });
 
-  it('evicts in correct order after multiple insertions', () => {
-    const cache = new LRUCache<string, number>(2);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.set('c', 3); // evicts 'a'
-    cache.set('d', 4); // evicts 'b'
-    expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toBeUndefined();
-    expect(cache.get('c')).toBe(3);
-    expect(cache.get('d')).toBe(4);
-  });
-});
-
-describe('LRUCache access order', () => {
-  it('updates access order on get', () => {
+  it('get promotes entry so it is not evicted next', () => {
     const cache = new LRUCache<string, number>(3);
     cache.set('a', 1);
     cache.set('b', 2);
     cache.set('c', 3);
-    // Access 'a' to make it most recent
     cache.get('a');
-    // Add 'd', should evict 'b' (oldest)
     cache.set('d', 4);
     expect(cache.get('a')).toBe(1);
     expect(cache.get('b')).toBeUndefined();
-    expect(cache.get('c')).toBe(3);
-    expect(cache.get('d')).toBe(4);
   });
 
-  it('updates access order on set of existing key', () => {
+  it('set of existing key promotes it', () => {
     const cache = new LRUCache<string, number>(3);
     cache.set('a', 1);
     cache.set('b', 2);
     cache.set('c', 3);
-    // Update 'a' to make it most recent
     cache.set('a', 42);
-    // Add 'd', should evict 'b' (oldest)
     cache.set('d', 4);
     expect(cache.get('a')).toBe(42);
     expect(cache.get('b')).toBeUndefined();
-    expect(cache.get('c')).toBe(3);
-    expect(cache.get('d')).toBe(4);
   });
 
-  it('preserves LRU order through multiple accesses', () => {
+  it('clear removes all entries', () => {
     const cache = new LRUCache<string, number>(3);
     cache.set('a', 1);
     cache.set('b', 2);
-    cache.set('c', 3);
-    cache.get('a'); // a is now newest
-    cache.get('b'); // b is now newest, a is middle, c is oldest
-    cache.set('d', 4); // should evict c
-    expect(cache.get('c')).toBeUndefined();
-    expect(cache.get('a')).toBe(1);
-    expect(cache.get('b')).toBe(2);
-    expect(cache.get('d')).toBe(4);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.get('a')).toBeUndefined();
   });
-});
 
-describe('LRUCache edge cases', () => {
-  it('handles maxSize of 0 (no items stored)', () => {
+  it('maxSize 0 stores nothing', () => {
     const cache = new LRUCache<string, number>(0);
     cache.set('a', 1);
-    expect(cache.get('a')).toBeUndefined();
     expect(cache.size).toBe(0);
-  });
-
-  it('handles maxSize of 1', () => {
-    const cache = new LRUCache<string, number>(1);
-    cache.set('a', 1);
-    expect(cache.get('a')).toBe(1);
-    cache.set('b', 2);
     expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toBe(2);
-    expect(cache.size).toBe(1);
-  });
-
-  it('handles large maxSize', () => {
-    const cache = new LRUCache<string, number>(1000);
-    for (let i = 0; i < 1000; i++) {
-      cache.set(`key${String(i)}`, i);
-    }
-    expect(cache.size).toBe(1000);
-    cache.set('overflow', 9999);
-    expect(cache.size).toBe(1000);
-    expect(cache.get('key0')).toBeUndefined(); // oldest evicted
-    expect(cache.get('key1')).toBe(1);
-    expect(cache.get('overflow')).toBe(9999);
-  });
-
-  it('works with different key types', () => {
-    const cache = new LRUCache<number, string>(3);
-    cache.set(1, 'one');
-    cache.set(2, 'two');
-    expect(cache.get(1)).toBe('one');
-    expect(cache.get(2)).toBe('two');
-  });
-
-  it('works with object values', () => {
-    const cache = new LRUCache<string, { value: number }>(3);
-    const obj1 = { value: 1 };
-    const obj2 = { value: 2 };
-    cache.set('a', obj1);
-    cache.set('b', obj2);
-    expect(cache.get('a')).toBe(obj1);
-    expect(cache.get('b')).toBe(obj2);
-  });
-});
-
-describe('LRUCache iterators', () => {
-  it('returns entries in LRU order', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.set('c', 3);
-    cache.get('a'); // move 'a' to end
-    const entries = Array.from(cache.entries());
-    expect(entries).toEqual([
-      ['b', 2],
-      ['c', 3],
-      ['a', 1],
-    ]);
-  });
-
-  it('returns keys in LRU order', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.set('c', 3);
-    const keys = Array.from(cache.keys());
-    expect(keys).toEqual(['a', 'b', 'c']);
-  });
-
-  it('returns values in LRU order', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.set('c', 3);
-    const values = Array.from(cache.values());
-    expect(values).toEqual([1, 2, 3]);
-  });
-
-  it('iterators reflect current state after modifications', () => {
-    const cache = new LRUCache<string, number>(3);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.delete('a');
-    const keys = Array.from(cache.keys());
-    expect(keys).toEqual(['b']);
-  });
-});
-
-describe('LRUCache stress tests', () => {
-  it('handles rapid set/get cycles', () => {
-    const cache = new LRUCache<string, number>(10);
-    for (let i = 0; i < 100; i++) {
-      cache.set(`key${String(i % 15)}`, i);
-    }
-    expect(cache.size).toBe(10);
-  });
-
-  it('maintains integrity after mixed operations', () => {
-    const cache = new LRUCache<string, number>(5);
-    cache.set('a', 1);
-    cache.set('b', 2);
-    cache.get('a');
-    cache.delete('b');
-    cache.set('c', 3);
-    cache.set('d', 4);
-    cache.set('e', 5);
-    cache.get('a');
-    cache.set('f', 6);
-    expect(cache.has('a')).toBe(true);
-    expect(cache.has('b')).toBe(false);
-    expect(cache.size).toBe(5);
   });
 });

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -515,7 +515,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
       void materializedBase.drop((s) => ctx.db.runQuery(s), () => { resultCache.clear(); }).then(() => { void warmupBase(); });
     },
     invalidateColumnCache: () => { columnCache.clear(); },
-    warmupBase: () => { void warmupBase(); },
+    warmupBase: () => { resultCache.clear(); void warmupBase(); },
   };
 }
 

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -433,7 +433,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     if (cached !== undefined) return Promise.resolve(cached);
     return dedup(sql, async () => {
       const result = await wrappedRunQuery(sql);
-      resultCache.set(sql, result);
+      if (result.length > 0) resultCache.set(sql, result);
       return result;
     });
   };
@@ -444,7 +444,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     if (cached !== undefined) return Promise.resolve(cached);
     return dedup(key, async () => {
       const result = await wrappedRunPreparedQuery(sql, params);
-      resultCache.set(key, result);
+      if (result.length > 0) resultCache.set(key, result);
       return result;
     });
   };

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -1,4 +1,5 @@
 import type { DuckDBClient, RawRow } from '../duckdb-client.js';
+import { LRUCache } from '../lru-cache.js';
 import { QueryLog } from '../query-log.js';
 import { MaterializedBase, configHash } from '../materialized-base.js';
 import {
@@ -411,6 +412,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
 
   const queryLog = new QueryLog();
   const materializedBase = new MaterializedBase();
+  const resultCache = new LRUCache<string, RawRow[]>(50);
 
   const wrappedRunQuery = queryLog.wrapQuery((sql, onStarted) => ctx.db.runQuery(sql, onStarted));
   const wrappedRunPreparedQuery = queryLog.wrapPreparedQuery((sql, params, onStarted) => ctx.db.runPreparedQuery(sql, params, onStarted));
@@ -426,11 +428,26 @@ export function createAppContext(ctx: IpcContext): AppContext {
     return promise;
   }
 
-  const runQuery = (sql: string) => dedup(sql, () => wrappedRunQuery(sql));
-  const runPreparedQuery = (sql: string, params: readonly unknown[]) => dedup(
-    `${sql}\0${JSON.stringify(params)}`,
-    () => wrappedRunPreparedQuery(sql, params),
-  );
+  const runQuery = (sql: string): Promise<RawRow[]> => {
+    const cached = resultCache.get(sql);
+    if (cached !== undefined) return Promise.resolve(cached);
+    return dedup(sql, async () => {
+      const result = await wrappedRunQuery(sql);
+      resultCache.set(sql, result);
+      return result;
+    });
+  };
+
+  const runPreparedQuery = (sql: string, params: readonly unknown[]): Promise<RawRow[]> => {
+    const key = `${sql}\0${JSON.stringify(params)}`;
+    const cached = resultCache.get(key);
+    if (cached !== undefined) return Promise.resolve(cached);
+    return dedup(key, async () => {
+      const result = await wrappedRunPreparedQuery(sql, params);
+      resultCache.set(key, result);
+      return result;
+    });
+  };
 
   async function warmupBase(): Promise<void> {
     try {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -507,12 +507,12 @@ export function createAppContext(ctx: IpcContext): AppContext {
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => {
       state.dimensions = null; state.accountMap = null; state.accountReverseMap = null; state.regionMap = null; state.orgAccountsPath = null;
-      void materializedBase.drop((s) => ctx.db.runQuery(s)).then(() => { void warmupBase(); });
+      void materializedBase.drop((s) => ctx.db.runQuery(s), () => { resultCache.clear(); }).then(() => { void warmupBase(); });
     },
     invalidateViews: () => { state.views = null; },
     invalidateCostScope: () => {
       state.costScope = null;
-      void materializedBase.drop((s) => ctx.db.runQuery(s)).then(() => { void warmupBase(); });
+      void materializedBase.drop((s) => ctx.db.runQuery(s), () => { resultCache.clear(); }).then(() => { void warmupBase(); });
     },
     invalidateColumnCache: () => { columnCache.clear(); },
     warmupBase: () => { void warmupBase(); },

--- a/packages/desktop/src/main/lru-cache.ts
+++ b/packages/desktop/src/main/lru-cache.ts
@@ -1,0 +1,108 @@
+/**
+ * Generic LRU (Least Recently Used) cache with automatic eviction.
+ *
+ * Uses a Map to track insertion order; when an item is accessed, it's
+ * deleted and re-inserted to move it to the end (most recent).
+ * When the cache reaches maxSize, the oldest (first) entry is evicted.
+ */
+export class LRUCache<K, V> {
+  private readonly maxSize: number;
+  private readonly cache: Map<K, V>;
+
+  constructor(maxSize: number) {
+    if (maxSize < 0) {
+      throw new Error('LRUCache maxSize must be non-negative');
+    }
+    this.maxSize = maxSize;
+    this.cache = new Map();
+  }
+
+  /**
+   * Retrieves a value from the cache and marks it as recently used.
+   * Returns undefined if the key is not in the cache.
+   */
+  get(key: K): V | undefined {
+    const value = this.cache.get(key);
+    if (value === undefined) {
+      return undefined;
+    }
+    // Move to end by deleting and re-inserting
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return value;
+  }
+
+  /**
+   * Adds or updates a value in the cache.
+   * If the cache is full, evicts the least recently used entry first.
+   */
+  set(key: K, value: V): void {
+    // If key already exists, delete it first so re-insertion moves it to the end
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+    // Evict oldest entry if we're at capacity and this is a new key
+    if (this.cache.size >= this.maxSize && this.maxSize > 0) {
+      const oldest = this.cache.keys().next();
+      if (!oldest.done) {
+        this.cache.delete(oldest.value);
+      }
+    }
+    // Only insert if maxSize > 0
+    if (this.maxSize > 0) {
+      this.cache.set(key, value);
+    }
+  }
+
+  /**
+   * Checks if a key exists in the cache without updating access order.
+   */
+  has(key: K): boolean {
+    return this.cache.has(key);
+  }
+
+  /**
+   * Removes a specific entry from the cache.
+   */
+  delete(key: K): boolean {
+    return this.cache.delete(key);
+  }
+
+  /**
+   * Removes all entries from the cache.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Returns the current number of entries in the cache.
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * Returns an iterator over the cache entries in access order
+   * (least recently used first).
+   */
+  entries(): IterableIterator<[K, V]> {
+    return this.cache.entries();
+  }
+
+  /**
+   * Returns an iterator over the cache keys in access order
+   * (least recently used first).
+   */
+  keys(): IterableIterator<K> {
+    return this.cache.keys();
+  }
+
+  /**
+   * Returns an iterator over the cache values in access order
+   * (least recently used first).
+   */
+  values(): IterableIterator<V> {
+    return this.cache.values();
+  }
+}

--- a/packages/desktop/src/main/lru-cache.ts
+++ b/packages/desktop/src/main/lru-cache.ts
@@ -1,108 +1,32 @@
-/**
- * Generic LRU (Least Recently Used) cache with automatic eviction.
- *
- * Uses a Map to track insertion order; when an item is accessed, it's
- * deleted and re-inserted to move it to the end (most recent).
- * When the cache reaches maxSize, the oldest (first) entry is evicted.
- */
+// Map-based LRU: delete+re-insert moves entries to the end; eviction pops the first.
 export class LRUCache<K, V> {
   private readonly maxSize: number;
-  private readonly cache: Map<K, V>;
+  private readonly cache = new Map<K, V>();
 
   constructor(maxSize: number) {
-    if (maxSize < 0) {
-      throw new Error('LRUCache maxSize must be non-negative');
-    }
+    if (maxSize < 0) throw new Error('LRUCache maxSize must be non-negative');
     this.maxSize = maxSize;
-    this.cache = new Map();
   }
 
-  /**
-   * Retrieves a value from the cache and marks it as recently used.
-   * Returns undefined if the key is not in the cache.
-   */
   get(key: K): V | undefined {
     const value = this.cache.get(key);
-    if (value === undefined) {
-      return undefined;
-    }
-    // Move to end by deleting and re-inserting
+    if (value === undefined) return undefined;
     this.cache.delete(key);
     this.cache.set(key, value);
     return value;
   }
 
-  /**
-   * Adds or updates a value in the cache.
-   * If the cache is full, evicts the least recently used entry first.
-   */
   set(key: K, value: V): void {
-    // If key already exists, delete it first so re-insertion moves it to the end
-    if (this.cache.has(key)) {
-      this.cache.delete(key);
-    }
-    // Evict oldest entry if we're at capacity and this is a new key
+    if (this.cache.has(key)) this.cache.delete(key);
     if (this.cache.size >= this.maxSize && this.maxSize > 0) {
       const oldest = this.cache.keys().next();
-      if (!oldest.done) {
-        this.cache.delete(oldest.value);
-      }
+      if (!oldest.done) this.cache.delete(oldest.value);
     }
-    // Only insert if maxSize > 0
-    if (this.maxSize > 0) {
-      this.cache.set(key, value);
-    }
+    if (this.maxSize > 0) this.cache.set(key, value);
   }
 
-  /**
-   * Checks if a key exists in the cache without updating access order.
-   */
-  has(key: K): boolean {
-    return this.cache.has(key);
-  }
-
-  /**
-   * Removes a specific entry from the cache.
-   */
-  delete(key: K): boolean {
-    return this.cache.delete(key);
-  }
-
-  /**
-   * Removes all entries from the cache.
-   */
-  clear(): void {
-    this.cache.clear();
-  }
-
-  /**
-   * Returns the current number of entries in the cache.
-   */
-  get size(): number {
-    return this.cache.size;
-  }
-
-  /**
-   * Returns an iterator over the cache entries in access order
-   * (least recently used first).
-   */
-  entries(): IterableIterator<[K, V]> {
-    return this.cache.entries();
-  }
-
-  /**
-   * Returns an iterator over the cache keys in access order
-   * (least recently used first).
-   */
-  keys(): IterableIterator<K> {
-    return this.cache.keys();
-  }
-
-  /**
-   * Returns an iterator over the cache values in access order
-   * (least recently used first).
-   */
-  values(): IterableIterator<V> {
-    return this.cache.values();
-  }
+  has(key: K): boolean { return this.cache.has(key); }
+  delete(key: K): boolean { return this.cache.delete(key); }
+  clear(): void { this.cache.clear(); }
+  get size(): number { return this.cache.size; }
 }

--- a/packages/desktop/src/main/materialized-base.ts
+++ b/packages/desktop/src/main/materialized-base.ts
@@ -49,9 +49,15 @@ export class MaterializedBase {
     return this.pending;
   }
 
-  async drop(runQuery: (sql: string) => Promise<RawRow[]>): Promise<void> {
+  async drop(
+    runQuery: (sql: string) => Promise<RawRow[]>,
+    onDrop?: () => void,
+  ): Promise<void> {
     this.state = null;
     this.pending = null;
+    if (onDrop !== undefined) {
+      onDrop();
+    }
     try {
       await runQuery('DROP TABLE IF EXISTS cost_base');
     } catch {


### PR DESCRIPTION
## Summary

- Adds an LRU cache (50 entries) in front of DuckDB query execution in `createAppContext`
- Repeat queries (e.g. navigating back to a view) return cached results instantly
- Cache is invalidated when dimensions or cost scope change (via `materializedBase.drop`)