### PR TITLE
Document E2E tests and perf benchmarks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ make dev        # launch Electron in dev mode
 make prod       # build and launch in production mode
 make test       # run vitest
 make lint       # run tsc + eslint
-make reset      # wipe app data, restart with wizard
+make reset      # wipe app data and config (next launch shows wizard)
 ```
 
 ### E2E Tests
@@ -218,6 +218,16 @@ make e2e-stress   # widget growth stress tests
 
 ```bash
 make perf       # build + run full benchmark suite
+```
+
+### Packaging & Release
+
+```bash
+make dist         # build distributable installer for current platform
+make dist-mac     # build macOS .dmg and .zip (current arch)
+make dist-win     # build Windows .exe installer
+make dist-linux   # build Linux .AppImage and .deb
+make release      # interactive version bump (patch/minor/major), tag, and push
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -193,9 +193,31 @@ packages/
 ```bash
 make help       # show available commands
 make dev        # launch Electron in dev mode
+make prod       # build and launch in production mode
 make test       # run vitest
 make lint       # run tsc + eslint
 make reset      # wipe app data, restart with wizard
+```
+
+### E2E Tests
+
+```bash
+make e2e          # all E2E suites + coverage
+make e2e-core     # core views (Overview, Trends, Missing Tags, Savings, Explorer)
+make e2e-config   # config views (Sync, Dimensions, Cost Scope)
+make e2e-stress   # widget growth stress tests
+```
+
+### Performance Benchmarks
+
+`make perf` launches the app with `COSTGOBLIN_PERF_MODE=1` and runs a Playwright suite that measures every view and interaction:
+
+- Wall clock time, IPC call count/duration, React render count/duration, heap delta
+- CPU profiles per section (loadable in Chrome DevTools → Performance tab)
+- Outputs a markdown report to `/tmp/costgoblin-perf/report.md`
+
+```bash
+make perf       # build + run full benchmark suite
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Adds missing Makefile commands to the Development section (`make prod`, E2E targets)
- Documents `make perf` and what it measures (wall clock, IPC, React renders, heap, CPU profiles)