### PR TITLE
UI polish: remove dead histogram tabs, improve tooltip

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -257,16 +257,8 @@ test.describe('Cost Overview', () => {
     }
   });
 
-  test('stacked bar chart renders with tab toggles (Groups, Products, Services)', async () => {
-    for (const tabName of ['Groups', 'Products', 'Services']) {
-      const tab = page.getByRole('button', { name: tabName });
-      await expect(tab).toBeVisible();
-    }
-
-    // switch between tabs
-    for (const tabName of ['Products', 'Services', 'Groups']) {
-      await page.getByRole('button', { name: tabName }).click();
-    }
+  test('stacked bar chart renders with title', async () => {
+    await expect(page.getByText('Daily Costs')).toBeVisible();
   });
 
   test('histogram expand/collapse toggle works', async () => {

--- a/packages/ui/src/__tests__/cost-overview.test.tsx
+++ b/packages/ui/src/__tests__/cost-overview.test.tsx
@@ -38,14 +38,11 @@ describe('CostOverview', () => {
     expect(screen.getByText('Daily Costs')).toBeDefined();
   });
 
-  it('renders daily costs chart with tab selector', async () => {
+  it('renders daily costs chart', async () => {
     renderOverview();
     await waitFor(() => {
       expect(screen.getByText('Daily Costs')).toBeDefined();
     });
-    expect(screen.getByText('Groups')).toBeDefined();
-    expect(screen.getByText('Products')).toBeDefined();
-    expect(screen.getByText('Services')).toBeDefined();
   });
 
   it('changing date range triggers a new query', async () => {

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -91,7 +91,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         const minChartHeight = expanded ? 360 : 180;
         const ticks = [1, 0.75, 0.5, 0.25, 0];
         return (
-        <div className="relative flex-1" style={{ minHeight: `${String(minChartHeight)}px` }}>
+        <div className="relative flex-1 pb-5" style={{ minHeight: `${String(minChartHeight)}px` }}>
           {/* Y axis ticks */}
           <div className="absolute left-0 top-0 w-10 h-full">
             {ticks.map(pct => (
@@ -230,15 +230,19 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
 
           {/* X axis */}
-          <div className="flex ml-12 mt-1" style={{ gap: '2px' }}>
+          <div className="relative ml-12 h-4 mt-1">
             {days.map((day, idx) => {
               const step = Math.max(1, Math.ceil(days.length / 7));
+              if (idx % step !== 0) return null;
+              const pct = days.length > 1 ? (idx / (days.length - 1)) * 100 : 0;
               return (
-              <div key={day.date} className="flex-1 min-w-0 text-center overflow-hidden">
-                {idx % step === 0 ? (
-                  <span className="text-[10px] text-text-muted whitespace-nowrap">{day.date.slice(5)}</span>
-                ) : null}
-              </div>
+                <span
+                  key={day.date}
+                  className="absolute text-[10px] text-text-muted whitespace-nowrap -translate-x-1/2"
+                  style={{ left: `${String(pct)}%` }}
+                >
+                  {day.date.slice(5)}
+                </span>
               );
             })}
           </div>

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -110,7 +110,8 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
 
           <div className="flex items-end ml-12 relative z-10 h-full" style={{ gap: '2px' }}>
-            {days.map((day) => {
+            {days.map((day, dayIdx) => {
+              const prevDay = dayIdx > 0 ? days[dayIdx - 1] : undefined;
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys
                 .map((key, ki) => ({
@@ -154,37 +155,59 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                     })}
                   </div>
 
-                  {isHovered && (
+                  {isHovered && (() => {
+                    const prevTotal = prevDay?.total ?? 0;
+                    const totalDelta = prevDay !== undefined && prevTotal > 0
+                      ? ((day.total - prevTotal) / prevTotal) * 100
+                      : undefined;
+                    return (
                     <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20">
-                      <div className="rounded-lg bg-bg-secondary/95 px-3 py-2 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[160px]">
-                        <div className="font-semibold mb-1.5 text-xs">{day.date}</div>
-                        <div className="flex items-center justify-between font-medium mb-1 pb-1 border-b border-border-subtle">
-                          <span>Total</span>
-                          <span>{formatDollars(day.total)}</span>
+                      <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px]">
+                        <div className="flex items-center justify-between mb-2 pb-2 border-b border-border-subtle">
+                          <span className="font-semibold text-xs">{day.date}</span>
+                          <span className="font-semibold text-xs">
+                            Total: {formatDollars(day.total)}
+                            {totalDelta !== undefined && (
+                              <span className={`ml-1.5 text-[10px] font-normal ${totalDelta >= 0 ? 'text-negative' : 'text-positive'}`}>
+                                {totalDelta >= 0 ? '↑' : '↓'}{Math.abs(totalDelta).toFixed(1)}%
+                              </span>
+                            )}
+                          </span>
                         </div>
-                        <div className="flex flex-col gap-0.5 mt-1">
+                        <div className="flex flex-col gap-px">
                           {segments
-                            .slice(0, 8)
+                            .slice(0, 12)
                             .map(seg => {
                               const color = getColor(seg.colorIdx, palette);
-                              const isHighlighted = highlightedGroup === seg.key;
+                              const isHigh = highlightedGroup === seg.key;
+                              const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
+                              const prevVal = prevDay?.breakdown[seg.key] ?? 0;
+                              const delta = prevDay !== undefined && prevVal > 0
+                                ? ((seg.value - prevVal) / prevVal) * 100
+                                : undefined;
                               return (
                                 <div
                                   key={seg.key}
-                                  className={`flex items-center justify-between gap-3 rounded px-1 -mx-1 ${isHighlighted ? 'bg-white/10' : ''}`}
+                                  className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}
                                 >
-                                  <div className="flex items-center gap-1.5">
-                                    <span className="inline-block w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: color }} />
-                                    <span className={`truncate max-w-[120px] ${isHighlighted ? 'text-text-primary font-medium' : 'text-text-secondary'}`}>{seg.key}</span>
-                                  </div>
-                                  <span className={`tabular-nums ${isHighlighted ? 'text-text-primary font-medium' : 'text-text-primary'}`}>{formatDollars(seg.value)}</span>
+                                  <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                                  <span className={`truncate flex-1 min-w-0 ${isHigh ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>{seg.key}</span>
+                                  <span className={`tabular-nums shrink-0 ${isHigh ? 'font-semibold' : ''}`}>
+                                    {formatDollars(seg.value)} <span className="text-text-muted">({pct.toFixed(1)}%)</span>
+                                  </span>
+                                  {delta !== undefined && (
+                                    <span className={`tabular-nums text-[10px] shrink-0 ${delta >= 0 ? 'text-negative' : 'text-positive'}`}>
+                                      {delta >= 0 ? '↑' : '↓'}{Math.abs(delta).toFixed(1)}%
+                                    </span>
+                                  )}
                                 </div>
                               );
                             })}
                         </div>
                       </div>
                     </div>
-                  )}
+                    );
+                  })()}
                 </button>
               );
             })}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -15,8 +15,8 @@ export type HistogramTab = 'owner' | 'product' | 'service';
 interface StackedBarChartProps {
   readonly days: readonly BarDay[];
   readonly highlightedGroup?: string | null;
-  readonly tab: HistogramTab;
-  readonly onTabChange: (tab: HistogramTab) => void;
+  readonly tab?: HistogramTab | undefined;
+  readonly onTabChange?: ((tab: HistogramTab) => void) | undefined;
   readonly expanded?: boolean | undefined;
   readonly onExpandToggle?: (() => void) | undefined;
   readonly title?: string | undefined;
@@ -37,34 +37,34 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
 
   const maxCost = days.reduce((m, d) => Math.max(m, d.total), 0);
 
-  const tabs: readonly { key: HistogramTab; label: string }[] = [
-    { key: 'owner', label: 'Groups' },
-    { key: 'product', label: 'Products' },
-    { key: 'service', label: 'Services' },
-  ];
-
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4 flex flex-col h-full">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-medium text-text-secondary">{title ?? 'Daily Costs'}</h3>
         <div className="flex items-center gap-2">
-        <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-          {tabs.map(t => (
-            <button
-              key={t.key}
-              type="button"
-              onClick={() => { onTabChange(t.key); }}
-              className={[
-                'rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors',
-                tab === t.key
-                  ? 'bg-accent text-bg-primary shadow-sm'
-                  : 'text-text-secondary hover:text-text-primary',
-              ].join(' ')}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
+        {tab !== undefined && onTabChange !== undefined && (
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
+            {([
+              { key: 'owner' as const, label: 'Groups' },
+              { key: 'product' as const, label: 'Products' },
+              { key: 'service' as const, label: 'Services' },
+            ]).map(t => (
+              <button
+                key={t.key}
+                type="button"
+                onClick={() => { onTabChange(t.key); }}
+                className={[
+                  'rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors',
+                  tab === t.key
+                    ? 'bg-accent text-bg-primary shadow-sm'
+                    : 'text-text-secondary hover:text-text-primary',
+                ].join(' ')}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        )}
         {onExpandToggle !== undefined && (
           <button
             type="button"

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -109,9 +109,68 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             ))}
           </div>
 
+          {/* Floating tooltip — anchored to top-right of chart area */}
+          {hoveredDay !== null && (() => {
+            const idx = days.findIndex(d => d.date === hoveredDay);
+            if (idx < 0) return null;
+            const day = days[idx];
+            if (day === undefined) return null;
+            const prev = idx > 0 ? days[idx - 1] : undefined;
+            const prevTotal = prev?.total ?? 0;
+            const totalDelta = prev !== undefined && prevTotal > 0
+              ? ((day.total - prevTotal) / prevTotal) * 100
+              : undefined;
+            const segs = breakdownKeys
+              .map((key, ki) => ({ key, value: day.breakdown[key] ?? 0, colorIdx: ki }))
+              .filter(s => s.value > 0)
+              .sort((a, b) => b.value - a.value);
+            const segTotal = segs.reduce((sum, s) => sum + s.value, 0);
+            return (
+              <div className="pointer-events-none absolute top-0 right-0 z-20 mr-1 mt-1">
+                <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px]">
+                  <div className="flex items-center justify-between mb-2 pb-2 border-b border-border-subtle">
+                    <span className="font-semibold text-xs">{day.date}</span>
+                    <span className="font-semibold text-xs">
+                      Total: {formatDollars(day.total)}
+                      {totalDelta !== undefined && (
+                        <span className={`ml-1.5 text-[10px] font-normal ${totalDelta >= 0 ? 'text-negative' : 'text-positive'}`}>
+                          {totalDelta >= 0 ? '↑' : '↓'}{Math.abs(totalDelta).toFixed(1)}%
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-px">
+                    {segs.slice(0, 12).map(seg => {
+                      const color = getColor(seg.colorIdx, palette);
+                      const isHigh = highlightedGroup === seg.key;
+                      const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
+                      const prevVal = prev?.breakdown[seg.key] ?? 0;
+                      const delta = prev !== undefined && prevVal > 0
+                        ? ((seg.value - prevVal) / prevVal) * 100
+                        : undefined;
+                      return (
+                        <div key={seg.key} className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}>
+                          <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                          <span className={`truncate flex-1 min-w-0 ${isHigh ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>{seg.key}</span>
+                          <span className={`tabular-nums shrink-0 ${isHigh ? 'font-semibold' : ''}`}>
+                            {formatDollars(seg.value)} <span className="text-text-muted">({pct.toFixed(1)}%)</span>
+                          </span>
+                          {delta !== undefined && (
+                            <span className={`tabular-nums text-[10px] shrink-0 ${delta >= 0 ? 'text-negative' : 'text-positive'}`}>
+                              {delta >= 0 ? '↑' : '↓'}{Math.abs(delta).toFixed(1)}%
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })()}
+
           <div className="flex items-end ml-12 relative z-10 h-full" style={{ gap: '2px' }}>
-            {days.map((day, dayIdx) => {
-              const prevDay = dayIdx > 0 ? days[dayIdx - 1] : undefined;
+            {days.map((day) => {
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys
                 .map((key, ki) => ({
@@ -122,7 +181,6 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                 .filter(s => s.value > 0)
                 .sort((a, b) => b.value - a.value);
               const segTotal = segments.reduce((sum, s) => sum + s.value, 0);
-              const isHovered = hoveredDay === day.date;
 
               return (
                 <button
@@ -155,59 +213,6 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                     })}
                   </div>
 
-                  {isHovered && (() => {
-                    const prevTotal = prevDay?.total ?? 0;
-                    const totalDelta = prevDay !== undefined && prevTotal > 0
-                      ? ((day.total - prevTotal) / prevTotal) * 100
-                      : undefined;
-                    return (
-                    <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20">
-                      <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px]">
-                        <div className="flex items-center justify-between mb-2 pb-2 border-b border-border-subtle">
-                          <span className="font-semibold text-xs">{day.date}</span>
-                          <span className="font-semibold text-xs">
-                            Total: {formatDollars(day.total)}
-                            {totalDelta !== undefined && (
-                              <span className={`ml-1.5 text-[10px] font-normal ${totalDelta >= 0 ? 'text-negative' : 'text-positive'}`}>
-                                {totalDelta >= 0 ? '↑' : '↓'}{Math.abs(totalDelta).toFixed(1)}%
-                              </span>
-                            )}
-                          </span>
-                        </div>
-                        <div className="flex flex-col gap-px">
-                          {segments
-                            .slice(0, 12)
-                            .map(seg => {
-                              const color = getColor(seg.colorIdx, palette);
-                              const isHigh = highlightedGroup === seg.key;
-                              const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
-                              const prevVal = prevDay?.breakdown[seg.key] ?? 0;
-                              const delta = prevDay !== undefined && prevVal > 0
-                                ? ((seg.value - prevVal) / prevVal) * 100
-                                : undefined;
-                              return (
-                                <div
-                                  key={seg.key}
-                                  className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}
-                                >
-                                  <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                                  <span className={`truncate flex-1 min-w-0 ${isHigh ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>{seg.key}</span>
-                                  <span className={`tabular-nums shrink-0 ${isHigh ? 'font-semibold' : ''}`}>
-                                    {formatDollars(seg.value)} <span className="text-text-muted">({pct.toFixed(1)}%)</span>
-                                  </span>
-                                  {delta !== undefined && (
-                                    <span className={`tabular-nums text-[10px] shrink-0 ${delta >= 0 ? 'text-negative' : 'text-positive'}`}>
-                                      {delta >= 0 ? '↑' : '↓'}{Math.abs(delta).toFixed(1)}%
-                                    </span>
-                                  )}
-                                </div>
-                              );
-                            })}
-                        </div>
-                      </div>
-                    </div>
-                    );
-                  })()}
                 </button>
               );
             })}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -229,15 +229,12 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             })}
           </div>
 
-          {/* X axis — full width so first label aligns with Y axis ticks */}
-          <div className="relative h-4 mt-1">
+          {/* X axis — aligned with bar area (ml-12) */}
+          <div className="relative ml-12 h-4 mt-1">
             {days.map((day, idx) => {
               const step = Math.max(1, Math.ceil(days.length / 7));
               if (idx % step !== 0) return null;
-              const frac = days.length > 1 ? idx / (days.length - 1) : 0;
-              // Interpolate from Y axis edge (2.5rem) to right edge (100%).
-              // left = 2.5rem + frac * (100% - 2.5rem) = 2.5rem*(1-frac) + frac*100%
-              const left = `calc(${String((1 - frac) * 2.5)}rem + ${String(frac * 100)}%)`;
+              const pct = days.length > 1 ? (idx / (days.length - 1)) * 100 : 0;
               const isFirst = idx === 0;
               const isLast = idx >= days.length - step;
               const align = isFirst ? '' : isLast ? '-translate-x-full' : '-translate-x-1/2';
@@ -245,7 +242,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                 <span
                   key={day.date}
                   className={`absolute text-[10px] text-text-muted whitespace-nowrap ${align}`}
-                  style={{ left }}
+                  style={{ left: `${String(pct)}%` }}
                 >
                   {day.date.slice(5)}
                 </span>

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -235,7 +235,9 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
               const step = Math.max(1, Math.ceil(days.length / 7));
               if (idx % step !== 0) return null;
               const frac = days.length > 1 ? idx / (days.length - 1) : 0;
-              const left = `calc(3rem + ${String(frac * 100)}% - ${String(frac * 3)}rem)`;
+              // Interpolate from Y axis edge (2.5rem) to right edge (100%).
+              // left = 2.5rem + frac * (100% - 2.5rem) = 2.5rem*(1-frac) + frac*100%
+              const left = `calc(${String((1 - frac) * 2.5)}rem + ${String(frac * 100)}%)`;
               const isFirst = idx === 0;
               const isLast = idx >= days.length - step;
               const align = isFirst ? '' : isLast ? '-translate-x-full' : '-translate-x-1/2';

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -93,7 +93,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         return (
         <div className="relative flex-1 pb-5" style={{ minHeight: `${String(minChartHeight)}px` }}>
           {/* Y axis ticks */}
-          <div className="absolute left-0 top-0 w-10 h-full">
+          <div className="absolute left-0 top-0 bottom-5 w-10">
             {ticks.map(pct => (
               <div
                 key={pct}
@@ -106,7 +106,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
 
           {/* Grid lines */}
-          <div className="absolute left-12 right-0 top-0 h-full">
+          <div className="absolute left-12 right-0 top-0 bottom-5">
             {ticks.map(pct => (
               <div
                 key={pct}
@@ -177,7 +177,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             );
           })()}
 
-          <div className="flex items-end ml-12 relative z-10 h-full" style={{ gap: '2px' }}>
+          <div className="absolute left-12 right-0 top-0 bottom-5 flex items-end z-10" style={{ gap: '2px' }}>
             {days.map((day) => {
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getColor } from '../lib/palette.js';
 import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
@@ -21,11 +21,18 @@ interface StackedBarChartProps {
   readonly onExpandToggle?: (() => void) | undefined;
   readonly title?: string | undefined;
   readonly loading?: boolean | undefined;
+  readonly onSegmentClick?: ((name: string) => void) | undefined;
 }
 
-export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading }: StackedBarChartProps) {
+export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading, onSegmentClick }: StackedBarChartProps) {
   const { palette } = usePalette();
   const [hoveredDay, setHoveredDay] = useState<string | null>(null);
+  const [hoveredSegment, setHoveredSegment] = useState<string | null>(null);
+  const highlightRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [hoveredSegment]);
 
   const allKeys = new Set<string>();
   for (const day of days) {
@@ -143,14 +150,14 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                   <div className="flex flex-col gap-px">
                     {segs.slice(0, 12).map(seg => {
                       const color = getColor(seg.colorIdx, palette);
-                      const isHigh = highlightedGroup === seg.key;
+                      const isHigh = highlightedGroup === seg.key || hoveredSegment === seg.key;
                       const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
                       const prevVal = prev?.breakdown[seg.key] ?? 0;
                       const delta = prev !== undefined && prevVal > 0
                         ? ((seg.value - prevVal) / prevVal) * 100
                         : undefined;
                       return (
-                        <div key={seg.key} className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}>
+                        <div key={seg.key} ref={isHigh ? highlightRef : undefined} className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}>
                           <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
                           <span className={`truncate flex-1 min-w-0 ${isHigh ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>{seg.key}</span>
                           <span className={`tabular-nums shrink-0 ${isHigh ? 'font-semibold' : ''}`}>
@@ -190,7 +197,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                   className="group relative flex-1 min-w-0"
                   style={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}
                   onMouseEnter={() => { setHoveredDay(day.date); }}
-                  onMouseLeave={() => { setHoveredDay(null); }}
+                  onMouseLeave={() => { setHoveredDay(null); setHoveredSegment(null); }}
                 >
                   <div
                     className="w-full overflow-hidden rounded-t-sm"
@@ -203,11 +210,14 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                       return (
                         <div
                           key={seg.key}
+                          onMouseEnter={() => { setHoveredSegment(seg.key); }}
+                          onClick={(e) => { e.stopPropagation(); onSegmentClick?.(seg.key); }}
                           style={{
                             height: `${String(pct)}%`,
                             backgroundColor: color,
                             opacity: isDimmed ? 0.25 : 0.85,
                             transition: 'opacity 0.15s',
+                            cursor: onSegmentClick !== undefined ? 'pointer' : undefined,
                           }}
                         />
                       );

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -91,9 +91,9 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         const minChartHeight = expanded ? 360 : 180;
         const ticks = [1, 0.75, 0.5, 0.25, 0];
         return (
-        <div className="relative flex-1 pb-5" style={{ minHeight: `${String(minChartHeight)}px` }}>
+        <div className="relative flex-1 pb-7" style={{ minHeight: `${String(minChartHeight)}px` }}>
           {/* Y axis ticks */}
-          <div className="absolute left-0 top-0 bottom-5 w-10">
+          <div className="absolute left-0 top-0 bottom-7 w-10">
             {ticks.map(pct => (
               <div
                 key={pct}
@@ -106,7 +106,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
 
           {/* Grid lines */}
-          <div className="absolute left-12 right-0 top-0 bottom-5">
+          <div className="absolute left-12 right-0 top-0 bottom-7">
             {ticks.map(pct => (
               <div
                 key={pct}
@@ -177,7 +177,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             );
           })()}
 
-          <div className="absolute left-12 right-0 top-0 bottom-5 flex items-end z-10" style={{ gap: '2px' }}>
+          <div className="absolute left-12 right-0 top-0 bottom-7 flex items-end z-10" style={{ gap: '2px' }}>
             {days.map((day) => {
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -229,12 +229,13 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             })}
           </div>
 
-          {/* X axis */}
-          <div className="relative ml-12 h-4 mt-1">
+          {/* X axis — full width so first label aligns with Y axis ticks */}
+          <div className="relative h-4 mt-1">
             {days.map((day, idx) => {
               const step = Math.max(1, Math.ceil(days.length / 7));
               if (idx % step !== 0) return null;
-              const pct = days.length > 1 ? (idx / (days.length - 1)) * 100 : 0;
+              const frac = days.length > 1 ? idx / (days.length - 1) : 0;
+              const left = `calc(3rem + ${String(frac * 100)}% - ${String(frac * 3)}rem)`;
               const isFirst = idx === 0;
               const isLast = idx >= days.length - step;
               const align = isFirst ? '' : isLast ? '-translate-x-full' : '-translate-x-1/2';
@@ -242,7 +243,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                 <span
                   key={day.date}
                   className={`absolute text-[10px] text-text-muted whitespace-nowrap ${align}`}
-                  style={{ left: `${String(pct)}%` }}
+                  style={{ left }}
                 >
                   {day.date.slice(5)}
                 </span>

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -235,10 +235,13 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
               const step = Math.max(1, Math.ceil(days.length / 7));
               if (idx % step !== 0) return null;
               const pct = days.length > 1 ? (idx / (days.length - 1)) * 100 : 0;
+              const isFirst = idx === 0;
+              const isLast = idx >= days.length - step;
+              const align = isFirst ? '' : isLast ? '-translate-x-full' : '-translate-x-1/2';
               return (
                 <span
                   key={day.date}
-                  className="absolute text-[10px] text-text-muted whitespace-nowrap -translate-x-1/2"
+                  className={`absolute text-[10px] text-text-muted whitespace-nowrap ${align}`}
                   style={{ left: `${String(pct)}%` }}
                 >
                   {day.date.slice(5)}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -229,8 +229,8 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             })}
           </div>
 
-          {/* X axis — aligned with bar area (ml-12) */}
-          <div className="relative ml-12 h-4 mt-1">
+          {/* X axis — pinned to bottom of pb-5 zone */}
+          <div className="absolute bottom-0 left-12 right-0 h-5">
             {days.map((day, idx) => {
               const step = Math.max(1, Math.ceil(days.length / 7));
               if (idx % step !== 0) return null;

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -109,12 +109,13 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             ))}
           </div>
 
-          {/* Floating tooltip — anchored to top-right of chart area */}
+          {/* Floating tooltip — opposite side of hovered bar, full height */}
           {hoveredDay !== null && (() => {
             const idx = days.findIndex(d => d.date === hoveredDay);
             if (idx < 0) return null;
             const day = days[idx];
             if (day === undefined) return null;
+            const onLeft = idx < days.length / 2;
             const prev = idx > 0 ? days[idx - 1] : undefined;
             const prevTotal = prev?.total ?? 0;
             const totalDelta = prev !== undefined && prevTotal > 0
@@ -126,8 +127,8 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
               .sort((a, b) => b.value - a.value);
             const segTotal = segs.reduce((sum, s) => sum + s.value, 0);
             return (
-              <div className="pointer-events-none absolute top-0 right-0 z-20 mr-1 mt-1">
-                <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px]">
+              <div className={`pointer-events-none absolute top-0 bottom-0 z-20 ${onLeft ? 'right-0 mr-1' : 'left-12 ml-1'}`}>
+                <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px] max-h-full overflow-y-auto">
                   <div className="flex items-center justify-between mb-2 pb-2 border-b border-border-subtle">
                     <span className="font-semibold text-xs">{day.date}</span>
                     <span className="font-semibold text-xs">

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { daysBetween } from '../lib/dates.js';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
-import { StackedBarChart, type BarDay, type HistogramTab } from '../components/stacked-bar-chart.js';
+import { StackedBarChart, type BarDay } from '../components/stacked-bar-chart.js';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
@@ -50,7 +50,6 @@ export function StackedBarWidget({
   globalFilters,
 }: WidgetCommonProps) {
   const focus = useCostFocus();
-  const [tab, setTab] = useState<HistogramTab>('service');
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
 
   const { query, dailyResult } = useDailyWidgetQuery({
@@ -81,8 +80,6 @@ export function StackedBarWidget({
     <StackedBarChart
       days={barDays}
       highlightedGroup={focus.hoveredEntity}
-      tab={tab}
-      onTabChange={setTab}
       title={title}
       loading={loading}
     />

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { daysBetween } from '../lib/dates.js';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { StackedBarChart, type BarDay } from '../components/stacked-bar-chart.js';
+import { asTagValue } from '@costgoblin/core/browser';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
@@ -48,6 +49,7 @@ export function StackedBarWidget({
   dateRange,
   granularity,
   globalFilters,
+  onSetFilter,
 }: WidgetCommonProps) {
   const focus = useCostFocus();
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
@@ -82,6 +84,7 @@ export function StackedBarWidget({
       highlightedGroup={focus.hoveredEntity}
       title={title}
       loading={loading}
+      onSegmentClick={specGroupBy !== undefined ? (name) => { onSetFilter(specGroupBy, asTagValue(name)); } : undefined}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Remove dead Groups/Products/Services tabs from Cost Overview histogram (dimension is controlled by view editor). Tabs remain functional in Entity Detail where they switch the query dimension.
- Improved histogram tooltip: date + total header, per-item percentages, day-over-day deltas (↑↓ colored), 12 items shown (was 8), wider layout