### PR TITLE
Pie chart: HTML legend with truncating names, always-visible amounts

### DIFF
--- a/packages/ui/src/__tests__/cost-overview.test.tsx
+++ b/packages/ui/src/__tests__/cost-overview.test.tsx
@@ -38,14 +38,11 @@ describe('CostOverview', () => {
     expect(screen.getByText('Daily Costs')).toBeDefined();
   });
 
-  it('renders daily costs chart with tab selector', async () => {
+  it('renders daily costs chart', async () => {
     renderOverview();
     await waitFor(() => {
       expect(screen.getByText('Daily Costs')).toBeDefined();
     });
-    expect(screen.getByText('Groups')).toBeDefined();
-    expect(screen.getByText('Products')).toBeDefined();
-    expect(screen.getByText('Services')).toBeDefined();
   });
 
   it('changing date range triggers a new query', async () => {

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -206,7 +206,7 @@ export function PieChart(props: PieChartProps) {
   }
 
   return (
-    <div ref={containerRef} style={{ height: PIE_HEIGHT }}>
+    <div ref={containerRef} style={{ height: PIE_HEIGHT, overflow: 'hidden' }}>
       {width > 10 && <PieChartInner {...props} width={width} height={PIE_HEIGHT} />}
     </div>
   );

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -50,7 +50,7 @@ function PieChartInner({
   onSliceHover,
   externalHoveredName,
   onExpandToggle,
-  maxSlices = 100,
+  maxSlices = 50,
   dimensions,
   activeDimensionId,
   onDimensionChange,

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -50,7 +50,7 @@ function PieChartInner({
   onSliceHover,
   externalHoveredName,
   onExpandToggle,
-  maxSlices = 25,
+  maxSlices = 100,
   dimensions,
   activeDimensionId,
   onDimensionChange,

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -50,7 +50,7 @@ function PieChartInner({
   onSliceHover,
   externalHoveredName,
   onExpandToggle,
-  maxSlices = 15,
+  maxSlices = 25,
   dimensions,
   activeDimensionId,
   onDimensionChange,

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { getColor } from '../lib/palette.js';
@@ -60,6 +60,13 @@ function PieChartInner({
   const { palette } = usePalette();
   const [localHovered, setLocalHovered] = useState<string | null>(null);
   const hoveredName = externalHoveredName ?? localHovered;
+  const legendRefs = useRef(new Map<string, HTMLDivElement>());
+
+  useEffect(() => {
+    if (hoveredName !== null) {
+      legendRefs.current.get(hoveredName)?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [hoveredName]);
 
   const displayData = aggregateOther(data, maxSlices);
   const pieSize = Math.min(width * 0.38, height - 60);
@@ -76,7 +83,7 @@ function PieChartInner({
   }, [onSliceHover]);
 
   return (
-    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col">
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col h-full">
       <div className="flex items-center justify-between mb-3">
         {dimensions !== undefined && dimensions.length > 0 && onDimensionChange !== undefined ? (
           <select
@@ -171,6 +178,7 @@ function PieChartInner({
             return (
               <div
                 key={d.name}
+                ref={(el) => { if (el !== null) { legendRefs.current.set(d.name, el); } else { legendRefs.current.delete(d.name); } }}
                 onMouseEnter={() => { handleMouseEnter(d.name); }}
                 onMouseLeave={handleMouseLeave}
                 onClick={() => { if (d.name !== OTHER_KEY) onSliceClick?.(d.name); }}

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -62,10 +62,8 @@ function PieChartInner({
   const hoveredName = externalHoveredName ?? localHovered;
 
   const displayData = aggregateOther(data, maxSlices);
-  const pieSize = Math.min(width * 0.42, height - 60);
+  const pieSize = Math.min(width * 0.38, height - 60);
   const radius = pieSize / 2;
-  const centerX = radius + 16;
-  const centerY = height / 2;
 
   const handleMouseEnter = useCallback((name: string) => {
     setLocalHovered(name);
@@ -76,8 +74,6 @@ function PieChartInner({
     setLocalHovered(null);
     onSliceHover?.(null);
   }, [onSliceHover]);
-
-  const legendX = pieSize + 44;
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col">
@@ -117,95 +113,85 @@ function PieChartInner({
           )}
         </div>
       </div>
-      <svg width={width} height={height - 50}>
-        <Group top={centerY - 25} left={centerX}>
-          <Pie<PieSlice>
-            data={displayData}
-            pieValue={(d) => d.cost}
-            outerRadius={radius}
-            innerRadius={0}
-            padAngle={0.015}
-          >
-            {(pie) =>
-              pie.arcs.map((arc, i) => {
-                const sliceName = arc.data.name;
-                const color = sliceName === OTHER_KEY ? '#374151' : getColor(i, palette);
-                const isHovered = hoveredName === sliceName;
-                const isDimmed = hoveredName !== null && !isHovered;
-                const path = pie.path(arc) ?? '';
+      <div className="flex flex-1 min-h-0 gap-2">
+        {/* Pie */}
+        <div className="shrink-0" style={{ width: pieSize + 32 }}>
+          <svg width={pieSize + 32} height={pieSize + 16}>
+            <Group top={radius + 8} left={radius + 16}>
+              <Pie<PieSlice>
+                data={displayData}
+                pieValue={(d) => d.cost}
+                outerRadius={radius}
+                innerRadius={0}
+                padAngle={0.015}
+              >
+                {(pie) =>
+                  pie.arcs.map((arc, i) => {
+                    const sliceName = arc.data.name;
+                    const color = sliceName === OTHER_KEY ? '#374151' : getColor(i, palette);
+                    const isHovered = hoveredName === sliceName;
+                    const isDimmed = hoveredName !== null && !isHovered;
+                    const path = pie.path(arc) ?? '';
 
-                return (
-                  <g
-                    key={sliceName}
-                    onMouseEnter={() => { handleMouseEnter(sliceName); }}
-                    onMouseLeave={handleMouseLeave}
-                    onClick={() => { if (sliceName !== OTHER_KEY) onSliceClick?.(sliceName); }}
-                    style={{ cursor: sliceName !== OTHER_KEY && onSliceClick !== undefined ? 'pointer' : 'default' }}
-                  >
-                    <path
-                      d={path}
-                      fill={color}
-                      opacity={isDimmed ? 0.3 : 1}
-                      stroke={isHovered ? '#ffffff' : 'transparent'}
-                      strokeWidth={isHovered ? 2 : 0}
-                      style={{
-                        filter: isHovered ? 'brightness(1.3)' : 'none',
-                        transition: 'all 0.15s ease',
-                      }}
-                    />
-                  </g>
-                );
-              })
-            }
-          </Pie>
-        </Group>
+                    return (
+                      <g
+                        key={sliceName}
+                        onMouseEnter={() => { handleMouseEnter(sliceName); }}
+                        onMouseLeave={handleMouseLeave}
+                        onClick={() => { if (sliceName !== OTHER_KEY) onSliceClick?.(sliceName); }}
+                        style={{ cursor: sliceName !== OTHER_KEY && onSliceClick !== undefined ? 'pointer' : 'default' }}
+                      >
+                        <path
+                          d={path}
+                          fill={color}
+                          opacity={isDimmed ? 0.3 : 1}
+                          stroke={isHovered ? '#ffffff' : 'transparent'}
+                          strokeWidth={isHovered ? 2 : 0}
+                          style={{
+                            filter: isHovered ? 'brightness(1.3)' : 'none',
+                            transition: 'all 0.15s ease',
+                          }}
+                        />
+                      </g>
+                    );
+                  })
+                }
+              </Pie>
+            </Group>
+          </svg>
+        </div>
 
-        {/* Legend */}
-        <Group top={6} left={legendX}>
+        {/* Legend — HTML for proper text truncation */}
+        <div className="flex-1 min-w-0 overflow-y-auto flex flex-col gap-0.5 py-1">
           {displayData.map((d, i) => {
             const color = d.name === OTHER_KEY ? '#374151' : getColor(i, palette);
             const isHovered = hoveredName === d.name;
             const isDimmed = hoveredName !== null && !isHovered;
-            const y = i * 22;
-            if (y > height - 80) return null;
 
             return (
-              <g
+              <div
                 key={d.name}
                 onMouseEnter={() => { handleMouseEnter(d.name); }}
                 onMouseLeave={handleMouseLeave}
                 onClick={() => { if (d.name !== OTHER_KEY) onSliceClick?.(d.name); }}
-                style={{ cursor: d.name !== OTHER_KEY && onSliceClick !== undefined ? 'pointer' : 'default' }}
+                className={[
+                  'flex items-center gap-1.5 px-1.5 py-0.5 rounded text-[11px] transition-colors',
+                  d.name !== OTHER_KEY && onSliceClick !== undefined ? 'cursor-pointer' : '',
+                  isHovered ? 'bg-accent-muted/50' : '',
+                ].join(' ')}
               >
-                {isHovered && (
-                  <rect
-                    x={-6}
-                    y={y - 4}
-                    width={width - legendX}
-                    height={20}
-                    rx={4}
-                    fill="var(--color-accent-muted)"
-                  />
-                )}
-                <rect x={0} y={y} width={8} height={8} rx={2} fill={color} />
-                <text
-                  x={14}
-                  y={y + 8}
-                  fontSize={isHovered ? 12 : 11}
-                  fill={(() => { if (isDimmed) { return 'var(--color-text-muted)'; } return isHovered ? 'var(--color-text-primary)' : 'var(--color-text-secondary)'; })()}
-                  fontWeight={isHovered ? 600 : 400}
-                  style={{ transition: 'all 0.12s' }}
-                >
-                  {d.name.length > 22 ? `${d.name.slice(0, 21)}…` : d.name}
-                  {' — '}
-                  {formatDollars(d.cost)}
-                  {` (${d.percentage.toFixed(1)}%)`}
-                </text>
-              </g>
+                <span className="inline-block w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: color }} />
+                <span className={`truncate min-w-0 flex-1 ${isDimmed ? 'text-text-muted' : isHovered ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>
+                  {d.name}
+                </span>
+                <span className={`tabular-nums shrink-0 whitespace-nowrap ${isDimmed ? 'text-text-muted' : isHovered ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>
+                  {formatDollars(d.cost)} ({d.percentage.toFixed(1)}%)
+                </span>
+              </div>
             );
           })}
-        </Group>
-      </svg>
+        </div>
+      </div>
     </div>
   );
 }
@@ -220,7 +206,7 @@ export function PieChart(props: PieChartProps) {
   }
 
   return (
-    <div ref={containerRef} style={{ height: PIE_HEIGHT, overflow: 'hidden' }}>
+    <div ref={containerRef} style={{ height: PIE_HEIGHT }}>
       {width > 10 && <PieChartInner {...props} width={width} height={PIE_HEIGHT} />}
     </div>
   );

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -110,7 +110,8 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
 
           <div className="flex items-end ml-12 relative z-10 h-full" style={{ gap: '2px' }}>
-            {days.map((day) => {
+            {days.map((day, dayIdx) => {
+              const prevDay = dayIdx > 0 ? days[dayIdx - 1] : undefined;
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys
                 .map((key, ki) => ({
@@ -154,37 +155,59 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                     })}
                   </div>
 
-                  {isHovered && (
+                  {isHovered && (() => {
+                    const prevTotal = prevDay?.total ?? 0;
+                    const totalDelta = prevDay !== undefined && prevTotal > 0
+                      ? ((day.total - prevTotal) / prevTotal) * 100
+                      : undefined;
+                    return (
                     <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20">
-                      <div className="rounded-lg bg-bg-secondary/95 px-3 py-2 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[160px]">
-                        <div className="font-semibold mb-1.5 text-xs">{day.date}</div>
-                        <div className="flex items-center justify-between font-medium mb-1 pb-1 border-b border-border-subtle">
-                          <span>Total</span>
-                          <span>{formatDollars(day.total)}</span>
+                      <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px]">
+                        <div className="flex items-center justify-between mb-2 pb-2 border-b border-border-subtle">
+                          <span className="font-semibold text-xs">{day.date}</span>
+                          <span className="font-semibold text-xs">
+                            Total: {formatDollars(day.total)}
+                            {totalDelta !== undefined && (
+                              <span className={`ml-1.5 text-[10px] font-normal ${totalDelta >= 0 ? 'text-negative' : 'text-positive'}`}>
+                                {totalDelta >= 0 ? '↑' : '↓'}{Math.abs(totalDelta).toFixed(1)}%
+                              </span>
+                            )}
+                          </span>
                         </div>
-                        <div className="flex flex-col gap-0.5 mt-1">
+                        <div className="flex flex-col gap-px">
                           {segments
-                            .slice(0, 8)
+                            .slice(0, 12)
                             .map(seg => {
                               const color = getColor(seg.colorIdx, palette);
-                              const isHighlighted = highlightedGroup === seg.key;
+                              const isHigh = highlightedGroup === seg.key;
+                              const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
+                              const prevVal = prevDay?.breakdown[seg.key] ?? 0;
+                              const delta = prevDay !== undefined && prevVal > 0
+                                ? ((seg.value - prevVal) / prevVal) * 100
+                                : undefined;
                               return (
                                 <div
                                   key={seg.key}
-                                  className={`flex items-center justify-between gap-3 rounded px-1 -mx-1 ${isHighlighted ? 'bg-white/10' : ''}`}
+                                  className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}
                                 >
-                                  <div className="flex items-center gap-1.5">
-                                    <span className="inline-block w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: color }} />
-                                    <span className={`truncate max-w-[120px] ${isHighlighted ? 'text-text-primary font-medium' : 'text-text-secondary'}`}>{seg.key}</span>
-                                  </div>
-                                  <span className={`tabular-nums ${isHighlighted ? 'text-text-primary font-medium' : 'text-text-primary'}`}>{formatDollars(seg.value)}</span>
+                                  <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                                  <span className={`truncate flex-1 min-w-0 ${isHigh ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>{seg.key}</span>
+                                  <span className={`tabular-nums shrink-0 ${isHigh ? 'font-semibold' : ''}`}>
+                                    {formatDollars(seg.value)} <span className="text-text-muted">({pct.toFixed(1)}%)</span>
+                                  </span>
+                                  {delta !== undefined && (
+                                    <span className={`tabular-nums text-[10px] shrink-0 ${delta >= 0 ? 'text-negative' : 'text-positive'}`}>
+                                      {delta >= 0 ? '↑' : '↓'}{Math.abs(delta).toFixed(1)}%
+                                    </span>
+                                  )}
                                 </div>
                               );
                             })}
                         </div>
                       </div>
                     </div>
-                  )}
+                    );
+                  })()}
                 </button>
               );
             })}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -15,8 +15,8 @@ export type HistogramTab = 'owner' | 'product' | 'service';
 interface StackedBarChartProps {
   readonly days: readonly BarDay[];
   readonly highlightedGroup?: string | null;
-  readonly tab: HistogramTab;
-  readonly onTabChange: (tab: HistogramTab) => void;
+  readonly tab?: HistogramTab | undefined;
+  readonly onTabChange?: ((tab: HistogramTab) => void) | undefined;
   readonly expanded?: boolean | undefined;
   readonly onExpandToggle?: (() => void) | undefined;
   readonly title?: string | undefined;
@@ -37,34 +37,34 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
 
   const maxCost = days.reduce((m, d) => Math.max(m, d.total), 0);
 
-  const tabs: readonly { key: HistogramTab; label: string }[] = [
-    { key: 'owner', label: 'Groups' },
-    { key: 'product', label: 'Products' },
-    { key: 'service', label: 'Services' },
-  ];
-
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4 flex flex-col h-full">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-medium text-text-secondary">{title ?? 'Daily Costs'}</h3>
         <div className="flex items-center gap-2">
-        <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
-          {tabs.map(t => (
-            <button
-              key={t.key}
-              type="button"
-              onClick={() => { onTabChange(t.key); }}
-              className={[
-                'rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors',
-                tab === t.key
-                  ? 'bg-accent text-bg-primary shadow-sm'
-                  : 'text-text-secondary hover:text-text-primary',
-              ].join(' ')}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
+        {tab !== undefined && onTabChange !== undefined && (
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
+            {([
+              { key: 'owner' as const, label: 'Groups' },
+              { key: 'product' as const, label: 'Products' },
+              { key: 'service' as const, label: 'Services' },
+            ]).map(t => (
+              <button
+                key={t.key}
+                type="button"
+                onClick={() => { onTabChange(t.key); }}
+                className={[
+                  'rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors',
+                  tab === t.key
+                    ? 'bg-accent text-bg-primary shadow-sm'
+                    : 'text-text-secondary hover:text-text-primary',
+                ].join(' ')}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        )}
         {onExpandToggle !== undefined && (
           <button
             type="button"

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { daysBetween } from '../lib/dates.js';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
-import { StackedBarChart, type BarDay, type HistogramTab } from '../components/stacked-bar-chart.js';
+import { StackedBarChart, type BarDay } from '../components/stacked-bar-chart.js';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
@@ -50,7 +50,6 @@ export function StackedBarWidget({
   globalFilters,
 }: WidgetCommonProps) {
   const focus = useCostFocus();
-  const [tab, setTab] = useState<HistogramTab>('service');
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
 
   const { query, dailyResult } = useDailyWidgetQuery({
@@ -81,8 +80,6 @@ export function StackedBarWidget({
     <StackedBarChart
       days={barDays}
       highlightedGroup={focus.hoveredEntity}
-      tab={tab}
-      onTabChange={setTab}
       title={title}
       loading={loading}
     />


### PR DESCRIPTION
## Summary

- Replaced SVG text legend with HTML flex layout — names truncate with ellipsis while amounts always stay visible
- Legend is now scrollable when items exceed the chart height (no more bottom row clipping)
- Removed `overflow: hidden` from container