### PR TITLE
Add aria-live region for sync status and nav badge updates

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -109,6 +109,52 @@ type SetupCheck =
 
 const FALLBACK_VIEWS: ViewsConfig = { views: [OVERVIEW_SEED_VIEW] };
 
+interface SyncAnnouncerProps {
+  syncError: string | null;
+  syncActivity: 'idle' | 'syncing' | 'downloading';
+  syncFilesRemaining: number;
+  missingPeriods: number;
+}
+
+/** Visually-hidden aria-live region that announces sync status changes to
+ *  screen readers. Uses assertive for errors (interrupt immediately) and
+ *  polite for status updates (wait for user pause). */
+function SyncAnnouncer({ syncError, syncActivity, syncFilesRemaining, missingPeriods }: Readonly<SyncAnnouncerProps>): React.JSX.Element {
+  // Generate error announcement (assertive — interrupts immediately)
+  const errorMessage = syncError !== null ? `Sync error: ${syncError}` : '';
+
+  // Generate status announcement (polite — waits for pause)
+  let statusMessage = '';
+  if (syncActivity === 'downloading' && syncFilesRemaining > 0) {
+    statusMessage = `Downloading ${String(syncFilesRemaining)} file${syncFilesRemaining === 1 ? '' : 's'}`;
+  } else if (syncActivity === 'syncing') {
+    statusMessage = 'Checking for updates';
+  } else if (syncActivity === 'idle' && missingPeriods > 0) {
+    statusMessage = `${String(missingPeriods)} billing period${missingPeriods === 1 ? '' : 's'} not synced`;
+  }
+
+  return (
+    <>
+      {/* Assertive announcements for errors — interrupts screen reader */}
+      <div
+        aria-live="assertive"
+        aria-atomic="true"
+        className="absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap border-0"
+      >
+        {errorMessage}
+      </div>
+      {/* Polite announcements for status updates — waits for pause */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap border-0"
+      >
+        {statusMessage}
+      </div>
+    </>
+  );
+}
+
 /** Top-level app shell — just establishes the context providers. All the
  *  state + navigation lives in `AppShell` below so it can call
  *  `useConfirmLeave()` from inside the UnsavedChangesProvider. */
@@ -327,6 +373,13 @@ function AppShell(): React.JSX.Element {
   return (
     <PaletteProvider palette={palette}>
       <div className="min-h-screen bg-bg-primary text-text-primary">
+        {/* Screen reader announcements for sync status */}
+        <SyncAnnouncer
+          syncError={syncError}
+          syncActivity={syncActivity}
+          syncFilesRemaining={syncFilesRemaining}
+          missingPeriods={missingPeriods}
+        />
         {/* Title bar + nav */}
         <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center px-4 pt-7 pb-2">

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -109,21 +109,19 @@ type SetupCheck =
 
 const FALLBACK_VIEWS: ViewsConfig = { views: [OVERVIEW_SEED_VIEW] };
 
-interface SyncAnnouncerProps {
+function SyncAnnouncer({
+  syncError,
+  syncActivity,
+  syncFilesRemaining,
+  missingPeriods,
+}: {
   syncError: string | null;
   syncActivity: 'idle' | 'syncing' | 'downloading';
   syncFilesRemaining: number;
   missingPeriods: number;
-}
-
-/** Visually-hidden aria-live region that announces sync status changes to
- *  screen readers. Uses assertive for errors (interrupt immediately) and
- *  polite for status updates (wait for user pause). */
-function SyncAnnouncer({ syncError, syncActivity, syncFilesRemaining, missingPeriods }: Readonly<SyncAnnouncerProps>): React.JSX.Element {
-  // Generate error announcement (assertive — interrupts immediately)
+}): React.JSX.Element {
   const errorMessage = syncError !== null ? `Sync error: ${syncError}` : '';
 
-  // Generate status announcement (polite — waits for pause)
   let statusMessage = '';
   if (syncActivity === 'downloading' && syncFilesRemaining > 0) {
     statusMessage = `Downloading ${String(syncFilesRemaining)} file${syncFilesRemaining === 1 ? '' : 's'}`;
@@ -135,20 +133,10 @@ function SyncAnnouncer({ syncError, syncActivity, syncFilesRemaining, missingPer
 
   return (
     <>
-      {/* Assertive announcements for errors — interrupts screen reader */}
-      <div
-        aria-live="assertive"
-        aria-atomic="true"
-        className="absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap border-0"
-      >
+      <div aria-live="assertive" aria-atomic="true" className="sr-only">
         {errorMessage}
       </div>
-      {/* Polite announcements for status updates — waits for pause */}
-      <div
-        aria-live="polite"
-        aria-atomic="true"
-        className="absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap border-0"
-      >
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
         {statusMessage}
       </div>
     </>
@@ -373,7 +361,6 @@ function AppShell(): React.JSX.Element {
   return (
     <PaletteProvider palette={palette}>
       <div className="min-h-screen bg-bg-primary text-text-primary">
-        {/* Screen reader announcements for sync status */}
         <SyncAnnouncer
           syncError={syncError}
           syncActivity={syncActivity}


### PR DESCRIPTION
Dynamic status changes (sync errors, missing period counts, auto-sync status) update the nav bar badges and indicators silently. Screen readers do not announce when a sync error occurs, when missing periods are detected, or when sync status changes. These are important operational signals that the user needs to notice.