### PR TITLE
Replace entity detail page with dashboard filter navigation

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, EntityDetail, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider } from '@costgoblin/ui';
-import type { CostApi, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
+import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider } from '@costgoblin/ui';
+import type { CostApi, FilterMap, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
+import { asDimensionId, asTagValue } from '@costgoblin/core/browser';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 
 // ---------------------------------------------------------------------------
@@ -32,7 +33,7 @@ function getApi(): CostApi {
 
 type View =
   | { page: 'setup' }
-  | { page: 'custom'; viewId: string }
+  | { page: 'custom'; viewId: string; initialFilter?: FilterMap }
   | { page: 'trends' }
   | { page: 'missing-tags' }
   | { page: 'savings' }
@@ -40,8 +41,7 @@ type View =
   | { page: 'dimensions' }
   | { page: 'cost-scope' }
   | { page: 'views-editor' }
-  | { page: 'sync' }
-  | { page: 'entity-detail'; entity: string; dimension: string };
+  | { page: 'sync' };
 
 const STATIC_LEFT_NAV: { id: string; label: string }[] = [
   { id: 'trends', label: 'Trends' },
@@ -277,15 +277,9 @@ function AppShell(): React.JSX.Element {
   function handleEntityClick(entity: string, dimension: string) {
     confirmLeave(() => {
       api.cancelPendingQueries().catch(() => undefined);
-      setView({ page: 'entity-detail', entity, dimension });
-    });
-  }
-
-  function handleBack() {
-    confirmLeave(() => {
-      api.cancelPendingQueries().catch(() => undefined);
       const firstId = viewsConfig?.views[0]?.id ?? OVERVIEW_SEED_VIEW.id;
-      setView({ page: 'custom', viewId: firstId });
+      const initialFilter: FilterMap = { [asDimensionId(dimension)]: [asTagValue(entity)] };
+      setView({ page: 'custom', viewId: firstId, initialFilter });
     });
   }
 
@@ -460,7 +454,7 @@ function AppShell(): React.JSX.Element {
         const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
         return (
           <Profiler id={`custom:${view.viewId}`} onRender={onPerfRender}>
-            <CustomView spec={spec} headerSubtitle="Cloud spending visibility" onEntityClick={handleEntityClick} />
+            <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} />
           </Profiler>
         );
       })()}
@@ -504,15 +498,6 @@ function AppShell(): React.JSX.Element {
           <DataManagement />
         </Profiler>
       </div>
-      {view.page === 'entity-detail' && (
-        <Profiler id="entity-detail" onRender={onPerfRender}>
-          <EntityDetail
-            entity={view.entity}
-            dimension={view.dimension}
-            onBack={handleBack}
-          />
-        </Profiler>
-      )}
       {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} />}
       </div>
     </PaletteProvider>

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -536,13 +536,13 @@ function TableCell<TData>({ cell, row, onCellClick }: Readonly<{
   const dimId = meta?.dimId;
   const titleText = meta?.truncate === true && typeof rawValue === 'string' ? rawValue : undefined;
 
-  if (onCellClick !== undefined && dimId !== undefined && dimId !== null && rawValue !== undefined && rawValue !== null && rawValue !== '') {
+  if (onCellClick !== undefined && meta?.clickable === true && dimId !== undefined && dimId !== null && rawValue !== undefined && rawValue !== null && rawValue !== '') {
     return (
       <td className={classes} title={titleText}>
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onCellClick(row.original, cell.column.id, rawValue); }}
-          className="hover:underline hover:text-accent text-left"
+          className="text-accent hover:underline cursor-pointer text-left"
           title={`Add "${typeof rawValue === 'string' ? rawValue : ''}" to filter`}
         >
           {display}

--- a/packages/ui/src/lib/table-types.ts
+++ b/packages/ui/src/lib/table-types.ts
@@ -7,6 +7,7 @@ declare module '@tanstack/react-table' {
     mono?: boolean | undefined;
     truncate?: boolean | undefined;
     dimId?: string | null | undefined;
+    clickable?: boolean | undefined;
   }
 }
 
@@ -19,6 +20,7 @@ export interface TableColumn<TData> {
   readonly mono?: boolean | undefined;
   readonly truncate?: boolean | undefined;
   readonly dimId?: string | null | undefined;
+  readonly clickable?: boolean | undefined;
   readonly sortable?: boolean | undefined;
   readonly hideable?: boolean | undefined;
   readonly pinnable?: boolean | undefined;
@@ -34,6 +36,7 @@ export function toColumnDefs<TData>(columns: readonly TableColumn<TData>[]): Col
         mono: col.mono,
         truncate: col.truncate,
         dimId: col.dimId,
+        clickable: col.clickable,
       },
       enableSorting: col.sortable !== false,
       enableHiding: col.hideable !== false,

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { asDateString } from '@costgoblin/core/browser';
+import { asDateString, asTagValue } from '@costgoblin/core/browser';
 import { daysBetween } from '../lib/dates.js';
 import type {
   Dimension,
@@ -35,7 +35,7 @@ import { widgetFlexBasis } from '../widgets/widget.js';
 interface CustomViewProps {
   readonly spec: ViewSpec;
   readonly headerSubtitle?: string | undefined;
-  readonly onEntityClick?: ((entity: EntityRef, dim: DimensionId) => void) | undefined;
+  readonly initialFilter?: FilterMap | undefined;
 }
 
 function priorityFor(d: Dimension): number {
@@ -56,12 +56,12 @@ function previousRangeFor(dr: DateRange): DateRange {
   };
 }
 
-function CustomViewInner({ spec, headerSubtitle, onEntityClick }: CustomViewProps) {
+function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProps) {
   const api = useCostApi();
   const lagDays = useLagDays();
   const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
   const [granularity, setGranularity] = useState<Granularity>('daily');
-  const [filters, setFilters] = useState<FilterMap>({});
+  const [filters, setFilters] = useState<FilterMap>(initialFilter ?? {});
 
   const dimensionsQuery = useQuery(() => api.getDimensions(), [api]);
   const rawDimensions: Dimension[] = dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
@@ -77,6 +77,10 @@ function CustomViewInner({ spec, headerSubtitle, onEntityClick }: CustomViewProp
 
   function handleSetFilter(dim: DimensionId, value: TagValue) {
     setFilters(prev => ({ ...prev, [dim]: [value] }));
+  }
+
+  function handleEntityClick(entity: EntityRef, dim: DimensionId) {
+    handleSetFilter(dim, asTagValue(entity));
   }
 
   function handleGetFilterValues(dimensionId: DimensionId, currentFilters: FilterMap): Promise<{ value: string; label: string; count: number }[]> {
@@ -135,7 +139,7 @@ function CustomViewInner({ spec, headerSubtitle, onEntityClick }: CustomViewProp
                   globalFilters={filters}
                   dimensions={dimensions}
                   onSetFilter={handleSetFilter}
-                  onEntityClick={onEntityClick}
+                  onEntityClick={handleEntityClick}
                 />
               </div>
             );

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -52,7 +52,7 @@ function hourDisplay(hour: string): string {
 
 const BASE_COLUMNS: readonly TableColumn<ExplorerSampleRow>[] = [
   { id: 'usage_date', header: 'Date', accessorFn: r => r.date, mono: true },
-  { id: 'line_item_type', header: 'Line type', dimId: 'line_item_type', accessorFn: r => r.lineItemType },
+  { id: 'line_item_type', header: 'Line type', dimId: 'line_item_type', clickable: true, accessorFn: r => r.lineItemType },
   {
     id: 'cost', header: 'Cost', align: 'right', mono: true,
     accessorFn: r => r.cost,
@@ -62,19 +62,19 @@ const BASE_COLUMNS: readonly TableColumn<ExplorerSampleRow>[] = [
       return <span className={cls}>{formatSignedDollars(n)}</span>;
     },
   },
-  { id: 'service_family', header: 'Family', dimId: 'service_family', accessorFn: r => r.serviceFamily },
-  { id: 'region', header: 'Region', dimId: 'region', accessorFn: r => r.region, mono: true },
-  { id: 'account_name', header: 'Account', dimId: 'account', accessorFn: r => r.accountName.length > 0 ? r.accountName : r.accountId },
-  { id: 'resource_id', header: 'Resource', dimId: 'resource_id', accessorFn: r => r.resourceId, mono: true, truncate: true },
+  { id: 'service_family', header: 'Family', dimId: 'service_family', clickable: true, accessorFn: r => r.serviceFamily },
+  { id: 'region', header: 'Region', dimId: 'region', clickable: true, accessorFn: r => r.region, mono: true },
+  { id: 'account_name', header: 'Account', dimId: 'account', clickable: true, accessorFn: r => r.accountName.length > 0 ? r.accountName : r.accountId },
+  { id: 'resource_id', header: 'Resource', dimId: 'resource_id', clickable: true, accessorFn: r => r.resourceId, mono: true, truncate: true },
   { id: 'description', header: 'Description', accessorFn: r => r.description, truncate: true },
-  { id: 'usage_type', header: 'Usage type', dimId: 'usage_type', accessorFn: r => r.usageType, mono: true },
+  { id: 'usage_type', header: 'Usage type', dimId: 'usage_type', clickable: true, accessorFn: r => r.usageType, mono: true },
   { id: 'usage_hour', header: 'Hour', accessorFn: r => hourDisplay(r.hour), mono: true },
   {
     id: 'list_cost', header: 'List', align: 'right', mono: true,
     accessorFn: r => r.listCost,
     cell: (v) => formatSignedDollars(v as number),
   },
-  { id: 'service', header: 'Service', dimId: 'service', accessorFn: r => r.service },
+  { id: 'service', header: 'Service', dimId: 'service', clickable: true, accessorFn: r => r.service },
   {
     id: 'usage_amount', header: 'Usage', align: 'right', mono: true,
     accessorFn: r => r.usageAmount,
@@ -83,7 +83,7 @@ const BASE_COLUMNS: readonly TableColumn<ExplorerSampleRow>[] = [
       return n === 0 ? '' : n.toLocaleString(undefined, { maximumFractionDigits: 4 });
     },
   },
-  { id: 'operation', header: 'Operation', dimId: 'operation', accessorFn: r => r.operation },
+  { id: 'operation', header: 'Operation', dimId: 'operation', clickable: true, accessorFn: r => r.operation },
 ];
 
 const DEFAULT_HIDDEN: ReadonlySet<string> = new Set([
@@ -248,6 +248,7 @@ export function ExplorerView(): React.JSX.Element {
       id: t.id,
       header: t.label,
       dimId: t.id,
+      clickable: true,
       accessorFn: (r: ExplorerSampleRow) => r.tags[t.id] ?? '',
     })),
   ], [tagColumns, granularity]);

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -10,6 +10,7 @@ import type { AggregatedTableRow, ExplorerFilterMap, ExplorerSort } from '@costg
 import type { SortingState } from '@tanstack/react-table';
 import type { WidgetCommonProps } from './widget.js';
 import { filtersKey, mergeFilters } from './widget.js';
+import { getDimensionId } from '../lib/dimensions.js';
 import type { TableColumn } from '../lib/table-types.js';
 
 const ROW_LIMIT = 500;
@@ -22,11 +23,12 @@ function formatSignedDollars(n: number): string {
   return formatDollars(n);
 }
 
-function specToTableColumn(spec: ColumnSpec): TableColumn<AggregatedTableRow> {
+function specToTableColumn(spec: ColumnSpec, activeDimIds: ReadonlySet<string>): TableColumn<AggregatedTableRow> {
   return {
     id: spec.key,
     header: spec.label,
     dimId: spec.dimId,
+    clickable: spec.dimId !== null && activeDimIds.has(spec.dimId),
     align: spec.align,
     mono: spec.mono,
     truncate: spec.truncate,
@@ -61,6 +63,7 @@ export function TableWidget({
   dateRange,
   granularity,
   globalFilters,
+  dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
@@ -115,16 +118,22 @@ export function TableWidget({
     [fk, dateRange.start, dateRange.end, granularity, groupByKey, sort?.column, sort?.direction, api],
   );
 
+  const activeDimIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const d of dimensions) ids.add(getDimensionId(d));
+    return ids;
+  }, [dimensions]);
+
   const allTableColumns = useMemo(
-    () => allColumnSpecs.map(specToTableColumn),
-    [allColumnSpecs],
+    () => allColumnSpecs.map(s => specToTableColumn(s, activeDimIds)),
+    [allColumnSpecs, activeDimIds],
   );
 
   const visibleTableColumns = useMemo(() => {
     const enabled = allColumnSpecs.filter(c => enabledSet.has(c.key));
     const ordered = applyColumnOrder(enabled, [...enabledColumns]);
-    return ordered.map(specToTableColumn);
-  }, [allColumnSpecs, enabledSet, enabledColumns]);
+    return ordered.map(s => specToTableColumn(s, activeDimIds));
+  }, [allColumnSpecs, enabledSet, enabledColumns, activeDimIds]);
 
   const hiddenColumns = useMemo(
     () => allColumnSpecs.filter(c => !enabledSet.has(c.key)).map(c => c.key),
@@ -151,10 +160,10 @@ export function TableWidget({
 
   const handleCellClick = useCallback((_row: AggregatedTableRow, columnId: string, value: unknown) => {
     const col = allColumnSpecs.find(c => c.key === columnId);
-    if (col?.dimId !== undefined && col.dimId !== null && typeof value === 'string' && value.length > 0) {
+    if (col?.dimId !== undefined && col.dimId !== null && activeDimIds.has(col.dimId) && typeof value === 'string' && value.length > 0) {
       onSetFilter(asDimensionId(col.dimId), asTagValue(value));
     }
-  }, [allColumnSpecs, onSetFilter]);
+  }, [allColumnSpecs, onSetFilter, activeDimIds]);
 
   const handleHiddenChange = useCallback((nextHidden: readonly string[]) => {
     const hiddenSet = new Set(nextHidden);


### PR DESCRIPTION
## Summary

- Entity clicks (bubble charts, trend rows) now add a filter on the current dashboard instead of navigating to the separate entity detail page
- From CostTrends, clicking an entity navigates to the overview dashboard with the filter pre-applied
- Removes the `entity-detail` route from the app shell; the `EntityDetail` component remains available in the codebase