### PR TITLE
Missing tags: copy issue template for remediation

### DIFF
--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -97,53 +97,123 @@ function ExpandedRow({ row }: Readonly<{ row: MissingTagRow }>) {
   );
 }
 
-function buildIssueTemplate(rows: readonly MissingTagRow[], tagLabel: string): string {
-  const sections = rows.map(row => {
-    const owner = row.closestOwner !== null && row.closestOwner.length > 0
-      ? String(row.closestOwner)
-      : 'Unknown';
-    return [
-      `## Missing Tags: ${row.service} / ${row.resourceId}`,
-      '',
-      `**Resource:** ${row.resourceId}`,
-      `**Account:** ${row.accountName} (${row.accountId})`,
-      `**Service:** ${row.service} — ${row.serviceFamily}`,
-      `**Owner (fallback):** ${owner}`,
-      `**Monthly Cost:** ${formatDollars(row.cost)}`,
-      '',
-      '### Action Required',
-      `Please add the following tag to this resource:`,
-      `- ${tagLabel}: TBD`,
-    ].join('\n');
-  });
-  return sections.join('\n\n---\n\n');
+interface CopyContext {
+  readonly rows: readonly MissingTagRow[];
+  readonly tagLabel: string;
+  readonly selectedOwner: string | null;
+  readonly totalCost: number;
 }
 
-function CopyIssueTemplateButton({ rows, tagLabel }: Readonly<{ rows: readonly MissingTagRow[]; tagLabel: string }>) {
-  const [copied, setCopied] = useState(false);
+function rowLine(r: MissingTagRow): string {
+  return `${r.accountName} | ${r.resourceId} | ${r.service} — ${r.serviceFamily} | ${formatDollars(r.cost)}`;
+}
+
+function header(ctx: CopyContext): { title: string; subtitle: string } {
+  const owner = ctx.selectedOwner !== null && ctx.selectedOwner.length > 0
+    ? ` — ${ctx.selectedOwner}`
+    : '';
+  return {
+    title: `Missing ${ctx.tagLabel} Tag${owner}`,
+    subtitle: `${String(ctx.rows.length)} resources | ${formatDollars(ctx.totalCost)} total`,
+  };
+}
+
+function buildJira(ctx: CopyContext): string {
+  const h = header(ctx);
+  const lines = [
+    `h2. ${h.title}`,
+    h.subtitle,
+    '',
+    '||Account||Resource||Service||Cost||',
+    ...ctx.rows.map(r =>
+      `|${r.accountName}|${r.resourceId}|${r.service} — ${r.serviceFamily}|${formatDollars(r.cost)}|`
+    ),
+    '',
+    `Please add the *${ctx.tagLabel}* tag to these resources.`,
+  ];
+  return lines.join('\n');
+}
+
+function buildSlack(ctx: CopyContext): string {
+  const h = header(ctx);
+  const lines = [
+    `*${h.title}*`,
+    h.subtitle,
+    '',
+    '```',
+    'Account | Resource | Service | Cost',
+    ...ctx.rows.map(rowLine),
+    '```',
+    '',
+    `Please add the *${ctx.tagLabel}* tag to these resources.`,
+  ];
+  return lines.join('\n');
+}
+
+function buildPlainText(ctx: CopyContext): string {
+  const h = header(ctx);
+  const lines = [
+    h.title,
+    h.subtitle,
+    '',
+    'Account | Resource | Service | Cost',
+    '-'.repeat(60),
+    ...ctx.rows.map(rowLine),
+    '',
+    `Please add the ${ctx.tagLabel} tag to these resources.`,
+  ];
+  return lines.join('\n');
+}
+
+type CopyFormat = 'jira' | 'slack' | 'text';
+const FORMAT_LABELS: Record<CopyFormat, string> = { jira: 'Jira', slack: 'Slack', text: 'Plain text' };
+const FORMAT_BUILDERS: Record<CopyFormat, (ctx: CopyContext) => string> = {
+  jira: buildJira,
+  slack: buildSlack,
+  text: buildPlainText,
+};
+
+function CopyButton({ ctx }: Readonly<{ ctx: CopyContext }>) {
+  const [copied, setCopied] = useState<CopyFormat | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = useCallback(() => {
-    if (rows.length === 0) return;
-    const text = buildIssueTemplate(rows, tagLabel);
+  const handleCopy = useCallback((format: CopyFormat) => {
+    if (ctx.rows.length === 0) return;
+    const text = FORMAT_BUILDERS[format](ctx);
     void navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
+      setCopied(format);
       if (timerRef.current !== null) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => { setCopied(false); }, 1500);
+      timerRef.current = setTimeout(() => { setCopied(null); }, 1500);
     });
-  }, [rows, tagLabel]);
+  }, [ctx]);
 
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      disabled={rows.length === 0}
-      className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed"
-      title="Copy issue template for all visible rows"
-    >
-      {copied ? <Check size={12} /> : <ClipboardCopy size={12} />}
-      <span>{copied ? 'Copied!' : 'Issue template'}</span>
-    </button>
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={ctx.rows.length === 0}
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <ClipboardCopy size={12} />
+          <span>Copy as…</span>
+          <ChevronDown className="h-3 w-3 text-text-muted" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-40 p-1" align="end">
+        {(['jira', 'slack', 'text'] as const).map(format => (
+          <button
+            key={format}
+            type="button"
+            onClick={() => { handleCopy(format); }}
+            className="w-full flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary transition-colors"
+          >
+            {copied === format ? <Check size={12} className="text-accent" /> : <span className="w-3" />}
+            <span>{copied === format ? 'Copied!' : FORMAT_LABELS[format]}</span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -392,7 +462,7 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
                 renderExpandedRow={renderExpandedRow}
                 height={Math.max(200, window.innerHeight - 520)}
                 csvFilename={`costgoblin-missing-tags-actionable-${dateRange.start}-${dateRange.end}`}
-                headerRight={<CopyIssueTemplateButton rows={filteredActionable} tagLabel={activeDimLabel} />}
+                headerRight={<CopyButton ctx={{ rows: filteredActionable, tagLabel: activeDimLabel, selectedOwner: selectedClosest, totalCost: filteredActionable.reduce((s, r) => s + Number(r.cost), 0) }} />}
               />
             </div>
           )}

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -199,21 +199,16 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
     [data],
   );
 
-  const visibleRows = useMemo(
-    () => [...actionableRows, ...likelyUntaggableRows],
-    [actionableRows, likelyUntaggableRows],
-  );
-
   const closestOptions = useMemo(() => {
     const totals = new Map<string, number>();
-    for (const r of visibleRows) {
+    for (const r of actionableRows) {
       const key = r.closestOwner ?? '';
       totals.set(key, (totals.get(key) ?? 0) + Number(r.cost));
     }
     return [...totals.entries()]
       .sort((a, b) => b[1] - a[1])
       .map(([entity, cost]) => ({ entity, cost }));
-  }, [visibleRows]);
+  }, [actionableRows]);
 
   const filteredActionable = useMemo(
     () => selectedClosest === null ? actionableRows : actionableRows.filter(r => (r.closestOwner ?? '') === selectedClosest),

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -17,7 +17,8 @@ import { DataTable } from '../components/data-table.js';
 import type { TableColumn } from '../lib/table-types.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
-import { ClipboardCopy, Check } from 'lucide-react';
+import { ClipboardCopy, Check, ChevronDown, CheckIcon } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '../components/ui/popover.js';
 
 function buildColumns(showRatio: boolean, dimLabel: string): readonly TableColumn<MissingTagRow>[] {
   const cols: TableColumn<MissingTagRow>[] = [
@@ -289,21 +290,55 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
         </label>
 
         {closestOptions.length > 0 && (
-          <label className="flex items-center gap-1.5 text-xs text-text-secondary">
-            <span>Fallback {activeDimLabel}</span>
-            <select
-              value={selectedClosest ?? '__all__'}
-              onChange={(e) => { setSelectedClosest(e.target.value === '__all__' ? null : e.target.value); }}
-              className="rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary"
-            >
-              <option value="__all__">All</option>
-              {closestOptions.map(opt => (
-                <option key={`opt-${opt.entity}`} value={opt.entity}>
-                  {opt.entity.length === 0 ? '(none)' : opt.entity} — {formatDollars(opt.cost)}
-                </option>
-              ))}
-            </select>
-          </label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-lg border border-border bg-bg-tertiary/30 px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary/50 transition-colors"
+              >
+                <span className="text-text-muted">Fallback {activeDimLabel}</span>
+                <span>{selectedClosest === null ? 'All' : (selectedClosest.length === 0 ? '(none)' : selectedClosest)}</span>
+                <ChevronDown className="h-3 w-3 text-text-muted" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72 p-1 max-h-80 overflow-y-auto" align="start">
+              <button
+                type="button"
+                onClick={() => { setSelectedClosest(null); }}
+                className={[
+                  'w-full flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors',
+                  selectedClosest === null
+                    ? 'bg-accent/10 text-accent font-medium'
+                    : 'text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary',
+                ].join(' ')}
+              >
+                {selectedClosest === null && <CheckIcon className="h-3 w-3" />}
+                {selectedClosest !== null && <span className="w-3" />}
+                <span>All</span>
+              </button>
+              {closestOptions.map(opt => {
+                const label = opt.entity.length === 0 ? '(none)' : opt.entity;
+                const isSelected = selectedClosest === opt.entity;
+                return (
+                  <button
+                    key={`opt-${opt.entity}`}
+                    type="button"
+                    onClick={() => { setSelectedClosest(opt.entity); }}
+                    className={[
+                      'w-full flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors',
+                      isSelected
+                        ? 'bg-accent/10 text-accent font-medium'
+                        : 'text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary',
+                    ].join(' ')}
+                  >
+                    {isSelected ? <CheckIcon className="h-3 w-3" /> : <span className="w-3" />}
+                    <span className="truncate">{label}</span>
+                    <span className="ml-auto tabular-nums text-text-muted">{formatDollars(opt.cost)}</span>
+                  </button>
+                );
+              })}
+            </PopoverContent>
+          </Popover>
         )}
 
       </div>

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type {
   Dimension,
   DimensionId,
@@ -17,6 +17,7 @@ import { DataTable } from '../components/data-table.js';
 import type { TableColumn } from '../lib/table-types.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
+import { ClipboardCopy, Check } from 'lucide-react';
 
 function buildColumns(showRatio: boolean, dimLabel: string): readonly TableColumn<MissingTagRow>[] {
   const cols: TableColumn<MissingTagRow>[] = [
@@ -92,6 +93,56 @@ function ExpandedRow({ row }: Readonly<{ row: MissingTagRow }>) {
         <span className="text-text-primary">{`${String(Math.round(row.categoryTaggedRatio * 100))}%`}</span>
       </div>
     </div>
+  );
+}
+
+function buildIssueTemplate(rows: readonly MissingTagRow[], tagLabel: string): string {
+  const sections = rows.map(row => {
+    const owner = row.closestOwner !== null && row.closestOwner.length > 0
+      ? String(row.closestOwner)
+      : 'Unknown';
+    return [
+      `## Missing Tags: ${row.service} / ${row.resourceId}`,
+      '',
+      `**Resource:** ${row.resourceId}`,
+      `**Account:** ${row.accountName} (${row.accountId})`,
+      `**Service:** ${row.service} — ${row.serviceFamily}`,
+      `**Owner (fallback):** ${owner}`,
+      `**Monthly Cost:** ${formatDollars(row.cost)}`,
+      '',
+      '### Action Required',
+      `Please add the following tag to this resource:`,
+      `- ${tagLabel}: TBD`,
+    ].join('\n');
+  });
+  return sections.join('\n\n---\n\n');
+}
+
+function CopyIssueTemplateButton({ rows, tagLabel }: Readonly<{ rows: readonly MissingTagRow[]; tagLabel: string }>) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(() => {
+    if (rows.length === 0) return;
+    const text = buildIssueTemplate(rows, tagLabel);
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => { setCopied(false); }, 1500);
+    });
+  }, [rows, tagLabel]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      disabled={rows.length === 0}
+      className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed"
+      title="Copy issue template for all visible rows"
+    >
+      {copied ? <Check size={12} /> : <ClipboardCopy size={12} />}
+      <span>{copied ? 'Copied!' : 'Issue template'}</span>
+    </button>
   );
 }
 
@@ -311,6 +362,7 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
                 renderExpandedRow={renderExpandedRow}
                 height={Math.max(200, window.innerHeight - 520)}
                 csvFilename={`costgoblin-missing-tags-actionable-${dateRange.start}-${dateRange.end}`}
+                headerRight={<CopyIssueTemplateButton rows={filteredActionable} tagLabel={activeDimLabel} />}
               />
             </div>
           )}

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -104,44 +104,79 @@ interface CopyContext {
   readonly totalCost: number;
 }
 
-function buildMessage(ctx: CopyContext): string {
+function buildMessageParts(ctx: CopyContext) {
   const owner = ctx.selectedOwner !== null && ctx.selectedOwner.length > 0
     ? ctx.selectedOwner
     : null;
-  const lines = [
-    `${String(ctx.rows.length)} resources are missing the ${ctx.tagLabel} tag`,
-    owner !== null ? `(filtered to ${owner})` : null,
-    `representing ${formatDollars(ctx.totalCost)}/month in unattributed spend.`,
-    '',
-    'The full list is in the attached CSV. Please tag these resources or confirm they should be excluded.',
-  ];
-  return lines.filter(l => l !== null).join(' ').replace('  ', '\n\n');
+  return { count: String(ctx.rows.length), tag: ctx.tagLabel, owner, cost: formatDollars(ctx.totalCost) };
 }
 
+function buildSlack(ctx: CopyContext): string {
+  const p = buildMessageParts(ctx);
+  const scope = p.owner !== null ? ` (filtered to *${p.owner}*)` : '';
+  return [
+    `*${p.count} resources* are missing the \`${p.tag}\` tag${scope}, representing *${p.cost}/month* in unattributed spend.`,
+    '',
+    'Full list in the attached CSV — please tag these resources or confirm they should be excluded.',
+  ].join('\n');
+}
+
+function buildJira(ctx: CopyContext): string {
+  const p = buildMessageParts(ctx);
+  const scope = p.owner !== null ? ` (filtered to *${p.owner}*)` : '';
+  return [
+    `h3. Missing {{${p.tag}}} tag`,
+    '',
+    `*${p.count} resources*${scope} representing *${p.cost}/month* in unattributed spend.`,
+    '',
+    'Full list in the attached CSV — please tag these resources or confirm they should be excluded.',
+  ].join('\n');
+}
+
+type CopyFormat = 'jira' | 'slack';
+const FORMAT_LABELS: Record<CopyFormat, string> = { jira: 'Jira', slack: 'Slack' };
+const FORMAT_BUILDERS: Record<CopyFormat, (ctx: CopyContext) => string> = { jira: buildJira, slack: buildSlack };
+
 function CopyMessageButton({ ctx }: Readonly<{ ctx: CopyContext }>) {
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<CopyFormat | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = useCallback(() => {
+  const handleCopy = useCallback((format: CopyFormat) => {
     if (ctx.rows.length === 0) return;
-    void navigator.clipboard.writeText(buildMessage(ctx)).then(() => {
-      setCopied(true);
+    void navigator.clipboard.writeText(FORMAT_BUILDERS[format](ctx)).then(() => {
+      setCopied(format);
       if (timerRef.current !== null) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => { setCopied(false); }, 1500);
+      timerRef.current = setTimeout(() => { setCopied(null); }, 1500);
     });
   }, [ctx]);
 
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      disabled={ctx.rows.length === 0}
-      className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-      title="Copy a message to accompany the CSV export"
-    >
-      {copied ? <Check size={12} className="text-accent" /> : <ClipboardCopy size={12} />}
-      <span>{copied ? 'Copied!' : 'Copy message'}</span>
-    </button>
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={ctx.rows.length === 0}
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <ClipboardCopy size={12} />
+          <span>Copy message</span>
+          <ChevronDown className="h-3 w-3 text-text-muted" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-36 p-1" align="end">
+        {(['slack', 'jira'] as const).map(format => (
+          <button
+            key={format}
+            type="button"
+            onClick={() => { handleCopy(format); }}
+            className="w-full flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary transition-colors"
+          >
+            {copied === format ? <Check size={12} className="text-accent" /> : <span className="w-3" />}
+            <span>{copied === format ? 'Copied!' : FORMAT_LABELS[format]}</span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -104,10 +104,6 @@ interface CopyContext {
   readonly totalCost: number;
 }
 
-function rowLine(r: MissingTagRow): string {
-  return `${r.accountName} | ${r.resourceId} | ${r.service} — ${r.serviceFamily} | ${formatDollars(r.cost)}`;
-}
-
 function header(ctx: CopyContext): { title: string; subtitle: string } {
   const owner = ctx.selectedOwner !== null && ctx.selectedOwner.length > 0
     ? ` — ${ctx.selectedOwner}`
@@ -149,27 +145,11 @@ function buildSlack(ctx: CopyContext): string {
   return lines.join('\n');
 }
 
-function buildPlainText(ctx: CopyContext): string {
-  const h = header(ctx);
-  const lines = [
-    h.title,
-    h.subtitle,
-    '',
-    'Account | Resource | Service | Cost',
-    '-'.repeat(60),
-    ...ctx.rows.map(rowLine),
-    '',
-    `Please add the ${ctx.tagLabel} tag to these resources.`,
-  ];
-  return lines.join('\n');
-}
-
-type CopyFormat = 'jira' | 'slack' | 'text';
-const FORMAT_LABELS: Record<CopyFormat, string> = { jira: 'Jira', slack: 'Slack', text: 'Plain text' };
+type CopyFormat = 'jira' | 'slack';
+const FORMAT_LABELS: Record<CopyFormat, string> = { jira: 'Jira', slack: 'Slack' };
 const FORMAT_BUILDERS: Record<CopyFormat, (ctx: CopyContext) => string> = {
   jira: buildJira,
   slack: buildSlack,
-  text: buildPlainText,
 };
 
 function CopyButton({ ctx }: Readonly<{ ctx: CopyContext }>) {
@@ -200,7 +180,7 @@ function CopyButton({ ctx }: Readonly<{ ctx: CopyContext }>) {
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-40 p-1" align="end">
-        {(['jira', 'slack', 'text'] as const).map(format => (
+        {(['jira', 'slack'] as const).map(format => (
           <button
             key={format}
             type="button"

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -140,10 +140,9 @@ function buildSlack(ctx: CopyContext): string {
     `*${h.title}*`,
     h.subtitle,
     '',
-    '```',
-    'Account | Resource | Service | Cost',
-    ...ctx.rows.map(rowLine),
-    '```',
+    ...ctx.rows.map(r =>
+      `• \`${r.accountName}\` — \`${r.resourceId}\` — ${r.service} / ${r.serviceFamily} — *${formatDollars(r.cost)}*`
+    ),
     '',
     `Please add the *${ctx.tagLabel}* tag to these resources.`,
   ];

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -104,95 +104,44 @@ interface CopyContext {
   readonly totalCost: number;
 }
 
-function header(ctx: CopyContext): { title: string; subtitle: string } {
+function buildMessage(ctx: CopyContext): string {
   const owner = ctx.selectedOwner !== null && ctx.selectedOwner.length > 0
-    ? ` — ${ctx.selectedOwner}`
-    : '';
-  return {
-    title: `Missing ${ctx.tagLabel} Tag${owner}`,
-    subtitle: `${String(ctx.rows.length)} resources | ${formatDollars(ctx.totalCost)} total`,
-  };
-}
-
-function buildJira(ctx: CopyContext): string {
-  const h = header(ctx);
+    ? ctx.selectedOwner
+    : null;
   const lines = [
-    `h2. ${h.title}`,
-    h.subtitle,
+    `${String(ctx.rows.length)} resources are missing the ${ctx.tagLabel} tag`,
+    owner !== null ? `(filtered to ${owner})` : null,
+    `representing ${formatDollars(ctx.totalCost)}/month in unattributed spend.`,
     '',
-    '||Account||Resource||Service||Cost||',
-    ...ctx.rows.map(r =>
-      `|${r.accountName}|${r.resourceId}|${r.service} — ${r.serviceFamily}|${formatDollars(r.cost)}|`
-    ),
-    '',
-    `Please add the *${ctx.tagLabel}* tag to these resources.`,
+    'The full list is in the attached CSV. Please tag these resources or confirm they should be excluded.',
   ];
-  return lines.join('\n');
+  return lines.filter(l => l !== null).join(' ').replace('  ', '\n\n');
 }
 
-function buildSlack(ctx: CopyContext): string {
-  const h = header(ctx);
-  const lines = [
-    `*${h.title}*`,
-    h.subtitle,
-    '',
-    ...ctx.rows.map(r =>
-      `• \`${r.accountName}\` — \`${r.resourceId}\` — ${r.service} / ${r.serviceFamily} — *${formatDollars(r.cost)}*`
-    ),
-    '',
-    `Please add the *${ctx.tagLabel}* tag to these resources.`,
-  ];
-  return lines.join('\n');
-}
-
-type CopyFormat = 'jira' | 'slack';
-const FORMAT_LABELS: Record<CopyFormat, string> = { jira: 'Jira', slack: 'Slack' };
-const FORMAT_BUILDERS: Record<CopyFormat, (ctx: CopyContext) => string> = {
-  jira: buildJira,
-  slack: buildSlack,
-};
-
-function CopyButton({ ctx }: Readonly<{ ctx: CopyContext }>) {
-  const [copied, setCopied] = useState<CopyFormat | null>(null);
+function CopyMessageButton({ ctx }: Readonly<{ ctx: CopyContext }>) {
+  const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = useCallback((format: CopyFormat) => {
+  const handleCopy = useCallback(() => {
     if (ctx.rows.length === 0) return;
-    const text = FORMAT_BUILDERS[format](ctx);
-    void navigator.clipboard.writeText(text).then(() => {
-      setCopied(format);
+    void navigator.clipboard.writeText(buildMessage(ctx)).then(() => {
+      setCopied(true);
       if (timerRef.current !== null) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => { setCopied(null); }, 1500);
+      timerRef.current = setTimeout(() => { setCopied(false); }, 1500);
     });
   }, [ctx]);
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={ctx.rows.length === 0}
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          <ClipboardCopy size={12} />
-          <span>Copy as…</span>
-          <ChevronDown className="h-3 w-3 text-text-muted" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent className="w-40 p-1" align="end">
-        {(['jira', 'slack'] as const).map(format => (
-          <button
-            key={format}
-            type="button"
-            onClick={() => { handleCopy(format); }}
-            className="w-full flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary transition-colors"
-          >
-            {copied === format ? <Check size={12} className="text-accent" /> : <span className="w-3" />}
-            <span>{copied === format ? 'Copied!' : FORMAT_LABELS[format]}</span>
-          </button>
-        ))}
-      </PopoverContent>
-    </Popover>
+    <button
+      type="button"
+      onClick={handleCopy}
+      disabled={ctx.rows.length === 0}
+      className="inline-flex items-center gap-1.5 rounded border border-border bg-bg-tertiary/30 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:border-border disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      title="Copy a message to accompany the CSV export"
+    >
+      {copied ? <Check size={12} className="text-accent" /> : <ClipboardCopy size={12} />}
+      <span>{copied ? 'Copied!' : 'Copy message'}</span>
+    </button>
   );
 }
 
@@ -441,7 +390,7 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
                 renderExpandedRow={renderExpandedRow}
                 height={Math.max(200, window.innerHeight - 520)}
                 csvFilename={`costgoblin-missing-tags-actionable-${dateRange.start}-${dateRange.end}`}
-                headerRight={<CopyButton ctx={{ rows: filteredActionable, tagLabel: activeDimLabel, selectedOwner: selectedClosest, totalCost: filteredActionable.reduce((s, r) => s + Number(r.cost), 0) }} />}
+                headerRight={<CopyMessageButton ctx={{ rows: filteredActionable, tagLabel: activeDimLabel, selectedOwner: selectedClosest, totalCost: filteredActionable.reduce((s, r) => s + Number(r.cost), 0) }} />}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- Reimplements the useful part of #142 (tag remediation workflow) without the stale branch baggage
- Adds an "Issue template" button in the actionable missing-tags DataTable header that copies a formatted markdown template to the clipboard
- Template includes resource ID, account, service, fallback owner, cost, and the missing tag key with a TBD placeholder
- No file persistence, no coverage chart, no new IPC handlers — just clipboard copy (~50 lines of new code)