### PR TITLE
Fix E2E: scope popover assertions, add Missing Tags heading

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -119,18 +119,18 @@ test.describe('Cost Overview', () => {
   });
 
   test('renders date range picker popover with presets', async () => {
-    // Trigger button shows active preset
     const trigger = page.locator('button:has(svg.lucide-calendar)');
     await expect(trigger).toBeVisible();
 
-    // Open popover and verify sections
     await trigger.click();
-    await expect(page.getByText('Daily')).toBeVisible();
-    await expect(page.getByText('Hourly')).toBeVisible();
-    await expect(page.getByText('Period')).toBeVisible();
-    await expect(page.getByText('Custom range…')).toBeVisible();
+    const popover = page.locator('[data-radix-popper-content-wrapper]');
+    await expect(popover).toBeVisible({ timeout: 5000 });
 
-    // Close by clicking trigger again
+    await expect(popover.getByText('Daily')).toBeVisible();
+    await expect(popover.getByText('Hourly')).toBeVisible();
+    await expect(popover.getByText('Period')).toBeVisible();
+    await expect(popover.getByText('Custom range…')).toBeVisible();
+
     await trigger.click();
   });
 
@@ -150,12 +150,13 @@ test.describe('Cost Overview', () => {
   test('custom date range inputs appear when Custom range is clicked', async () => {
     const trigger = page.locator('button:has(svg.lucide-calendar)');
     await trigger.click();
-    await page.getByText('Custom range…').click();
+    const popover = page.locator('[data-radix-popper-content-wrapper]');
+    await expect(popover).toBeVisible({ timeout: 5000 });
+    await popover.getByText('Custom range…').click();
 
-    await expect(page.getByText('From')).toBeVisible();
-    await expect(page.getByText('To')).toBeVisible();
+    await expect(popover.getByText('From', { exact: true })).toBeVisible();
+    await expect(popover.getByText('To', { exact: true })).toBeVisible();
 
-    // close popover
     await trigger.click();
   });
 

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -148,7 +148,7 @@ test.describe('Cost Overview', () => {
   });
 
   test('custom date range inputs appear when Custom range is clicked', async () => {
-    const trigger = page.locator('button:has(svg.lucide-calendar)');
+    const trigger = page.locator('button:has(svg.lucide-calendar)').first();
     await trigger.click();
     const popover = page.locator('[data-radix-popper-content-wrapper]');
     await expect(popover).toBeVisible({ timeout: 5000 });
@@ -157,7 +157,7 @@ test.describe('Cost Overview', () => {
     await expect(popover.getByText('From', { exact: true })).toBeVisible();
     await expect(popover.getByText('To', { exact: true })).toBeVisible();
 
-    await trigger.click();
+    await page.keyboard.press('Escape');
   });
 
   test('filter bar shows dimension chips and they are clickable', async () => {

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -194,7 +194,10 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
   return (
     <div className="flex flex-col gap-6 p-6">
       <div className="flex items-start justify-between">
-        <p className="text-base font-medium text-text-secondary">Resources without the selected allocation tag, classified by taggability.</p>
+        <div>
+          <h2 className="text-xl font-semibold text-text-primary">Missing Tags</h2>
+          <p className="text-sm text-text-secondary mt-0.5">Resources without the selected allocation tag, classified by taggability.</p>
+        </div>
         <DateRangePicker
           value={dateRange}
           granularity={granularity}


### PR DESCRIPTION
## Summary
- Scope date picker popover assertions to `[data-radix-popper-content-wrapper]` instead of page-global `getByText` — fixes flaky CI failures where popover content wasn't found
- Use `{ exact: true }` for "From"/"To" labels to avoid strict mode violation (3 elements match "From" globally)
- Add `<h2>Missing Tags</h2>` heading to the missing-tags view (was missing, E2E expected it)