### PR TITLE
Auto-update via electron-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            platform: mac
+          - os: windows-latest
+            platform: win
+          - os: ubuntu-latest
+            platform: linux
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build --workspaces
+
+      - name: Build installers
+        run: npx electron-builder --${{ matrix.platform }} --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,27 @@
+appId: com.costgoblin.app
+productName: CostGoblin
+directories:
+  buildResources: build
+  output: dist
+files:
+  - "packages/desktop/dist/**/*"
+  - "packages/ui/dist/**/*"
+  - "packages/core/dist/**/*"
+  - "node_modules/**/*"
+asar: true
+asarUnpack:
+  - "node_modules/duckdb/**"
+mac:
+  target:
+    - dmg
+    - zip
+  category: public.app-category.business
+win:
+  target:
+    - nsis
+linux:
+  target:
+    - AppImage
+    - deb
+publish:
+  provider: github

--- a/package-lock.json
+++ b/package-lock.json
@@ -6332,7 +6332,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -6506,6 +6505,19 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/cac": {
@@ -6919,7 +6931,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7106,6 +7117,57 @@
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-vite": {
       "version": "5.0.0",
@@ -7926,7 +7988,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -8187,7 +8248,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8348,6 +8408,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -8646,6 +8712,19 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8804,7 +8883,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -9618,6 +9696,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9641,7 +9728,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9917,6 +10003,12 @@
       "dependencies": {
         "readable-stream": "3"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -11594,6 +11686,7 @@
         "@aws-sdk/client-ssm": "^3.1038.0",
         "@duckdb/node-api": "^1.5.2-r.1",
         "@smithy/shared-ini-file-loader": "^4.4.9",
+        "electron-updater": "^6.8.3",
         "yaml": "^2.8.3"
       },
       "devDependencies": {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -204,3 +204,24 @@ export interface AccountMappingEntry {
 export type AccountMappingStatus =
   | { readonly status: 'found'; readonly accounts: readonly AccountMappingEntry[]; readonly path: string }
   | { readonly status: 'missing' };
+
+export interface UpdateInfo {
+  readonly version: string;
+  readonly releaseDate: string;
+  readonly releaseNotes: string | null;
+}
+
+export type UpdateStatus =
+  | { readonly state: 'idle' }
+  | { readonly state: 'checking' }
+  | { readonly state: 'available'; readonly info: UpdateInfo }
+  | { readonly state: 'downloading'; readonly percent: number; readonly info: UpdateInfo }
+  | { readonly state: 'downloaded'; readonly info: UpdateInfo }
+  | { readonly state: 'error'; readonly error: string };
+
+export interface UpdateApi {
+  checkForUpdates(): Promise<void>;
+  downloadUpdate(): Promise<void>;
+  quitAndInstall(): void;
+  onStatusChanged(callback: (status: UpdateStatus) => void): () => void;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -60,7 +60,7 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateStatus, UpdateApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -17,6 +17,7 @@
     "@aws-sdk/client-ssm": "^3.1038.0",
     "@duckdb/node-api": "^1.5.2-r.1",
     "@smithy/shared-ini-file-loader": "^4.4.9",
+    "electron-updater": "^6.8.3",
     "yaml": "^2.8.3"
   },
   "devDependencies": {

--- a/packages/desktop/src/main/handlers/update.ts
+++ b/packages/desktop/src/main/handlers/update.ts
@@ -9,7 +9,7 @@ import {
 export function registerUpdateHandlers(): void {
   ipcMain.handle('update:check', () => checkForUpdates());
   ipcMain.handle('update:download', () => downloadUpdate());
-  ipcMain.handle('update:quit-and-install', () => { quitAndInstall(); });
+  ipcMain.handle('update:quit-and-install', () => quitAndInstall());
 
   onStatusChanged((status) => {
     for (const win of BrowserWindow.getAllWindows()) {

--- a/packages/desktop/src/main/handlers/update.ts
+++ b/packages/desktop/src/main/handlers/update.ts
@@ -1,0 +1,19 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import {
+  checkForUpdates,
+  downloadUpdate,
+  quitAndInstall,
+  onStatusChanged,
+} from '../update-manager.js';
+
+export function registerUpdateHandlers(): void {
+  ipcMain.handle('update:check', () => checkForUpdates());
+  ipcMain.handle('update:download', () => downloadUpdate());
+  ipcMain.handle('update:quit-and-install', () => { quitAndInstall(); });
+
+  onStatusChanged((status) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('update:status-changed', status);
+    }
+  });
+}

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -10,6 +10,8 @@ import type { DuckDBClient } from './duckdb-client.js';
 import { createSyncClient } from './sync-client.js';
 import type { SyncClient } from './sync-client.js';
 import { registerIpcHandlers } from './ipc.js';
+import { initAutoUpdater } from './update-manager.js';
+import { registerUpdateHandlers } from './handlers/update.js';
 import { validateUrl, SecurityError } from './url-validator.js';
 import { validateProfileLabel } from './validators/path-validator.js';
 
@@ -219,6 +221,8 @@ async function main(): Promise<void> {
   logger.info('Sync worker ready');
 
   installCSP();
+  initAutoUpdater();
+  registerUpdateHandlers();
   await createWindow(db, syncClient);
 
   app.on('activate', () => {

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -221,7 +221,9 @@ async function main(): Promise<void> {
   logger.info('Sync worker ready');
 
   installCSP();
-  initAutoUpdater();
+  if (app.isPackaged) {
+    await initAutoUpdater();
+  }
   registerUpdateHandlers();
   await createWindow(db, syncClient);
 

--- a/packages/desktop/src/main/update-manager.ts
+++ b/packages/desktop/src/main/update-manager.ts
@@ -1,6 +1,15 @@
-import { autoUpdater } from 'electron-updater';
 import { logger, isStringRecord } from '@costgoblin/core';
 import type { UpdateInfo, UpdateStatus } from '@costgoblin/core';
+
+// Lazy-loaded — electron-updater crashes in dev/CI when app is not packaged
+let _updater: import('electron-updater').AppUpdater | null = null;
+async function loadUpdater(): Promise<import('electron-updater').AppUpdater> {
+  if (_updater === null) {
+    const mod = await import('electron-updater');
+    _updater = mod.autoUpdater;
+  }
+  return _updater;
+}
 
 type StatusListener = (status: UpdateStatus) => void;
 
@@ -42,51 +51,55 @@ function toUpdateInfo(info: { version: string; releaseDate: string; releaseNotes
 
 let currentInfo: UpdateInfo | null = null;
 
-export function initAutoUpdater(): void {
-  autoUpdater.autoDownload = false;
-  autoUpdater.autoInstallOnAppQuit = false;
+export async function initAutoUpdater(): Promise<void> {
+  const updater = await loadUpdater();
+  updater.autoDownload = false;
+  updater.autoInstallOnAppQuit = false;
 
-  autoUpdater.on('checking-for-update', () => {
+  updater.on('checking-for-update', () => {
     setStatus({ state: 'checking' });
   });
 
-  autoUpdater.on('update-available', (info) => {
+  updater.on('update-available', (info) => {
     currentInfo = toUpdateInfo(info);
     setStatus({ state: 'available', info: currentInfo });
   });
 
-  autoUpdater.on('update-not-available', () => {
+  updater.on('update-not-available', () => {
     setStatus({ state: 'idle' });
   });
 
-  autoUpdater.on('download-progress', (progress) => {
+  updater.on('download-progress', (progress) => {
     if (currentInfo === null) return;
     setStatus({ state: 'downloading', percent: Math.round(progress.percent), info: currentInfo });
   });
 
-  autoUpdater.on('update-downloaded', (info) => {
+  updater.on('update-downloaded', (info) => {
     const downloadedInfo = toUpdateInfo(info);
     currentInfo = downloadedInfo;
     setStatus({ state: 'downloaded', info: downloadedInfo });
   });
 
-  autoUpdater.on('error', (err) => {
+  updater.on('error', (err) => {
     setStatus({ state: 'error', error: err.message });
   });
 
   logger.info('Auto-updater initialized');
 }
 
-export function checkForUpdates(): Promise<void> {
-  return autoUpdater.checkForUpdates().then(() => undefined);
+export async function checkForUpdates(): Promise<void> {
+  const updater = await loadUpdater();
+  await updater.checkForUpdates();
 }
 
-export function downloadUpdate(): Promise<void> {
-  return autoUpdater.downloadUpdate().then(() => undefined);
+export async function downloadUpdate(): Promise<void> {
+  const updater = await loadUpdater();
+  await updater.downloadUpdate();
 }
 
-export function quitAndInstall(): void {
-  autoUpdater.quitAndInstall();
+export async function quitAndInstall(): Promise<void> {
+  const updater = await loadUpdater();
+  updater.quitAndInstall();
 }
 
 export function onStatusChanged(callback: StatusListener): () => void {

--- a/packages/desktop/src/main/update-manager.ts
+++ b/packages/desktop/src/main/update-manager.ts
@@ -1,0 +1,96 @@
+import { autoUpdater } from 'electron-updater';
+import { logger, isStringRecord } from '@costgoblin/core';
+import type { UpdateInfo, UpdateStatus } from '@costgoblin/core';
+
+type StatusListener = (status: UpdateStatus) => void;
+
+let currentStatus: UpdateStatus = { state: 'idle' };
+const listeners = new Set<StatusListener>();
+
+function setStatus(status: UpdateStatus): void {
+  currentStatus = status;
+  for (const listener of listeners) {
+    listener(status);
+  }
+}
+
+function extractReleaseNotes(raw: unknown): string | null {
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw)) {
+    const parts: string[] = [];
+    const items: unknown[] = raw;
+    for (const item of items) {
+      if (typeof item === 'string') {
+        parts.push(item);
+      } else if (isStringRecord(item)) {
+        const note = item['note'];
+        if (typeof note === 'string') parts.push(note);
+      }
+    }
+    return parts.length > 0 ? parts.join('\n') : null;
+  }
+  return null;
+}
+
+function toUpdateInfo(info: { version: string; releaseDate: string; releaseNotes?: unknown }): UpdateInfo {
+  return {
+    version: info.version,
+    releaseDate: info.releaseDate,
+    releaseNotes: extractReleaseNotes(info.releaseNotes),
+  };
+}
+
+let currentInfo: UpdateInfo | null = null;
+
+export function initAutoUpdater(): void {
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on('checking-for-update', () => {
+    setStatus({ state: 'checking' });
+  });
+
+  autoUpdater.on('update-available', (info) => {
+    currentInfo = toUpdateInfo(info);
+    setStatus({ state: 'available', info: currentInfo });
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    setStatus({ state: 'idle' });
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    if (currentInfo === null) return;
+    setStatus({ state: 'downloading', percent: Math.round(progress.percent), info: currentInfo });
+  });
+
+  autoUpdater.on('update-downloaded', (info) => {
+    const downloadedInfo = toUpdateInfo(info);
+    currentInfo = downloadedInfo;
+    setStatus({ state: 'downloaded', info: downloadedInfo });
+  });
+
+  autoUpdater.on('error', (err) => {
+    setStatus({ state: 'error', error: err.message });
+  });
+
+  logger.info('Auto-updater initialized');
+}
+
+export function checkForUpdates(): Promise<void> {
+  return autoUpdater.checkForUpdates().then(() => undefined);
+}
+
+export function downloadUpdate(): Promise<void> {
+  return autoUpdater.downloadUpdate().then(() => undefined);
+}
+
+export function quitAndInstall(): void {
+  autoUpdater.quitAndInstall();
+}
+
+export function onStatusChanged(callback: StatusListener): () => void {
+  listeners.add(callback);
+  callback(currentStatus);
+  return () => { listeners.delete(callback); };
+}

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -283,6 +283,23 @@ const api: CostApi = {
 
 contextBridge.exposeInMainWorld('costgoblin', api);
 
+contextBridge.exposeInMainWorld('costgoblinUpdate', {
+  checkForUpdates(): Promise<void> {
+    return invoke<undefined>('update:check').then(() => undefined);
+  },
+  downloadUpdate(): Promise<void> {
+    return invoke<undefined>('update:download').then(() => undefined);
+  },
+  quitAndInstall(): void {
+    ipcRenderer.invoke('update:quit-and-install').catch(() => undefined);
+  },
+  onStatusChanged(callback: (status: unknown) => void): () => void {
+    const handler = (_event: unknown, status: unknown): void => { callback(status); };
+    ipcRenderer.on('update:status-changed', handler);
+    return () => { ipcRenderer.removeListener('update:status-changed', handler); };
+  },
+});
+
 contextBridge.exposeInMainWorld('costgoblinDebug', {
   isSandboxed(): boolean { return process.sandboxed; },
   getInFlightCount(): number { return inFlightCount; },

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useMemo, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
-import type { CostApi, FilterMap, ViewsConfig, ViewSpec } from '@costgoblin/core/browser';
+import type { CostApi, FilterMap, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue } from '@costgoblin/core/browser';
+import { Download, RefreshCw } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 
 // ---------------------------------------------------------------------------
@@ -144,6 +145,104 @@ function SyncAnnouncer({
   );
 }
 
+function UpdateNotification({
+  status,
+  onShowReleaseNotes,
+}: {
+  status: UpdateStatus;
+  onShowReleaseNotes: () => void;
+}): React.JSX.Element | null {
+  if (status.state === 'available') {
+    return (
+      <button
+        type="button"
+        onClick={onShowReleaseNotes}
+        className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-accent hover:bg-bg-tertiary/50 transition-colors"
+      >
+        <Download size={14} />
+        v{status.info.version} available
+      </button>
+    );
+  }
+  if (status.state === 'downloading') {
+    return (
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-text-secondary">
+        <RefreshCw size={14} className="animate-spin" />
+        Downloading {String(status.percent)}%
+      </div>
+    );
+  }
+  if (status.state === 'downloaded') {
+    return (
+      <button
+        type="button"
+        onClick={onShowReleaseNotes}
+        className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-positive hover:bg-bg-tertiary/50 transition-colors"
+      >
+        <Download size={14} />
+        Restart to update
+      </button>
+    );
+  }
+  return null;
+}
+
+function ReleaseNotesModal({
+  open,
+  onOpenChange,
+  status,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  status: UpdateStatus;
+}): React.JSX.Element | null {
+  if (status.state !== 'available' && status.state !== 'downloaded') return null;
+  const { info } = status;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>
+          {status.state === 'downloaded' ? 'Ready to Install' : 'Update Available'} &mdash; v{info.version}
+        </DialogTitle>
+        <DialogDescription>
+          Released {info.releaseDate}
+        </DialogDescription>
+        {info.releaseNotes !== null && (
+          <div className="mt-3 max-h-60 overflow-y-auto rounded-md bg-bg-primary p-3 text-sm text-text-secondary whitespace-pre-wrap">
+            {info.releaseNotes}
+          </div>
+        )}
+        <div className="mt-4 flex justify-end gap-2">
+          <DialogClose>
+            <Button variant="ghost" size="sm">Dismiss</Button>
+          </DialogClose>
+          {status.state === 'available' && (
+            <Button
+              size="sm"
+              onClick={() => {
+                globalThis.costgoblinUpdate.downloadUpdate().catch(() => undefined);
+                onOpenChange(false);
+              }}
+            >
+              <Download size={14} className="mr-1.5" />
+              Download
+            </Button>
+          )}
+          {status.state === 'downloaded' && (
+            <Button
+              size="sm"
+              onClick={() => { globalThis.costgoblinUpdate.quitAndInstall(); }}
+            >
+              <RefreshCw size={14} className="mr-1.5" />
+              Install and Restart
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 /** Top-level app shell — just establishes the context providers. All the
  *  state + navigation lives in `AppShell` below so it can call
  *  `useConfirmLeave()` from inside the UnsavedChangesProvider. */
@@ -177,6 +276,12 @@ function AppShell(): React.JSX.Element {
   const [syncFilesRemaining, setSyncFilesRemaining] = useState(0);
   const [debugOpen, setDebugOpen] = useState(false);
   const inFlightCount = useDebugBadge();
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: 'idle' });
+  const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
+
+  useEffect(() => {
+    return globalThis.costgoblinUpdate.onStatusChanged(setUpdateStatus);
+  }, []);
 
   useEffect(() => {
     api.getSetupStatus().then(({ configured }) => {
@@ -396,6 +501,7 @@ function AppShell(): React.JSX.Element {
             <span className="text-sm font-bold text-accent tracking-wider">CostGoblin</span>
           </div>
           <div className="flex items-center justify-end gap-1 [-webkit-app-region:no-drag]" role="navigation" aria-label="Configuration views">
+            <UpdateNotification status={updateStatus} onShowReleaseNotes={() => { setReleaseNotesOpen(true); }} />
             <button
               type="button"
               onClick={() => { setDebugOpen(prev => !prev); }}
@@ -542,6 +648,7 @@ function AppShell(): React.JSX.Element {
         </Profiler>
       </div>
       {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} />}
+      <ReleaseNotesModal open={releaseNotesOpen} onOpenChange={setReleaseNotesOpen} status={updateStatus} />
       </div>
     </PaletteProvider>
   );

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -1,4 +1,4 @@
-import type { CostApi } from '@costgoblin/core/browser';
+import type { CostApi, UpdateApi } from '@costgoblin/core/browser';
 
 declare global {
   interface DebugQueryLogEntry {
@@ -43,11 +43,13 @@ declare global {
 
   interface Window {
     costgoblin: CostApi;
+    costgoblinUpdate: UpdateApi;
     costgoblinDebug: DebugApi;
     costgoblinPerf?: PerfApi;
     __PERF_REACT__?: RenderTiming[];
   }
   var costgoblin: CostApi;
+  var costgoblinUpdate: UpdateApi;
   var costgoblinDebug: DebugApi;
   var costgoblinPerf: PerfApi | undefined;
   var __PERF_REACT__: RenderTiming[] | undefined;

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '../../lib/utils.js';
+
+export const Dialog = DialogPrimitive.Root;
+
+export const DialogTrigger = DialogPrimitive.Trigger;
+
+export const DialogPortal = DialogPrimitive.Portal;
+
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 w-full max-w-md translate-x-[-50%] translate-y-[-50%] rounded-xl border border-border bg-bg-secondary p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export function DialogTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-sm font-semibold text-text-primary', className)}
+      {...props}
+    />
+  );
+}
+
+export function DialogDescription({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn('text-sm text-text-secondary', className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,6 +15,7 @@ export type { ButtonProps } from './components/ui/button.js';
 export { Calendar } from './components/ui/calendar.js';
 export type { CalendarProps } from './components/ui/calendar.js';
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from './components/ui/popover.js';
+export { Dialog, DialogTrigger, DialogPortal, DialogClose, DialogOverlay, DialogContent, DialogTitle, DialogDescription } from './components/ui/dialog.js';
 
 export { ErrorBoundary } from './components/error-boundary.js';
 export { BubbleChart } from './components/bubble-chart.js';


### PR DESCRIPTION
Reimplements #189 from scratch. Separate UpdateApi (not in CostApi), IPC push instead of polling, shadcn Dialog, Lucide icons. Includes electron-builder config and release workflow.

## Summary
- **Core types**: `UpdateInfo`, `UpdateStatus` discriminated union, `UpdateApi` interface -- all in `packages/core/src/types/api.ts`, exported from barrel
- **Update manager** (`packages/desktop/src/main/update-manager.ts`): wraps `electron-updater` autoUpdater with `Set<StatusListener>` pattern, `autoDownload: false`
- **IPC handlers** (`packages/desktop/src/main/handlers/update.ts`): `update:check`, `update:download`, `update:quit-and-install` + push-based status via `webContents.send`
- **Preload bridge**: `window.costgoblinUpdate` (separate from `window.costgoblin`) with IPC-backed methods
- **UI**: `UpdateNotification` (nav bar button for available/downloading/downloaded states) + `ReleaseNotesModal` (shadcn Dialog with version info, release notes, Download/Install buttons, Lucide icons)
- **shadcn Dialog component** (`packages/ui/src/components/ui/dialog.tsx`): Radix Dialog primitive with project styling
- **electron-builder.yml**: mac/win/linux targets with GitHub publish
- **release.yml**: GitHub Actions workflow triggered on `v*` tags, builds on all 3 platforms