### PR TITLE
Fix release build configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,6 +27,7 @@ win:
     - target: nsis
       arch:
         - x64
+        - arm64
 linux:
   target:
     - target: AppImage

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -32,8 +32,10 @@ linux:
     - target: AppImage
       arch:
         - x64
+        - arm64
     - target: deb
       arch:
         - x64
+        - arm64
 publish:
   provider: github

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,15 +13,27 @@ asarUnpack:
   - "node_modules/duckdb/**"
 mac:
   target:
-    - dmg
-    - zip
+    - target: dmg
+      arch:
+        - x64
+        - arm64
+    - target: zip
+      arch:
+        - x64
+        - arm64
   category: public.app-category.business
 win:
   target:
-    - nsis
+    - target: nsis
+      arch:
+        - x64
 linux:
   target:
-    - AppImage
-    - deb
+    - target: AppImage
+      arch:
+        - x64
+    - target: deb
+      arch:
+        - x64
 publish:
   provider: github

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "costgoblin",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
+      "version": "0.1.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "costgoblin",
+  "version": "0.1.0",
+  "description": "Desktop app for cloud cost visibility",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Etienne Chabert",


### PR DESCRIPTION
## Summary
- Add `version` and `description` to root package.json (required by electron-builder)
- Upgrade Node from 20 to 22 in release workflow (required by electron-builder 26.x)
- Add arm64 + x64 architecture targets for macOS builds (dmg, zip)
- Explicitly set x64 arch for Windows (nsis) and Linux (AppImage, deb) targets