### PR TITLE
Fix release assets uploading to wrong release

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,3 +42,5 @@ linux:
         - arm64
 publish:
   provider: github
+  vPrefixedTagName: true
+  releaseType: release


### PR DESCRIPTION
## Summary

- Set `releaseType: release` so electron-builder uploads assets directly to the existing tag release instead of creating a separate draft
- Set `vPrefixedTagName: true` so the release matches the `v*` git tag (e.g. `v0.2.2` instead of `0.2.2`)

Previously, assets ended up on a hidden draft release while the published release remained empty.