### PR TITLE
Savings table: Add keyboard navigation tests

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit && eslint src/ && vitest run",
-    "test": "vitest run"
+    "check": "tsc --noEmit && eslint src/ && vitest run --root ../.. --project=ui",
+    "test": "vitest run --root ../.. --project=ui"
   },
   "dependencies": {
     "@costgoblin/core": "*",

--- a/packages/ui/src/__tests__/savings.test.tsx
+++ b/packages/ui/src/__tests__/savings.test.tsx
@@ -104,6 +104,20 @@ describe('Savings', () => {
     });
   });
 
+  it('expands row with Enter key', async () => {
+    const { user } = renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    });
+    const row = screen.getByText(/Detach and delete/).closest('tr');
+    expect(row).not.toBeNull();
+    (row as HTMLElement).focus();
+    await user.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(screen.getByText('vol-abc123')).toBeDefined();
+    });
+  });
+
   it('shows effort badges with correct labels', async () => {
     renderSavings();
     await waitFor(() => {

--- a/packages/ui/src/__tests__/savings.test.tsx
+++ b/packages/ui/src/__tests__/savings.test.tsx
@@ -118,6 +118,20 @@ describe('Savings', () => {
     });
   });
 
+  it('expands row with Space key', async () => {
+    const { user } = renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    });
+    const row = screen.getByText(/Detach and delete/).closest('tr');
+    expect(row).not.toBeNull();
+    (row as HTMLElement).focus();
+    await user.keyboard(' ');
+    await waitFor(() => {
+      expect(screen.getByText('vol-abc123')).toBeDefined();
+    });
+  });
+
   it('shows effort badges with correct labels', async () => {
     renderSavings();
     await waitFor(() => {

--- a/packages/ui/src/__tests__/savings.test.tsx
+++ b/packages/ui/src/__tests__/savings.test.tsx
@@ -140,4 +140,15 @@ describe('Savings', () => {
       expect(screen.getByText('Medium')).toBeDefined();
     });
   });
+
+  it('sets proper accessibility attributes on table rows', async () => {
+    renderSavings();
+    await waitFor(() => {
+      expect(screen.getByText(/Detach and delete/)).toBeDefined();
+    });
+    const row = screen.getByText(/Detach and delete/).closest('tr');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('tabIndex')).toBe('0');
+    expect(row?.getAttribute('role')).toBe('row');
+  });
 });


### PR DESCRIPTION
The Savings view table (savings.tsx) uses clickable <tr> elements for row expansion, but these rows have no tabIndex, role, or onKeyDown handlers. Users cannot Tab to rows or use Enter/Space to expand them. This contrasts with the DataTable component (data-table.tsx) which correctly implements tabIndex={0}, role='row', and onKeyDown for Enter/Space on its expandable rows.