### PR TITLE
Fix vitest run from packages/ui directory

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit && eslint src/ && vitest run",
-    "test": "vitest run"
+    "check": "tsc --noEmit && eslint src/ && vitest run --root ../.. --project=ui",
+    "test": "vitest run --root ../.. --project=ui"
   },
   "dependencies": {
     "@costgoblin/core": "*",


### PR DESCRIPTION
## Summary
- `npm run check` and `npm run test` in `packages/ui/` fail with "No test files found" because vitest can't find the root config
- Add `--root ../.. --project=ui` flags to point at the monorepo root vitest config

Extracted from #203 (closed — tests were boilerplate, this config fix was the useful part).