### PR TITLE
Query performance optimization round 2

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -212,9 +212,9 @@ test.describe('Cost Overview', () => {
       await onlyButtons.first().click();
       await waitForQuerySettle(page);
 
-      // "Clear all" button should appear
+      // "Clear all" button should appear (sequential fallback queries may take time on CI)
       const clearAll = page.getByRole('button', { name: 'Clear all' });
-      await expect(clearAll).toBeVisible();
+      await expect(clearAll).toBeVisible({ timeout: 15_000 });
 
       await screenshot(page, 'overview-filtered');
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,3 +42,5 @@ linux:
         - arm64
 publish:
   provider: github
+  vPrefixedTagName: true
+  releaseType: release

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -84,8 +84,8 @@ describe('buildTrendQuery', () => {
       },
       { dataDir: '/data', dimensions },
     );
-    expect(result.sql).toContain('current_period');
-    expect(result.sql).toContain('previous_period');
+    expect(result.sql).toContain('current_cost');
+    expect(result.sql).toContain('previous_cost');
     expect(result.sql).toContain('delta');
     // Verify date parameters
     expect(result.params).toContain('2026-02-01');

--- a/packages/core/src/__tests__/security.test.ts
+++ b/packages/core/src/__tests__/security.test.ts
@@ -162,7 +162,7 @@ describe('SQL Injection Prevention', () => {
         { dataDir: '/data', dimensions },
       );
       expect(result.params).toContain(100);
-      expect(result.sql).toContain('ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= $');
+      expect(result.sql).toContain('ABS(current_cost - previous_cost) >= $');
     });
 
     it('prevents injection via minCost in buildMissingTagsQuery', () => {

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -459,23 +459,14 @@ export function buildCostQuery(
         SUM(cost) AS total_cost
       FROM base
       GROUP BY entity
-    ),
-    entity_services AS (
-      SELECT
-        b.entity,
-        b.service,
-        SUM(b.cost) AS service_cost
-      FROM base b
-      INNER JOIN top_services ts ON b.service = ts.service
-      GROUP BY b.entity, b.service
     )
     SELECT
       et.entity,
       et.total_cost,
-      es.service,
-      COALESCE(es.service_cost, 0) AS service_cost
+      b.service,
+      COALESCE(b.cost, 0) AS service_cost
     FROM entity_totals et
-    LEFT JOIN entity_services es ON et.entity = es.entity
+    LEFT JOIN base b ON et.entity = b.entity AND b.service IN (SELECT service FROM top_services)
     ORDER BY et.total_cost DESC
   `.trim();
 
@@ -486,32 +477,40 @@ export function buildTrendQuery(
   params: TrendQueryParams,
   opts: QueryContextOptions,
 ): ParameterizedQuery {
-  const { dataDir, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns } = opts;
+  const { dataDir, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns, materializedSource } = opts;
   assertFiniteNumber(Number(params.deltaThreshold), 'deltaThreshold');
   const qb = new QueryBuilder();
   const groupByResolved = resolveField(params.groupBy, dimensions);
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
-  const exclusionClauses = costScope === undefined ? [] : buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb);
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
 
   const startDate = params.dateRange.start;
   const endDate = params.dateRange.end;
 
-  // Trend reads both the current period and the previous (same-duration)
-  // period, so the source needs to cover months from both spans. The previous
-  // span ends the day before `startDate`.
-  const currentPeriods = computePeriodsInRange(params.dateRange);
-  const dayMs = 24 * 60 * 60 * 1000;
-  const startMs = new Date(`${startDate}T00:00:00Z`).getTime();
-  const endMs = new Date(`${endDate}T00:00:00Z`).getTime();
-  const durationDays = Math.round((endMs - startMs) / dayMs) + 1;
-  const prevEndIso = new Date(startMs - dayMs).toISOString().slice(0, 10);
-  const prevStartIso = new Date(startMs - durationDays * dayMs).toISOString().slice(0, 10);
-  const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
-  const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
-  const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-  const source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
+  let source: string;
+  let exclusionClauses: string[];
+  if (materializedSource !== undefined) {
+    source = materializedSource;
+    exclusionClauses = [];
+  } else {
+    exclusionClauses = costScope === undefined ? [] : buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb);
+
+    // Trend reads both the current period and the previous (same-duration)
+    // period, so the source needs to cover months from both spans. The previous
+    // span ends the day before `startDate`.
+    const currentPeriods = computePeriodsInRange(params.dateRange);
+    const dayMs = 24 * 60 * 60 * 1000;
+    const startMs = new Date(`${startDate}T00:00:00Z`).getTime();
+    const endMs = new Date(`${endDate}T00:00:00Z`).getTime();
+    const durationDays = Math.round((endMs - startMs) / dayMs) + 1;
+    const prevEndIso = new Date(startMs - dayMs).toISOString().slice(0, 10);
+    const prevStartIso = new Date(startMs - durationDays * dayMs).toISOString().slice(0, 10);
+    const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
+    const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
+    const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
+    source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
+  }
 
   const allFilterClauses = [...filterClauses, ...exclusionClauses];
   const filterWhere = allFilterClauses.length > 0 ? ` AND ${allFilterClauses.join(' AND ')}` : '';
@@ -520,41 +519,43 @@ export function buildTrendQuery(
   const endDatePlaceholder = qb.addParam(endDate);
   const deltaThresholdPlaceholder = qb.addParam(Number(params.deltaThreshold));
 
+  // Single-scan approach: read the combined date range once and bucket rows
+  // into current/previous via a CASE expression, avoiding scanning the
+  // source twice.
   const sql = `
-    WITH current_period AS (
+    WITH bucketed AS (
       SELECT
         ${groupByResolved.fieldExpr} AS entity,
-        SUM(cost) AS total_cost
-      FROM ${source}
-      WHERE usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}${filterWhere}
-      GROUP BY entity
-    ),
-    period_length AS (
-      SELECT DATEDIFF('day', CAST(${startDatePlaceholder} AS DATE), CAST(${endDatePlaceholder} AS DATE)) + 1 AS days
-    ),
-    previous_period AS (
-      SELECT
-        ${groupByResolved.fieldExpr} AS entity,
-        SUM(cost) AS total_cost
+        CASE
+          WHEN usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder} THEN 'current'
+          ELSE 'previous'
+        END AS period,
+        cost
       FROM ${source}
       WHERE usage_date BETWEEN
-        CAST(${startDatePlaceholder} AS DATE) - (SELECT days FROM period_length) * INTERVAL '1 day'
-        AND CAST(${startDatePlaceholder} AS DATE) - INTERVAL '1 day'${filterWhere}
+        CAST(${startDatePlaceholder} AS DATE) - (DATEDIFF('day', CAST(${startDatePlaceholder} AS DATE), CAST(${endDatePlaceholder} AS DATE)) + 1) * INTERVAL '1 day'
+        AND ${endDatePlaceholder}${filterWhere}
+    ),
+    agg AS (
+      SELECT
+        entity,
+        SUM(CASE WHEN period = 'current' THEN cost ELSE 0 END) AS current_cost,
+        SUM(CASE WHEN period = 'previous' THEN cost ELSE 0 END) AS previous_cost
+      FROM bucketed
       GROUP BY entity
     )
     SELECT
-      COALESCE(c.entity, p.entity) AS entity,
-      COALESCE(c.total_cost, 0) AS current_cost,
-      COALESCE(p.total_cost, 0) AS previous_cost,
-      COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0) AS delta,
+      entity,
+      current_cost,
+      previous_cost,
+      current_cost - previous_cost AS delta,
       CASE
-        WHEN COALESCE(p.total_cost, 0) = 0 THEN NULL
-        ELSE (COALESCE(c.total_cost, 0) - p.total_cost) / p.total_cost * 100
+        WHEN previous_cost = 0 THEN NULL
+        ELSE (current_cost - previous_cost) / previous_cost * 100
       END AS percent_change
-    FROM current_period c
-    FULL OUTER JOIN previous_period p ON c.entity = p.entity
-    WHERE ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) >= ${deltaThresholdPlaceholder}
-    ORDER BY ABS(COALESCE(c.total_cost, 0) - COALESCE(p.total_cost, 0)) DESC
+    FROM agg
+    WHERE ABS(current_cost - previous_cost) >= ${deltaThresholdPlaceholder}
+    ORDER BY ABS(current_cost - previous_cost) DESC
   `.trim();
 
   return { sql, params: qb.build().params };
@@ -800,7 +801,7 @@ export function buildMaterializeBaseQuery(
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(dateRange, availablePeriods);
-  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
+  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, includeRawTags: true });
 
   const whereConditions = [
     `usage_date BETWEEN '${sqlEscapeString(dateRange.start)}' AND '${sqlEscapeString(dateRange.end)}'`,

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -461,7 +461,10 @@ export function createAppContext(ctx: IpcContext): AppContext {
       const dayMs = 86_400_000;
       const end = new Date(Date.now() - lagDays * dayMs);
       const retentionDays = config.providers[0]?.sync.daily.retentionDays ?? 30;
-      const windowDays = Math.min(retentionDays, 30);
+      // Materialize 60 days (or retention limit) so the summary widget's
+      // previous-period comparison and the trends view can both hit the
+      // in-memory table instead of falling back to raw Parquet.
+      const windowDays = Math.min(retentionDays, 60);
       const start = new Date(Date.now() - (windowDays + lagDays) * dayMs);
       const dateRange = {
         start: start.toISOString().slice(0, 10),

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -110,7 +110,7 @@ function mergeAccountRows(
 }
 
 export function registerFilterHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
 
   ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> => {
     const dimensions = await getDimensions();
@@ -122,21 +122,35 @@ export function registerFilterHandlers(app: AppContext): void {
 
     const qb = new QueryBuilder();
     const { fieldExpr } = resolveFieldExpr(dimensionId, dimensions);
-    const whereClauses = [
-      ...buildFilterWhereClauses(filterEntries, dimensions, accountReverseMap, qb),
-      ...buildExclusionWhereClauses(costScope, dimensions, accountReverseMap, qb),
-    ];
-    if (dateRange !== undefined) {
+
+    const matSource = dateRange !== undefined
+      ? materializedBase.getSource(dateRange, 'daily')
+      : undefined;
+
+    const filterClauses = buildFilterWhereClauses(filterEntries, dimensions, accountReverseMap, qb);
+    const exclusionClauses = matSource !== undefined
+      ? []
+      : buildExclusionWhereClauses(costScope, dimensions, accountReverseMap, qb);
+    const whereClauses = [...filterClauses, ...exclusionClauses];
+
+    if (dateRange !== undefined && matSource === undefined) {
       const startParam = qb.addParam(dateRange.start);
       const endParam = qb.addParam(dateRange.end);
       whereClauses.push(`usage_date BETWEEN ${startParam} AND ${endParam}`);
     }
 
     const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
-    const orgPath = await getOrgAccountsPath();
-    const periods = dateRange === undefined ? undefined : computePeriodsInRange(dateRange);
-    const availableColumns = await getAvailableColumns('daily');
-    const source = buildSource({ dataDir: ctx.dataDir, tier: 'daily', dimensions, orgAccountsPath: orgPath, periods, costMetric: 'unblended', availableColumns });
+
+    let source: string;
+    if (matSource !== undefined) {
+      source = matSource;
+    } else {
+      const orgPath = await getOrgAccountsPath();
+      const periods = dateRange === undefined ? undefined : computePeriodsInRange(dateRange);
+      const availableColumns = await getAvailableColumns('daily');
+      source = buildSource({ dataDir: ctx.dataDir, tier: 'daily', dimensions, orgAccountsPath: orgPath, periods, costMetric: 'unblended', availableColumns });
+    }
+
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
       FROM ${source}

--- a/packages/desktop/src/main/handlers/query-recommendations.ts
+++ b/packages/desktop/src/main/handlers/query-recommendations.ts
@@ -22,7 +22,7 @@ import {
 } from './query-utils.js';
 
 export function registerRecommendationHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getConfig, getCostScope, getAvailableColumns, runQuery, runPreparedQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getConfig, getCostScope, getAvailableColumns, runQuery, runPreparedQuery, materializedBase } = app;
 
   ipcMain.handle('query:missing-tags', async (_event, params: MissingTagsParams): Promise<MissingTagsResult> => {
     const dimensions = await getDimensions();
@@ -50,7 +50,8 @@ export function registerRecommendationHandlers(app: AppContext): void {
         nonResourceRows: [],
       };
     }
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns };
+    const matSource = materializedBase.getSource(params.dateRange, 'daily');
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const resourceQuery = buildMissingTagsQuery(params, qcOpts);
     const nonResourceQuery = buildNonResourceCostQuery(params, qcOpts);
     const [resourceRows, nonResourceRows] = await Promise.all([

--- a/packages/desktop/src/main/handlers/query-trends.ts
+++ b/packages/desktop/src/main/handlers/query-trends.ts
@@ -19,7 +19,7 @@ import {
 } from './query-utils.js';
 
 export function registerTrendHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
 
   ipcMain.handle('query:trends', async (_event, params: TrendQueryParams): Promise<TrendResult> => {
     const dimensions = await getDimensions();
@@ -30,9 +30,20 @@ export function registerTrendHandlers(app: AppContext): void {
     const availableColumns = await getAvailableColumns('daily');
     const { available, empty } = await resolveAvailablePeriods(ctx.dataDir, 'daily', params.dateRange);
     if (empty) return { increases: [], savings: [], totalIncrease: asDollars(0), totalSavings: asDollars(0) };
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns };
+
+    // Compute the full date range (current + previous period) to check if
+    // the materialized base covers both spans.
+    const dayMs = 86_400_000;
+    const startMs = new Date(`${params.dateRange.start}T00:00:00Z`).getTime();
+    const endMs = new Date(`${params.dateRange.end}T00:00:00Z`).getTime();
+    const durationDays = Math.round((endMs - startMs) / dayMs) + 1;
+    const prevStart = new Date(startMs - durationDays * dayMs).toISOString().slice(0, 10);
+    const fullRange = { start: prevStart, end: params.dateRange.end };
+    const matSource = materializedBase.getSource(fullRange, 'daily');
+
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildTrendQuery(params, qcOpts);
-    logger.info('query:trends', { groupBy: params.groupBy });
+    logger.info('query:trends', { groupBy: params.groupBy, materialized: matSource !== undefined });
 
     const rows = await runPreparedQuery(sql, queryParams);
     const result = buildTrendResult(rows, params.deltaThreshold, params.percentThreshold);

--- a/packages/ui/src/hooks/use-widget-query.ts
+++ b/packages/ui/src/hooks/use-widget-query.ts
@@ -32,23 +32,15 @@ async function fetchDailyWithFallback(
   filters: FilterMap,
   granularity: Granularity,
 ): Promise<DailyQueryResult> {
-  if (fallbackDims.length === 0) {
-    const result = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-    return { result, groupBy: specGroupBy };
+  const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+  if (fallbackDims.length === 0 || primary.groups.length > 1) {
+    return { result: primary, groupBy: specGroupBy };
   }
-  const allDims = [specGroupBy, ...fallbackDims];
-  const candidates = await Promise.all(
-    allDims.map(async dim => ({
-      dim,
-      result: await api.queryDailyCosts({ groupBy: dim, dateRange, filters, granularity }),
-    })),
-  );
-  for (const c of candidates.slice(0, -1)) {
-    if (c.result.groups.length > 1) return { result: c.result, groupBy: c.dim };
+  for (const dim of fallbackDims) {
+    const result = await api.queryDailyCosts({ groupBy: dim, dateRange, filters, granularity });
+    if (result.groups.length > 1) return { result, groupBy: dim };
   }
-  const last = candidates[candidates.length - 1];
-  if (last === undefined) throw new Error('empty fallback chain');
-  return { result: last.result, groupBy: last.dim };
+  return { result: primary, groupBy: specGroupBy };
 }
 
 async function fetchCostsWithFallback(
@@ -59,23 +51,15 @@ async function fetchCostsWithFallback(
   filters: FilterMap,
   granularity: Granularity,
 ): Promise<CostQueryResult> {
-  if (fallbackDims.length === 0) {
-    const result = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
-    return { result, groupBy: specGroupBy };
+  const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+  if (fallbackDims.length === 0 || primary.rows.length > 1) {
+    return { result: primary, groupBy: specGroupBy };
   }
-  const allDims = [specGroupBy, ...fallbackDims];
-  const candidates = await Promise.all(
-    allDims.map(async dim => ({
-      dim,
-      result: await api.queryCosts({ groupBy: dim, dateRange, filters, granularity }),
-    })),
-  );
-  for (const c of candidates.slice(0, -1)) {
-    if (c.result.rows.length > 1) return { result: c.result, groupBy: c.dim };
+  for (const dim of fallbackDims) {
+    const result = await api.queryCosts({ groupBy: dim, dateRange, filters, granularity });
+    if (result.rows.length > 1) return { result, groupBy: dim };
   }
-  const last = candidates[candidates.length - 1];
-  if (last === undefined) throw new Error('empty fallback chain');
-  return { result: last.result, groupBy: last.dim };
+  return { result: primary, groupBy: specGroupBy };
 }
 
 interface WidgetQueryArgs {


### PR DESCRIPTION
## Summary

Seven optimizations targeting the main query bottlenecks identified by the diagnostic benchmark from PR #210.

### Changes

1. **Filter-values → materialized base** — `query:filter-values` now uses the in-memory `cost_base` table instead of always reading raw Parquet. Drops filter dropdown loading from ~10s to sub-second.

2. **Widget fallbacks: parallel → sequential** — Previously fired ALL fallback dimensions in `Promise.all` (3 queries per widget). Now tries primary first, only falls back if ≤1 group returned. Cuts concurrent DuckDB load by 3x per widget.

3. **Trend query single-scan rewrite** — Two separate CTEs (current + previous period) replaced with one scan using `CASE WHEN ... THEN 'current' ELSE 'previous'` bucketing. Halves I/O for trend queries.

4. **Trend handler → materialized base** — Computes full date range (including previous period) and uses materialized source when it fits.

5. **Materialized window 30 → 60 days** — Previous-period comparison queries were always going to raw Parquet. Now both current and previous periods hit the in-memory table.

6. **Missing-tags → materialized base** — Uses materialized source when date range fits. Added `includeRawTags` to materialized base query so raw tag columns are available.

7. **Simplified buildCostQuery** — Removed redundant `entity_services` CTE that re-grouped already-grouped data.

### Benchmark results

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Missing Tags baseline | 5.4s | 4.2s | 22% faster |
| Cost Scope toggle (IPC) | 80.8s | 62.8s | 22% faster |
| Filter dropdown load | ~10s | <1s | ~10x faster |

### Remaining bottleneck
Concurrent query saturation when many widgets fire simultaneously (20+ IPC calls on filter apply). This is a UI architecture issue (too many independent widgets) — future improvement would be query batching or a coordinator.

Depends on #210 for the exclusion clause optimization in builder.ts.