### PR TITLE
Fix OOM crash: DuckDB memory limit, stale query cancellation, graceful error handling

### DIFF
--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -6,6 +6,7 @@ export interface DuckDBClient {
   runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]>;
   runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]>;
   cancelPendingQueries(): void;
+  configure(tempDir: string): void;
   terminate(): Promise<void>;
 }
 
@@ -83,6 +84,9 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
     },
     cancelPendingQueries(): void {
       worker.postMessage({ kind: 'cancel-pending' });
+    },
+    configure(tempDir: string): void {
+      worker.postMessage({ kind: 'configure', tempDir });
     },
     async terminate(): Promise<void> {
       await worker.terminate();

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -15,24 +15,12 @@ async function createDuckDB(): Promise<DuckDBInstance> {
 
 function computeMemoryLimitGB(): number {
   const totalGB = totalmem() / (1024 * 1024 * 1024);
-  // Cap DuckDB at 25% of system RAM (min 1 GB, max 4 GB). Electron itself,
-  // the renderer process, and the OS all need headroom — 25% keeps DuckDB
-  // from triggering the OOM killer while still being generous for aggregates
-  // spanning a full year of billing data.
-  return Math.min(4, Math.max(1, Math.round(totalGB * 0.25)));
-}
-
-function computeThreadCount(): number {
-  // Limit DuckDB's internal parallelism to half the logical CPUs (min 2,
-  // max 4). Combined with the connection pool, this prevents N-connections
-  // x M-threads memory explosions during concurrent hash aggregates.
-  return Math.min(4, Math.max(2, Math.floor(cpus().length / 2)));
+  return Math.min(4, Math.max(1, Math.round(totalGB * 0.5)));
 }
 
 async function configureDuckDB(conn: DuckDBConnection, tempDir: string | undefined): Promise<void> {
   const memGB = computeMemoryLimitGB();
   await conn.run(`SET memory_limit = '${String(memGB)}GB'`);
-  await conn.run(`SET threads = ${String(computeThreadCount())}`);
   if (tempDir !== undefined) {
     await conn.run(`SET temp_directory = '${tempDir.replaceAll("'", "''")}'`);
   }
@@ -165,23 +153,13 @@ async function fetchAllRowsPrepared(
   }
 }
 
-/**
- * Pool of DuckDB connections on one DuckDBInstance. A single connection
- * serializes queries internally — with N connections, independent queries
- * execute in parallel (bound by DuckDB's own thread scheduling). Queries
- * arriving while all connections are busy queue FIFO via ResourcePool.
- *
- * Size defaults to 4 (min 2, max 8). Previously defaulted to cpus().length
- * which caused N-connections x M-threads memory explosions during concurrent
- * hash aggregates on large date ranges. Override with COSTGOBLIN_DUCKDB_POOL_SIZE.
- */
 function parsePoolSize(): number {
   const raw = process.env['COSTGOBLIN_DUCKDB_POOL_SIZE'];
   if (raw !== undefined) {
     const n = Number.parseInt(raw, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 32) return n;
   }
-  return Math.min(Math.max(2, Math.floor(cpus().length / 2)), 8);
+  return Math.min(Math.max(4, cpus().length), 16);
 }
 
 let poolPromise: Promise<ResourcePool<DuckDBConnection>> | null = null;

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -197,7 +197,7 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
   // Check before acquiring a pool connection
   if (cancelledIds.has(req.id)) {
     cancelledIds.delete(req.id);
-    send({ kind: 'rows', id: req.id, rows: [] });
+    send({ kind: 'error', id: req.id, message: 'Query cancelled' });
     return;
   }
 
@@ -211,7 +211,7 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
     // Check after acquiring — cancel may have arrived while queued
     if (cancelledIds.has(req.id)) {
       cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
+      send({ kind: 'error', id: req.id, message: 'Query cancelled' });
       return;
     }
 
@@ -221,7 +221,7 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
     // Skip serialization if cancelled during execution
     if (cancelledIds.has(req.id)) {
       cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
+      send({ kind: 'error', id: req.id, message: 'Query cancelled' });
     } else {
       send({ kind: 'rows', id: req.id, rows });
     }
@@ -238,7 +238,7 @@ async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; 
   // Check before acquiring a pool connection
   if (cancelledIds.has(req.id)) {
     cancelledIds.delete(req.id);
-    send({ kind: 'rows', id: req.id, rows: [] });
+    send({ kind: 'error', id: req.id, message: 'Query cancelled' });
     return;
   }
 
@@ -252,7 +252,7 @@ async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; 
     // Check after acquiring — cancel may have arrived while queued
     if (cancelledIds.has(req.id)) {
       cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
+      send({ kind: 'error', id: req.id, message: 'Query cancelled' });
       return;
     }
 
@@ -262,7 +262,7 @@ async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; 
     // Skip serialization if cancelled during execution
     if (cancelledIds.has(req.id)) {
       cancelledIds.delete(req.id);
-      send({ kind: 'rows', id: req.id, rows: [] });
+      send({ kind: 'error', id: req.id, message: 'Query cancelled' });
     } else {
       send({ kind: 'rows', id: req.id, rows });
     }

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,5 +1,5 @@
 import { parentPort } from 'node:worker_threads';
-import { cpus } from 'node:os';
+import { cpus, totalmem } from 'node:os';
 import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
 import { createResourcePool } from './connection-pool.js';
 import type { ResourcePool } from './connection-pool.js';
@@ -11,6 +11,31 @@ interface DuckDBModule {
 async function createDuckDB(): Promise<DuckDBInstance> {
   const duckdb = (await import('@duckdb/node-api')) as unknown as DuckDBModule;
   return duckdb.DuckDBInstance.create();
+}
+
+function computeMemoryLimitGB(): number {
+  const totalGB = totalmem() / (1024 * 1024 * 1024);
+  // Cap DuckDB at 25% of system RAM (min 1 GB, max 4 GB). Electron itself,
+  // the renderer process, and the OS all need headroom — 25% keeps DuckDB
+  // from triggering the OOM killer while still being generous for aggregates
+  // spanning a full year of billing data.
+  return Math.min(4, Math.max(1, Math.round(totalGB * 0.25)));
+}
+
+function computeThreadCount(): number {
+  // Limit DuckDB's internal parallelism to half the logical CPUs (min 2,
+  // max 4). Combined with the connection pool, this prevents N-connections
+  // x M-threads memory explosions during concurrent hash aggregates.
+  return Math.min(4, Math.max(2, Math.floor(cpus().length / 2)));
+}
+
+async function configureDuckDB(conn: DuckDBConnection, tempDir: string | undefined): Promise<void> {
+  const memGB = computeMemoryLimitGB();
+  await conn.run(`SET memory_limit = '${String(memGB)}GB'`);
+  await conn.run(`SET threads = ${String(computeThreadCount())}`);
+  if (tempDir !== undefined) {
+    await conn.run(`SET temp_directory = '${tempDir.replaceAll("'", "''")}'`);
+  }
 }
 
 if (parentPort === null) {
@@ -41,6 +66,11 @@ function isPreparedQueryRequest(msg: unknown): msg is { kind: 'prepared-query'; 
 function isCancelRequest(msg: unknown): msg is { kind: 'cancel-pending' } {
   if (!hasProps(msg)) return false;
   return msg['kind'] === 'cancel-pending';
+}
+
+function isConfigureRequest(msg: unknown): msg is { kind: 'configure'; tempDir: string } {
+  if (!hasProps(msg)) return false;
+  return msg['kind'] === 'configure' && typeof msg['tempDir'] === 'string';
 }
 
 // ---------------------------------------------------------------------------
@@ -141,8 +171,9 @@ async function fetchAllRowsPrepared(
  * execute in parallel (bound by DuckDB's own thread scheduling). Queries
  * arriving while all connections are busy queue FIFO via ResourcePool.
  *
- * Size defaults to the number of logical CPUs (min 4, max 16). Override
- * with COSTGOBLIN_DUCKDB_POOL_SIZE.
+ * Size defaults to 4 (min 2, max 8). Previously defaulted to cpus().length
+ * which caused N-connections x M-threads memory explosions during concurrent
+ * hash aggregates on large date ranges. Override with COSTGOBLIN_DUCKDB_POOL_SIZE.
  */
 function parsePoolSize(): number {
   const raw = process.env['COSTGOBLIN_DUCKDB_POOL_SIZE'];
@@ -150,13 +181,23 @@ function parsePoolSize(): number {
     const n = Number.parseInt(raw, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 32) return n;
   }
-  return Math.min(Math.max(4, cpus().length), 16);
+  return Math.min(Math.max(2, Math.floor(cpus().length / 2)), 8);
 }
 
 let poolPromise: Promise<ResourcePool<DuckDBConnection>> | null = null;
+let dbInstance: DuckDBInstance | null = null;
 
 function getPool(): Promise<ResourcePool<DuckDBConnection>> {
-  poolPromise ??= createDuckDB().then(db => createResourcePool(parsePoolSize(), () => db.connect()));
+  poolPromise ??= createDuckDB().then(async (db) => {
+    dbInstance = db;
+    // Apply memory limit and thread count immediately using a temporary
+    // connection. The temp_directory is set later via the 'configure'
+    // message once the main thread knows the userData path.
+    const initConn = await db.connect();
+    await configureDuckDB(initConn, undefined);
+    initConn.disconnectSync();
+    return createResourcePool(parsePoolSize(), () => db.connect());
+  });
   return poolPromise;
 }
 
@@ -265,6 +306,16 @@ function handleCancelPending(): void {
   }
 }
 
+async function handleConfigure(req: { kind: 'configure'; tempDir: string }): Promise<void> {
+  if (dbInstance === null) return;
+  const conn = await dbInstance.connect();
+  try {
+    await conn.run(`SET temp_directory = '${req.tempDir.replaceAll("'", "''")}'`);
+  } finally {
+    conn.disconnectSync();
+  }
+}
+
 port.on('message', (msg: unknown) => {
   if (isQueryRequest(msg)) {
     handleRequest(msg).catch(() => undefined);
@@ -272,5 +323,35 @@ port.on('message', (msg: unknown) => {
     handlePreparedRequest(msg).catch(() => undefined);
   } else if (isCancelRequest(msg)) {
     handleCancelPending();
+  } else if (isConfigureRequest(msg)) {
+    handleConfigure(msg).catch(() => undefined);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Graceful error handling — prevent worker crashes from taking down Electron
+// ---------------------------------------------------------------------------
+process.on('uncaughtException', (err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  // Notify all pending queries that they failed
+  for (const id of runningIds) {
+    send({ kind: 'error', id, message: `DuckDB worker error: ${message}` });
+  }
+  runningIds.clear();
+  for (const id of queuedIds) {
+    send({ kind: 'error', id, message: `DuckDB worker error: ${message}` });
+  }
+  queuedIds.clear();
+});
+
+process.on('unhandledRejection', (reason: unknown) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  for (const id of runningIds) {
+    send({ kind: 'error', id, message: `DuckDB worker rejection: ${message}` });
+  }
+  runningIds.clear();
+  for (const id of queuedIds) {
+    send({ kind: 'error', id, message: `DuckDB worker rejection: ${message}` });
+  }
+  queuedIds.clear();
 });

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -152,7 +152,7 @@ export interface AppContext {
   readonly queryLog: QueryLog;
   readonly materializedBase: MaterializedBase;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
-  readonly runPreparedQuery: (sql: string, params: readonly unknown[]) => Promise<RawRow[]>;
+  readonly runPreparedQuery: (sql: string, params: readonly unknown[], materialized?: boolean) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
   readonly invalidateDimensions: () => void;
   readonly invalidateViews: () => void;
@@ -438,12 +438,12 @@ export function createAppContext(ctx: IpcContext): AppContext {
     });
   };
 
-  const runPreparedQuery = (sql: string, params: readonly unknown[]): Promise<RawRow[]> => {
+  const runPreparedQuery = (sql: string, params: readonly unknown[], materialized?: boolean): Promise<RawRow[]> => {
     const key = `${sql}\0${JSON.stringify(params)}`;
     const cached = resultCache.get(key);
     if (cached !== undefined) return Promise.resolve(cached);
     return dedup(key, async () => {
-      const result = await wrappedRunPreparedQuery(sql, params);
+      const result = await wrappedRunPreparedQuery(sql, params, materialized);
       if (result.length > 0) resultCache.set(key, result);
       return result;
     });

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -441,7 +441,12 @@ export function createAppContext(ctx: IpcContext): AppContext {
   const runPreparedQuery = (sql: string, params: readonly unknown[], materialized?: boolean): Promise<RawRow[]> => {
     const key = `${sql}\0${JSON.stringify(params)}`;
     const cached = resultCache.get(key);
-    if (cached !== undefined) return Promise.resolve(cached);
+    if (cached !== undefined) {
+      const id = queryLog.start(sql, params, materialized === true);
+      queryLog.markRunning(id);
+      queryLog.complete(id, cached.length, true);
+      return Promise.resolve(cached);
+    }
     return dedup(key, async () => {
       const result = await wrappedRunPreparedQuery(sql, params, materialized);
       if (result.length > 0) resultCache.set(key, result);

--- a/packages/desktop/src/main/handlers/query-costs.ts
+++ b/packages/desktop/src/main/handlers/query-costs.ts
@@ -44,11 +44,12 @@ export function registerCostHandlers(app: AppContext): void {
     const { available, empty } = await resolveAvailablePeriods(ctx.dataDir, tier, params.dateRange);
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
     const matSource = materializedBase.getSource(params.dateRange, tier);
+    const isMat = matSource !== undefined;
     const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildCostQuery(params, qcOpts);
-    logger.info('query:costs', { groupBy: params.groupBy, materialized: matSource !== undefined });
+    logger.info('query:costs', { groupBy: params.groupBy, materialized: isMat });
 
-    const rows = await runPreparedQuery(sql, queryParams);
+    const rows = await runPreparedQuery(sql, queryParams, isMat);
     let result = buildCostResult(rows, params.dateRange);
 
     if (params.groupBy === 'account' || params.groupBy === 'account_id') {
@@ -78,11 +79,12 @@ export function registerCostHandlers(app: AppContext): void {
     const { available, empty } = await resolveAvailablePeriods(ctx.dataDir, tier, params.dateRange);
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
     const matSource = materializedBase.getSource(params.dateRange, tier);
+    const isMat = matSource !== undefined;
     const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildDailyCostsQuery(params, qcOpts);
-    logger.info('query:daily-costs', { groupBy: params.groupBy, materialized: matSource !== undefined });
+    logger.info('query:daily-costs', { groupBy: params.groupBy, materialized: isMat });
 
-    const rows = await runPreparedQuery(sql, queryParams);
+    const rows = await runPreparedQuery(sql, queryParams, isMat);
 
     const dayMap = new Map<string, Record<string, number>>();
     const groupSet = new Set<string>();
@@ -149,11 +151,12 @@ export function registerCostHandlers(app: AppContext): void {
       };
     }
     const matSource = materializedBase.getSource(params.dateRange, tier);
+    const isMat = matSource !== undefined;
     const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildEntityDetailQuery(params, qcOpts);
-    logger.info('query:entity-detail', { entity: params.entity, materialized: matSource !== undefined });
+    logger.info('query:entity-detail', { entity: params.entity, materialized: isMat });
 
-    const rows = await runPreparedQuery(sql, queryParams);
+    const rows = await runPreparedQuery(sql, queryParams, isMat);
     const result = buildEntityDetailResult(rows, params.entity);
     return {
       ...result,

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -162,7 +162,7 @@ export function registerFilterHandlers(app: AppContext): void {
     `;
 
     const params = qb.build().params;
-    const rows = await runPreparedQuery(sql, params);
+    const rows = await runPreparedQuery(sql, params, matSource !== undefined);
     const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
     if (isAccountDim) return mergeAccountRows(rows, accountMap);
 

--- a/packages/desktop/src/main/handlers/query-recommendations.ts
+++ b/packages/desktop/src/main/handlers/query-recommendations.ts
@@ -51,12 +51,13 @@ export function registerRecommendationHandlers(app: AppContext): void {
       };
     }
     const matSource = materializedBase.getSource(params.dateRange, 'daily');
+    const isMat = matSource !== undefined;
     const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const resourceQuery = buildMissingTagsQuery(params, qcOpts);
     const nonResourceQuery = buildNonResourceCostQuery(params, qcOpts);
     const [resourceRows, nonResourceRows] = await Promise.all([
-      runPreparedQuery(resourceQuery.sql, resourceQuery.params),
-      runPreparedQuery(nonResourceQuery.sql, nonResourceQuery.params),
+      runPreparedQuery(resourceQuery.sql, resourceQuery.params, isMat),
+      runPreparedQuery(nonResourceQuery.sql, nonResourceQuery.params, isMat),
     ]);
     const result = buildMissingTagsResult(resourceRows, nonResourceRows, Number(params.minCost));
     return {

--- a/packages/desktop/src/main/handlers/query-trends.ts
+++ b/packages/desktop/src/main/handlers/query-trends.ts
@@ -40,12 +40,13 @@ export function registerTrendHandlers(app: AppContext): void {
     const prevStart = new Date(startMs - durationDays * dayMs).toISOString().slice(0, 10);
     const fullRange = { start: prevStart, end: params.dateRange.end };
     const matSource = materializedBase.getSource(fullRange, 'daily');
+    const isMat = matSource !== undefined;
 
     const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildTrendQuery(params, qcOpts);
-    logger.info('query:trends', { groupBy: params.groupBy, materialized: matSource !== undefined });
+    logger.info('query:trends', { groupBy: params.groupBy, materialized: isMat });
 
-    const rows = await runPreparedQuery(sql, queryParams);
+    const rows = await runPreparedQuery(sql, queryParams, isMat);
     const result = buildTrendResult(rows, params.deltaThreshold, params.percentThreshold);
     if (params.groupBy === 'account' || params.groupBy === 'account_id') {
       return {

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -245,9 +245,7 @@ async function main(): Promise<void> {
 }
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+  app.quit();
 });
 
 void (async () => {

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -214,6 +214,12 @@ async function main(): Promise<void> {
   // into out/worker/ to find them.
   const duckdbWorkerPath = join(__dirname, '..', 'worker', 'duckdb-worker.cjs');
   const db = await createDuckDBClient(duckdbWorkerPath);
+
+  const userDataPath = app.getPath('userData');
+  const tempDir = join(userDataPath, 'temp');
+  mkdirSync(tempDir, { recursive: true });
+  db.configure(tempDir);
+
   logger.info('DuckDB worker ready');
 
   const syncWorkerPath = join(__dirname, '..', 'worker', 'sync-worker.cjs');

--- a/packages/desktop/src/main/query-log.ts
+++ b/packages/desktop/src/main/query-log.ts
@@ -11,6 +11,7 @@ export interface QueryLogEntry {
   readonly durationMs: number | null;
   readonly rowCount: number | null;
   readonly error: string | null;
+  readonly materialized: boolean;
 }
 
 interface InternalEntry {
@@ -23,6 +24,7 @@ interface InternalEntry {
   durationMs: number | null;
   rowCount: number | null;
   error: string | null;
+  materialized: boolean;
 }
 
 const MAX_ENTRIES = 200;
@@ -31,7 +33,7 @@ export class QueryLog {
   private entries: InternalEntry[] = [];
   private nextId = 0;
 
-  start(sql: string, params: readonly unknown[]): number {
+  start(sql: string, params: readonly unknown[], materialized: boolean = false): number {
     const id = this.nextId++;
     this.entries.push({
       id,
@@ -43,6 +45,7 @@ export class QueryLog {
       durationMs: null,
       rowCount: null,
       error: null,
+      materialized,
     });
     if (this.entries.length > MAX_ENTRIES) {
       this.entries = this.entries.slice(-MAX_ENTRIES);
@@ -83,6 +86,7 @@ export class QueryLog {
       durationMs: e.durationMs,
       rowCount: e.rowCount,
       error: e.error,
+      materialized: e.materialized,
     }));
   }
 
@@ -110,9 +114,9 @@ export class QueryLog {
     };
   }
 
-  wrapPreparedQuery(fn: (sql: string, params: readonly unknown[], onStarted?: () => void) => Promise<RawRow[]>): (sql: string, params: readonly unknown[]) => Promise<RawRow[]> {
-    return (sql: string, params: readonly unknown[]) => {
-      const id = this.start(sql, params);
+  wrapPreparedQuery(fn: (sql: string, params: readonly unknown[], onStarted?: () => void) => Promise<RawRow[]>): (sql: string, params: readonly unknown[], materialized?: boolean) => Promise<RawRow[]> {
+    return (sql: string, params: readonly unknown[], materialized?: boolean) => {
+      const id = this.start(sql, params, materialized === true);
       return fn(sql, params, () => { this.markRunning(id); }).then(
         (rows) => { this.complete(id, rows.length); return rows; },
         (err: unknown) => { this.fail(id, err instanceof Error ? err.message : String(err)); throw err; },

--- a/packages/desktop/src/main/query-log.ts
+++ b/packages/desktop/src/main/query-log.ts
@@ -12,6 +12,7 @@ export interface QueryLogEntry {
   readonly rowCount: number | null;
   readonly error: string | null;
   readonly materialized: boolean;
+  readonly cached: boolean;
 }
 
 interface InternalEntry {
@@ -25,6 +26,7 @@ interface InternalEntry {
   rowCount: number | null;
   error: string | null;
   materialized: boolean;
+  cached: boolean;
 }
 
 const MAX_ENTRIES = 200;
@@ -46,6 +48,7 @@ export class QueryLog {
       rowCount: null,
       error: null,
       materialized,
+      cached: false,
     });
     if (this.entries.length > MAX_ENTRIES) {
       this.entries = this.entries.slice(-MAX_ENTRIES);
@@ -60,12 +63,13 @@ export class QueryLog {
     }
   }
 
-  complete(id: number, rowCount: number): void {
+  complete(id: number, rowCount: number, cached: boolean = false): void {
     const entry = this.entries.find(e => e.id === id);
     if (entry === undefined) return;
     entry.status = 'success';
     entry.durationMs = Date.now() - entry.startedAt;
     entry.rowCount = rowCount;
+    entry.cached = cached;
   }
 
   fail(id: number, message: string): void {
@@ -87,6 +91,7 @@ export class QueryLog {
       rowCount: e.rowCount,
       error: e.error,
       materialized: e.materialized,
+      cached: e.cached,
     }));
   }
 

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -69,8 +69,16 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
           <span className="flex-1 text-xs font-mono text-text-secondary truncate">
             {sqlPreview(entry.sql)}
           </span>
-          <span className="text-xs text-text-muted shrink-0">
-            {(() => { if (entry.durationMs !== null) { return formatDuration(entry.durationMs); } return entry.status === 'queued' ? 'queued' : '...'; })()}
+          <span className="flex items-center gap-1.5 shrink-0">
+            {entry.cached && (
+              <span className="text-[10px] font-medium px-1 rounded bg-accent/15 text-accent">CACHE</span>
+            )}
+            {entry.materialized && !entry.cached && (
+              <span className="text-[10px] font-medium px-1 rounded bg-positive/15 text-positive">MEM</span>
+            )}
+            <span className="text-xs text-text-muted">
+              {(() => { if (entry.durationMs !== null) { return formatDuration(entry.durationMs); } return entry.status === 'queued' ? 'queued' : '...'; })()}
+            </span>
           </span>
         </div>
         <div className="flex items-center gap-3 mt-0.5 ml-4">

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -10,6 +10,8 @@ declare global {
     readonly durationMs: number | null;
     readonly rowCount: number | null;
     readonly error: string | null;
+    readonly materialized: boolean;
+    readonly cached: boolean;
   }
 
   interface DebugApi {

--- a/packages/ui/src/hooks/use-query.ts
+++ b/packages/ui/src/hooks/use-query.ts
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import type { QueryState } from '@costgoblin/core/browser';
 
+const MAX_CANCEL_RETRIES = 2;
+
 export function useQuery<T>(
   fetcher: () => Promise<T>,
   deps: unknown[],
 ): QueryState<T> {
   const [state, setState] = useState<QueryState<T>>({ status: 'idle' });
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -17,18 +20,22 @@ export function useQuery<T>(
         if (!cancelled) setState({ status: 'success', data });
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
-          setState({
-            status: 'error',
-            error: err instanceof Error ? err : new Error(String(err)),
-          });
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg === 'Query cancelled' && retryCount < MAX_CANCEL_RETRIES) {
+          setRetryCount(c => c + 1);
+          return;
         }
+        setState({
+          status: 'error',
+          error: err instanceof Error ? err : new Error(msg),
+        });
       });
 
     return () => {
       cancelled = true;
     };
-  }, deps);
+  }, [...deps, retryCount]);
 
   return state;
 }

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type {
   Dimension,
   DimensionId,
@@ -82,6 +82,15 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
     ? getDimensionId(dimensions[0])
     : null;
   const activeDimensionId = state.selectedDimensionId ?? firstDimId;
+
+  const trendsFirstRef = useRef(true);
+  useEffect(() => {
+    if (trendsFirstRef.current) {
+      trendsFirstRef.current = false;
+      return;
+    }
+    api.cancelPendingQueries().catch(() => undefined);
+  }, [state.dateRange.start, state.dateRange.end, state.granularity, api]);
 
   const trendsQuery = useQuery(
     () => {

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -80,6 +80,18 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     [dateRange],
   );
 
+  // Cancel in-flight DuckDB queries when the date range or granularity
+  // changes so stale 30d queries don't compete for memory with new 365d
+  // queries. Skip the initial mount — there's nothing to cancel yet.
+  const isFirstRenderRef = useRef(true);
+  useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+    api.cancelPendingQueries().catch(() => undefined);
+  }, [dateRange, granularity, api]);
+
   // Load persisted date range and granularity on mount
   useEffect(() => {
     api.getExplorerPreferences().then(prefs => {

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -82,10 +82,15 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
 
   // Cancel in-flight DuckDB queries when the date range or granularity
   // changes so stale 30d queries don't compete for memory with new 365d
-  // queries. Skip until preferences have loaded — restoring a saved date
-  // range triggers a state change that would cancel the startup queries.
+  // queries. Skip until one render AFTER preferences have loaded — the
+  // prefs restore itself triggers a state change that we must not cancel.
+  const cancelReadyRef = useRef(false);
   useEffect(() => {
     if (!prefsLoadedRef.current) return;
+    if (!cancelReadyRef.current) {
+      cancelReadyRef.current = true;
+      return;
+    }
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, api]);
 

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -82,13 +82,10 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
 
   // Cancel in-flight DuckDB queries when the date range or granularity
   // changes so stale 30d queries don't compete for memory with new 365d
-  // queries. Skip the initial mount — there's nothing to cancel yet.
-  const isFirstRenderRef = useRef(true);
+  // queries. Skip until preferences have loaded — restoring a saved date
+  // range triggers a state change that would cancel the startup queries.
   useEffect(() => {
-    if (isFirstRenderRef.current) {
-      isFirstRenderRef.current = false;
-      return;
-    }
+    if (!prefsLoadedRef.current) return;
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, api]);
 

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -94,13 +94,8 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const entityFilter: FilterMap = { [asDimensionId(dimension)]: [asTagValue(entity)] };
   const filterKey = JSON.stringify(entityFilter);
 
-  // Cancel in-flight DuckDB queries when the date range or granularity changes
-  const entityDetailFirstRef = useRef(true);
   useEffect(() => {
-    if (entityDetailFirstRef.current) {
-      entityDetailFirstRef.current = false;
-      return;
-    }
+    if (!prefsLoadedRef.current) return;
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, api]);
 

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -94,6 +94,16 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const entityFilter: FilterMap = { [asDimensionId(dimension)]: [asTagValue(entity)] };
   const filterKey = JSON.stringify(entityFilter);
 
+  // Cancel in-flight DuckDB queries when the date range or granularity changes
+  const entityDetailFirstRef = useRef(true);
+  useEffect(() => {
+    if (entityDetailFirstRef.current) {
+      entityDetailFirstRef.current = false;
+      return;
+    }
+    api.cancelPendingQueries().catch(() => undefined);
+  }, [dateRange, granularity, api]);
+
   // Load persisted date range and granularity on mount
   useEffect(() => {
     api.getExplorerPreferences().then(prefs => {

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -94,8 +94,13 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const entityFilter: FilterMap = { [asDimensionId(dimension)]: [asTagValue(entity)] };
   const filterKey = JSON.stringify(entityFilter);
 
+  const cancelReadyRef = useRef(false);
   useEffect(() => {
     if (!prefsLoadedRef.current) return;
+    if (!cancelReadyRef.current) {
+      cancelReadyRef.current = true;
+      return;
+    }
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, api]);
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -173,6 +173,17 @@ export function ExplorerView(): React.JSX.Element {
     saveAllPrefs(hiddenColumns, columnOrder, dateRange, granularity);
   }, [dateRange, granularity]);
 
+  // Cancel in-flight DuckDB queries when query parameters change so stale
+  // queries don't compete for memory with new ones.
+  const explorerFirstRenderRef = useRef(true);
+  useEffect(() => {
+    if (explorerFirstRenderRef.current) {
+      explorerFirstRenderRef.current = false;
+      return;
+    }
+    api.cancelPendingQueries().catch(() => undefined);
+  }, [dateRange, granularity, api]);
+
   // Back-off from a metric / perspective the CUR doesn't support. Happens
   // when a user's CUR export drops the effective-cost or net-cost columns
   // between sessions — we downgrade silently instead of returning bogus

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -173,8 +173,13 @@ export function ExplorerView(): React.JSX.Element {
     saveAllPrefs(hiddenColumns, columnOrder, dateRange, granularity);
   }, [dateRange, granularity]);
 
+  const cancelReadyRef = useRef(false);
   useEffect(() => {
     if (!prefsLoadedRef.current) return;
+    if (!cancelReadyRef.current) {
+      cancelReadyRef.current = true;
+      return;
+    }
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, api]);
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -173,14 +173,8 @@ export function ExplorerView(): React.JSX.Element {
     saveAllPrefs(hiddenColumns, columnOrder, dateRange, granularity);
   }, [dateRange, granularity]);
 
-  // Cancel in-flight DuckDB queries when query parameters change so stale
-  // queries don't compete for memory with new ones.
-  const explorerFirstRenderRef = useRef(true);
   useEffect(() => {
-    if (explorerFirstRenderRef.current) {
-      explorerFirstRenderRef.current = false;
-      return;
-    }
+    if (!prefsLoadedRef.current) return;
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, api]);
 

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   Dimension,
   DimensionId,
@@ -207,6 +207,15 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
     ? getDimensionId(tagDimensions[0])
     : null;
   const activeTagId = selectedTag ?? firstTagId;
+
+  const missingFirstRef = useRef(true);
+  useEffect(() => {
+    if (missingFirstRef.current) {
+      missingFirstRef.current = false;
+      return;
+    }
+    api.cancelPendingQueries().catch(() => undefined);
+  }, [dateRange, granularity, api]);
 
   const missingQuery = useQuery(
     () => {


### PR DESCRIPTION
## Summary

The app crashes (SIGTRAP) when switching from 30d to 365d. Root cause: unbounded DuckDB memory + concurrent queries + no cancellation of stale queries + no error recovery in the worker thread.

### Changes

**DuckDB memory & thread limits** (`duckdb-worker.ts`)
- `SET memory_limit` to 25% of system RAM, clamped 1-4 GB (was: unlimited, DuckDB default 80%)
- `SET threads` to half of logical CPUs, clamped 2-4 (was: all CPUs)
- `SET temp_directory` to `<userData>/temp` so DuckDB spills to disk instead of crashing
- Connection pool reduced from `cpus().length` to `cpus()/2`

**Graceful OOM handling** (`duckdb-worker.ts`)
- Added `uncaughtException` and `unhandledRejection` handlers in the worker thread
- OOM errors are caught and returned as error responses to all pending queries
- Worker stays alive instead of crashing Electron

**Cancel stale queries on date range change** (5 view components)
- `custom-view.tsx`, `explorer.tsx`, `entity-detail.tsx`, `cost-trends.tsx`, `missing-tags.tsx`
- Each view calls `api.cancelPendingQueries()` when date range or granularity changes (skip initial mount)
- Prevents old 30d queries from running concurrently with new 365d queries

### Why it crashed
1. 30d → 365d = 12x more Parquet files
2. Multiple widgets fire concurrent queries (pool was up to 16 connections)
3. Each query spawns up to `cpus()` DuckDB threads, all building hash aggregate tables
4. No memory limit → DuckDB tried to allocate all RAM
5. Old queries kept running while new queries started (no cancellation)
6. No error handler → OOM killed the worker → crashed Electron