### PR TITLE
Consistent coin rain loader across all widgets and views

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -48,7 +48,7 @@ type View =
 const STATIC_LEFT_NAV: { id: string; label: string }[] = [
   { id: 'trends', label: 'Trends' },
   { id: 'savings', label: 'Findings' },
-  { id: 'missing-tags', label: 'Missing Tags' },
+  { id: 'missing-tags', label: 'Tags' },
   { id: 'explorer', label: 'Explorer' },
 ];
 

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -300,7 +300,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         );
       })() : (() => {
         const placeholder = loading === true ? (
-          <div className="flex-1 min-h-40 flex items-center justify-center">
+          <div className="flex-1 min-h-40">
             <CoinRainLoader height={expanded ? 340 : 160} count={6} />
           </div>
         ) : (

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -16,6 +16,7 @@ import { DateRangePicker, getDefaultDateRange } from '../components/date-range-p
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
 import { DimensionSelector } from '../components/dimension-selector.js';
 import { formatDollars, formatPercent } from '../components/format.js';
+import { CoinRainLoader } from '../components/coin-rain-loader.js';
 
 type Direction = 'increases' | 'savings';
 
@@ -196,7 +197,9 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
       )}
 
       {trendsQuery.status === 'loading' && (
-        <div className="text-sm text-text-secondary">Loading trends...</div>
+        <div className="flex-1">
+          <CoinRainLoader height={500} count={10} />
+        </div>
       )}
       {trendsQuery.status === 'error' && (
         <div className="rounded-lg border border-negative bg-negative-muted px-4 py-3 text-sm text-negative">

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type {
   Dimension,
   DimensionId,
@@ -389,7 +390,9 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
       </div>
 
       {missingQuery.status === 'loading' && (
-        <div className="text-sm text-text-secondary">Loading...</div>
+        <div className="flex-1">
+          <CoinRainLoader height={500} count={10} />
+        </div>
       )}
       {missingQuery.status === 'error' && (
         <div className="rounded-lg border border-negative bg-negative-muted px-4 py-3 text-sm text-negative">

--- a/packages/ui/src/views/savings.tsx
+++ b/packages/ui/src/views/savings.tsx
@@ -3,6 +3,7 @@ import type { SortingState } from '@tanstack/react-table';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { formatDollars } from '../components/format.js';
+import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { DataTable } from '../components/data-table.js';
 import type { TableColumn } from '../lib/table-types.js';
 import { useState, useMemo, Fragment } from 'react';
@@ -335,7 +336,9 @@ export function Savings() {
       )}
 
       {savingsQuery.status === 'loading' && (
-        <div className="text-sm text-text-secondary">Loading recommendations...</div>
+        <div className="flex-1">
+          <CoinRainLoader height={500} count={10} />
+        </div>
       )}
       {savingsQuery.status === 'error' && (
         <div className="rounded-lg border border-negative bg-negative-muted px-4 py-3 text-sm text-negative">

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -46,7 +46,11 @@ export function BubbleWidget({
   );
 
   if (spec.type !== 'bubble' || specGroupBy === undefined) return null;
-  if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
+  if (query.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      <CoinRainLoader height={260} count={5} />
+    </div>
+  );
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -67,7 +67,11 @@ export function HeatmapWidget({
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
-  if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
+  if (query.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      <CoinRainLoader height={260} count={5} />
+    </div>
+  );
 
   return (
     <HeatmapChart

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -58,7 +58,11 @@ export function LineWidget({
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
-  if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
+  if (query.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      <CoinRainLoader height={260} count={5} />
+    </div>
+  );
 
   return (
     <LineChart

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -49,7 +49,11 @@ export function PieWidget({
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
-  if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
+  if (query.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 h-full">
+      <CoinRainLoader height={260} count={5} />
+    </div>
+  );
 
   return (
     <PieChart

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -69,7 +69,7 @@ export function StackedBarWidget({
 
   return (
     <StackedBarChart
-      days={barDays}
+      days={loading ? [] : barDays}
       highlightedGroup={focus.hoveredEntity}
       title={title}
       loading={loading}

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -2,6 +2,7 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { daysBetween } from '../lib/dates.js';
 import { SummaryCard } from '../components/summary-card.js';
+import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { asDimensionId } from '@costgoblin/core/browser';
 import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
@@ -31,6 +32,12 @@ export function SummaryWidget({
   );
 
   if (!isSummary) return null;
+
+  if (cur.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary px-6 py-5 h-full">
+      <CoinRainLoader height={200} count={4} />
+    </div>
+  );
 
   const totalCost = cur.status === 'success' && cur.data !== null ? cur.data.totalCost : null;
 

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -48,7 +48,11 @@ export function TopNBarWidget({
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
-  if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
+  if (query.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      <CoinRainLoader height={260} count={5} />
+    </div>
+  );
 
   return (
     <TopNBarChart

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -40,7 +40,11 @@ export function TreemapWidget({
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
-  if (query.status === 'loading') return <CoinRainLoader height={260} count={5} />;
+  if (query.status === 'loading') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      <CoinRainLoader height={260} count={5} />
+    </div>
+  );
 
   return (
     <TreemapChart


### PR DESCRIPTION
## Summary

- Wrap all widget loading states (pie, line, treemap, heatmap, topNBar, bubble) in card containers so coins render inside widget boundaries
- Fix StackedBarChart showing $0.00 chart shell during loading — now shows coin rain
- Add coin rain loader to SummaryWidget, Trends, Findings, and Tags views (replacing text placeholders)
- Use full vertical space for page-level loaders via flex-1 wrapper
- Rename "Missing Tags" to "Tags" in nav bar