### PR TITLE
Fix newsletter signup: Turnstile token not submitted

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1423,9 +1423,8 @@
         <input type="text" name="website" class="hp" tabindex="-1" autocomplete="off">
         <input type="email" name="email" placeholder="you@company.com" required autocomplete="email">
         <button type="submit">Subscribe</button>
+        <div class="cf-turnstile" id="turnstile-widget" data-sitekey="0x4AAAAAADHTvUnS8efYJ2uh" data-theme="dark" style="margin-top: 12px; display: flex; justify-content: center;"></div>
       </form>
-      <!-- Replace YOUR_SITE_KEY with your Cloudflare Turnstile site key -->
-      <div class="cf-turnstile" id="turnstile-widget" data-sitekey="0x4AAAAAADHTvUnS8efYJ2uh" data-theme="dark" style="margin-top: 12px; display: flex; justify-content: center;"></div>
       <div class="signup-error" id="signup-error"></div>
       <div class="signup-note" id="signup-note">No spam. Unsubscribe anytime.</div>
     </div>


### PR DESCRIPTION
## Summary

- The Cloudflare Turnstile widget was outside the `<form>` element, so its hidden `cf-turnstile-response` input was never included in the FormData
- The worker received an empty token, Cloudflare's siteverify rejected it, and signup always returned "Verification failed"
- Moved the Turnstile widget inside the form so the token is submitted correctly