### PR TITLE
Fix release workflow failing on mcp workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run build --workspaces
+      - run: npm run build --workspaces --if-present
 
       - name: Build installers
         run: npx --no-install electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish always


### PR DESCRIPTION
## Summary

- The release workflow failed because `npm run build --workspaces` errors on `@costgoblin/mcp` which has no `build` script
- Added `--if-present` flag to skip workspaces that don't define the script
- This was the reason the v0.0.1 release has no binaries attached