### PR TITLE
Perf benchmarks for parameter combos + query cancel optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ perf: ## Build and run performance benchmarks
 	$(BUILD)
 	npx playwright test e2e/perf.test.ts
 
+perf-queries: ## Build and run query performance diagnostics
+	$(BUILD)
+	npx playwright test e2e/perf-queries.test.ts
+
 lint: ## Run tsc + eslint
 	npx tsc --noEmit -p packages/core/tsconfig.json
 	npx tsc --noEmit -p packages/ui/tsconfig.json

--- a/e2e/perf-queries.test.ts
+++ b/e2e/perf-queries.test.ts
@@ -58,6 +58,71 @@ const viewReports: ViewReport[] = [];
 // Helpers
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Date picker & filter helpers
+// ---------------------------------------------------------------------------
+
+async function openDatePicker(pg: Page): Promise<void> {
+  const trigger = pg.locator('button:has(svg.lucide-calendar)').first();
+  await trigger.click();
+  await pg.waitForTimeout(300);
+}
+
+async function selectPreset(pg: Page, label: string): Promise<void> {
+  await openDatePicker(pg);
+  const popover = pg.getByRole('dialog');
+  await popover.getByRole('button', { name: label, exact: true }).click();
+  await pg.waitForTimeout(200);
+}
+
+async function setComparison(pg: Page, enabled: boolean): Promise<void> {
+  await openDatePicker(pg);
+  const popover = pg.getByRole('dialog');
+  const checkbox = popover.getByLabel('Compare to previous period');
+  const checked = await checkbox.isChecked();
+  if (enabled && !checked) await checkbox.check();
+  else if (!enabled && checked) await checkbox.uncheck();
+  await pg.keyboard.press('Escape');
+  await pg.waitForTimeout(200);
+}
+
+async function applyDimensionFilter(pg: Page, dimLabel: string): Promise<boolean> {
+  const chip = pg.getByRole('button', { name: dimLabel, exact: true }).first();
+  if (!await chip.isVisible().catch(() => false)) return false;
+  await chip.click();
+  const dropdown = pg.locator('.absolute.left-0.top-full.z-50');
+  try {
+    await expect(dropdown).toBeVisible({ timeout: 5_000 });
+  } catch { return false; }
+  // Wait for filter values to actually load (checkbox appears when ready)
+  const firstCheckbox = dropdown.locator('input[type="checkbox"]').first();
+  try {
+    await expect(firstCheckbox).toBeVisible({ timeout: 60_000 });
+  } catch {
+    // Filter values too slow to load — close dropdown and report failure
+    await pg.keyboard.press('Escape');
+    return false;
+  }
+  // Deselect all then select just the first value
+  const clearBtn = dropdown.getByRole('button', { name: 'Clear', exact: true });
+  if (await clearBtn.isEnabled().catch(() => false)) await clearBtn.click();
+  await firstCheckbox.check();
+  await dropdown.getByRole('button', { name: 'Apply', exact: true }).click();
+  return true;
+}
+
+async function clearFilters(pg: Page): Promise<void> {
+  const btn = pg.getByRole('button', { name: 'Clear all' });
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click();
+    await pg.waitForTimeout(200);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App launch
+// ---------------------------------------------------------------------------
+
 function launchApp(): Promise<ElectronApplication> {
   return _electron.launch({
     args: [join(DESKTOP_DIR, 'out', 'main', 'main.js')],
@@ -65,6 +130,7 @@ function launchApp(): Promise<ElectronApplication> {
       ...process.env,
       NODE_ENV: 'production',
       COSTGOBLIN_PERF_MODE: '1',
+      COSTGOBLIN_HEADLESS: '1',
       COSTGOBLIN_DATA_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'data'),
       COSTGOBLIN_CONFIG_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'config'),
     },
@@ -407,6 +473,168 @@ test.describe('Query Performance Diagnostics', () => {
 
   test('Data Management', async () => {
     await navigateAndCollect(page, 'Sync', 'Data Management', 'Data Management');
+  });
+
+  // -----------------------------------------------------------------------
+  // Parameter Combinations — hourly, comparison, dimension filters
+  // -----------------------------------------------------------------------
+
+  test('Combo: hourly 7d', async () => {
+    await page.getByRole('button', { name: 'Cost Overview', exact: true }).first().click();
+    await expect(page.getByRole('heading', { name: 'Cost Overview' })).toBeVisible({ timeout: 10_000 });
+    await waitForAllQueriesComplete(page);
+    // Reset state
+    await setComparison(page, false);
+    await clearFilters(page);
+    await selectPreset(page, 'Last 30 days');
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await selectPreset(page, 'Last 7 days');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: hourly 7d');
+    viewReports.push(report);
+  });
+
+  test('Combo: comparison (daily 30d)', async () => {
+    await selectPreset(page, 'Last 30 days');
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await setComparison(page, true);
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: comparison 30d');
+    viewReports.push(report);
+  });
+
+  test('Combo: comparison + hourly 7d', async () => {
+    // comparison still on
+    await clearQueryLog(page);
+    await selectPreset(page, 'Last 7 days');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: comparison + hourly 7d');
+    viewReports.push(report);
+  });
+
+  test('Combo: service filter (daily 30d)', async () => {
+    await setComparison(page, false);
+    await selectPreset(page, 'Last 30 days');
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await applyDimensionFilter(page, 'Service');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: service filter');
+    viewReports.push(report);
+  });
+
+  test('Combo: multi-dimension filter (daily 30d)', async () => {
+    await clearFilters(page);
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await applyDimensionFilter(page, 'Account');
+    await applyDimensionFilter(page, 'Service');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: multi-dim filter');
+    viewReports.push(report);
+  });
+
+  test('Combo: hourly + filter', async () => {
+    await clearFilters(page);
+    await waitForAllQueriesComplete(page);
+    await applyDimensionFilter(page, 'Service');
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await selectPreset(page, 'Last 7 days');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: hourly + filter');
+    viewReports.push(report);
+  });
+
+  test('Combo: comparison + filter (daily 30d)', async () => {
+    await clearFilters(page);
+    await selectPreset(page, 'Last 30 days');
+    await waitForAllQueriesComplete(page);
+    await applyDimensionFilter(page, 'Account');
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await setComparison(page, true);
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: SETTLE_TIMEOUT });
+    } catch { /* */ }
+    await page.waitForTimeout(1000);
+    const report = await collectViewQueries(page, 'Combo: comparison + filter');
+    viewReports.push(report);
+  });
+
+  test('Combo: hourly + comparison + filter', async () => {
+    // comparison + Account filter still active
+    await clearQueryLog(page);
+    await selectPreset(page, 'Last 7 days');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: 180_000 });
+    } catch { /* */ }
+    await page.waitForTimeout(2000);
+    const report = await collectViewQueries(page, 'Combo: hourly + comparison + filter');
+    viewReports.push(report);
+  });
+
+  test('Combo: 365d + comparison', async () => {
+    await clearFilters(page);
+    await waitForAllQueriesComplete(page);
+
+    await clearQueryLog(page);
+    await selectPreset(page, 'Last 365 days');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: 180_000 });
+    } catch { /* */ }
+    await page.waitForTimeout(2000);
+    const report = await collectViewQueries(page, 'Combo: 365d + comparison');
+    viewReports.push(report);
+  });
+
+  test('Combo: 365d + comparison + filter', async () => {
+    // comparison still on
+    await clearQueryLog(page);
+    await applyDimensionFilter(page, 'Account');
+    try {
+      await expect(page.getByText('Loading', { exact: false }).first()).toBeHidden({ timeout: 180_000 });
+    } catch { /* */ }
+    await page.waitForTimeout(2000);
+    const report = await collectViewQueries(page, 'Combo: 365d + comparison + filter');
+    viewReports.push(report);
+  });
+
+  // -----------------------------------------------------------------------
+  // Restore and continue to Custom Views
+  // -----------------------------------------------------------------------
+
+  test('Combo: cleanup', async () => {
+    await setComparison(page, false);
+    await clearFilters(page);
+    await selectPreset(page, 'Last 30 days');
+    await waitForAllQueriesComplete(page);
   });
 
   test('Custom Views', async () => {

--- a/e2e/perf.test.ts
+++ b/e2e/perf.test.ts
@@ -61,6 +61,7 @@ function launchApp(): Promise<ElectronApplication> {
       ...process.env,
       NODE_ENV: 'production',
       COSTGOBLIN_PERF_MODE: '1',
+      COSTGOBLIN_HEADLESS: '1',
       COSTGOBLIN_DATA_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'data'),
       COSTGOBLIN_CONFIG_DIR: join(homedir(), 'Library', 'Application Support', '@costgoblin', 'desktop', 'config'),
     },
@@ -83,6 +84,67 @@ async function waitForCostScopePreview(page: Page): Promise<void> {
     await expect(marker).toBeHidden({ timeout: LOAD_TIMEOUT });
   } catch { /* may have finished */ }
   await page.waitForTimeout(200);
+}
+
+// ---------------------------------------------------------------------------
+// Date picker & filter helpers for parameter combination benchmarks
+// ---------------------------------------------------------------------------
+
+async function openDatePicker(page: Page): Promise<void> {
+  const trigger = page.locator('button:has(svg.lucide-calendar)').first();
+  await trigger.click();
+  await page.waitForTimeout(300);
+}
+
+async function selectPreset(page: Page, label: string): Promise<void> {
+  await openDatePicker(page);
+  const popover = page.getByRole('dialog');
+  await popover.getByRole('button', { name: label, exact: true }).click();
+  await page.waitForTimeout(200);
+}
+
+async function setComparison(page: Page, enabled: boolean): Promise<void> {
+  await openDatePicker(page);
+  const popover = page.getByRole('dialog');
+  const checkbox = popover.getByLabel('Compare to previous period');
+  const checked = await checkbox.isChecked();
+  if (enabled && !checked) await checkbox.check();
+  else if (!enabled && checked) await checkbox.uncheck();
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(200);
+}
+
+async function applyDimensionFilter(page: Page, dimLabel: string): Promise<boolean> {
+  const chip = page.getByRole('button', { name: dimLabel, exact: true }).first();
+  if (!await chip.isVisible().catch(() => false)) return false;
+  await chip.click();
+  const dropdown = page.locator('.absolute.left-0.top-full.z-50');
+  try {
+    await expect(dropdown).toBeVisible({ timeout: 5_000 });
+  } catch { return false; }
+  // Wait for filter values to actually load (checkbox appears when ready)
+  const firstCheckbox = dropdown.locator('input[type="checkbox"]').first();
+  try {
+    await expect(firstCheckbox).toBeVisible({ timeout: 60_000 });
+  } catch {
+    // Filter values too slow to load — close dropdown and report failure
+    await page.keyboard.press('Escape');
+    return false;
+  }
+  // Deselect all then select just the first value
+  const clearBtn = dropdown.getByRole('button', { name: 'Clear', exact: true });
+  if (await clearBtn.isEnabled().catch(() => false)) await clearBtn.click();
+  await firstCheckbox.check();
+  await dropdown.getByRole('button', { name: 'Apply', exact: true }).click();
+  return true;
+}
+
+async function clearFilters(page: Page): Promise<void> {
+  const btn = page.getByRole('button', { name: 'Clear all' });
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click();
+    await page.waitForTimeout(200);
+  }
 }
 
 function heapMB(bytes: number): number {
@@ -648,6 +710,130 @@ test.describe('Performance Benchmarks', () => {
       await measure(page, 'Data Management → baseline', async () => {
         await page.getByRole('button', { name: 'Sync' }).click();
         await expect(page.getByRole('heading', { name: 'Data Management' })).toBeVisible();
+        await waitForQuerySettle(page);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Parameter Combinations (hourly, comparison, dimension filters)
+  // -------------------------------------------------------------------------
+  test.describe('Parameter Combinations', () => {
+    test.setTimeout(120_000);
+
+    test.beforeAll(async () => {
+      await page.getByRole('button', { name: 'Cost Overview', exact: true }).click();
+      await waitForQuerySettle(page);
+      // Reset to clean state: daily 30d, no comparison, no filters
+      await selectPreset(page, 'Last 30 days');
+      await waitForQuerySettle(page);
+      await setComparison(page, false);
+      await clearFilters(page);
+      await waitForQuerySettle(page);
+      await page.evaluate(() => window.costgoblinPerf?.startCpuProfile());
+    });
+
+    test.afterAll(async () => {
+      const result: any = await page.evaluate(() =>
+        window.costgoblinPerf?.stopCpuProfile('param-combos'),
+      );
+      if (result?.path) cpuProfiles.push({ label: 'Parameter Combinations', path: result.path });
+      // Restore defaults
+      await setComparison(page, false);
+      await clearFilters(page);
+      await selectPreset(page, 'Last 30 days');
+      await waitForQuerySettle(page);
+    });
+
+    test('hourly 7d', async () => {
+      await measure(page, 'Combo → hourly 7d', async () => {
+        await selectPreset(page, 'Last 7 days');
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('comparison enabled (daily 30d)', async () => {
+      await selectPreset(page, 'Last 30 days');
+      await waitForQuerySettle(page);
+      await measure(page, 'Combo → comparison 30d', async () => {
+        await setComparison(page, true);
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('comparison + hourly 7d', async () => {
+      // comparison still on from previous test
+      await measure(page, 'Combo → comparison + hourly 7d', async () => {
+        await selectPreset(page, 'Last 7 days');
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('service filter (daily 30d)', async () => {
+      await setComparison(page, false);
+      await selectPreset(page, 'Last 30 days');
+      await waitForQuerySettle(page);
+      await measure(page, 'Combo → service filter', async () => {
+        const applied = await applyDimensionFilter(page, 'Service');
+        if (!applied) return;
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('multi-dimension filter (daily 30d)', async () => {
+      await clearFilters(page);
+      await waitForQuerySettle(page);
+      await measure(page, 'Combo → multi-dim filter', async () => {
+        await applyDimensionFilter(page, 'Account');
+        await applyDimensionFilter(page, 'Service');
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('hourly + filter', async () => {
+      await clearFilters(page);
+      await waitForQuerySettle(page);
+      await applyDimensionFilter(page, 'Service');
+      await waitForQuerySettle(page);
+      await measure(page, 'Combo → hourly + filter', async () => {
+        await selectPreset(page, 'Last 7 days');
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('comparison + filter (daily 30d)', async () => {
+      await clearFilters(page);
+      await selectPreset(page, 'Last 30 days');
+      await waitForQuerySettle(page);
+      await applyDimensionFilter(page, 'Account');
+      await waitForQuerySettle(page);
+      await measure(page, 'Combo → comparison + filter', async () => {
+        await setComparison(page, true);
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('hourly + comparison + filter', async () => {
+      // comparison + Account filter still active
+      await measure(page, 'Combo → hourly + comparison + filter', async () => {
+        await selectPreset(page, 'Last 7 days');
+        await waitForQuerySettle(page);
+      });
+    });
+
+    test('365d + comparison', async () => {
+      await clearFilters(page);
+      await waitForQuerySettle(page);
+      await measure(page, 'Combo → 365d + comparison', async () => {
+        await selectPreset(page, 'Last 365 days');
+        await waitForQuerySettle(page);
+      });
+      // comparison still on
+    });
+
+    test('365d + comparison + filter', async () => {
+      await measure(page, 'Combo → 365d + comparison + filter', async () => {
+        await applyDimensionFilter(page, 'Account');
         await waitForQuerySettle(page);
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.2.3",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.2.3",
+      "version": "0.0.1",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.3",
+  "version": "0.0.1",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/src/main/duckdb-loader.ts
+++ b/packages/desktop/src/main/duckdb-loader.ts
@@ -15,6 +15,7 @@ export interface DuckDBInstance {
 export interface DuckDBConnection {
   run: (sql: string) => Promise<DuckDBResult>;
   prepare: (sql: string) => Promise<DuckDBPreparedStatement>;
+  interrupt: () => void;
   disconnectSync: () => void;
 }
 

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -67,6 +67,7 @@ function isConfigureRequest(msg: unknown): msg is { kind: 'configure'; tempDir: 
 const cancelledIds = new Set<number>();
 const queuedIds = new Set<number>();  // waiting for pool.acquire()
 const runningIds = new Set<number>(); // executing in DuckDB
+const runningConns = new Map<number, DuckDBConnection>(); // id → connection for interrupt()
 
 async function fetchAllRows(
   conn: DuckDBConnection,
@@ -216,6 +217,7 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
     }
 
     runningIds.add(req.id);
+    runningConns.set(req.id, conn);
     const rows = await fetchAllRows(conn, req.sql, () => cancelledIds.has(req.id));
 
     // Skip serialization if cancelled during execution
@@ -227,9 +229,12 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    send({ kind: 'error', id: req.id, message });
+    const isCancelled = cancelledIds.has(req.id) || message.includes('INTERRUPT');
+    cancelledIds.delete(req.id);
+    send({ kind: 'error', id: req.id, message: isCancelled ? 'Query cancelled' : message });
   } finally {
     runningIds.delete(req.id);
+    runningConns.delete(req.id);
     pool.release(conn);
   }
 }
@@ -257,6 +262,7 @@ async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; 
     }
 
     runningIds.add(req.id);
+    runningConns.set(req.id, conn);
     const rows = await fetchAllRowsPrepared(conn, req.sql, req.params, () => cancelledIds.has(req.id));
 
     // Skip serialization if cancelled during execution
@@ -268,9 +274,12 @@ async function handlePreparedRequest(req: { kind: 'prepared-query'; id: number; 
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    send({ kind: 'error', id: req.id, message });
+    const isCancelled = cancelledIds.has(req.id) || message.includes('INTERRUPT');
+    cancelledIds.delete(req.id);
+    send({ kind: 'error', id: req.id, message: isCancelled ? 'Query cancelled' : message });
   } finally {
     runningIds.delete(req.id);
+    runningConns.delete(req.id);
     pool.release(conn);
   }
 }
@@ -281,6 +290,11 @@ function handleCancelPending(): void {
   }
   for (const id of runningIds) {
     cancelledIds.add(id);
+  }
+  // Actively interrupt running DuckDB queries so they release pool
+  // connections immediately instead of running to completion.
+  for (const conn of runningConns.values()) {
+    try { conn.interrupt(); } catch { /* connection may already be closed */ }
   }
 }
 

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -173,11 +173,14 @@ async function createWindow(db: DuckDBClient, syncClient: SyncClient, vaultState
     logger.warn(`mcp: failed to start — ${err instanceof Error ? err.message : String(err)}`);
   });
 
+  const headless = process.env['COSTGOBLIN_HEADLESS'] === '1';
+
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
     minWidth: 900,
     minHeight: 600,
+    show: !headless,
     backgroundColor: '#0a0a0a',
     titleBarStyle: 'hiddenInset',
     icon: join(__dirname, '..', '..', 'resources', 'icon.png'),

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -435,8 +435,9 @@ function AppShell(): React.JSX.Element {
         return;
       }
 
-      // Vault auto-unlocked (safeStorage) or already unlocked
-      void api.getDimensions().catch(() => undefined);
+      // Vault auto-unlocked (safeStorage) or already unlocked —
+      // pre-fetch dimensions so they're cached when the dashboard mounts.
+      await api.getDimensions().catch(() => undefined);
 
       if (!skipSplash) {
         await new Promise<void>(resolve => {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -358,7 +358,7 @@ function shuffled<T>(arr: readonly T[]): T[] {
   return copy;
 }
 
-function SplashScreen(): React.JSX.Element {
+function SplashScreen({ step }: Readonly<{ step: string }>): React.JSX.Element {
   const [order] = useState(() => shuffled(SPLASH_IMAGES));
   const [index, setIndex] = useState(0);
   const [fadeOut, setFadeOut] = useState(false);
@@ -388,7 +388,7 @@ function SplashScreen(): React.JSX.Element {
         ))}
       </div>
       <h1 className="text-2xl font-bold text-accent tracking-wider mb-1">CostGoblin</h1>
-      <p className="text-sm text-text-muted mb-8">Crunching your cloud costs...</p>
+      <p className="text-sm text-text-muted mb-8">{step}</p>
       <div className="w-64">
         <CoinRainLoader height={120} count={6} />
       </div>
@@ -405,6 +405,7 @@ function AppShell(): React.JSX.Element {
   const [palette, setPalette] = useState<'standard' | 'colorblind'>('standard');
   const [vaultCheck, setVaultCheck] = useState<VaultCheck>({ status: 'checking' });
   const [setupCheck, setSetupCheck] = useState<SetupCheck>({ status: 'checking' });
+  const [splashStep, setSplashStep] = useState('Connecting...');
   const splashMinElapsed = useRef(false);
   const [viewsConfig, setViewsConfig] = useState<ViewsConfig | null>(null);
   const { syncError, setSyncError, syncActivity, syncFilesRemaining } = useSyncPolling(api, setupCheck);
@@ -420,6 +421,7 @@ function AppShell(): React.JSX.Element {
   useEffect(() => {
     const skipSplash = globalThis.costgoblinDebug.isE2E();
 
+    setSplashStep('Checking configuration...');
     const vaultStatusCheck = globalThis.costgoblinVault.getStatus();
     const statusCheck = api.getSetupStatus().then(({ configured }) => configured);
 
@@ -437,8 +439,10 @@ function AppShell(): React.JSX.Element {
 
       // Vault auto-unlocked (safeStorage) or already unlocked —
       // pre-fetch dimensions so they're cached when the dashboard mounts.
+      setSplashStep('Loading dimensions...');
       await api.getDimensions().catch(() => undefined);
 
+      setSplashStep('Preparing dashboard...');
       if (!skipSplash) {
         await new Promise<void>(resolve => {
           setTimeout(() => { splashMinElapsed.current = true; resolve(); }, SPLASH_DURATION);
@@ -584,7 +588,7 @@ function AppShell(): React.JSX.Element {
   }
 
   if (setupCheck.status === 'checking') {
-    return <SplashScreen />;
+    return <SplashScreen step={splashStep} />;
   }
 
   if (setupCheck.status === 'needs-setup') {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useMemo, useRef, Profiler } from 'react';
 import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
-import type { CostApi, FilterMap, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
-import { asDimensionId, asTagValue } from '@costgoblin/core/browser';
+import type { CostApi, Dimension, FilterMap, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
+import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagColumnName } from '@costgoblin/core/browser';
 import { Download, RefreshCw } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { VaultLockScreen } from './vault-lock-screen.js';
@@ -358,6 +358,16 @@ function shuffled<T>(arr: readonly T[]): T[] {
   return copy;
 }
 
+function dimId(dim: Dimension): string {
+  return 'tagName' in dim ? tagColumnName(dim.tagName) : dim.name;
+}
+
+function defaultDateRange(): { start: string; end: string } {
+  const end = new Date(Date.now() - DEFAULT_LAG_DAYS * 86_400_000);
+  const start = new Date(end.getTime() - 30 * 86_400_000);
+  return { start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) };
+}
+
 function SplashScreen({ step }: Readonly<{ step: string }>): React.JSX.Element {
   const [order] = useState(() => shuffled(SPLASH_IMAGES));
   const [index, setIndex] = useState(0);
@@ -439,8 +449,19 @@ function AppShell(): React.JSX.Element {
 
       // Vault auto-unlocked (safeStorage) or already unlocked —
       // pre-fetch dimensions so they're cached when the dashboard mounts.
-      setSplashStep('Loading dimensions...');
-      await api.getDimensions().catch(() => undefined);
+      // Load dimensions, then pre-warm filter values for each one so
+      // dropdowns open instantly when the dashboard appears.
+      const dims = await api.getDimensions().catch(() => [] as Dimension[]);
+      if (dims.length > 0) {
+        const range = defaultDateRange();
+        let done = 0;
+        setSplashStep(`Loading dimensions 0/${String(dims.length)}...`);
+        await Promise.all(dims.map(async (dim) => {
+          await api.getFilterValues(dimId(dim), {}, range).catch(() => undefined);
+          done++;
+          setSplashStep(`Loading dimensions ${String(done)}/${String(dims.length)}...`);
+        }));
+      }
 
       setSplashStep('Preparing dashboard...');
       if (!skipSplash) {

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -96,23 +96,14 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     api.cancelPendingQueries().catch(() => undefined);
   }, [dateRange, granularity, filtersKeyRef, compareEnabled, api]);
 
-  // Load persisted date range and granularity on mount
+  // Load column preferences on mount. Date range, granularity, and comparison
+  // always start at defaults (30d daily, comparison off) for a clean session.
   useEffect(() => {
     api.getExplorerPreferences().then(prefs => {
-      // Store column preferences to preserve them when saving
       columnPrefsRef.current = {
         hiddenColumns: prefs.hiddenColumns,
         columnOrder: prefs.columnOrder,
       };
-      if (prefs.lastUsedDateRange !== undefined) {
-        setDateRange(prefs.lastUsedDateRange);
-      }
-      if (prefs.lastUsedGranularity !== undefined) {
-        setGranularity(prefs.lastUsedGranularity);
-      }
-      if (prefs.compareEnabled === true) {
-        setCompareEnabled(true);
-      }
       prefsLoadedRef.current = true;
     }).catch(() => {
       prefsLoadedRef.current = true;

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -18,6 +18,7 @@ import {
   useCostFocusReducer,
 } from '../hooks/use-cost-focus.js';
 import {
+  getDimensionId,
   isEnvironmentDimension,
   isOwnerDimension,
   isProductDimension,
@@ -130,6 +131,28 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     };
   }, [dateRange, granularity, compareEnabled, api]);
 
+  // Pre-fetch filter values for all dimensions so dropdowns open instantly.
+  // Cache is keyed by date range — invalidated when the range changes.
+  type FilterValue = { value: string; label: string; count: number };
+  const filterCacheRef = useRef(new Map<string, FilterValue[]>());
+  const filterCacheDateKeyRef = useRef('');
+
+  useEffect(() => {
+    if (dimensions.length === 0) return;
+    const dateKey = `${dateRange.start}|${dateRange.end}`;
+    if (filterCacheDateKeyRef.current !== dateKey) {
+      filterCacheRef.current.clear();
+      filterCacheDateKeyRef.current = dateKey;
+    }
+    for (const dim of dimensions) {
+      const dimId = getDimensionId(dim);
+      if (filterCacheRef.current.has(dimId)) continue;
+      api.getFilterValues(dimId, {}, dateRange).then(values => {
+        filterCacheRef.current.set(dimId, values);
+      }).catch(() => undefined);
+    }
+  }, [dimensions, dateRange, api]);
+
   function handleSetFilter(dim: DimensionId, value: TagValue) {
     setFilters(prev => ({ ...prev, [dim]: [value] }));
   }
@@ -138,7 +161,15 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     handleSetFilter(dim, asTagValue(entity));
   }
 
-  function handleGetFilterValues(dimensionId: DimensionId, currentFilters: FilterMap): Promise<{ value: string; label: string; count: number }[]> {
+  function handleGetFilterValues(dimensionId: DimensionId, currentFilters: FilterMap): Promise<FilterValue[]> {
+    const hasActiveFilters = Object.keys(currentFilters).some(k => {
+      const v = currentFilters[k as DimensionId];
+      return v !== undefined && v.length > 0;
+    });
+    const cached = filterCacheRef.current.get(dimensionId);
+    if (!hasActiveFilters && cached !== undefined) {
+      return Promise.resolve(cached);
+    }
     const plain: Record<string, readonly string[]> = {};
     for (const [k, v] of Object.entries(currentFilters)) if (v !== undefined) plain[k] = v;
     return api.getFilterValues(dimensionId, plain, dateRange);

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -81,11 +81,12 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     [dateRange],
   );
 
-  // Cancel in-flight DuckDB queries when the date range or granularity
-  // changes so stale 30d queries don't compete for memory with new 365d
-  // queries. Skip until one render AFTER preferences have loaded — the
-  // prefs restore itself triggers a state change that we must not cancel.
+  // Cancel in-flight DuckDB queries when query-affecting state changes so
+  // stale queries don't hog pool connections while new ones queue behind them.
+  // Skip until one render AFTER preferences have loaded — the prefs restore
+  // itself triggers a state change that we must not cancel.
   const cancelReadyRef = useRef(false);
+  const filtersKeyRef = JSON.stringify(filters);
   useEffect(() => {
     if (!prefsLoadedRef.current) return;
     if (!cancelReadyRef.current) {
@@ -93,7 +94,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
       return;
     }
     api.cancelPendingQueries().catch(() => undefined);
-  }, [dateRange, granularity, api]);
+  }, [dateRange, granularity, filtersKeyRef, compareEnabled, api]);
 
   // Load persisted date range and granularity on mount
   useEffect(() => {
@@ -118,20 +119,24 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     });
   }, [api]);
 
-  // Save date range and granularity whenever they change. Skip saves until
-  // after preferences have loaded — the prefsLoadedRef flag is set in the
-  // mount effect once the initial load completes (or fails). This prevents
-  // redundant writes when restoring persisted values on mount. Preserve
-  // column preferences from Explorer to avoid overwriting them.
+  // Save preferences with debounce — rapid parameter changes (e.g. applying
+  // two filters back-to-back) only trigger a single write.
+  const savePendingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (!prefsLoadedRef.current) return;
-    api.saveExplorerPreferences({
-      hiddenColumns: columnPrefsRef.current.hiddenColumns,
-      columnOrder: columnPrefsRef.current.columnOrder,
-      lastUsedDateRange: dateRange,
-      lastUsedGranularity: granularity,
-      compareEnabled,
-    }).catch(() => undefined);
+    if (savePendingRef.current !== null) clearTimeout(savePendingRef.current);
+    savePendingRef.current = setTimeout(() => {
+      api.saveExplorerPreferences({
+        hiddenColumns: columnPrefsRef.current.hiddenColumns,
+        columnOrder: columnPrefsRef.current.columnOrder,
+        lastUsedDateRange: dateRange,
+        lastUsedGranularity: granularity,
+        compareEnabled,
+      }).catch(() => undefined);
+    }, 500);
+    return () => {
+      if (savePendingRef.current !== null) clearTimeout(savePendingRef.current);
+    };
   }, [dateRange, granularity, compareEnabled, api]);
 
   function handleSetFilter(dim: DimensionId, value: TagValue) {

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -389,6 +389,15 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
 
       </div>
 
+      {dimensionsQuery.status === 'success' && tagDimensions.length === 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center">
+          <p className="text-sm font-medium text-text-primary">No tag dimensions configured</p>
+          <p className="text-xs text-text-secondary mt-1">
+            Add custom tag dimensions in the <strong>Dimensions</strong> page to start tracking missing tags.
+          </p>
+        </div>
+      )}
+
       {missingQuery.status === 'loading' && (
         <div className="flex-1">
           <CoinRainLoader height={500} count={10} />


### PR DESCRIPTION
## Summary

- Add parameter combination benchmarks to `perf.test.ts` and `perf-queries.test.ts` covering hourly resolution, period comparison, dimension filters, and their explosive combinations
- Add `COSTGOBLIN_HEADLESS=1` env for windowless benchmark runs
- Add `make perf-queries` target for SQL-level diagnostics
- Fix stale queries hogging the DuckDB pool when filters or comparison toggle changes
- Debounce preferences save to avoid redundant file writes during rapid parameter changes
- Use `connection.interrupt()` to actively kill running DuckDB queries instead of passively waiting for chunk fetch boundaries

## Benchmark results (before fix)

| Scenario | Wall clock (ms) | IPC total (ms) |
|----------|----------------|----------------|
| hourly 7d | 876 | 15,706 |
| comparison 30d | 878 | 12,515 |
| multi-dim filter | 11,371 | 104,900 |
| hourly + comparison + filter | 930 | 3 |
| **365d + comparison + filter** | **60,353** | **2,042,454** |