### PR TITLE
Bubble chart: start X axis at 0

### DIFF
--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -73,7 +73,7 @@ function BubbleChartInner({
   const costMax = Math.max(...costs);
 
   const xScale = scaleSymlog<number>({
-    domain: [percentMin - percentPad, percentMax + percentPad],
+    domain: [0, percentMax + percentPad],
     range: [0, innerWidth],
     nice: true,
     constant: 10,


### PR DESCRIPTION
## Summary
- Clamp the X axis (Percent Change) domain lower bound to 0 instead of `percentMin - padding`, which could push the axis into negative territory
- No negative values need to be displayed since the chart shows increases/savings separately