### PR TITLE
Harden SQL injection defenses

### DIFF
--- a/packages/core/src/__tests__/identifier-validator.test.ts
+++ b/packages/core/src/__tests__/identifier-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
+import { assertDateString, validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId } from '../types/branded.js';
 
@@ -82,6 +82,29 @@ describe('validateColumnName', () => {
   it('throws SecurityError with descriptive message', () => {
     expect(() => { validateColumnName('bad_column', testDimensions); })
       .toThrow('Invalid column name "bad_column" - not in dimensions config allow-list');
+  });
+});
+
+describe('assertDateString', () => {
+  it('accepts valid YYYY-MM-DD dates', () => {
+    expect(() => { assertDateString('2026-01-01'); }).not.toThrow();
+    expect(() => { assertDateString('2026-12-31'); }).not.toThrow();
+    expect(() => { assertDateString('2025-06-15'); }).not.toThrow();
+  });
+
+  it('rejects invalid formats', () => {
+    expect(() => { assertDateString('2026-1-01'); }).toThrow(SecurityError);
+    expect(() => { assertDateString('2026-13-01'); }).toThrow(SecurityError);
+    expect(() => { assertDateString('2026-00-01'); }).toThrow(SecurityError);
+    expect(() => { assertDateString('2026-01-00'); }).toThrow(SecurityError);
+    expect(() => { assertDateString('2026-01-32'); }).toThrow(SecurityError);
+    expect(() => { assertDateString('not-a-date'); }).toThrow(SecurityError);
+    expect(() => { assertDateString(''); }).toThrow(SecurityError);
+  });
+
+  it('rejects SQL injection attempts', () => {
+    expect(() => { assertDateString("2026-01-01' OR 1=1 --"); }).toThrow(SecurityError);
+    expect(() => { assertDateString("2026-01-01'; DROP TABLE cost_base; --"); }).toThrow(SecurityError);
   });
 });
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -6,7 +6,7 @@ import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
-import { SecurityError } from './identifier-validator.js';
+import { assertDateString, SecurityError } from './identifier-validator.js';
 
 function assertFiniteNumber(value: number, name: string): void {
   if (!Number.isFinite(value) || value < 0) {
@@ -270,7 +270,8 @@ function buildTagSelect(
   t: DimensionsConfig['tags'][number],
   needsOrgJoin: boolean,
 ): string {
-  const curKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
+  const rawKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
+  const curKey = sqlEscapeString(rawKey);
   const colName = tagColumnName(t.tagName);
   const tablePrefix = needsOrgJoin ? 'cur.' : '';
   const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;
@@ -313,7 +314,8 @@ function buildRawTagSelects(dimensions: DimensionsConfig): string[] {
   const selects: string[] = [];
   for (const t of dimensions.tags) {
     if (t.accountTagFallback === undefined) continue;
-    const curKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
+    const rawKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
+    const curKey = sqlEscapeString(rawKey);
     const colName = tagColumnName(t.tagName);
     selects.push(`element_at(cur.resource_tags, '${curKey}')[1] AS raw_${colName}`);
   }
@@ -845,8 +847,11 @@ export function buildMaterializeBaseQuery(
   const periods = resolveQueryPeriods(dateRange, availablePeriods);
   const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, includeRawTags: true, slim: true });
 
+  assertDateString(dateRange.start);
+  assertDateString(dateRange.end);
+
   const whereConditions = [
-    `usage_date BETWEEN '${sqlEscapeString(dateRange.start)}' AND '${sqlEscapeString(dateRange.end)}'`,
+    `usage_date BETWEEN '${dateRange.start}' AND '${dateRange.end}'`,
     ...exclusionClauses,
   ];
 

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -140,6 +140,25 @@ const BILLING_PERIOD_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
  * @param tablePath - The table path to validate
  * @throws {SecurityError} If the table path does not match the expected pattern
  */
+/**
+ * Pattern for valid YYYY-MM-DD date strings.
+ */
+const DATE_STRING_PATTERN = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+
+/**
+ * Validate that a string is a well-formed YYYY-MM-DD date.
+ * Throws SecurityError if the format is invalid, preventing SQL injection
+ * via date values interpolated into queries.
+ */
+export function assertDateString(value: string): void {
+  if (!DATE_STRING_PATTERN.test(value)) {
+    throw new SecurityError(
+      `Invalid date string "${value}" - must be YYYY-MM-DD format. ` +
+      `This prevents SQL injection via untrusted date values.`
+    );
+  }
+}
+
 export function validateTablePath(tablePath: string): void {
   // Extract the tier and period from the path
   // Expected formats:

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -14,7 +14,7 @@ export type { QueryContextOptions, BuildSourceOptions } from './builder.js';
 
 export { costExprFor } from './cost-metric.js';
 
-export { validateColumnName, validateTablePath, SecurityError } from './identifier-validator.js';
+export { assertDateString, validateColumnName, validateTablePath, SecurityError } from './identifier-validator.js';
 
 export type { ParameterizedQuery } from './parameterized.js';
 export { QueryBuilder } from './parameterized.js';

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -89,7 +89,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const dailyDir = path.join(ctx.dataDir, 'aws', 'raw');
     let dirs: string[] = [];
     try {
-      dirs = (await fs.readdir(dailyDir)).filter(d => d.startsWith('daily-')).sort((a, b) => a.localeCompare(b));
+      dirs = (await fs.readdir(dailyDir)).filter(d => /^daily-\d{4}-(0[1-9]|1[0-2])$/.test(d)).sort((a, b) => a.localeCompare(b));
     } catch { /* no data */ }
     const recentDirs = dirs.slice(-2);
     const parquetGlobs = recentDirs.map(d => `'${ctx.dataDir}/aws/raw/${d}/*.parquet'`).join(', ');
@@ -172,7 +172,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
     let dirs: string[] = [];
     try {
-      dirs = (await fs.readdir(rawDir)).filter(d => d.startsWith('daily-')).sort((a, b) => a.localeCompare(b));
+      dirs = (await fs.readdir(rawDir)).filter(d => /^daily-\d{4}-(0[1-9]|1[0-2])$/.test(d)).sort((a, b) => a.localeCompare(b));
     } catch { /* no data */ }
     const latest = dirs.at(-1);
     if (latest === undefined) return { values: [], distinctCount: 0, period: '' };
@@ -190,7 +190,8 @@ export function registerDimensionsHandlers(app: AppContext): void {
       operation: 'line_item_operation',
       usage_type: 'line_item_usage_type',
     };
-    const col = RAW_COL[field] ?? field;
+    const col = RAW_COL[field];
+    if (col === undefined) return { values: [], distinctCount: 0, period: '' };
 
     const distinctSql = `SELECT COUNT(DISTINCT ${col}) AS n FROM ${source} WHERE ${col} IS NOT NULL AND ${col} != ''`;
     const valuesSql = `
@@ -278,7 +279,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
     let dirs: string[] = [];
     try {
-      dirs = (await fs.readdir(rawDir)).filter(d => d.startsWith('daily-')).sort();
+      dirs = (await fs.readdir(rawDir)).filter(d => /^daily-\d{4}-(0[1-9]|1[0-2])$/.test(d)).sort();
     } catch { /* no data */ }
     const latest = dirs.at(-1);
     if (latest === undefined) return [];

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -60,6 +60,9 @@ export function registerSyncHandlers(app: AppContext): void {
   });
 
   ipcMain.handle('data:delete-period', async (_event, period: string, tier: ExpectedDataType = 'daily'): Promise<void> => {
+    if (!/^\d{4}-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?$/.test(period)) {
+      throw new Error(`Invalid period format: "${period}" — expected YYYY-MM or YYYY-MM-DD`);
+    }
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -14,8 +14,8 @@ import { runSql } from './run-sql.js';
 import { toolError } from './tool-helpers.js';
 
 const dateRangeSchema = z.object({
-  start: z.string().describe('Start date (YYYY-MM-DD)'),
-  end: z.string().describe('End date (YYYY-MM-DD)'),
+  start: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/, 'Must be YYYY-MM-DD').describe('Start date (YYYY-MM-DD)'),
+  end: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/, 'Must be YYYY-MM-DD').describe('End date (YYYY-MM-DD)'),
 }).optional();
 
 const filtersSchema = z.record(z.string(), z.array(z.string())).optional()

--- a/packages/mcp/src/tools/run-sql.ts
+++ b/packages/mcp/src/tools/run-sql.ts
@@ -1,4 +1,5 @@
 import {
+  assertDateString,
   buildSource,
   computePeriodsInRange,
   DEFAULT_LAG_DAYS,
@@ -38,6 +39,8 @@ export async function runSql(
 
   let dateRange: { start: string; end: string };
   if (params.dateRange !== undefined) {
+    assertDateString(params.dateRange.start);
+    assertDateString(params.dateRange.end);
     dateRange = params.dateRange;
   } else {
     const dayMs = 86_400_000;


### PR DESCRIPTION
## Summary

- **Date format validation**: new `assertDateString()` in `identifier-validator.ts` — strict `YYYY-MM-DD` regex that throws `SecurityError`, applied in `buildMaterializeBaseQuery` (DDL) and MCP `runSql` (user-facing)
- **Tag name escaping**: `element_at(resource_tags, '${curKey}')` in `buildTagSelect` and `buildRawTagSelects` now escapes tag names with `sqlEscapeString()` to prevent config-driven injection
- **Directory name validation**: all 3 `readdir` filters in dimensions handlers changed from `startsWith('daily-')` to strict `^daily-\d{4}-(0[1-9]|1[0-2])$` regex before SQL interpolation
- **MCP schema hardening**: added `YYYY-MM-DD` regex to shared Zod `dateRangeSchema` (covers all 9 MCP tools)
- **Column name safety**: removed `?? field` fallback in `discover-column-values` handler — strict `RAW_COL` lookup only
- **IPC input validation**: `data:delete-period` handler now validates `period` param format before use