### PR TITLE
Add macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    environment: release
     strategy:
       matrix:
         include:
@@ -44,3 +45,8 @@ jobs:
         run: npx --no-install electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MAC_CERTIFICATE_P12 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MAC_CERTIFICATE_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -23,6 +23,7 @@ mac:
         - x64
         - arm64
   category: public.app-category.business
+  notarize: true
 win:
   target:
     - target: nsis


### PR DESCRIPTION
## Summary
- Enable macOS code signing and Apple notarization in the release workflow so users don't get Gatekeeper warnings
- Signing secrets are scoped to a `release` GitHub Environment for supply chain protection
- `notarize: true` added to electron-builder config

## Setup required before merging

Store secrets in the **`release` environment** (not repo-level) — see PR comments for step-by-step guide.

| Secret | Description |
|---|---|
| `MAC_CERTIFICATE_P12` | Base64-encoded Developer ID Application `.p12` |
| `MAC_CERTIFICATE_PASSWORD` | Password for the `.p12` export |
| `APPLE_ID` | Apple ID email |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for notarization |
| `APPLE_TEAM_ID` | 10-char Apple Developer Team ID |