### PR TITLE
Fix subscribe form Turnstile widget breaking layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1680,8 +1680,8 @@ Format:   <span class="code-file">Parquet</span>
         <input type="text" name="website" class="hp" tabindex="-1" autocomplete="off">
         <input type="email" name="email" placeholder="you@company.com" required autocomplete="email">
         <button type="submit">Subscribe</button>
-        <div class="cf-turnstile" id="turnstile-widget" data-sitekey="0x4AAAAAADHTvUnS8efYJ2uh" data-theme="dark" style="margin-top: 12px; display: flex; justify-content: center;"></div>
       </form>
+      <div class="cf-turnstile" id="turnstile-widget" data-sitekey="0x4AAAAAADHTvUnS8efYJ2uh" data-theme="dark" style="margin-top: 12px; display: flex; justify-content: center;"></div>
       <div class="signup-error" id="signup-error"></div>
       <div class="signup-note" id="signup-note">No spam. Unsubscribe anytime.</div>
     </div>
@@ -1861,7 +1861,8 @@ Format:   <span class="code-file">Parquet</span>
 
       // Include Turnstile token only if widget is configured
       if (turnstileConfigured) {
-        payload['cf-turnstile-response'] = formData.get('cf-turnstile-response');
+        const tokenInput = document.querySelector('#turnstile-widget [name="cf-turnstile-response"]');
+        payload['cf-turnstile-response'] = tokenInput ? tokenInput.value : '';
       }
 
       try {


### PR DESCRIPTION
## Summary

- The Cloudflare Turnstile CAPTCHA widget was rendered as a flex child inside the `.signup-form` row (input + button), causing it to appear inline and break the form layout
- Moved the Turnstile widget outside the `<form>` element so it renders below the input row as intended
- Updated the token retrieval to query the widget's hidden input directly since it's no longer part of the form's `FormData`