### PR TITLE
Detect missing AWS CLI and show install link

### DIFF
--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -214,12 +214,24 @@ export function registerSyncHandlers(app: AppContext): void {
     const currentPath = process.env['PATH'] ?? '';
     const extraPaths = ['/usr/local/bin', '/opt/homebrew/bin', '/usr/bin'];
     const fullPath = [...new Set([...currentPath.split(':'), ...extraPaths])].join(':');
-    const child = spawn('aws', ['sso', 'login', '--profile', profile], {
-      stdio: 'ignore',
-      detached: true,
-      env: { ...process.env, PATH: fullPath },
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn('aws', ['sso', 'login', '--profile', profile], {
+        stdio: 'ignore',
+        detached: true,
+        env: { ...process.env, PATH: fullPath },
+      });
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          reject(new Error('AWS_CLI_NOT_FOUND'));
+        } else {
+          reject(err);
+        }
+      });
+      child.on('spawn', () => {
+        child.unref();
+        resolve();
+      });
     });
-    child.unref();
   });
 
   ipcMain.handle('data:account-mapping', async (): Promise<AccountMappingStatus> => {

--- a/packages/ui/src/components/sso-login-button.tsx
+++ b/packages/ui/src/components/sso-login-button.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useCostApi } from '../hooks/use-cost-api.js';
+
+const AWS_CLI_INSTALL_URL = 'https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html';
+
+export function SsoLoginButton({ profile }: Readonly<{ profile: string }>) {
+  const api = useCostApi();
+  const [cliMissing, setCliMissing] = useState(false);
+
+  if (cliMissing) {
+    return (
+      <div className="mt-2 text-xs text-text-secondary">
+        <span>AWS CLI is not installed. </span>
+        <a href={AWS_CLI_INSTALL_URL} target="_blank" rel="noopener noreferrer" className="text-accent underline underline-offset-2 hover:text-accent-hover">
+          Install the AWS CLI
+        </a>
+        <span> and restart CostGoblin.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3 mt-2">
+      <button
+        type="button"
+        onClick={() => {
+          api.ssoLogin(profile).catch((err: unknown) => {
+            if (err instanceof Error && err.message.includes('AWS_CLI_NOT_FOUND')) {
+              setCliMissing(true);
+            }
+          });
+        }}
+        className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover transition-colors"
+      >
+        Open SSO Login
+      </button>
+      <span className="text-xs text-text-secondary">A browser window will open. Refresh this page after logging in.</span>
+    </div>
+  );
+}

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -7,6 +7,7 @@ import { SetupWizard } from './setup-wizard.js';
 import { OrgAccountsSection } from './data-management-org.js';
 import { SsmParameterSection } from './data-management-ssm.js';
 import { TierPanel, type SyncState } from './data-management-tier.js';
+import { SsoLoginButton } from '../components/sso-login-button.js';
 
 function syncStatusToState(s: SyncStatus): SyncState | null {
   if (s.status === 'syncing') {
@@ -435,16 +436,7 @@ export function DataManagement() {
         <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3">
           <p className="text-sm font-medium text-negative">{inventoryQuery.error.message}</p>
           {inventoryQuery.error.message.includes('aws sso login') && awsProfile !== null && (
-            <div className="flex items-center gap-3 mt-2">
-              <button
-                type="button"
-                onClick={() => { api.ssoLogin(awsProfile).catch(() => undefined); }}
-                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover transition-colors"
-              >
-                Open SSO Login
-              </button>
-              <span className="text-xs text-text-secondary">A browser window will open. Refresh this page after logging in.</span>
-            </div>
+            <SsoLoginButton profile={awsProfile} />
           )}
         </div>
       )}

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { Card, CardContent } from '../components/ui/card.js';
 import { Button } from '../components/ui/button.js';
+import { SsoLoginButton } from '../components/sso-login-button.js';
 
 type DataSource = 'daily' | 'hourly' | 'costOptimization';
 
@@ -147,7 +148,6 @@ function BucketStep({ state, onSelect, onSkip, onBack }: Readonly<{
   onSkip?: (() => void) | undefined;
   onBack: () => void;
 }>) {
-  const api = useCostApi();
   const [filter, setFilter] = useState('');
   const filtered = state.buckets.filter(b => filter.length === 0 || b.name.toLowerCase().includes(filter.toLowerCase()));
   const sourceLabel = SOURCE_LABELS[state.source];
@@ -164,16 +164,7 @@ function BucketStep({ state, onSelect, onSkip, onBack }: Readonly<{
         <div className="rounded-lg border border-negative bg-negative-muted px-4 py-3">
           <p className="text-sm text-negative">{state.error}</p>
           {state.error.includes('aws sso login') && (
-            <div className="flex items-center gap-3 mt-2">
-              <button
-                type="button"
-                onClick={() => { api.ssoLogin(state.profile).catch(() => undefined); }}
-                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover transition-colors"
-              >
-                Open SSO Login
-              </button>
-              <span className="text-xs text-text-secondary">A browser window will open. Refresh this page after logging in.</span>
-            </div>
+            <SsoLoginButton profile={state.profile} />
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

- Catch `ENOENT` when spawning `aws` CLI so the app doesn't crash if it's not installed
- Show an "Install the AWS CLI" link pointing to the AWS docs instead
- Extracted shared `SsoLoginButton` component used in both wizard and sync views