### PR TITLE
Add code signing policy page

### DIFF
--- a/docs/code-signing.html
+++ b/docs/code-signing.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Code Signing Policy — CostGoblin</title>
+  <meta name="description" content="How CostGoblin release binaries are signed and verified.">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" href="goblin.png">
+  <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
+  <link href="https://fonts.bunny.net/css?family=dm-mono:400,500|outfit:300,400,500,600,700&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #050505;
+      --bg-raised: #0a0a0a;
+      --border: #1a1f1a;
+      --text: #e2e8e2;
+      --text-dim: #6b7b6b;
+      --text-muted: #3a4a3a;
+      --emerald: #10b981;
+      --font-display: 'Outfit', sans-serif;
+      --font-mono: 'DM Mono', monospace;
+    }
+
+    html { scroll-behavior: smooth; overflow-x: hidden; }
+
+    body {
+      font-family: var(--font-display);
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.7;
+      overflow-x: hidden;
+      width: 100%;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      padding: 16px 24px;
+      background: rgba(5, 5, 5, 0.9);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
+    }
+
+    nav .inner {
+      max-width: 820px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .nav-logo {
+      font-family: var(--font-mono);
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--emerald);
+      letter-spacing: 0.05em;
+      text-decoration: none;
+    }
+
+    .nav-back {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--text-dim);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .nav-back:hover { color: var(--emerald); }
+
+    main {
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 64px 24px 96px;
+    }
+
+    h1 {
+      font-size: clamp(32px, 5vw, 44px);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 48px;
+    }
+
+    h2 {
+      font-size: 22px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      margin-top: 48px;
+      margin-bottom: 16px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+    }
+
+    h2:first-of-type {
+      border-top: none;
+      padding-top: 0;
+      margin-top: 0;
+    }
+
+    h3 {
+      font-size: 16px;
+      font-weight: 600;
+      margin-top: 24px;
+      margin-bottom: 8px;
+      color: var(--text);
+    }
+
+    p, li {
+      color: var(--text-dim);
+      margin-bottom: 12px;
+      font-size: 15px;
+    }
+
+    ul, ol { padding-left: 24px; margin-bottom: 16px; }
+
+    a { color: var(--emerald); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 24px;
+      font-size: 14px;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    th {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    td { color: var(--text-dim); }
+
+    td:first-child { color: var(--text); font-weight: 500; }
+
+    code {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 2px 6px;
+    }
+
+    footer {
+      padding: 32px 24px;
+      border-top: 1px solid var(--border);
+    }
+
+    footer .inner {
+      max-width: 820px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+
+    footer .left {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    footer .right { display: flex; gap: 20px; }
+
+    footer .right a {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-dim);
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="inner">
+      <a href="/" class="nav-logo">CostGoblin</a>
+      <a href="/" class="nav-back">&larr; Back to home</a>
+    </div>
+  </nav>
+
+  <main>
+    <h1>Code Signing Policy</h1>
+
+    <h2>Overview</h2>
+    <p>All CostGoblin release binaries are cryptographically signed so you can verify their authenticity and integrity. Unsigned or tampered binaries will trigger operating system warnings.</p>
+
+    <h2>Signing status by platform</h2>
+    <table>
+      <thead>
+        <tr><th>Platform</th><th>Status</th><th>Identity</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>macOS</td>
+          <td>Signed &amp; notarized</td>
+          <td>Developer ID Application: Etienne Chabert (VDA7669Q4Y)</td>
+        </tr>
+        <tr>
+          <td>Windows</td>
+          <td>Pending</td>
+          <td>SignPath Foundation (application in progress)</td>
+        </tr>
+        <tr>
+          <td>Linux</td>
+          <td>Not signed</td>
+          <td>Verified via package checksums</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Build process</h2>
+    <p>All release artifacts are built in <a href="https://github.com/etiennechabert/cost-goblin/actions" target="_blank" rel="noopener">GitHub Actions</a> from the public source code. The build process is fully automated and reproducible:</p>
+    <ul>
+      <li>A version tag (<code>v*</code>) triggers the release workflow</li>
+      <li>Builds run on GitHub-hosted runners (macOS, Windows, Linux)</li>
+      <li>Signing credentials are stored in GitHub Actions environment secrets and never touch developer machines during the build</li>
+      <li>macOS binaries are automatically notarized with Apple</li>
+    </ul>
+
+    <h2>How to verify</h2>
+
+    <h3>macOS</h3>
+    <p>Right-click the <code>.dmg</code> or <code>.app</code> and choose <strong>Get Info</strong>, or run:</p>
+    <p><code>codesign -dv --verbose=2 /Applications/CostGoblin.app</code></p>
+    <p>You should see <code>Developer ID Application: Etienne Chabert (VDA7669Q4Y)</code> in the output.</p>
+
+    <h3>Windows</h3>
+    <p>Right-click the <code>.exe</code> installer, select <strong>Properties &rarr; Digital Signatures</strong>. The signer name and certificate chain will be displayed once Windows signing is active.</p>
+
+    <h2>Team roles</h2>
+    <table>
+      <thead>
+        <tr><th>Role</th><th>Person</th><th>Responsibility</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Author &amp; Maintainer</td>
+          <td>Etienne Chabert</td>
+          <td>Development, code review, release approval</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Security practices</h2>
+    <ul>
+      <li>Signing keys are stored in GitHub Actions environment secrets, protected by deployment approval rules</li>
+      <li>Every release requires manual approval before the signing workflow runs</li>
+      <li>All maintainer accounts use multi-factor authentication</li>
+      <li>Source code is publicly auditable at <a href="https://github.com/etiennechabert/cost-goblin" target="_blank" rel="noopener">github.com/etiennechabert/cost-goblin</a></li>
+    </ul>
+
+    <h2>Reporting issues</h2>
+    <p>If you believe a CostGoblin binary has been tampered with or you encounter a signature verification failure:</p>
+    <ol>
+      <li>Do not run the binary</li>
+      <li>Open an issue at <a href="https://github.com/etiennechabert/cost-goblin/issues" target="_blank" rel="noopener">github.com/etiennechabert/cost-goblin/issues</a></li>
+      <li>Or email <a href="mailto:etienne.chabert.de@gmail.com">etienne.chabert.de@gmail.com</a></li>
+    </ol>
+
+    <h2>Acknowledgements</h2>
+    <p>Free code signing provided by <a href="https://signpath.io" target="_blank" rel="noopener">SignPath.io</a>, certificate by <a href="https://signpath.org" target="_blank" rel="noopener">SignPath Foundation</a>.</p>
+  </main>
+
+  <footer>
+    <div class="inner">
+      <div class="left">&copy; 2026 CostGoblin</div>
+      <div class="right">
+        <a href="/imprint.html">Imprint</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/code-signing.html">Code Signing</a>
+        <a href="https://github.com/etiennechabert/cost-goblin" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1725,6 +1725,7 @@ Format:   <span class="code-file">Parquet</span>
       <div class="right">
         <a href="/imprint.html">Imprint</a>
         <a href="/privacy.html">Privacy</a>
+        <a href="/code-signing.html">Code Signing</a>
         <a href="https://github.com/etiennechabert/cost-goblin" target="_blank" rel="noopener">GitHub</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Adds `/code-signing.html` page documenting signing status per platform, build process, verification instructions, team roles, and security practices
- Includes SignPath Foundation attribution (required for their free code signing program)
- Adds footer link on the main landing page

Preparatory work for Windows code signing via SignPath Foundation.