### PR TITLE
Skip encryption when user picks No in vault setup

### DIFF
--- a/packages/desktop/src/main/handlers/vault.ts
+++ b/packages/desktop/src/main/handlers/vault.ts
@@ -1,7 +1,6 @@
 import { ipcMain, safeStorage } from 'electron';
 import { readFile, writeFile, readdir, mkdir, rm, unlink } from 'node:fs/promises';
-import { existsSync, writeFileSync, readFileSync } from 'node:fs';
-import { randomBytes } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import {
   deriveKey,
@@ -93,11 +92,6 @@ function collectParquetFiles(dataDir: string): Promise<string[]> {
   return collectFiles(join(dataDir, 'aws', 'raw'), '.parquet');
 }
 
-function storeKeyInSafeStorage(userDataPath: string, rawKey: Buffer): void {
-  const encrypted = safeStorage.encryptString(rawKey.toString('hex'));
-  writeFileSync(safeStorageKeyPath(userDataPath), encrypted);
-}
-
 function loadKeyFromSafeStorage(userDataPath: string): Buffer | null {
   try {
     const encrypted = readFileSync(safeStorageKeyPath(userDataPath));
@@ -126,6 +120,11 @@ export function registerVaultHandlers(vaultCtx: VaultContext): VaultState {
 
     if (config === null) {
       return { state: 'not-configured' };
+    }
+
+    if (!config.usePassword && config.keyCheck === '') {
+      vaultState.encryptionConfig = config;
+      return { state: 'unlocked' };
     }
 
     if (vaultState.derivedKey !== null) {
@@ -173,23 +172,26 @@ export function registerVaultHandlers(vaultCtx: VaultContext): VaultState {
   });
 
   ipcMain.handle('vault:setup', async (_event, password: string | null): Promise<void> => {
-    const usePassword = password !== null;
-    const salt = generateSalt();
-    let key: Buffer;
-
-    if (usePassword) {
-      key = await deriveKey(password, salt);
-    } else {
-      key = randomBytes(32);
-      storeKeyInSafeStorage(userDataPath, key);
+    if (password === null) {
+      const config: EncryptionConfig = {
+        salt: '',
+        keyCheck: '',
+        usePassword: false,
+      };
+      await saveEncryptionConfig(userDataPath, config);
+      vaultState.encryptionConfig = config;
+      logger.info('Vault setup complete (no encryption)');
+      return;
     }
 
+    const salt = generateSalt();
+    const key = await deriveKey(password, salt);
     const keyCheck = createKeyCheck(key);
 
     const config: EncryptionConfig = {
       salt: salt.toString('hex'),
       keyCheck: keyCheck.toString('hex'),
-      usePassword,
+      usePassword: true,
     };
 
     const parquetFiles = await collectParquetFiles(dataDir);
@@ -207,7 +209,7 @@ export function registerVaultHandlers(vaultCtx: VaultContext): VaultState {
     await mkdirRestricted(tempDir);
     vaultState.tempDataDir = tempDir;
 
-    logger.info(`Vault setup complete (password=${String(usePassword)}): ${String(parquetFiles.length)} files encrypted`);
+    logger.info(`Vault setup complete (password): ${String(parquetFiles.length)} files encrypted`);
   });
 
   ipcMain.handle('vault:reset', async (): Promise<void> => {

--- a/packages/desktop/src/main/handlers/vault.ts
+++ b/packages/desktop/src/main/handlers/vault.ts
@@ -146,7 +146,7 @@ export function registerVaultHandlers(vaultCtx: VaultContext): VaultState {
     return { state: 'locked' };
   });
 
-  ipcMain.handle('vault:unlock', async (_event, password: string): Promise<{ success: boolean; dataDir: string | null }> => {
+  ipcMain.handle('vault:unlock', async (event, password: string): Promise<{ success: boolean; dataDir: string | null }> => {
     const config = await loadEncryptionConfig(userDataPath);
     if (config === null) {
       return { success: true, dataDir };
@@ -164,7 +164,9 @@ export function registerVaultHandlers(vaultCtx: VaultContext): VaultState {
     vaultState.encryptionConfig = config;
 
     const tempDir = tempVaultDir(userDataPath);
-    await decryptDataToTemp(dataDir, tempDir, key);
+    await decryptDataToTemp(dataDir, tempDir, key, (done, total) => {
+      event.sender.send('vault:decrypt-progress', done, total);
+    });
     vaultState.tempDataDir = tempDir;
 
     logger.info('Vault unlocked, data decrypted to temp');
@@ -242,19 +244,28 @@ export function registerVaultHandlers(vaultCtx: VaultContext): VaultState {
   return vaultState;
 }
 
-async function decryptDataToTemp(dataDir: string, tempDir: string, key: Buffer): Promise<void> {
+async function decryptDataToTemp(
+  dataDir: string,
+  tempDir: string,
+  key: Buffer,
+  onProgress?: (done: number, total: number) => void,
+): Promise<void> {
   await cleanupTemp(dirname(tempDir));
   await mkdirRestricted(tempDir);
 
   const encFiles = await collectEncryptedFiles(dataDir);
-  for (const encPath of encFiles) {
+  const total = encFiles.length;
+  for (let i = 0; i < total; i++) {
+    const encPath = encFiles[i];
+    if (encPath === undefined) continue;
     const rel = relative(join(dataDir, 'aws', 'raw'), encPath).replace(/\.enc$/, '');
     const outPath = join(tempDir, 'aws', 'raw', rel);
     await mkdirRestricted(dirname(outPath));
     await decryptFile(encPath, outPath, key);
+    onProgress?.(i + 1, total);
   }
 
-  logger.info(`Decrypted ${String(encFiles.length)} files to temp`);
+  logger.info(`Decrypted ${String(total)} files to temp`);
 }
 
 export async function cleanupTemp(userDataPath: string): Promise<void> {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -299,6 +299,13 @@ contextBridge.exposeInMainWorld('costgoblinVault', {
   reset(): Promise<void> {
     return invoke<undefined>('vault:reset').then(() => undefined);
   },
+  onDecryptProgress(callback: (done: number, total: number) => void): () => void {
+    const handler = (_event: Electron.IpcRendererEvent, done: number, total: number): void => {
+      callback(done, total);
+    };
+    ipcRenderer.on('vault:decrypt-progress', handler);
+    return () => { ipcRenderer.removeListener('vault:decrypt-progress', handler); };
+  },
 });
 
 contextBridge.exposeInMainWorld('costgoblinUpdate', {

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -51,6 +51,7 @@ declare global {
     unlock(password: string): Promise<{ success: boolean; dataDir: string | null }>;
     setup(password: string | null): Promise<void>;
     reset(): Promise<void>;
+    onDecryptProgress(callback: (done: number, total: number) => void): () => void;
   }
 
   interface Window {

--- a/packages/desktop/src/renderer/vault-lock-screen.tsx
+++ b/packages/desktop/src/renderer/vault-lock-screen.tsx
@@ -100,6 +100,14 @@ export function VaultLockScreen({ onUnlocked, onReset }: VaultLockScreenProps): 
   const [error, setError] = useState<string | null>(null);
   const [unlocking, setUnlocking] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
+  const [decryptProgress, setDecryptProgress] = useState<{ done: number; total: number } | null>(null);
+
+  useEffect(() => {
+    if (!unlocking) return;
+    return globalThis.costgoblinVault.onDecryptProgress((done, total) => {
+      setDecryptProgress({ done, total });
+    });
+  }, [unlocking]);
 
   const handleSubmit = useCallback(async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -107,6 +115,7 @@ export function VaultLockScreen({ onUnlocked, onReset }: VaultLockScreenProps): 
 
     setUnlocking(true);
     setError(null);
+    setDecryptProgress(null);
 
     const result = await globalThis.costgoblinVault.unlock(password);
     if (result.success) {
@@ -114,6 +123,7 @@ export function VaultLockScreen({ onUnlocked, onReset }: VaultLockScreenProps): 
     } else {
       setError('Wrong password');
       setUnlocking(false);
+      setDecryptProgress(null);
     }
   }, [password, unlocking, onUnlocked]);
 
@@ -191,8 +201,21 @@ export function VaultLockScreen({ onUnlocked, onReset }: VaultLockScreenProps): 
         </form>
 
         {unlocking && (
-          <div className="mt-6 flex justify-center">
+          <div className="mt-6 flex flex-col items-center gap-3">
             <KeyUnlockAnimation />
+            {decryptProgress !== null && decryptProgress.total > 0 && (
+              <div className="w-full space-y-1.5">
+                <div className="h-1.5 rounded-full bg-bg-tertiary overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-accent transition-all duration-150 ease-out"
+                    style={{ width: `${String(Math.round((decryptProgress.done / decryptProgress.total) * 100))}%` }}
+                  />
+                </div>
+                <p className="text-xs text-text-muted text-center">
+                  Decrypting {String(decryptProgress.done)}/{String(decryptProgress.total)} files
+                </p>
+              </div>
+            )}
           </div>
         )}
 

--- a/packages/desktop/src/renderer/vault-setup-screen.tsx
+++ b/packages/desktop/src/renderer/vault-setup-screen.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { Lock, LockOpen } from 'lucide-react';
 
 interface VaultSetupScreenProps {
   readonly onComplete: () => void;
@@ -40,18 +41,24 @@ export function VaultSetupScreen({ onComplete }: VaultSetupScreenProps): React.J
           <button
             type="button"
             onClick={() => { setWantEncryption(true); }}
-            className="w-full rounded-lg border border-border bg-bg-tertiary/20 p-4 text-left hover:border-accent/50 hover:bg-bg-tertiary/40 transition-colors"
+            className="w-full rounded-lg border border-border bg-bg-tertiary/20 p-4 text-left hover:border-accent/50 hover:bg-bg-tertiary/40 transition-colors flex items-start gap-3"
           >
-            <span className="text-sm font-medium text-text-primary">Yes, set a password</span>
-            <p className="text-xs text-text-muted mt-0.5">Data is encrypted on disk. You&apos;ll enter the password each time you open CostGoblin.</p>
+            <Lock className="size-5 text-accent mt-0.5 shrink-0" />
+            <div>
+              <span className="text-sm font-medium text-text-primary">Yes, set a password</span>
+              <p className="text-xs text-text-muted mt-0.5">Data is encrypted on disk. You&apos;ll enter the password each time you open CostGoblin.</p>
+            </div>
           </button>
           <button
             type="button"
             onClick={() => { globalThis.costgoblinVault.setup(null).then(onComplete).catch(() => undefined); }}
-            className="w-full rounded-lg border border-border bg-bg-tertiary/20 p-4 text-left hover:border-border hover:bg-bg-tertiary/40 transition-colors"
+            className="w-full rounded-lg border border-border bg-bg-tertiary/20 p-4 text-left hover:border-border hover:bg-bg-tertiary/40 transition-colors flex items-start gap-3"
           >
-            <span className="text-sm font-medium text-text-primary">No thanks</span>
-            <p className="text-xs text-text-muted mt-0.5">Data is encrypted automatically using your system keychain. No password prompt on startup.</p>
+            <LockOpen className="size-5 text-text-muted mt-0.5 shrink-0" />
+            <div>
+              <span className="text-sm font-medium text-text-primary">No thanks</span>
+              <p className="text-xs text-text-muted mt-0.5">Data is stored unencrypted on disk. You can enable encryption later in settings.</p>
+            </div>
           </button>
         </div>
       </div>
@@ -63,7 +70,7 @@ export function VaultSetupScreen({ onComplete }: VaultSetupScreenProps): React.J
       <div>
         <h2 className="text-xl font-semibold text-text-primary">Set your password</h2>
         <p className="text-sm text-text-secondary mt-1">
-          This password encrypts your billing data. If you forget it, you&apos;ll need to re-sync from S3.
+          Pick something simple and easy to remember — no need for special characters. If you forget it, you can always re-sync from S3.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- **"No thanks" no longer triggers system keychain prompt** — data is stored unencrypted instead of generating a key and calling `safeStorage.encryptString()` which shows a scary OS-level keychain authorization dialog
- Adds Lock/LockOpen icons to the vault setup choice buttons
- Softens password screen copy to encourage a simple, memorable password
- Backwards compatible: existing keychain-based setups continue to auto-unlock normally