### PR TITLE
Add clickable group-by dropdown to widget titles

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -267,7 +267,7 @@ test.describe('Cost Overview', () => {
   });
 
   test('stacked bar chart renders with title', async () => {
-    await expect(page.getByText('Daily Costs')).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Service' }).first()).toBeVisible();
   });
 
   test('histogram expand/collapse toggle works', async () => {

--- a/packages/desktop/src/renderer/vault-lock-screen.tsx
+++ b/packages/desktop/src/renderer/vault-lock-screen.tsx
@@ -57,7 +57,7 @@ function KeyUnlockAnimation(): React.JSX.Element {
         stroke="currentColor"
         strokeWidth="2.5"
         strokeLinecap="round"
-        className="origin-[42px_28px]"
+        className="origin-[22px_28px]"
         style={{
           animation: 'shackle-open 1.2s ease-in-out forwards',
         }}
@@ -74,8 +74,8 @@ function KeyUnlockAnimation(): React.JSX.Element {
       </g>
       <style>{`
         @keyframes shackle-open {
-          0%, 50% { transform: rotate(0deg) translateY(0); opacity: 1; }
-          100% { transform: rotate(-30deg) translateY(-4px); opacity: 0.4; }
+          0%, 50% { transform: rotate(0deg); }
+          100% { transform: rotate(-45deg); }
         }
         @keyframes key-enter {
           0% { transform: translateX(20px); opacity: 0; }
@@ -83,7 +83,7 @@ function KeyUnlockAnimation(): React.JSX.Element {
         }
         @keyframes key-turn {
           0% { transform: rotate(0deg); transform-origin: 38px 40px; }
-          100% { transform: rotate(-45deg); transform-origin: 38px 40px; }
+          100% { transform: rotate(45deg); transform-origin: 38px 40px; }
         }
       `}</style>
     </svg>

--- a/packages/ui/src/__tests__/cost-overview.test.tsx
+++ b/packages/ui/src/__tests__/cost-overview.test.tsx
@@ -35,13 +35,13 @@ describe('CostOverview', () => {
     await waitFor(() => {
       expect(screen.getByText('Total Cost')).toBeDefined();
     });
-    expect(screen.getByText('Daily Costs')).toBeDefined();
+    expect(screen.getAllByText('Service').length).toBeGreaterThan(0);
   });
 
   it('renders daily costs chart', async () => {
     renderOverview();
     await waitFor(() => {
-      expect(screen.getByText('Daily Costs')).toBeDefined();
+      expect(screen.getAllByText('Service').length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/ui/src/components/collapsed-chart.tsx
+++ b/packages/ui/src/components/collapsed-chart.tsx
@@ -1,4 +1,4 @@
-export function CollapsedChart({ title, onExpandToggle }: Readonly<{ title: string; onExpandToggle?: (() => void) | undefined }>) {
+export function CollapsedChart({ title, onExpandToggle }: Readonly<{ title: React.ReactNode; onExpandToggle?: (() => void) | undefined }>) {
   return (
     <button
       type="button"

--- a/packages/ui/src/components/group-by-title.tsx
+++ b/packages/ui/src/components/group-by-title.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.js';
+import type { Dimension, DimensionId } from '@costgoblin/core/browser';
+import { getDimensionId, getDimensionLabel } from '../lib/dimensions.js';
+
+interface GroupByTitleProps {
+  readonly dimensions: readonly Dimension[];
+  readonly currentGroupBy: DimensionId;
+  readonly onGroupByChange: (id: DimensionId) => void;
+  readonly label: string;
+  readonly suffix?: string | undefined;
+}
+
+export function GroupByTitle({ dimensions, currentGroupBy, onGroupByChange, label, suffix }: GroupByTitleProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+        >
+          {label}{suffix !== undefined ? ` ${suffix}` : ''}
+          <ChevronDown className="size-3.5 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-48 p-1">
+        {dimensions.map((dim) => {
+          const id = getDimensionId(dim);
+          const isActive = id === currentGroupBy;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => { onGroupByChange(id); setOpen(false); }}
+              className={[
+                'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors',
+                isActive
+                  ? 'bg-accent/15 text-accent font-medium'
+                  : 'text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary',
+              ].join(' ')}
+            >
+              {getDimensionLabel(dim)}
+            </button>
+          );
+        })}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/src/components/heatmap-chart.tsx
+++ b/packages/ui/src/components/heatmap-chart.tsx
@@ -14,7 +14,7 @@ interface HeatmapChartProps {
   readonly cells: readonly HeatmapCell[];
   readonly groups: readonly string[];
   readonly dates: readonly string[];
-  readonly title?: string | undefined;
+  readonly title?: React.ReactNode | undefined;
   readonly subtitle?: string | undefined;
   readonly height?: number | undefined;
   readonly onCellClick?: ((group: string, date: string) => void) | undefined;

--- a/packages/ui/src/components/line-chart.tsx
+++ b/packages/ui/src/components/line-chart.tsx
@@ -28,7 +28,7 @@ interface LineChartProps {
   /** Previous period series, rendered as dashed ghost lines. Dates should
    *  be mapped onto the current period so lines overlay by position. */
   readonly previousSeries?: readonly LineSeries[] | undefined;
-  readonly title?: string | undefined;
+  readonly title?: React.ReactNode | undefined;
   readonly subtitle?: string | undefined;
   readonly height?: number | undefined;
   readonly onSeriesClick?: ((name: string) => void) | undefined;

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -17,7 +17,7 @@ export interface PieSlice {
 
 interface PieChartProps {
   readonly data: readonly PieSlice[];
-  readonly title: string;
+  readonly title: React.ReactNode;
   readonly subtitle?: string;
   readonly onSliceClick?: (name: string) => void;
   readonly onSliceHover?: (name: string | null) => void;
@@ -99,7 +99,7 @@ function PieChartInner({
           <select
             value={activeDimensionId ?? ''}
             onChange={(e) => { onDimensionChange(e.target.value); }}
-            aria-label={`Group by dimension (current: ${title})`}
+            aria-label="Group by dimension"
             className="text-sm font-medium text-text-secondary bg-transparent border-none outline-none cursor-pointer hover:text-text-primary transition-colors appearance-none pr-4"
             style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'10\' height=\'6\' viewBox=\'0 0 10 6\' fill=\'none\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath d=\'M1 1l4 4 4-4\' stroke=\'%236b7280\' stroke-width=\'1.5\' stroke-linecap=\'round\'/%3E%3C/svg%3E")', backgroundRepeat: 'no-repeat', backgroundPosition: 'right center' }}
           >

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -19,7 +19,7 @@ interface StackedBarChartProps {
   readonly onTabChange?: ((tab: HistogramTab) => void) | undefined;
   readonly expanded?: boolean | undefined;
   readonly onExpandToggle?: (() => void) | undefined;
-  readonly title?: string | undefined;
+  readonly title?: React.ReactNode | undefined;
   readonly loading?: boolean | undefined;
   readonly onSegmentClick?: ((name: string) => void) | undefined;
   /** Previous period daily totals, aligned by position index. Rendered as
@@ -104,8 +104,7 @@ interface BarColumnProps {
 
 function BarColumn({ day, segments, segTotal, barPct, highlightedGroup, palette, onSegmentClick, setHoveredDay, setHoveredSegment }: BarColumnProps) {
   return (
-    <button
-      type="button"
+    <div
       className="group relative flex-1 min-w-0"
       style={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}
       onMouseEnter={() => { setHoveredDay(day.date); }}
@@ -127,7 +126,7 @@ function BarColumn({ day, segments, segTotal, barPct, highlightedGroup, palette,
           />
         ))}
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/packages/ui/src/components/top-n-bar-chart.tsx
+++ b/packages/ui/src/components/top-n-bar-chart.tsx
@@ -15,7 +15,7 @@ export interface TopNBar {
 
 interface TopNBarChartProps {
   readonly data: readonly TopNBar[];
-  readonly title: string;
+  readonly title: React.ReactNode;
   readonly subtitle?: string | undefined;
   readonly topN?: number | undefined;
   readonly onBarClick?: ((name: string) => void) | undefined;
@@ -86,7 +86,7 @@ function TopNBarChartInner({
           <select
             value={activeDimensionId ?? ''}
             onChange={(e) => { onDimensionChange(e.target.value); }}
-            aria-label={`Group by dimension (current: ${title})`}
+            aria-label="Group by dimension"
             className="text-sm font-medium text-text-secondary bg-transparent border-none outline-none cursor-pointer hover:text-text-primary transition-colors appearance-none pr-4"
             style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'10\' height=\'6\' viewBox=\'0 0 10 6\' fill=\'none\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath d=\'M1 1l4 4 4-4\' stroke=\'%236b7280\' stroke-width=\'1.5\' stroke-linecap=\'round\'/%3E%3C/svg%3E")', backgroundRepeat: 'no-repeat', backgroundPosition: 'right center' }}
           >

--- a/packages/ui/src/components/treemap-chart.tsx
+++ b/packages/ui/src/components/treemap-chart.tsx
@@ -13,7 +13,7 @@ export interface TreemapCell {
 
 interface TreemapChartProps {
   readonly data: readonly TreemapCell[];
-  readonly title?: string | undefined;
+  readonly title?: React.ReactNode | undefined;
   readonly subtitle?: string | undefined;
   readonly height?: number | undefined;
   readonly onCellClick?: ((name: string) => void) | undefined;

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -1,12 +1,13 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { BubbleChart } from '../components/bubble-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { asDollars } from '@costgoblin/core/browser';
-import type { TrendResult } from '@costgoblin/core/browser';
+import type { DimensionId, TrendResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 
 const DEFAULT_DELTA_THRESHOLD = asDollars(50);
 const DEFAULT_PERCENT_THRESHOLD = 5;
@@ -20,24 +21,27 @@ export function BubbleWidget({
   spec,
   dateRange,
   globalFilters,
+  dimensions,
   onEntityClick,
 }: WidgetCommonProps) {
   const api = useCostApi();
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'bubble' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
 
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
   const query = useQuery(
-    () => specGroupBy === undefined
+    () => effectiveGroupBy === undefined
       ? Promise.resolve(null)
       : api.queryTrends({
-          groupBy: specGroupBy,
+          groupBy: effectiveGroupBy,
           dateRange,
           filters,
           deltaThreshold: DEFAULT_DELTA_THRESHOLD,
           percentThreshold: DEFAULT_PERCENT_THRESHOLD,
         }),
-    [specGroupBy, dateRange.start, dateRange.end, fk, api],
+    [effectiveGroupBy, dateRange.start, dateRange.end, fk, api],
   );
 
   const data = useMemo(
@@ -45,7 +49,7 @@ export function BubbleWidget({
     [query],
   );
 
-  if (spec.type !== 'bubble' || specGroupBy === undefined) return null;
+  if (spec.type !== 'bubble' || effectiveGroupBy === undefined) return null;
   if (query.status === 'loading') return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
       <CoinRainLoader height={260} count={5} />
@@ -54,12 +58,12 @@ export function BubbleWidget({
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
-      {spec.title !== undefined && (
-        <h3 className="text-sm font-medium text-text-secondary mb-2">{spec.title}</h3>
-      )}
+      <div className="mb-2">
+        {spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={effectiveGroupBy} onGroupByChange={setGroupByOverride} label={dimensionLabelFor(dimensions, effectiveGroupBy)} />}
+      </div>
       <BubbleChart
         data={data}
-        onEntityClick={(entity) => { onEntityClick?.(entity, specGroupBy); }}
+        onEntityClick={(entity) => { onEntityClick?.(entity, effectiveGroupBy); }}
       />
     </div>
   );

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { HeatmapChart } from '../components/heatmap-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { HeatmapCell } from '../components/heatmap-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
+import type { DimensionId } from '@costgoblin/core/browser';
 import type { DailyCostsResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor } from './widget.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 
 interface BuiltCells {
   readonly cells: readonly HeatmapCell[];
@@ -47,11 +49,13 @@ export function HeatmapWidget({
   dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'heatmap' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const topN = spec.type === 'heatmap' ? (spec.topN ?? 12) : 12;
 
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
-    specGroupBy,
+    specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
@@ -63,7 +67,7 @@ export function HeatmapWidget({
     [dailyResult, topN],
   );
 
-  if (spec.type !== 'heatmap' || specGroupBy === undefined || activeGroupBy === undefined) return null;
+  if (spec.type !== 'heatmap' || effectiveGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
@@ -78,7 +82,7 @@ export function HeatmapWidget({
       cells={cells}
       groups={groups}
       dates={dates}
-      title={spec.title ?? `${label} × Day`}
+      title={spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} suffix="× Day" />}
       subtitle="Click a cell to filter"
       onCellClick={(group) => { onSetFilter(activeGroupBy, asTagValue(group)); }}
     />

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -6,9 +6,10 @@ import { LineChart } from '../components/line-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { LineSeries } from '../components/line-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { DailyCostsResult } from '@costgoblin/core/browser';
+import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 
 function buildSeries(data: DailyCostsResult | null, topN: number): LineSeries[] {
   if (data === null) return [];
@@ -61,13 +62,15 @@ export function LineWidget({
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'line' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const topN = spec.type === 'line' ? (spec.topN ?? 6) : 6;
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
-    specGroupBy,
+    specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
@@ -75,10 +78,10 @@ export function LineWidget({
   });
 
   const prevQuery = useQuery<DailyCostsResult | null>(
-    () => compareEnabled && specGroupBy !== undefined
-      ? api.queryDailyCosts({ groupBy: specGroupBy, dateRange: previousDateRange, filters, granularity })
+    () => compareEnabled && effectiveGroupBy !== undefined
+      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, specGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
 
   const series = useMemo(
@@ -97,7 +100,7 @@ export function LineWidget({
     [prevHasCoverage, prevQuery, series, currentDates],
   );
 
-  if (spec.type !== 'line' || specGroupBy === undefined || activeGroupBy === undefined) return null;
+  if (spec.type !== 'line' || effectiveGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
@@ -111,7 +114,7 @@ export function LineWidget({
     <LineChart
       series={series}
       previousSeries={compareEnabled ? previousSeries : undefined}
-      title={spec.title ?? `${label} over time`}
+      title={spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} suffix="over time" />}
       subtitle={`Top ${String(topN)} • Click to filter, dbl-click to hide`}
       onSeriesClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
     />

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -1,13 +1,14 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useCostWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { PieChart } from '../components/pie-chart.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 import type { PieSlice } from '../components/pie-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult } from '@costgoblin/core/browser';
+import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
 
@@ -39,13 +40,15 @@ export function PieWidget({
   const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'pie' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const specTitle = spec.title;
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
-    specGroupBy,
+    specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
@@ -53,10 +56,10 @@ export function PieWidget({
   });
 
   const prevQuery = useQuery<CostResult | null>(
-    () => compareEnabled && specGroupBy !== undefined
-      ? api.queryCosts({ groupBy: specGroupBy, dateRange: previousDateRange, filters, granularity })
+    () => compareEnabled && effectiveGroupBy !== undefined
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, specGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
 
   const slices = useMemo(
@@ -70,7 +73,7 @@ export function PieWidget({
     [prevHasCoverage, prevQuery],
   );
 
-  if (spec.type !== 'pie' || specGroupBy === undefined || activeGroupBy === undefined) return null;
+  if (spec.type !== 'pie' || effectiveGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
@@ -85,7 +88,7 @@ export function PieWidget({
   return (
     <PieChart
       data={slices}
-      title={specTitle ?? label}
+      title={specTitle ?? <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} />}
       subtitle="Click to filter"
       onSliceClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
       onSliceHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: activeGroupBy }); }}

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,13 +1,14 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { StackedBarChart, bucketBars, type BarDay } from '../components/stacked-bar-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
-import type { DailyCostsResult } from '@costgoblin/core/browser';
+import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
+import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 
 const MAX_BARS = 170;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -48,16 +49,19 @@ export function StackedBarWidget({
   compareEnabled,
   granularity,
   globalFilters,
+  dimensions,
   onSetFilter,
 }: WidgetCommonProps) {
   const api = useCostApi();
   const focus = useCostFocus();
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
-    specGroupBy,
+    specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
@@ -65,10 +69,10 @@ export function StackedBarWidget({
   });
 
   const prevQuery = useQuery<DailyCostsResult | null>(
-    () => compareEnabled && specGroupBy !== undefined
-      ? api.queryDailyCosts({ groupBy: specGroupBy, dateRange: previousDateRange, filters, granularity })
+    () => compareEnabled && effectiveGroupBy !== undefined
+      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, specGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
 
   const barDays = useMemo(
@@ -102,7 +106,11 @@ export function StackedBarWidget({
   const loading = query.status === 'loading';
 
   const defaultTitle = granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs';
-  const title = spec.title ?? defaultTitle;
+  let title: React.ReactNode = spec.title ?? defaultTitle;
+  if (spec.title === undefined && activeGroupBy !== undefined) {
+    const label = dimensionLabelFor(dimensions, activeGroupBy);
+    title = <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} />;
+  }
 
   return (
     <StackedBarChart

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useCostWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -7,9 +7,10 @@ import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { TopNBar } from '../components/top-n-bar-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult } from '@costgoblin/core/browser';
+import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 
 function rowsToBars(data: CostResult | null): TopNBar[] {
   if (data === null) return [];
@@ -39,12 +40,14 @@ export function TopNBarWidget({
   const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'topNBar' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
-    specGroupBy,
+    specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
@@ -52,10 +55,10 @@ export function TopNBarWidget({
   });
 
   const prevQuery = useQuery<CostResult | null>(
-    () => compareEnabled && specGroupBy !== undefined
-      ? api.queryCosts({ groupBy: specGroupBy, dateRange: previousDateRange, filters, granularity })
+    () => compareEnabled && effectiveGroupBy !== undefined
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, specGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
 
   const bars = useMemo(
@@ -69,7 +72,7 @@ export function TopNBarWidget({
     [prevHasCoverage, prevQuery],
   );
 
-  if (spec.type !== 'topNBar' || specGroupBy === undefined || activeGroupBy === undefined) return null;
+  if (spec.type !== 'topNBar' || effectiveGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
@@ -82,7 +85,7 @@ export function TopNBarWidget({
   return (
     <TopNBarChart
       data={bars}
-      title={spec.title ?? label}
+      title={spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} />}
       subtitle="Click to filter"
       topN={spec.topN ?? 12}
       onBarClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useCostWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -7,9 +7,10 @@ import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import type { TreemapCell } from '../components/treemap-chart.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
-import type { CostResult } from '@costgoblin/core/browser';
+import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
+import { GroupByTitle } from '../components/group-by-title.js';
 
 function rowsToCells(data: CostResult | null): TreemapCell[] {
   if (data === null) return [];
@@ -34,12 +35,14 @@ export function TreemapWidget({
   const api = useCostApi();
   const focus = useCostFocus();
   const dispatch = useCostFocusDispatch();
+  const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'treemap' ? spec.groupBy : undefined;
+  const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
-    specGroupBy,
+    specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
@@ -47,10 +50,10 @@ export function TreemapWidget({
   });
 
   const prevQuery = useQuery<CostResult | null>(
-    () => compareEnabled && specGroupBy !== undefined
-      ? api.queryCosts({ groupBy: specGroupBy, dateRange: previousDateRange, filters, granularity })
+    () => compareEnabled && effectiveGroupBy !== undefined
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, specGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
   );
 
   const cells = useMemo(
@@ -64,7 +67,7 @@ export function TreemapWidget({
     [prevHasCoverage, prevQuery],
   );
 
-  if (spec.type !== 'treemap' || specGroupBy === undefined || activeGroupBy === undefined) return null;
+  if (spec.type !== 'treemap' || effectiveGroupBy === undefined || activeGroupBy === undefined) return null;
 
   const label = dimensionLabelFor(dimensions, activeGroupBy);
 
@@ -77,7 +80,7 @@ export function TreemapWidget({
   return (
     <TreemapChart
       data={cells}
-      title={spec.title ?? label}
+      title={spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} />}
       subtitle="Click to filter"
       onCellClick={(name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
       onCellHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: activeGroupBy }); }}


### PR DESCRIPTION
## Summary
- Widget titles now show the current group-by dimension with a chevron — clicking opens a popover to switch dimensions on the fly
- Override is ephemeral (local `useState`) and resets on dashboard re-render
- All 7 group-by widgets updated: pie, treemap, top-n-bar, heatmap, line, stacked-bar, bubble
- New `GroupByTitle` component using Radix Popover
- Chart component `title` props widened from `string` to `React.ReactNode`
- Fixes nested `<button>` in stacked-bar `BarColumn` (now a `<div>`)
- Bubble widget now shows dimension label as title (was missing)