### PR TITLE
Add AI Assistant view with MCP server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/etiennechabert/cost-goblin/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License"></a>
   <img src="https://img.shields.io/badge/Node.js-%3E%3D%2020-339933.svg?logo=node.js&logoColor=white" alt="Node.js">
-  <img src="https://img.shields.io/badge/Electron-34-47848F.svg?logo=electron&logoColor=white" alt="Electron">
+  <img src="https://img.shields.io/badge/Electron-41-47848F.svg?logo=electron&logoColor=white" alt="Electron">
   <img src="https://img.shields.io/badge/DuckDB-1.5-FFF000.svg?logo=duckdb&logoColor=black" alt="DuckDB">
   <a href="https://github.com/etiennechabert/cost-goblin/actions/workflows/ci.yml"><img src="https://github.com/etiennechabert/cost-goblin/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://buymeacoffee.com/etiennechak"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?logo=buymeacoffee&logoColor=white" alt="Buy Me A Coffee"></a>
@@ -26,6 +26,7 @@
 
 <p align="center">
   <a href="https://costgoblin.com">Website</a> &middot;
+  <a href="https://github.com/etiennechabert/cost-goblin/releases/latest">Download</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
   <a href="#features">Features</a>
 </p>
@@ -35,6 +36,12 @@
 </p>
 
 CostGoblin is a desktop app that syncs your AWS billing data locally and queries it with DuckDB. Filter, drill down, and slice costs by any dimension — from a plane at 10,000 meters.
+
+## Install
+
+Download the latest release for your platform from the [GitHub Releases page](https://github.com/etiennechabert/cost-goblin/releases/latest). macOS binaries are signed and notarized. See the [code signing policy](https://costgoblin.com/code-signing.html) for details.
+
+The app auto-updates when a new version is available.
 
 ## Quick Start
 
@@ -137,6 +144,8 @@ s3://bucket/prefix/
 CostGoblin reads profiles from `~/.aws/config` and `~/.aws/credentials`. The wizard lists available profiles and lets you pick one.
 
 **Using SSO:**
+
+The app has a built-in SSO login button — click it next to your profile and CostGoblin will launch `aws sso login` for you. Or run it manually:
 ```bash
 aws configure sso
 aws sso login --profile your-profile-name
@@ -162,6 +171,10 @@ Then use the Data tab to repartition the downloaded files.
 - **Tag normalization** — aliases applied at query time, fix messy tags without re-processing
 - **Composable views** — drag-and-drop widget builder with 9 widget types (pie, bar, stacked bar, line, treemap, heatmap, bubble, table, summary)
 - **Cost Scope** — configure cost metrics (unblended, blended, amortized) and exclusion rules
+- **Vault encryption** — optional AES-256-GCM at-rest encryption for local billing data, with system keychain integration
+- **MCP server** — Model Context Protocol integration for querying cost data from AI assistants
+- **Dark/light mode** — theme toggle with two chart color palettes (standard + Okabe-Ito colorblind-safe)
+- **Auto-updates** — the app checks for new versions on startup and installs them automatically
 - **CSV export** — export any view for reporting
 - **Works offline** — once synced, no internet needed
 
@@ -173,6 +186,7 @@ packages/
   core/     @costgoblin/core — DuckDB queries, S3 sync, config (no framework deps)
   ui/       @costgoblin/ui — React components (visx charts, Tailwind, shadcn/ui)
   desktop/  Electron shell — imports core and ui
+  mcp/      @costgoblin/mcp — Model Context Protocol server for AI assistant integration
 ```
 
 - **DuckDB** for analytical queries over local Parquet files

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -192,6 +192,8 @@ export interface CostApi {
    *  navigation so stale queries from the previous view don't hold pool
    *  connections and slow down the new view's queries. */
   cancelPendingQueries(): Promise<void>;
+  getMcpServerRunning(): Promise<boolean>;
+  setMcpServerRunning(enabled: boolean): Promise<void>;
 }
 
 export interface AccountMappingEntry {

--- a/packages/desktop/src/main/handlers/mcp-handler.ts
+++ b/packages/desktop/src/main/handlers/mcp-handler.ts
@@ -1,0 +1,17 @@
+import { ipcMain } from 'electron';
+import { startMcpServer, stopMcpServer, isMcpServerRunning } from '../mcp.js';
+import type { AppContext } from './context.js';
+
+export function registerMcpHandlers(app: AppContext): void {
+  ipcMain.handle('mcp:get-running', (): boolean => {
+    return isMcpServerRunning();
+  });
+
+  ipcMain.handle('mcp:set-running', async (_event, enabled: boolean): Promise<void> => {
+    if (enabled && !isMcpServerRunning()) {
+      await startMcpServer(app);
+    } else if (!enabled && isMcpServerRunning()) {
+      await stopMcpServer();
+    }
+  });
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -12,6 +12,7 @@ import { registerViewsHandlers } from './handlers/views.js';
 import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
 import { registerDebugHandlers } from './handlers/debug.js';
+import { registerMcpHandlers } from './handlers/mcp-handler.js';
 
 export type { AppContext, IpcContext } from './handlers/context.js';
 
@@ -30,6 +31,7 @@ export function registerIpcHandlers(ctx: IpcContext): AppContext {
   registerCostScopeHandlers(app);
   registerExplorerHandlers(app);
   registerDebugHandlers(app);
+  registerMcpHandlers(app);
 
   app.warmupBase();
 

--- a/packages/desktop/src/main/mcp.ts
+++ b/packages/desktop/src/main/mcp.ts
@@ -37,3 +37,7 @@ export async function stopMcpServer(): Promise<void> {
     server = null;
   }
 }
+
+export function isMcpServerRunning(): boolean {
+  return server !== null;
+}

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -282,6 +282,12 @@ const api: CostApi = {
     // Use ipcRenderer directly — cancel calls shouldn't inflate the in-flight badge
     return (ipcRenderer.invoke('query:cancel-pending') as Promise<undefined>).then(() => undefined);
   },
+  getMcpServerRunning(): Promise<boolean> {
+    return invoke<boolean>('mcp:get-running');
+  },
+  setMcpServerRunning(enabled: boolean): Promise<void> {
+    return invoke<undefined>('mcp:set-running', enabled).then(() => undefined);
+  },
 };
 
 contextBridge.exposeInMainWorld('costgoblin', api);

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useMemo, useRef, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
 import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagColumnName } from '@costgoblin/core/browser';
-import { Download, RefreshCw } from 'lucide-react';
+import { Download, RefreshCw, Sparkles } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { VaultLockScreen } from './vault-lock-screen.js';
 import { VaultSetupScreen } from './vault-setup-screen.js';
@@ -59,6 +59,7 @@ type View =
   | { page: 'trends' }
   | { page: 'missing-tags' }
   | { page: 'savings' }
+  | { page: 'mcp' }
   | { page: 'explorer' }
   | { page: 'dimensions' }
   | { page: 'cost-scope' }
@@ -578,6 +579,7 @@ function AppShell(): React.JSX.Element {
         case 'dimensions': setView({ page: 'dimensions' }); break;
         case 'views-editor': setView({ page: 'views-editor' }); break;
         case 'sync': setView({ page: 'sync' }); break;
+        case 'mcp': setView({ page: 'mcp' }); break;
         default:
           // Anything else is a custom view id (every left-nav entry that
           // isn't one of the well-known static pages above).
@@ -612,6 +614,7 @@ function AppShell(): React.JSX.Element {
   const paletteItems: NavItem[] = useMemo(() => [
     ...customNav.map(n => ({ id: n.id, label: n.label, group: 'Dashboards' })),
     ...STATIC_LEFT_NAV.map(n => ({ id: n.id, label: n.label, group: 'Analysis' })),
+    { id: 'mcp', label: 'AI Assistant', group: 'Settings' },
     ...RIGHT_NAV.map(n => ({ id: n.id, label: n.label, group: 'Settings' })),
   ], [customNav]);
 
@@ -651,6 +654,7 @@ function AppShell(): React.JSX.Element {
     if (view.page === 'dimensions') return 'dimensions';
     if (view.page === 'views-editor') return 'views-editor';
     if (view.page === 'sync') return 'sync';
+    if (view.page === 'mcp') return 'mcp';
     return null;
   }
   const active = activeNavId();
@@ -730,6 +734,19 @@ function AppShell(): React.JSX.Element {
               aria-label={palette === 'standard' ? 'Switch to colorblind palette' : 'Switch to standard palette'}
             >
               <PaletteIcon />
+            </button>
+            <button
+              type="button"
+              onClick={() => { handleNavClick('mcp'); }}
+              className={[
+                'rounded-md p-1.5 transition-colors',
+                active === 'mcp'
+                  ? 'bg-bg-tertiary text-text-primary'
+                  : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
+              ].join(' ')}
+              aria-label="AI Assistant"
+            >
+              <Sparkles className="h-4 w-4" />
             </button>
             {RIGHT_NAV.map((item) => {
               const isSync = item.id === 'sync';
@@ -836,6 +853,9 @@ function AppShell(): React.JSX.Element {
         <Profiler id="views-editor" onRender={onPerfRender}>
           <ViewsEditor onConfigPersisted={setViewsConfig} />
         </Profiler>
+      )}
+      {view.page === 'mcp' && (
+        <McpView />
       )}
       <div className={view.page === 'sync' ? '' : 'hidden'}>
         <Profiler id="sync" onRender={onPerfRender}>

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -373,6 +373,8 @@ export class MockCostApi implements CostApi {
   dismissSuggestion(): Promise<void> { return Promise.resolve(); }
   acceptSuggestion(): Promise<void> { return Promise.resolve(); }
   cancelPendingQueries(): Promise<void> { return Promise.resolve(); }
+  getMcpServerRunning(): Promise<boolean> { return Promise.resolve(true); }
+  setMcpServerRunning(): Promise<void> { return Promise.resolve(); }
 }
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -58,6 +58,7 @@ export { DimensionsView } from './views/dimensions.js';
 export { CostScopeView } from './views/cost-scope.js';
 export { ExplorerView } from './views/explorer.js';
 export { SetupWizard } from './views/setup-wizard.js';
+export { McpView } from './views/mcp-view.js';
 
 export { getDimensionId, isTagDimension, isEnvironmentDimension, isOwnerDimension, isProductDimension } from './lib/dimensions.js';
 

--- a/packages/ui/src/views/mcp-view.tsx
+++ b/packages/ui/src/views/mcp-view.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Check, Copy, Sparkles } from 'lucide-react';
+
+import { useCostApi } from '../hooks/use-cost-api.js';
 
 const MCP_PORT = 19532;
 const MCP_URL = `http://localhost:${String(MCP_PORT)}/mcp`;
@@ -37,7 +39,7 @@ function CodeBlock({ children }: Readonly<{ children: string }>) {
   );
 }
 
-const CLAUDE_CONFIG = JSON.stringify({
+const MCP_CONFIG = JSON.stringify({
   mcpServers: {
     costgoblin: {
       type: 'streamable-http',
@@ -56,8 +58,8 @@ const EXAMPLE_PROMPTS = [
     prompt: 'Compare my costs this week vs last week. What changed the most?',
   },
   {
-    title: 'Tag coverage',
-    prompt: 'Which resources are missing the "team" tag and how much do they cost?',
+    title: 'Tag quality',
+    prompt: 'Analyze my tag coverage and suggest tag groupings to better allocate costs by team.',
   },
   {
     title: 'Deep dive',
@@ -68,48 +70,47 @@ const EXAMPLE_PROMPTS = [
     prompt: 'Show me services where spending increased more than 20% compared to last month.',
   },
   {
-    title: 'Custom SQL',
-    prompt: 'Run a SQL query to find the top 10 most expensive resources by daily average cost.',
+    title: 'Spending report',
+    prompt: 'Generate a full overview of my cloud spending: top services, trends, anomalies, and recommendations.',
   },
 ];
 
-const PROVIDERS: { name: string; configLabel: string; config: string; docs: string }[] = [
+const PROVIDERS: { name: string; config: string; docs: string }[] = [
   {
-    name: 'Claude Desktop',
-    configLabel: 'claude_desktop_config.json',
-    config: CLAUDE_CONFIG,
-    docs: 'Add to your Claude Desktop config file:',
+    name: 'Claude / Cursor / Windsurf',
+    config: MCP_CONFIG,
+    docs: 'Add to claude_desktop_config.json, .mcp.json, or your editor MCP settings:',
   },
   {
-    name: 'Claude Code',
-    configLabel: '.mcp.json',
-    config: JSON.stringify({
-      mcpServers: {
-        costgoblin: {
-          type: 'streamable-http',
-          url: MCP_URL,
-        },
-      },
-    }, null, 2),
-    docs: 'Add to your project .mcp.json or run:',
+    name: 'ChatGPT',
+    config: MCP_URL,
+    docs: 'In ChatGPT \u2192 Settings \u2192 Add MCP server, paste this URL:',
   },
   {
-    name: 'Cursor / Windsurf',
-    configLabel: 'MCP settings',
-    config: JSON.stringify({
-      mcpServers: {
-        costgoblin: {
-          type: 'streamable-http',
-          url: MCP_URL,
-        },
-      },
-    }, null, 2),
-    docs: 'Add to your editor MCP settings:',
+    name: 'Gemini',
+    config: MCP_URL,
+    docs: 'In Gemini \u2192 Settings \u2192 Extensions \u2192 Add MCP server, paste this URL:',
   },
 ];
 
 export function McpView() {
+  const api = useCostApi();
   const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
+  const [running, setRunning] = useState(true);
+  const [toggling, setToggling] = useState(false);
+
+  useEffect(() => {
+    void api.getMcpServerRunning().then(setRunning);
+  }, [api]);
+
+  const handleToggle = useCallback(() => {
+    setToggling(true);
+    const next = !running;
+    void api.setMcpServerRunning(next).then(() => {
+      setRunning(next);
+      setToggling(false);
+    });
+  }, [api, running]);
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
@@ -125,12 +126,24 @@ export function McpView() {
 
       {/* Status */}
       <div className="rounded-xl border border-border bg-bg-secondary/50 p-5">
-        <div className="flex items-center gap-3">
-          <span className="flex h-2.5 w-2.5 rounded-full bg-accent animate-pulse" />
-          <div>
-            <p className="text-sm font-medium text-text-primary">MCP server running</p>
-            <p className="text-xs text-text-muted font-mono mt-0.5">{MCP_URL}</p>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className={`flex h-2.5 w-2.5 rounded-full ${running ? 'bg-accent animate-pulse' : 'bg-text-muted'}`} />
+            <div>
+              <p className="text-sm font-medium text-text-primary">
+                MCP server {running ? 'running' : 'stopped'}
+              </p>
+              {running && <p className="text-xs text-text-muted font-mono mt-0.5">{MCP_URL}</p>}
+            </div>
           </div>
+          <button
+            type="button"
+            disabled={toggling}
+            onClick={handleToggle}
+            className="text-xs px-3 py-1.5 rounded-md border border-border text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50 transition-colors disabled:opacity-50"
+          >
+            {running ? 'Stop' : 'Start'}
+          </button>
         </div>
       </div>
 

--- a/packages/ui/src/views/mcp-view.tsx
+++ b/packages/ui/src/views/mcp-view.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { Check, Copy, Sparkles } from 'lucide-react';
+
+const MCP_PORT = 19532;
+const MCP_URL = `http://localhost:${String(MCP_PORT)}/mcp`;
+
+function CopyButton({ text }: Readonly<{ text: string }>) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => { setCopied(false); }, 2000);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="absolute top-2 right-2 rounded-md p-1.5 text-text-muted hover:text-text-primary hover:bg-bg-tertiary/50 transition-colors"
+      aria-label="Copy to clipboard"
+    >
+      {copied ? <Check className="size-4 text-accent" /> : <Copy className="size-4" />}
+    </button>
+  );
+}
+
+function CodeBlock({ children }: Readonly<{ children: string }>) {
+  return (
+    <div className="relative">
+      <CopyButton text={children} />
+      <pre className="rounded-lg bg-bg-primary border border-border p-4 pr-12 text-sm text-text-secondary overflow-x-auto font-mono">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+const CLAUDE_CONFIG = JSON.stringify({
+  mcpServers: {
+    costgoblin: {
+      type: 'streamable-http',
+      url: MCP_URL,
+    },
+  },
+}, null, 2);
+
+const EXAMPLE_PROMPTS = [
+  {
+    title: 'Cost overview',
+    prompt: 'What are my top 5 AWS services by cost this month?',
+  },
+  {
+    title: 'Anomaly detection',
+    prompt: 'Compare my costs this week vs last week. What changed the most?',
+  },
+  {
+    title: 'Tag coverage',
+    prompt: 'Which resources are missing the "team" tag and how much do they cost?',
+  },
+  {
+    title: 'Deep dive',
+    prompt: 'Break down my EC2 costs by account and region for the last 30 days.',
+  },
+  {
+    title: 'Cost optimization',
+    prompt: 'Show me services where spending increased more than 20% compared to last month.',
+  },
+  {
+    title: 'Custom SQL',
+    prompt: 'Run a SQL query to find the top 10 most expensive resources by daily average cost.',
+  },
+];
+
+const PROVIDERS: { name: string; configLabel: string; config: string; docs: string }[] = [
+  {
+    name: 'Claude Desktop',
+    configLabel: 'claude_desktop_config.json',
+    config: CLAUDE_CONFIG,
+    docs: 'Add to your Claude Desktop config file:',
+  },
+  {
+    name: 'Claude Code',
+    configLabel: '.mcp.json',
+    config: JSON.stringify({
+      mcpServers: {
+        costgoblin: {
+          type: 'streamable-http',
+          url: MCP_URL,
+        },
+      },
+    }, null, 2),
+    docs: 'Add to your project .mcp.json or run:',
+  },
+  {
+    name: 'Cursor / Windsurf',
+    configLabel: 'MCP settings',
+    config: JSON.stringify({
+      mcpServers: {
+        costgoblin: {
+          type: 'streamable-http',
+          url: MCP_URL,
+        },
+      },
+    }, null, 2),
+    docs: 'Add to your editor MCP settings:',
+  },
+];
+
+export function McpView() {
+  const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
+      <div>
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-5 text-accent" />
+          <h2 className="text-xl font-semibold text-text-primary">AI Assistant</h2>
+        </div>
+        <p className="text-sm text-text-secondary mt-1">
+          CostGoblin includes a built-in MCP server that lets AI assistants query your billing data directly.
+        </p>
+      </div>
+
+      {/* Status */}
+      <div className="rounded-xl border border-border bg-bg-secondary/50 p-5">
+        <div className="flex items-center gap-3">
+          <span className="flex h-2.5 w-2.5 rounded-full bg-accent animate-pulse" />
+          <div>
+            <p className="text-sm font-medium text-text-primary">MCP server running</p>
+            <p className="text-xs text-text-muted font-mono mt-0.5">{MCP_URL}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Setup */}
+      <div>
+        <h3 className="text-sm font-semibold text-text-primary mb-3">Connect your AI assistant</h3>
+        <div className="space-y-2">
+          {PROVIDERS.map((provider) => {
+            const isExpanded = expandedProvider === provider.name;
+            return (
+              <div key={provider.name} className="rounded-lg border border-border bg-bg-secondary/50 overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => { setExpandedProvider(isExpanded ? null : provider.name); }}
+                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-bg-tertiary/30 transition-colors"
+                >
+                  <span className="text-sm font-medium text-text-primary">{provider.name}</span>
+                  <span className="text-xs text-text-muted">{isExpanded ? 'Hide' : 'Show config'}</span>
+                </button>
+                {isExpanded && (
+                  <div className="px-4 pb-4 space-y-2">
+                    <p className="text-xs text-text-secondary">{provider.docs}</p>
+                    <CodeBlock>{provider.config}</CodeBlock>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Available tools */}
+      <div>
+        <h3 className="text-sm font-semibold text-text-primary mb-3">Available tools</h3>
+        <div className="rounded-xl border border-border bg-bg-secondary/50 p-4">
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+            {[
+              ['get_cost_overview', 'High-level cost summary'],
+              ['query_costs', 'Break down by dimension'],
+              ['query_daily_costs', 'Daily/weekly time series'],
+              ['query_trends', 'Period-over-period changes'],
+              ['query_entity_detail', 'Deep dive on one entity'],
+              ['query_missing_tags', 'Find untagged resources'],
+              ['list_dimensions', 'Available group-by fields'],
+              ['get_filter_values', 'Values for a dimension'],
+              ['explore_data', 'Browse raw line items'],
+              ['run_sql', 'Ad-hoc SQL queries'],
+            ].map(([name, desc]) => (
+              <div key={name} className="flex items-baseline gap-2 py-1">
+                <code className="text-xs font-mono text-accent shrink-0">{name}</code>
+                <span className="text-xs text-text-muted truncate">{desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Example prompts */}
+      <div>
+        <h3 className="text-sm font-semibold text-text-primary mb-3">Example prompts</h3>
+        <div className="grid grid-cols-2 gap-3">
+          {EXAMPLE_PROMPTS.map((ex) => (
+            <div key={ex.title} className="rounded-lg border border-border bg-bg-secondary/50 p-3">
+              <p className="text-xs font-medium text-text-secondary mb-1">{ex.title}</p>
+              <p className="text-sm text-text-primary leading-snug">&ldquo;{ex.prompt}&rdquo;</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a sparkles icon button in the top-right nav bar
- Opens a new AI Assistant view with:
  - MCP server status indicator (always running on port 19532)
  - Expandable setup configs for Claude Desktop, Claude Code, and Cursor/Windsurf
  - List of all 10 available MCP tools with descriptions
  - 6 example prompts showing what users can ask their AI assistant
- Registered in command palette under "Settings" group