### PR TITLE
Fix bubble chart negative values and add configurable log scale

### DIFF
--- a/packages/core/src/config/views-serialize.ts
+++ b/packages/core/src/config/views-serialize.ts
@@ -27,8 +27,11 @@ export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
       return base;
     case 'pie':
     case 'stackedBar':
+      addGroupByFields(base, w);
+      return base;
     case 'bubble':
       addGroupByFields(base, w);
+      if (w.logScale !== undefined) base['logScale'] = w.logScale;
       return base;
     case 'treemap':
       addGroupByFields(base, w);

--- a/packages/core/src/config/views-validator.ts
+++ b/packages/core/src/config/views-validator.ts
@@ -103,6 +103,14 @@ function validateGroupByWidget(raw: Record<string, unknown>, ctx: string, base: 
     return { type, ...base, groupBy, ...(drillTo === undefined ? {} : { drillTo }) };
   }
   if (type === 'pie') return { type, ...base, groupBy };
+  if (type === 'bubble') {
+    let logScale: number | undefined;
+    if (raw['logScale'] !== undefined) {
+      assertNumber(raw['logScale'], `${ctx}.logScale`);
+      logScale = raw['logScale'];
+    }
+    return { type, ...base, groupBy, ...(logScale === undefined ? {} : { logScale }) };
+  }
   return { type, ...base, groupBy };
 }
 

--- a/packages/core/src/types/views.ts
+++ b/packages/core/src/types/views.ts
@@ -53,6 +53,7 @@ export type WidgetSpec =
   | (WidgetBase & {
       readonly type: 'bubble';
       readonly groupBy: DimensionId;
+      readonly logScale?: number | undefined;
     })
   | (WidgetBase & {
       readonly type: 'table';

--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -14,13 +14,17 @@ const MARGIN = { top: 20, right: 30, bottom: 50, left: 70 };
 const MIN_RADIUS = 4;
 const MAX_RADIUS = 40;
 
+const DEFAULT_LOG_SCALE = 10;
+
 interface BubbleChartProps {
   readonly data: readonly TrendRow[];
+  readonly logScale?: number | undefined;
   readonly onEntityClick: (entity: EntityRef) => void;
 }
 
 function BubbleChartInner({
   data,
+  logScale,
   onEntityClick,
   width,
   height,
@@ -72,18 +76,20 @@ function BubbleChartInner({
   const deltaMax = Math.max(...absDeltas);
   const costMax = Math.max(...costs);
 
+  const symlogConstant = logScale ?? DEFAULT_LOG_SCALE;
+
   const xScale = scaleSymlog<number>({
-    domain: [0, percentMax + percentPad],
+    domain: [percentMin - percentPad, percentMax + percentPad],
     range: [0, innerWidth],
     nice: true,
-    constant: 10,
+    constant: symlogConstant,
   });
 
   const yScale = scaleSymlog<number>({
     domain: [0, deltaMax * 1.15],
     range: [innerHeight, 0],
     nice: true,
-    constant: 10,
+    constant: symlogConstant,
   });
 
   const rScale = scaleSqrt<number>({
@@ -114,6 +120,17 @@ function BubbleChartInner({
             stroke={gridColor}
             strokeDasharray="2,3"
             numTicks={5}
+          />
+
+          {/* Zero reference line */}
+          <line
+            x1={xScale(0)}
+            x2={xScale(0)}
+            y1={0}
+            y2={innerHeight}
+            stroke={axisColor}
+            strokeOpacity={0.5}
+            strokeWidth={1}
           />
 
           <AxisBottom
@@ -209,13 +226,14 @@ function BubbleChartInner({
   );
 }
 
-export function BubbleChart({ data, onEntityClick }: BubbleChartProps) {
+export function BubbleChart({ data, logScale, onEntityClick }: BubbleChartProps) {
   return (
     <div className="h-[350px] w-full rounded-xl border border-border bg-bg-secondary/50">
       <ParentSize>
         {({ width, height }) => (
           <BubbleChartInner
             data={data}
+            logScale={logScale}
             onEntityClick={onEntityClick}
             width={width}
             height={height}

--- a/packages/ui/src/components/widget-inspector.tsx
+++ b/packages/ui/src/components/widget-inspector.tsx
@@ -35,8 +35,9 @@ function stripTitle(w: WidgetSpec): WidgetSpec {
     case 'pie':
       return { ...common, type: w.type, groupBy: w.groupBy, ...(w.showLegend === false ? { showLegend: false } : {}) };
     case 'stackedBar':
-    case 'bubble':
       return { ...common, type: w.type, groupBy: w.groupBy };
+    case 'bubble':
+      return { ...common, type: w.type, groupBy: w.groupBy, ...(w.logScale === undefined ? {} : { logScale: w.logScale }) };
     case 'treemap':
       return { ...common, type: w.type, groupBy: w.groupBy, ...(w.drillTo === undefined ? {} : { drillTo: w.drillTo }) };
     case 'line':
@@ -61,8 +62,9 @@ function defaultSpecForType(type: WidgetType, prev: WidgetSpec, fallbackDim: str
     case 'pie':
       return { ...base, type, groupBy: existingGroupBy };
     case 'stackedBar':
-    case 'bubble':
       return { ...base, type, groupBy: existingGroupBy };
+    case 'bubble':
+      return { ...base, type, groupBy: existingGroupBy, ...('logScale' in prev && prev.logScale !== undefined ? { logScale: prev.logScale } : {}) };
     case 'treemap':
       return { ...base, type, groupBy: existingGroupBy };
     case 'line':
@@ -230,6 +232,23 @@ export function WidgetInspector({
             ].join(' ')} />
           </button>
         </div>
+      )}
+
+      {widget.type === 'bubble' && (
+        <label className="flex items-center gap-2">
+          <span className="text-text-muted shrink-0 w-14">Log scale</span>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            value={widget.logScale ?? 10}
+            onChange={(e) => {
+              const v = Number.parseInt(e.target.value, 10);
+              if (Number.isFinite(v) && v >= 1) onChange({ ...widget, logScale: v });
+            }}
+            className="w-20 bg-transparent border border-border rounded px-2 py-1 text-text-primary"
+          />
+        </label>
       )}
 
       {(widget.type === 'line' || widget.type === 'topNBar' || widget.type === 'heatmap') && (

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -63,6 +63,7 @@ export function BubbleWidget({
       </div>
       <BubbleChart
         data={data}
+        logScale={spec.logScale}
         onEntityClick={(entity) => { onEntityClick?.(entity, effectiveGroupBy); }}
       />
     </div>


### PR DESCRIPTION
## Summary

- Fix bubble chart X-axis domain starting at 0, which clamped negative percent changes (cost savings) to the left edge — now uses the full data range
- Add a vertical zero reference line to visually separate savings from increases
- Add configurable `logScale` (symlog constant) to the bubble widget spec, editable from the dashboard widget inspector