### PR TITLE
Add click-and-drag period selection to histograms

### DIFF
--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -126,8 +126,7 @@ test.describe('Cost Overview', () => {
     const popover = page.locator('[data-radix-popper-content-wrapper]');
     await expect(popover).toBeVisible({ timeout: 5000 });
 
-    await expect(popover.getByText('Daily')).toBeVisible();
-    await expect(popover.getByText('Hourly')).toBeVisible();
+    await expect(popover.getByText('Days', { exact: true })).toBeVisible();
     await expect(popover.getByText('Period', { exact: true })).toBeVisible();
     await expect(popover.getByText('Custom range…')).toBeVisible();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8467,10 +8467,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -8546,7 +8548,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -9046,7 +9050,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9260,7 +9266,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/packages/ui/src/__tests__/date-range-picker.test.tsx
+++ b/packages/ui/src/__tests__/date-range-picker.test.tsx
@@ -34,9 +34,8 @@ describe('DateRangePicker', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText('Last 30 days'));
 
-    expect(screen.getByText('Daily')).toBeDefined();
+    expect(screen.getByText('Days')).toBeDefined();
     expect(screen.getByText('Period')).toBeDefined();
-    expect(screen.getByText('Hourly')).toBeDefined();
   });
 
   it('shows all presets when open', async () => {
@@ -44,6 +43,8 @@ describe('DateRangePicker', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText('Last 30 days'));
 
+    expect(screen.getByText('Last 7 days')).toBeDefined();
+    expect(screen.getByText('Last 14 days')).toBeDefined();
     expect(screen.getByText('Last 90 days')).toBeDefined();
     expect(screen.getByText('Last 365 days')).toBeDefined();
     expect(screen.getByText('This month')).toBeDefined();
@@ -52,9 +53,6 @@ describe('DateRangePicker', () => {
     expect(screen.getByText('Last quarter')).toBeDefined();
     expect(screen.getByText('This year')).toBeDefined();
     expect(screen.getByText('Last year')).toBeDefined();
-    expect(screen.getByText('Last 7 days')).toBeDefined();
-    expect(screen.getByText('Last 14 days')).toBeDefined();
-    expect(screen.getByText('Last 28 days')).toBeDefined();
     expect(screen.getByText('Custom range…')).toBeDefined();
   });
 
@@ -71,7 +69,7 @@ describe('DateRangePicker', () => {
     expect(granularity).toBe('daily');
   });
 
-  it('clicking hourly preset calls onChange with hourly granularity', async () => {
+  it('Last 7 days preset stays daily without hourly tier configured', async () => {
     const onChange = vi.fn();
     renderPicker({ onChange });
     const user = userEvent.setup();
@@ -81,7 +79,7 @@ describe('DateRangePicker', () => {
 
     expect(onChange).toHaveBeenCalledOnce();
     const granularity = onChange.mock.calls[0]?.[1] as Granularity;
-    expect(granularity).toBe('hourly');
+    expect(granularity).toBe('daily');
   });
 
   it('shows custom range inputs when Custom range is clicked', async () => {

--- a/packages/ui/src/__tests__/drag-select.test.ts
+++ b/packages/ui/src/__tests__/drag-select.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { pixelToIndex, bucketKeyToDate, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+
+describe('pixelToIndex', () => {
+  it('maps the left edge to index 0', () => {
+    expect(pixelToIndex(0, 700, 7)).toBe(0);
+  });
+
+  it('maps the right edge to the last index', () => {
+    expect(pixelToIndex(699, 700, 7)).toBe(6);
+  });
+
+  it('clamps x past the container to the last index', () => {
+    expect(pixelToIndex(1000, 700, 7)).toBe(6);
+  });
+
+  it('clamps negative x to index 0', () => {
+    expect(pixelToIndex(-50, 700, 7)).toBe(0);
+  });
+
+  it('returns 0 on degenerate inputs', () => {
+    expect(pixelToIndex(50, 0, 7)).toBe(0);
+    expect(pixelToIndex(50, 700, 0)).toBe(0);
+  });
+
+  it('splits the container into equal bins', () => {
+    // 7 bars, 700px wide → each bar = 100px
+    expect(pixelToIndex(0, 700, 7)).toBe(0);
+    expect(pixelToIndex(99, 700, 7)).toBe(0);
+    expect(pixelToIndex(100, 700, 7)).toBe(1);
+    expect(pixelToIndex(350, 700, 7)).toBe(3);
+  });
+});
+
+describe('bucketKeyToDate', () => {
+  it('returns daily keys unchanged', () => {
+    expect(bucketKeyToDate('2026-04-15')).toBe('2026-04-15');
+  });
+
+  it('trims hourly timestamps to the date part', () => {
+    expect(bucketKeyToDate('2026-04-15 14:00:00')).toBe('2026-04-15');
+    expect(bucketKeyToDate('2026-04-15 00:00:00')).toBe('2026-04-15');
+  });
+
+  it('returns short input unchanged', () => {
+    expect(bucketKeyToDate('')).toBe('');
+    expect(bucketKeyToDate('2026')).toBe('2026');
+  });
+});
+
+describe('shouldAutoSwitchToHourly', () => {
+  it('switches when daily and the window is 7 days or fewer', () => {
+    expect(shouldAutoSwitchToHourly('2026-04-01', '2026-04-01', 'daily')).toBe(true);
+    expect(shouldAutoSwitchToHourly('2026-04-01', '2026-04-07', 'daily')).toBe(true);
+  });
+
+  it('does not switch when the window is wider than 7 days', () => {
+    expect(shouldAutoSwitchToHourly('2026-04-01', '2026-04-08', 'daily')).toBe(false);
+    expect(shouldAutoSwitchToHourly('2026-04-01', '2026-04-30', 'daily')).toBe(false);
+  });
+
+  it('never switches away from hourly', () => {
+    expect(shouldAutoSwitchToHourly('2026-04-01', '2026-04-01', 'hourly')).toBe(false);
+    expect(shouldAutoSwitchToHourly('2026-04-01', '2026-04-07', 'hourly')).toBe(false);
+  });
+});

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -3,6 +3,8 @@ import { CalendarIcon, ChevronDown } from 'lucide-react';
 import type { DateString } from '@costgoblin/core/browser';
 import { DEFAULT_LAG_DAYS, asDateString } from '@costgoblin/core/browser';
 import { daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getLastQuarter, getYTD, getLastYear } from '../lib/dates.js';
+import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { Calendar } from './ui/calendar.js';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.js';
 
@@ -13,6 +15,7 @@ type DayPreset = {
   readonly type: 'days';
   readonly days: number;
   readonly granularity: Granularity;
+  readonly hint?: string;
 };
 
 type CalendarPreset = {
@@ -20,26 +23,21 @@ type CalendarPreset = {
   readonly type: 'calendar';
   readonly getRange: () => { start: DateString; end: DateString };
   readonly granularity: Granularity;
+  readonly hint?: string;
 };
 
 type Preset = DayPreset | CalendarPreset;
 
 const PRESETS: readonly { section: string; items: readonly Preset[] }[] = [
   {
-    section: 'Daily',
+    section: 'Days',
     items: [
+      { label: 'Last 7 days', type: 'days', days: 7, granularity: 'hourly', hint: 'hourly' },
+      { label: 'Last 14 days', type: 'days', days: 14, granularity: 'daily' },
       { label: 'Last 30 days', type: 'days', days: 30, granularity: 'daily' },
       { label: 'Last 90 days', type: 'days', days: 90, granularity: 'daily' },
       { label: 'Last 180 days', type: 'days', days: 180, granularity: 'daily' },
       { label: 'Last 365 days', type: 'days', days: 365, granularity: 'daily' },
-    ],
-  },
-  {
-    section: 'Hourly',
-    items: [
-      { label: 'Last 7 days', type: 'days', days: 7, granularity: 'hourly' },
-      { label: 'Last 14 days', type: 'days', days: 14, granularity: 'hourly' },
-      { label: 'Last 28 days', type: 'days', days: 28, granularity: 'hourly' },
     ],
   },
   {
@@ -77,6 +75,8 @@ export function getDefaultDateRange(lagDays: number = DEFAULT_LAG_DAYS): DateRan
 }
 
 export function DateRangePicker({ value, granularity, onChange, hideHourly, lagDays = DEFAULT_LAG_DAYS, compareEnabled, onCompareChange }: DateRangePickerProps) {
+  const hourlyConfigured = useHourlyConfigured();
+  const hourlyAvailable = hideHourly !== true && hourlyConfigured;
   const [open, setOpen] = useState(false);
   const [showCustom, setShowCustom] = useState(false);
   const latestDate = daysAgo(lagDays);
@@ -88,11 +88,17 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
     return preset.getRange();
   }
 
+  function resolveGranularity(range: DateRange, preferred: Granularity): Granularity {
+    if (preferred === 'hourly' && !hourlyAvailable) return 'daily';
+    if (preferred === 'daily' && hourlyAvailable && shouldAutoSwitchToHourly(range.start, range.end, 'daily')) return 'hourly';
+    return preferred;
+  }
+
   function getActiveLabel(): string {
     let label: string | undefined;
     for (const preset of ALL_PRESETS) {
       const range = getPresetRange(preset);
-      if (value.start === range.start && value.end === range.end && granularity === preset.granularity) {
+      if (value.start === range.start && value.end === range.end && granularity === resolveGranularity(range, preset.granularity)) {
         label = preset.label;
         break;
       }
@@ -103,22 +109,67 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
 
   function handlePreset(preset: Preset) {
     const range = getPresetRange(preset);
-    onChange(range, preset.granularity);
+    onChange(range, resolveGranularity(range, preset.granularity));
     setShowCustom(false);
     setOpen(false);
   }
 
+  function handleCustomRange(range: DateRange) {
+    onChange(range, resolveGranularity(range, granularity));
+  }
+
+  function handleGranularityToggle(next: Granularity) {
+    if (next === granularity) return;
+    if (next === 'hourly' && !hourlyAvailable) return;
+    onChange(value, next);
+  }
+
   function isActivePreset(preset: Preset): boolean {
     const range = getPresetRange(preset);
-    return value.start === range.start && value.end === range.end && granularity === preset.granularity;
+    return value.start === range.start && value.end === range.end && granularity === resolveGranularity(range, preset.granularity);
   }
 
   const sections = hideHourly === true
-    ? PRESETS.filter(s => s.section !== 'Hourly')
+    ? PRESETS.map(s => ({
+        section: s.section,
+        items: s.items.filter(p => p.granularity !== 'hourly'),
+      })).filter(s => s.items.length > 0)
     : PRESETS;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <div className="flex items-center gap-2">
+      {hideHourly !== true && (
+        <div className="inline-flex items-center rounded-lg border border-border bg-bg-tertiary/30 p-0.5">
+          <button
+            type="button"
+            onClick={() => { handleGranularityToggle('daily'); }}
+            className={[
+              'px-2.5 py-1 text-xs font-medium rounded-md transition-colors',
+              granularity === 'daily'
+                ? 'bg-accent text-bg-primary shadow-sm'
+                : 'text-text-muted hover:text-text-primary',
+            ].join(' ')}
+          >
+            Daily
+          </button>
+          <button
+            type="button"
+            onClick={() => { handleGranularityToggle('hourly'); }}
+            disabled={!hourlyAvailable}
+            title={hourlyAvailable ? undefined : 'Hourly tier is not configured'}
+            className={[
+              'px-2.5 py-1 text-xs font-medium rounded-md transition-colors',
+              granularity === 'hourly'
+                ? 'bg-accent text-bg-primary shadow-sm'
+                : 'text-text-muted hover:text-text-primary',
+              !hourlyAvailable ? 'opacity-50 cursor-not-allowed' : '',
+            ].join(' ')}
+          >
+            Hourly
+          </button>
+        </div>
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -136,21 +187,27 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
               <div className="px-3 pt-2.5 pb-1">
                 <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">{section}</span>
               </div>
-              {items.map(preset => (
-                <button
-                  key={preset.label}
-                  type="button"
-                  onClick={() => { handlePreset(preset); }}
-                  className={[
-                    'w-full text-left px-3 py-1.5 text-xs transition-colors',
-                    isActivePreset(preset)
-                      ? 'bg-accent/10 text-accent font-medium border-l-2 border-accent'
-                      : 'text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary border-l-2 border-transparent',
-                  ].join(' ')}
-                >
-                  {preset.label}
-                </button>
-              ))}
+              {items.map(preset => {
+                const showHint = preset.hint !== undefined && hourlyAvailable;
+                return (
+                  <button
+                    key={preset.label}
+                    type="button"
+                    onClick={() => { handlePreset(preset); }}
+                    className={[
+                      'w-full flex items-center justify-between gap-2 px-3 py-1.5 text-xs transition-colors',
+                      isActivePreset(preset)
+                        ? 'bg-accent/10 text-accent font-medium border-l-2 border-accent'
+                        : 'text-text-secondary hover:bg-bg-tertiary/50 hover:text-text-primary border-l-2 border-transparent',
+                    ].join(' ')}
+                  >
+                    <span>{preset.label}</span>
+                    {showHint && (
+                      <span className="text-[10px] uppercase tracking-wider text-text-muted">{preset.hint}</span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
           ))}
 
@@ -188,7 +245,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
                         selected={new Date(value.start + 'T00:00:00')}
                         onSelect={(date) => {
                           if (date) {
-                            onChange({ ...value, start: asDateString(date.toISOString().slice(0, 10)) }, 'daily');
+                            handleCustomRange({ ...value, start: asDateString(date.toISOString().slice(0, 10)) });
                           }
                         }}
                         disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
@@ -215,7 +272,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
                         selected={new Date(value.end + 'T00:00:00')}
                         onSelect={(date) => {
                           if (date) {
-                            onChange({ ...value, end: asDateString(date.toISOString().slice(0, 10)) }, 'daily');
+                            handleCustomRange({ ...value, end: asDateString(date.toISOString().slice(0, 10)) });
                           }
                         }}
                         disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
@@ -243,6 +300,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
           )}
         </div>
       </PopoverContent>
-    </Popover>
+      </Popover>
+    </div>
   );
 }

--- a/packages/ui/src/components/hourly-hint-banner.tsx
+++ b/packages/ui/src/components/hourly-hint-banner.tsx
@@ -1,0 +1,22 @@
+interface HourlyHintBannerProps {
+  readonly onDismiss: () => void;
+  readonly className?: string;
+}
+
+export function HourlyHintBanner({ onDismiss, className }: HourlyHintBannerProps): React.JSX.Element {
+  return (
+    <div className={['flex items-center justify-between gap-3 rounded-md border border-border bg-bg-tertiary/30 px-3 py-2 text-xs', className ?? ''].join(' ')}>
+      <span className="text-text-secondary">
+        This range is small enough for hourly resolution, but the hourly tier isn&apos;t configured.
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-text-muted hover:text-text-primary"
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -3,6 +3,7 @@ import { getColor } from '../lib/palette.js';
 import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
 import { usePalette } from '../hooks/use-palette.js';
+import { useBarDragSelect } from '../hooks/use-bar-drag-select.js';
 
 export interface BarDay {
   readonly date: string;
@@ -25,6 +26,7 @@ interface StackedBarChartProps {
   /** Previous period daily totals, aligned by position index. Rendered as
    *  a dashed line overlay when present. */
   readonly previousTotals?: readonly number[] | undefined;
+  readonly onRangeSelect?: ((startIdx: number, endIdx: number) => void) | undefined;
 }
 
 export function bucketBars(bars: readonly BarDay[], maxBuckets: number): readonly BarDay[] {
@@ -130,11 +132,19 @@ function BarColumn({ day, segments, segTotal, barPct, highlightedGroup, palette,
   );
 }
 
-export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading, onSegmentClick, previousTotals }: StackedBarChartProps) {
+export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading, onSegmentClick, previousTotals, onRangeSelect }: StackedBarChartProps) {
   const { palette } = usePalette();
   const [hoveredDay, setHoveredDay] = useState<string | null>(null);
   const [hoveredSegment, setHoveredSegment] = useState<string | null>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
+  const barsRef = useRef<HTMLDivElement>(null);
+
+  const { isDragging, overlay, handleMouseDown } = useBarDragSelect({
+    containerRef: barsRef,
+    bucketCount: days.length,
+    onRangeSelect,
+    disabled: onRangeSelect === undefined || loading === true,
+  });
 
   useEffect(() => {
     highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
@@ -224,7 +234,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
           </div>
 
           {/* Floating tooltip — opposite side of hovered bar, full height */}
-          {hoveredDay !== null && (() => {
+          {hoveredDay !== null && !isDragging && (() => {
             const idx = days.findIndex(d => d.date === hoveredDay);
             if (idx < 0) return null;
             const day = days[idx];
@@ -293,7 +303,15 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
             );
           })()}
 
-          <div className="absolute left-12 right-0 top-0 bottom-7 flex items-end z-10" style={{ gap: days.length > 100 ? '1px' : '2px' }}>
+          <div
+            ref={barsRef}
+            className={[
+              'absolute left-12 right-0 top-0 bottom-7 flex items-end z-10',
+              onRangeSelect !== undefined ? 'cursor-crosshair select-none' : '',
+            ].join(' ')}
+            style={{ gap: days.length > 100 ? '1px' : '2px' }}
+            onMouseDown={handleMouseDown}
+          >
             {days.map((day) => {
               const barPct = maxCost > 0 ? (day.total / maxCost) * 100 : 0;
               const segments = breakdownKeys
@@ -321,6 +339,12 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                 />
               );
             })}
+            {overlay !== null && (
+              <div
+                className="pointer-events-none absolute top-0 bottom-0 bg-accent/20 border-l border-r border-accent z-30"
+                style={{ left: overlay.left, width: overlay.width }}
+              />
+            )}
           </div>
 
           {/* Previous period overlay line */}

--- a/packages/ui/src/hooks/use-bar-drag-select.ts
+++ b/packages/ui/src/hooks/use-bar-drag-select.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { pixelToIndex } from '../lib/drag-select.js';
+
+interface DragState {
+  startX: number;
+  currentX: number;
+  rect: DOMRect;
+}
+
+interface OverlayRect {
+  readonly left: number;
+  readonly width: number;
+}
+
+interface UseBarDragSelectOptions {
+  readonly containerRef: RefObject<HTMLDivElement | null>;
+  readonly bucketCount: number;
+  readonly onRangeSelect: ((startIdx: number, endIdx: number) => void) | undefined;
+  readonly disabled?: boolean | undefined;
+}
+
+interface UseBarDragSelectResult {
+  readonly isDragging: boolean;
+  readonly overlay: OverlayRect | null;
+  readonly handleMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+const MIN_DRAG_PX = 4;
+
+export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSelectResult {
+  const { containerRef, bucketCount, onRangeSelect, disabled } = options;
+  const [overlay, setOverlay] = useState<OverlayRect | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const bucketCountRef = useRef(bucketCount);
+  const onRangeSelectRef = useRef(onRangeSelect);
+  bucketCountRef.current = bucketCount;
+  onRangeSelectRef.current = onRangeSelect;
+
+  const handleMouseDown = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    if (disabled === true) return;
+    if (bucketCount <= 0) return;
+    if (event.button !== 0) return;
+    const container = containerRef.current;
+    if (container === null) return;
+    const rect = container.getBoundingClientRect();
+    const startX = event.clientX - rect.left;
+    dragRef.current = { startX, currentX: startX, rect };
+    setOverlay({ left: startX, width: 0 });
+    event.preventDefault();
+  }, [containerRef, bucketCount, disabled]);
+
+  useEffect(() => {
+    const handleMove = (e: MouseEvent) => {
+      const drag = dragRef.current;
+      if (drag === null) return;
+      const x = Math.max(0, Math.min(drag.rect.width, e.clientX - drag.rect.left));
+      drag.currentX = x;
+      const minX = Math.min(drag.startX, x);
+      const maxX = Math.max(drag.startX, x);
+      setOverlay({ left: minX, width: maxX - minX });
+    };
+    const handleUp = () => {
+      const drag = dragRef.current;
+      if (drag === null) return;
+      const minX = Math.min(drag.startX, drag.currentX);
+      const maxX = Math.max(drag.startX, drag.currentX);
+      // Sub-4px drags are treated as plain clicks so bar hover/click still works.
+      if (maxX - minX >= MIN_DRAG_PX) {
+        const count = bucketCountRef.current;
+        const startIdx = pixelToIndex(minX, drag.rect.width, count);
+        const endIdx = pixelToIndex(maxX, drag.rect.width, count);
+        if (startIdx <= endIdx) onRangeSelectRef.current?.(startIdx, endIdx);
+      }
+      dragRef.current = null;
+      setOverlay(null);
+    };
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      dragRef.current = null;
+      setOverlay(null);
+    };
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+    window.addEventListener('keydown', handleEsc);
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, []);
+
+  return { isDragging: overlay !== null, overlay, handleMouseDown };
+}

--- a/packages/ui/src/hooks/use-cost-api.ts
+++ b/packages/ui/src/hooks/use-cost-api.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { CostApi } from '@costgoblin/core/browser';
 
-const CostApiContext = createContext<CostApi | null>(null);
+export const CostApiContext = createContext<CostApi | null>(null);
 
 export function useCostApi(): CostApi {
   const api = useContext(CostApiContext);

--- a/packages/ui/src/hooks/use-hourly-configured.ts
+++ b/packages/ui/src/hooks/use-hourly-configured.ts
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
-import { useCostApi } from './use-cost-api.js';
+import { useContext, useEffect, useState } from 'react';
+import { CostApiContext } from './use-cost-api.js';
 
 export function useHourlyConfigured(): boolean {
-  const api = useCostApi();
+  const api = useContext(CostApiContext);
   const [configured, setConfigured] = useState(false);
 
   useEffect(() => {
+    if (api === null) return;
     let cancelled = false;
     api.getConfig().then(config => {
       if (cancelled) return;

--- a/packages/ui/src/hooks/use-hourly-configured.ts
+++ b/packages/ui/src/hooks/use-hourly-configured.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { useCostApi } from './use-cost-api.js';
+
+export function useHourlyConfigured(): boolean {
+  const api = useCostApi();
+  const [configured, setConfigured] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getConfig().then(config => {
+      if (cancelled) return;
+      const provider = config.providers[0];
+      const hourly = provider?.sync.hourly;
+      setConfigured(hourly !== undefined && hourly.bucket.length > 0);
+    }).catch(() => {
+      if (cancelled) return;
+      setConfigured(false);
+    });
+    return () => { cancelled = true; };
+  }, [api]);
+
+  return configured;
+}

--- a/packages/ui/src/lib/drag-select.ts
+++ b/packages/ui/src/lib/drag-select.ts
@@ -1,0 +1,26 @@
+import type { Granularity } from '../components/date-range-picker.js';
+import { daysBetween } from './dates.js';
+
+const HOURLY_THRESHOLD_DAYS = 7;
+
+export function pixelToIndex(x: number, containerWidth: number, bucketCount: number): number {
+  if (bucketCount <= 0 || containerWidth <= 0) return 0;
+  const slot = containerWidth / bucketCount;
+  const idx = Math.floor(x / slot);
+  if (idx < 0) return 0;
+  if (idx >= bucketCount) return bucketCount - 1;
+  return idx;
+}
+
+export function bucketKeyToDate(key: string): string {
+  return key.length >= 10 ? key.slice(0, 10) : key;
+}
+
+export function shouldAutoSwitchToHourly(
+  startDate: string,
+  endDate: string,
+  currentGranularity: Granularity,
+): boolean {
+  if (currentGranularity !== 'daily') return false;
+  return daysBetween(startDate, endDate) <= HOURLY_THRESHOLD_DAYS;
+}

--- a/packages/ui/src/lib/drag-select.ts
+++ b/packages/ui/src/lib/drag-select.ts
@@ -24,3 +24,33 @@ export function shouldAutoSwitchToHourly(
   if (currentGranularity !== 'daily') return false;
   return daysBetween(startDate, endDate) <= HOURLY_THRESHOLD_DAYS;
 }
+
+interface BucketLike {
+  readonly date: string;
+}
+
+// For bucketed bars (one bar can cover multiple days) the bar's date is the
+// *start* of its chunk. The actual end of the selected range is the day
+// before the next chunk starts; the last bar falls back to the visible end.
+export function computeBucketedRange(
+  bars: readonly BucketLike[],
+  startIdx: number,
+  endIdx: number,
+  fallbackEnd: string,
+): { startDate: string; endDate: string } | null {
+  const startBar = bars[startIdx];
+  const endBar = bars[endIdx];
+  if (startBar === undefined || endBar === undefined) return null;
+  const startDate = bucketKeyToDate(startBar.date);
+  const nextBar = bars[endIdx + 1];
+  let endDate: string;
+  if (nextBar !== undefined) {
+    const d = new Date(bucketKeyToDate(nextBar.date) + 'T00:00:00Z');
+    d.setUTCDate(d.getUTCDate() - 1);
+    endDate = d.toISOString().slice(0, 10);
+  } else {
+    endDate = fallbackEnd;
+  }
+  if (endDate < startDate) endDate = startDate;
+  return { startDate, endDate };
+}

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { asDateString, asTagValue } from '@costgoblin/core/browser';
+import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
+import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { daysBetween } from '../lib/dates.js';
 import type {
   Dimension,
@@ -60,10 +63,12 @@ function previousRangeFor(dr: DateRange): DateRange {
 function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProps) {
   const api = useCostApi();
   const lagDays = useLagDays();
+  const hourlyConfigured = useHourlyConfigured();
   const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [compareEnabled, setCompareEnabled] = useState(false);
   const [filters, setFilters] = useState<FilterMap>(initialFilter ?? {});
+  const [hourlyHint, setHourlyHint] = useState(false);
   const prefsLoadedRef = useRef(false);
   const columnPrefsRef = useRef<{ hiddenColumns: readonly string[]; columnOrder: readonly string[] }>({
     hiddenColumns: [],
@@ -157,6 +162,31 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     setFilters(prev => ({ ...prev, [dim]: [value] }));
   }
 
+  const handleDateRangeChange = useCallback((range: DateRange, g?: Granularity) => {
+    setDateRange(range);
+    if (g !== undefined) {
+      setGranularity(g);
+      setHourlyHint(false);
+      return;
+    }
+    if (shouldAutoSwitchToHourly(range.start, range.end, granularity)) {
+      if (hourlyConfigured) {
+        setGranularity('hourly');
+        setHourlyHint(false);
+      } else {
+        setHourlyHint(true);
+      }
+    } else {
+      setHourlyHint(false);
+    }
+  }, [granularity, hourlyConfigured]);
+
+  useEffect(() => {
+    if (!shouldAutoSwitchToHourly(dateRange.start, dateRange.end, granularity)) {
+      setHourlyHint(false);
+    }
+  }, [dateRange.start, dateRange.end, granularity]);
+
   function handleEntityClick(entity: EntityRef, dim: DimensionId) {
     handleSetFilter(dim, asTagValue(entity));
   }
@@ -205,6 +235,10 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
 
       <FilterActiveBanner />
 
+      {hourlyHint && (
+        <HourlyHintBanner onDismiss={() => { setHourlyHint(false); }} />
+      )}
+
       {dimensionsQuery.status === 'loading' && (
         <div className="text-sm text-text-secondary">Loading...</div>
       )}
@@ -229,6 +263,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
                   dimensions={dimensions}
                   onSetFilter={handleSetFilter}
                   onEntityClick={handleEntityClick}
+                  onDateRangeChange={handleDateRangeChange}
                 />
               </div>
             );

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -21,7 +21,7 @@ import type { PieSlice } from '../components/pie-chart.js';
 import { StackedBarChart, bucketBars } from '../components/stacked-bar-chart.js';
 import type { BarDay, HistogramTab } from '../components/stacked-bar-chart.js';
 import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension } from '../lib/dimensions.js';
-import { bucketKeyToDate, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { computeBucketedRange, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 
 interface EntityDetailProps {
   entity: string;
@@ -215,22 +215,9 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const barDays = bucketBars(dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null), 170);
 
   const handleHistogramRangeSelect = useCallback((startIdx: number, endIdx: number) => {
-    const startBar = barDays[startIdx];
-    const endBar = barDays[endIdx];
-    if (startBar === undefined || endBar === undefined) return;
-    const startDate = bucketKeyToDate(startBar.date);
-    // bucketBars stores the date of the first entry in each chunk; the
-    // covered bucket really ends the day before the next chunk starts.
-    let endDate: string;
-    const nextBar = barDays[endIdx + 1];
-    if (nextBar !== undefined) {
-      const d = new Date(bucketKeyToDate(nextBar.date) + 'T00:00:00Z');
-      d.setUTCDate(d.getUTCDate() - 1);
-      endDate = d.toISOString().slice(0, 10);
-    } else {
-      endDate = dateRange.end;
-    }
-    if (endDate < startDate) endDate = startDate;
+    const range = computeBucketedRange(barDays, startIdx, endIdx, dateRange.end);
+    if (range === null) return;
+    const { startDate, endDate } = range;
     setDateRange({ start: asDateString(startDate), end: asDateString(endDate) });
     if (shouldAutoSwitchToHourly(startDate, endDate, granularity)) {
       if (hourlyConfigured) {

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   CostResult,
   DailyCostsResult,
@@ -7,18 +7,21 @@ import type {
   EntityDetailResult,
   FilterMap,
 } from '@costgoblin/core/browser';
-import { asDimensionId, asEntityRef, asTagValue } from '@costgoblin/core/browser';
+import { asDateString, asDimensionId, asEntityRef, asTagValue } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
+import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { formatDollars, formatPercent } from '../components/format.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
+import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { PieChart } from '../components/pie-chart.js';
 import type { PieSlice } from '../components/pie-chart.js';
 import { StackedBarChart, bucketBars } from '../components/stacked-bar-chart.js';
 import type { BarDay, HistogramTab } from '../components/stacked-bar-chart.js';
 import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension } from '../lib/dimensions.js';
+import { bucketKeyToDate, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 
 interface EntityDetailProps {
   entity: string;
@@ -77,10 +80,12 @@ function handleCsvExport(data: EntityDetailResult, entity: string) {
 export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetailProps>) {
   const api = useCostApi();
   const lagDays = useLagDays();
+  const hourlyConfigured = useHourlyConfigured();
   const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [histogramTab, setHistogramTab] = useState<HistogramTab>('service');
   const [histogramExpanded, setHistogramExpanded] = useState(false);
+  const [hourlyHint, setHourlyHint] = useState(false);
   const [pie1DimId, setPie1DimId] = useState<DimensionId | null>(null);
   const [pie2DimId, setPie2DimId] = useState<DimensionId | null>(null);
   const [pie3DimId, setPie3DimId] = useState<DimensionId | null>(null);
@@ -209,6 +214,42 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   );
   const barDays = bucketBars(dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null), 170);
 
+  const handleHistogramRangeSelect = useCallback((startIdx: number, endIdx: number) => {
+    const startBar = barDays[startIdx];
+    const endBar = barDays[endIdx];
+    if (startBar === undefined || endBar === undefined) return;
+    const startDate = bucketKeyToDate(startBar.date);
+    // bucketBars stores the date of the first entry in each chunk; the
+    // covered bucket really ends the day before the next chunk starts.
+    let endDate: string;
+    const nextBar = barDays[endIdx + 1];
+    if (nextBar !== undefined) {
+      const d = new Date(bucketKeyToDate(nextBar.date) + 'T00:00:00Z');
+      d.setUTCDate(d.getUTCDate() - 1);
+      endDate = d.toISOString().slice(0, 10);
+    } else {
+      endDate = dateRange.end;
+    }
+    if (endDate < startDate) endDate = startDate;
+    setDateRange({ start: asDateString(startDate), end: asDateString(endDate) });
+    if (shouldAutoSwitchToHourly(startDate, endDate, granularity)) {
+      if (hourlyConfigured) {
+        setGranularity('hourly');
+        setHourlyHint(false);
+      } else {
+        setHourlyHint(true);
+      }
+    } else {
+      setHourlyHint(false);
+    }
+  }, [barDays, dateRange.end, granularity, hourlyConfigured]);
+
+  useEffect(() => {
+    if (!shouldAutoSwitchToHourly(dateRange.start, dateRange.end, granularity)) {
+      setHourlyHint(false);
+    }
+  }, [dateRange.start, dateRange.end, granularity]);
+
   const totalCost = data === null ? 0 : data.totalCost;
   const isIncrease = data !== null && data.percentChange > 0;
   const isDecrease = data !== null && data.percentChange < 0;
@@ -294,7 +335,11 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
                 onExpandToggle={() => { setHistogramExpanded(prev => !prev); }}
                 title={granularity === 'hourly' ? 'Hourly Costs' : 'Daily Costs'}
                 loading={dailyQuery.status === 'loading'}
+                onRangeSelect={handleHistogramRangeSelect}
               />
+              {hourlyHint && (
+                <HourlyHintBanner className="mt-2" onDismiss={() => { setHourlyHint(false); }} />
+              )}
             </div>
           </div>
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -13,15 +13,20 @@ import type {
   ExplorerSort,
   Granularity,
 } from '@costgoblin/core/browser';
+import { asDateString } from '@costgoblin/core/browser';
 import type { SortingState } from '@tanstack/react-table';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
+import { useBarDragSelect } from '../hooks/use-bar-drag-select.js';
+import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { formatDollars } from '../components/format.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
 import { DataTable } from '../components/data-table.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
+import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { getDimensionId } from '../lib/dimensions.js';
+import { bucketKeyToDate, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import type { TableColumn } from '../lib/table-types.js';
 
 const DEBOUNCE_MS = 250;
@@ -93,6 +98,7 @@ const DEFAULT_HIDDEN: ReadonlySet<string> = new Set([
 export function ExplorerView(): React.JSX.Element {
   const api = useCostApi();
   const lagDays = useLagDays();
+  const hourlyConfigured = useHourlyConfigured();
   const [filters, setFilters] = useState<ExplorerFilterMap>({});
   const [sort, setSort] = useState<ExplorerSort | undefined>(undefined);
   const [dimensions, setDimensions] = useState<Dimension[]>([]);
@@ -106,6 +112,7 @@ export function ExplorerView(): React.JSX.Element {
   const [rows, setRows] = useState<RowsState>({ data: null, loading: true, error: null });
   const [hiddenColumns, setHiddenColumns] = useState<readonly string[]>([...DEFAULT_HIDDEN]);
   const [columnOrder, setColumnOrder] = useState<readonly string[]>([]);
+  const [hourlyHint, setHourlyHint] = useState(false);
   const overviewDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rowsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const overviewReqIdRef = useRef(0);
@@ -379,6 +386,32 @@ export function ExplorerView(): React.JSX.Element {
 
   const activeFilterCount = Object.values(filters).reduce((n, vs) => n + vs.length, 0);
   const overviewData = overview.data;
+  const dailyTotals = useMemo(() => overviewData?.dailyTotals ?? [], [overviewData]);
+
+  const handleHistogramRangeSelect = useCallback((startIdx: number, endIdx: number) => {
+    const startBar = dailyTotals[startIdx];
+    const endBar = dailyTotals[endIdx];
+    if (startBar === undefined || endBar === undefined) return;
+    const startDate = bucketKeyToDate(startBar.date);
+    const endDate = bucketKeyToDate(endBar.date);
+    setDateRange({ start: asDateString(startDate), end: asDateString(endDate) });
+    if (shouldAutoSwitchToHourly(startDate, endDate, granularity)) {
+      if (hourlyConfigured) {
+        setGranularity('hourly');
+        setHourlyHint(false);
+      } else {
+        setHourlyHint(true);
+      }
+    } else {
+      setHourlyHint(false);
+    }
+  }, [dailyTotals, granularity, hourlyConfigured]);
+
+  useEffect(() => {
+    if (!shouldAutoSwitchToHourly(dateRange.start, dateRange.end, granularity)) {
+      setHourlyHint(false);
+    }
+  }, [dateRange.start, dateRange.end, granularity]);
 
   return (
     <div className="p-6 max-w-[1800px] mx-auto space-y-4">
@@ -439,10 +472,17 @@ export function ExplorerView(): React.JSX.Element {
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-sm">Daily total</CardTitle>
+          <CardTitle className="text-sm">{granularity === 'hourly' ? 'Hourly total' : 'Daily total'}</CardTitle>
         </CardHeader>
         <CardContent>
-          <Histogram days={overviewData?.dailyTotals ?? []} loading={overview.loading} />
+          <Histogram
+            days={dailyTotals}
+            loading={overview.loading}
+            onRangeSelect={handleHistogramRangeSelect}
+          />
+          {hourlyHint && (
+            <HourlyHintBanner className="mt-3" onDismiss={() => { setHourlyHint(false); }} />
+          )}
         </CardContent>
       </Card>
 
@@ -573,6 +613,7 @@ function ExplorerOptions({
 interface HistogramProps {
   readonly days: readonly { readonly date: string; readonly cost: number; readonly rows: number }[];
   readonly loading: boolean;
+  readonly onRangeSelect?: (startIdx: number, endIdx: number) => void;
 }
 
 const CHART_HEIGHT = 200;
@@ -584,8 +625,15 @@ const Y_TICKS = [1, 0.75, 0.5, 0.25, 0] as const;
  *  but single-series — Explorer doesn't split the total, it's raw counts
  *  over time. Bucket width follows whatever the handler emits (day or
  *  hour), so the same component handles daily and hourly granularities. */
-function Histogram({ days, loading }: HistogramProps): React.JSX.Element {
+function Histogram({ days, loading, onRangeSelect }: HistogramProps): React.JSX.Element {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const barsRef = useRef<HTMLDivElement>(null);
+  const { isDragging, overlay, handleMouseDown } = useBarDragSelect({
+    containerRef: barsRef,
+    bucketCount: days.length,
+    onRangeSelect,
+    disabled: onRangeSelect === undefined || loading,
+  });
 
   if (loading) {
     return <CoinRainLoader height={CHART_HEIGHT} count={6} />;
@@ -632,8 +680,13 @@ function Histogram({ days, loading }: HistogramProps): React.JSX.Element {
 
         {/* Bars */}
         <div
-          className="absolute top-0 right-0 h-full flex items-end"
+          ref={barsRef}
+          className={[
+            'absolute top-0 right-0 h-full flex items-end',
+            onRangeSelect !== undefined ? 'cursor-crosshair select-none' : '',
+          ].join(' ')}
           style={{ left: Y_AXIS_WIDTH, gap: 2 }}
+          onMouseDown={handleMouseDown}
         >
           {days.map(d => {
             const pct = (d.cost / max) * 100;
@@ -651,11 +704,11 @@ function Histogram({ days, loading }: HistogramProps): React.JSX.Element {
                 <div
                   className={[
                     'w-full rounded-t-sm transition-colors',
-                    isHovered ? 'bg-accent' : 'bg-accent/80',
+                    isHovered && !isDragging ? 'bg-accent' : 'bg-accent/80',
                   ].join(' ')}
                   style={{ height: `${String(Math.max(pct, 0.5))}%` }}
                 />
-                {isHovered && (
+                {isHovered && !isDragging && (
                   <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20">
                     <div className="rounded-lg border border-border bg-bg-secondary/95 px-3 py-2 text-[11px] text-text-primary whitespace-nowrap shadow-lg min-w-[160px]">
                       <div className="font-semibold mb-1.5 text-xs">{d.date}</div>
@@ -673,6 +726,12 @@ function Histogram({ days, loading }: HistogramProps): React.JSX.Element {
               </div>
             );
           })}
+          {overlay !== null && (
+            <div
+              className="pointer-events-none absolute top-0 bottom-0 bg-accent/20 border-l border-r border-accent z-30"
+              style={{ left: overlay.left, width: overlay.width }}
+            />
+          )}
         </div>
       </div>
 

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -1,14 +1,15 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { StackedBarChart, bucketBars, type BarDay } from '../components/stacked-bar-chart.js';
-import { asTagValue } from '@costgoblin/core/browser';
+import { asDateString, asTagValue } from '@costgoblin/core/browser';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
+import { computeBucketedRange } from '../lib/drag-select.js';
 
 const MAX_BARS = 170;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -51,6 +52,7 @@ export function StackedBarWidget({
   globalFilters,
   dimensions,
   onSetFilter,
+  onDateRangeChange,
 }: WidgetCommonProps) {
   const api = useCostApi();
   const focus = useCostFocus();
@@ -101,6 +103,16 @@ export function StackedBarWidget({
     [prevHasCoverage, prevQuery],
   );
 
+  const handleRangeSelect = useCallback((startIdx: number, endIdx: number) => {
+    if (onDateRangeChange === undefined) return;
+    const range = computeBucketedRange(barDays, startIdx, endIdx, dateRange.end);
+    if (range === null) return;
+    onDateRangeChange({
+      start: asDateString(range.startDate),
+      end: asDateString(range.endDate),
+    });
+  }, [barDays, dateRange.end, onDateRangeChange]);
+
   if (spec.type !== 'stackedBar') return null;
 
   const loading = query.status === 'loading';
@@ -120,6 +132,7 @@ export function StackedBarWidget({
       loading={loading}
       onSegmentClick={activeGroupBy === undefined ? undefined : (name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
       previousTotals={compareEnabled ? previousTotals : undefined}
+      onRangeSelect={onDateRangeChange === undefined ? undefined : handleRangeSelect}
     />
   );
 }

--- a/packages/ui/src/widgets/widget.ts
+++ b/packages/ui/src/widgets/widget.ts
@@ -44,6 +44,10 @@ export interface WidgetCommonProps {
   readonly dimensions: readonly Dimension[];
   readonly onSetFilter: (dim: DimensionId, value: TagValue) => void;
   readonly onEntityClick?: ((entity: EntityRef, dim: DimensionId) => void) | undefined;
+  /** Optional callback letting widgets request a new visible range — used by
+   *  drag-to-zoom interactions. Granularity is omitted when the widget has
+   *  no opinion (caller keeps the current setting). */
+  readonly onDateRangeChange?: ((range: DateRange, granularity?: Granularity) => void) | undefined;
 }
 
 export type WidgetComponent = ComponentType<WidgetCommonProps>;


### PR DESCRIPTION
Drag across the Explorer histogram or the StackedBarChart in
entity-detail to set a new date range. When the resulting window is
7 days or fewer, granularity auto-switches to hourly if the hourly
tier is synced; otherwise a dismissible banner suggests configuring
it. Drags under 4px fall through as plain clicks so bar
hover/segment-click still work.