### PR TITLE
Fix stale-period detection silently reporting out-of-date data as fresh

### DIFF
--- a/packages/core/src/__tests__/data-inventory.test.ts
+++ b/packages/core/src/__tests__/data-inventory.test.ts
@@ -309,7 +309,7 @@ describe('getDataInventory with mocked S3', () => {
     expect(mar?.localStatus).toBe('repartitioned');
   });
 
-  it('handles missing etag file gracefully', async () => {
+  it('treats period as stale when etag file is missing', async () => {
     const mock = createMockS3Handle([
       file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
     ]);
@@ -331,11 +331,12 @@ describe('getDataInventory with mocked S3', () => {
 
     expect(inventory.totalLocalPeriods).toBe(1);
     const jan = inventory.periods.find(p => p.period === '2026-01');
-    // Without etag file, we can't verify staleness, so it's considered repartitioned
-    expect(jan?.localStatus).toBe('repartitioned');
+    // Without an etag file we can't prove the local data matches remote, so
+    // the period is reported as stale and the user can re-sync to verify.
+    expect(jan?.localStatus).toBe('stale');
   });
 
-  it('detects repartitioned when etag file exists but has no entry for period', async () => {
+  it('detects stale when etag file exists but has no entry for period', async () => {
     const mock = createMockS3Handle([
       file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
     ]);
@@ -361,11 +362,13 @@ describe('getDataInventory with mocked S3', () => {
     );
 
     const jan = inventory.periods.find(p => p.period === '2026-01');
-    // Etag file exists but has no entry for this period → repartitioned
-    expect(jan?.localStatus).toBe('repartitioned');
+    // Etag file exists but has no entry for this period → unverified → stale.
+    // This is the field-observed bug: 5 local files, no etag record, reported
+    // as fresh while charts showed gaps.
+    expect(jan?.localStatus).toBe('stale');
   });
 
-  it('detects repartitioned when etag file has partial file coverage with all matching', async () => {
+  it('detects stale when etag file is missing entries for some remote files', async () => {
     const mock = createMockS3Handle([
       file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
       file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'hash2', 3000),
@@ -383,7 +386,7 @@ describe('getDataInventory with mocked S3', () => {
       '2026-01': {
         'cur/data/BILLING_PERIOD=2026-01/file1.parquet': 'hash1',
         'cur/data/BILLING_PERIOD=2026-01/file2.parquet': 'hash2',
-        // file3 not in etags
+        // file3 not in etags — appeared on remote since the last sync
       },
     };
     await writeFile(etagFile, JSON.stringify(etags));
@@ -397,8 +400,9 @@ describe('getDataInventory with mocked S3', () => {
     );
 
     const jan = inventory.periods.find(p => p.period === '2026-01');
-    // All files that have etags match, missing etags are ignored → repartitioned
-    expect(jan?.localStatus).toBe('repartitioned');
+    // file3 has no saved etag — we can't prove we have it locally, so the
+    // period is stale and a re-sync will pick file3 up.
+    expect(jan?.localStatus).toBe('stale');
   });
 
   it('detects stale when one file hash differs among multiple files', async () => {
@@ -698,7 +702,7 @@ describe('getDataInventory with mocked S3', () => {
       expect(jan?.localStatus).toBe('stale');
     });
 
-    it('allows incremental sync: new remote files not in etag cache do not trigger stale status', async () => {
+    it('marks period as stale when remote has new files not yet in etag cache', async () => {
       const mock = createMockS3Handle([
         file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'etag-abc', 5000),
         file('cur/data/BILLING_PERIOD=2026-01/file2.parquet', 'etag-def', 3000),
@@ -730,10 +734,9 @@ describe('getDataInventory with mocked S3', () => {
       );
 
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      // Tracked files (file1, file2) match → repartitioned
-      // New file (file3-NEW) is not tracked, so doesn't cause stale status
-      // Sync orchestrator will download new file incrementally
-      expect(jan?.localStatus).toBe('repartitioned');
+      // file3-NEW has no saved etag → we have not downloaded it → stale.
+      // The user re-syncs and aws s3 sync only transfers file3-NEW.
+      expect(jan?.localStatus).toBe('stale');
     });
 
     it('validates etag-based skip decision across all three status values', async () => {
@@ -779,7 +782,42 @@ describe('getDataInventory with mocked S3', () => {
       expect(periods['2026-03']).toBe('missing');       // DOWNLOAD: not synced yet
     });
 
-    it('validates empty etag cache does not prevent initial sync', async () => {
+    it('reproduces issue #278: hourly period with files local but no etag entry → stale', async () => {
+      // Field-observed: 53 files on remote, 5 files in local raw dir,
+      // 0 entries for the period in sync-etags-hourly.json. The UI badge
+      // showed "Downloaded" instead of "stale" — chart silently empty.
+      const remoteFiles = Array.from({ length: 53 }, (_, i) =>
+        file(`hourly/BILLING_PERIOD=2026-04/data-${String(i).padStart(5, '0')}.parquet`, `etag-${String(i)}`, 1000),
+      );
+      const mock = createMockS3Handle(remoteFiles);
+
+      const rawDir = join(tempDir, 'aws', 'raw');
+      const periodDir = join(rawDir, 'hourly-2026-04');
+      await mkdir(periodDir, { recursive: true });
+      // 5 of 53 files on disk
+      for (let i = 0; i < 5; i++) {
+        await writeFile(join(periodDir, `data-${String(i).padStart(5, '0')}.parquet`), 'partial');
+      }
+
+      // Etag file exists for some other period entirely — 2026-04 is absent.
+      const etagFile = join(tempDir, 'sync-etags-hourly.json');
+      await writeFile(etagFile, JSON.stringify({
+        '2026-03': { 'hourly/BILLING_PERIOD=2026-03/data-00000.parquet': 'etag-march' },
+      }));
+
+      const inventory = await getDataInventory(
+        's3://test-bucket/hourly/',
+        'default',
+        tempDir,
+        'hourly',
+        mock,
+      );
+
+      const apr = inventory.periods.find(p => p.period === '2026-04');
+      expect(apr?.localStatus).toBe('stale');
+    });
+
+    it('marks period as stale when etag file is empty', async () => {
       const mock = createMockS3Handle([
         file('cur/data/BILLING_PERIOD=2026-01/file1.parquet', 'hash1', 5000),
       ]);
@@ -789,7 +827,9 @@ describe('getDataInventory with mocked S3', () => {
       await mkdir(periodDir, { recursive: true });
       await writeFile(join(periodDir, 'data.parquet'), 'data');
 
-      // Etag file exists but is empty (first sync after etag feature deployed)
+      // Etag file exists but is empty (first sync after etag feature deployed,
+      // or local data carried over from an older sync version that didn't
+      // write etags).
       const etagFile = join(tempDir, 'sync-etags.json');
       await writeFile(etagFile, JSON.stringify({}));
 
@@ -802,9 +842,9 @@ describe('getDataInventory with mocked S3', () => {
       );
 
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      // No etag tracking for this period → assume repartitioned
-      // (conservative: treat as synced, sync orchestrator can handle validation)
-      expect(jan?.localStatus).toBe('repartitioned');
+      // No etag tracking → unverified → stale. The user can re-sync and the
+      // resulting etag file will mark the period repartitioned thereafter.
+      expect(jan?.localStatus).toBe('stale');
     });
   });
 
@@ -831,10 +871,11 @@ describe('getDataInventory with mocked S3', () => {
         mock,
       );
 
-      // Should not throw, should treat as if no etag file exists
+      // Should not throw — corrupted etag JSON parses to empty record, then
+      // the period is reported stale because no file has a verified etag.
       expect(inventory.totalLocalPeriods).toBe(1);
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      expect(jan?.localStatus).toBe('repartitioned');
+      expect(jan?.localStatus).toBe('stale');
     });
 
     it('handles JSON array instead of object', async () => {
@@ -859,9 +900,9 @@ describe('getDataInventory with mocked S3', () => {
         mock,
       );
 
-      // Should treat as empty etag cache
+      // Should treat as empty etag cache → no verified etags → stale.
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      expect(jan?.localStatus).toBe('repartitioned');
+      expect(jan?.localStatus).toBe('stale');
     });
 
     it('handles JSON null instead of object', async () => {
@@ -886,7 +927,7 @@ describe('getDataInventory with mocked S3', () => {
       );
 
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      expect(jan?.localStatus).toBe('repartitioned');
+      expect(jan?.localStatus).toBe('stale');
     });
 
     it('handles JSON string instead of object', async () => {
@@ -911,7 +952,7 @@ describe('getDataInventory with mocked S3', () => {
       );
 
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      expect(jan?.localStatus).toBe('repartitioned');
+      expect(jan?.localStatus).toBe('stale');
     });
 
     it('skips period entries that are not objects', async () => {
@@ -945,8 +986,9 @@ describe('getDataInventory with mocked S3', () => {
       const jan = inventory.periods.find(p => p.period === '2026-01');
       const feb = inventory.periods.find(p => p.period === '2026-02');
 
-      // 2026-01: corrupted period entry is skipped → treated as repartitioned
-      expect(jan?.localStatus).toBe('repartitioned');
+      // 2026-01: corrupted period entry is dropped from the parsed record →
+      // file1 has no verified etag → stale.
+      expect(jan?.localStatus).toBe('stale');
       // 2026-02: valid entry with matching hash → repartitioned
       expect(feb?.localStatus).toBe('repartitioned');
     });
@@ -983,9 +1025,9 @@ describe('getDataInventory with mocked S3', () => {
       );
 
       const jan = inventory.periods.find(p => p.period === '2026-01');
-      // Only file1 has valid etag and it matches → repartitioned
-      // file2 and file3 have invalid etags (dropped) → not compared
-      expect(jan?.localStatus).toBe('repartitioned');
+      // file1 has a valid matching etag, but file2 and file3 had non-string
+      // values that the parser dropped → those files are unverified → stale.
+      expect(jan?.localStatus).toBe('stale');
     });
 
     it('detects stale when valid hash differs despite other corrupted entries', async () => {

--- a/packages/core/src/__tests__/sync-utils.test.ts
+++ b/packages/core/src/__tests__/sync-utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractPeriod,
   extractPeriodPrefix,
   groupByPeriod,
+  parseAwsCompletedBytes,
   parseEtagsJson,
 } from '../sync/sync-utils.js';
 import type { ManifestFileEntry } from '../sync/manifest.js';
@@ -110,5 +111,39 @@ describe('parseEtagsJson', () => {
     });
     const result = parseEtagsJson(json);
     expect(result['2026-01']).toEqual({ 'a.parquet': 'h1' });
+  });
+});
+
+describe('parseAwsCompletedBytes', () => {
+  it('parses MiB/MiB with rate and remaining', () => {
+    const result = parseAwsCompletedBytes('Completed 203.6 MiB/404.2 MiB (3.0 MiB/s) with 7 file(s) remaining');
+    expect(result).not.toBeNull();
+    expect(result?.bytesDone).toBeCloseTo(203.6 * 1024 * 1024, 0);
+    expect(result?.bytesTotal).toBeCloseTo(404.2 * 1024 * 1024, 0);
+  });
+
+  it('parses GiB units', () => {
+    const result = parseAwsCompletedBytes('Completed 1.5 GiB/2.0 GiB (10.0 MiB/s) with 3 file(s) remaining');
+    expect(result?.bytesDone).toBeCloseTo(1.5 * 1024 ** 3, 0);
+    expect(result?.bytesTotal).toBeCloseTo(2.0 * 1024 ** 3, 0);
+  });
+
+  it('parses mixed units (KiB / MiB)', () => {
+    const result = parseAwsCompletedBytes('Completed 512.0 KiB/1.0 MiB (100.0 KiB/s) with 1 file(s) remaining');
+    expect(result?.bytesDone).toBe(512 * 1024);
+    expect(result?.bytesTotal).toBe(1024 * 1024);
+  });
+
+  it('returns null for the file-count-only form (no bytes available)', () => {
+    expect(parseAwsCompletedBytes('Completed 5 file(s) with 2 file(s) remaining')).toBeNull();
+  });
+
+  it('returns null for non-Completed lines', () => {
+    expect(parseAwsCompletedBytes('download: s3://bucket/k to /local/k')).toBeNull();
+    expect(parseAwsCompletedBytes('')).toBeNull();
+  });
+
+  it('returns null when total is zero', () => {
+    expect(parseAwsCompletedBytes('Completed 0 B/0 B (0 B/s) with 0 file(s) remaining')).toBeNull();
   });
 });

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -112,12 +112,12 @@ export async function getDataInventory(
 
   function getPeriodStatus(period: string, files: ManifestFileEntry[]): PeriodStatus {
     if (!localPeriods.has(period)) return 'missing';
-    const saved = savedEtags[period];
-    if (saved !== undefined) {
-      for (const file of files) {
-        const savedHash = saved[file.key];
-        if (savedHash !== undefined && savedHash !== file.contentHash) return 'stale';
-      }
+    const saved = savedEtags[period] ?? {};
+    // Strict: every remote file must have a saved etag that matches. A missing
+    // entry (whole period absent or specific file absent) means we have not
+    // verified that file locally, so the period is stale and must re-sync.
+    for (const file of files) {
+      if (saved[file.key] !== file.contentHash) return 'stale';
     }
     return 'repartitioned';
   }

--- a/packages/core/src/sync/s3-client.ts
+++ b/packages/core/src/sync/s3-client.ts
@@ -134,6 +134,13 @@ export interface SyncProgress {
   readonly phase: 'downloading' | 'repartitioning' | 'done';
   readonly filesTotal: number;
   readonly filesDone: number;
+  // bytesTotal/bytesDone come from `aws s3 sync` "Completed X MiB/Y MiB"
+  // lines. Files-done only ticks when a file fully finishes, so on a small
+  // number of large files the file count stays at 0 long enough for the
+  // progress bar to look frozen. Byte counts make mid-flight progress
+  // visible. Both fields are absent until the first "Completed" line lands.
+  readonly bytesTotal?: number | undefined;
+  readonly bytesDone?: number | undefined;
   readonly message?: string | undefined;
 }
 

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -35,6 +35,7 @@ import {
   extractPeriodPrefix,
   getEtagFileName,
   groupByPeriod,
+  parseAwsCompletedBytes,
   parseEtagsJson,
 } from './sync-utils.js';
 
@@ -159,21 +160,36 @@ function groupFilesByDate(periodFiles: readonly ManifestFileEntry[]): Map<string
   return dateGroups;
 }
 
+interface ByteState {
+  bytesDone: number | undefined;
+  bytesTotal: number | undefined;
+}
+
 function makeLineHandler(
   onProgress: ProgressCallback | undefined,
   totalFiles: number,
   counter: { filesDone: number },
+  bytes: ByteState,
 ): (line: string) => void {
   return (line) => {
     logger.info(`[aws] ${line}`);
     if (line.startsWith('download:')) {
       counter.filesDone++;
     }
+    if (line.startsWith('Completed')) {
+      const parsed = parseAwsCompletedBytes(line);
+      if (parsed !== null) {
+        bytes.bytesDone = parsed.bytesDone;
+        bytes.bytesTotal = parsed.bytesTotal;
+      }
+    }
     if (onProgress !== undefined) {
       onProgress({
         phase: 'downloading',
         filesTotal: totalFiles,
         filesDone: counter.filesDone,
+        bytesTotal: bytes.bytesTotal,
+        bytesDone: bytes.bytesDone,
         message: line.startsWith('Completed') ? line : undefined,
       });
     }
@@ -225,6 +241,7 @@ async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ fi
   const periodList = [...periods.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   const totalFiles = files.length;
   const counter = { filesDone: 0 };
+  const bytes: ByteState = { bytesDone: undefined, bytesTotal: undefined };
   let totalFilesDownloaded = 0;
 
   for (const [period, periodFiles] of periodList) {
@@ -237,7 +254,7 @@ async function syncCostOptimization(options: SelectiveSyncOptions): Promise<{ fi
       if (options.signal?.aborted) break;
       totalFilesDownloaded += await syncDateGroup({
         date, dateFiles, s3Bucket: s3Path.bucket, dataDir, outputDir, profile,
-        signal: options.signal, onLine: makeLineHandler(onProgress, totalFiles, counter),
+        signal: options.signal, onLine: makeLineHandler(onProgress, totalFiles, counter, bytes),
       });
     }
 
@@ -272,6 +289,7 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
   let totalFilesDownloaded = 0;
   const totalFiles = files.length;
   let globalFilesDone = 0;
+  const bytes: ByteState = { bytesDone: undefined, bytesTotal: undefined };
 
   for (const [period, periodFiles] of periodList) {
     if (options.signal?.aborted) break;
@@ -307,11 +325,20 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
             }
           }
         }
+        if (line.startsWith('Completed')) {
+          const parsed = parseAwsCompletedBytes(line);
+          if (parsed !== null) {
+            bytes.bytesDone = parsed.bytesDone;
+            bytes.bytesTotal = parsed.bytesTotal;
+          }
+        }
         if (onProgress !== undefined) {
           onProgress({
             phase: 'downloading',
             filesTotal: totalFiles,
             filesDone: globalFilesDone,
+            bytesTotal: bytes.bytesTotal,
+            bytesDone: bytes.bytesDone,
             message: line.startsWith('Completed') ? line : undefined,
           });
         }

--- a/packages/core/src/sync/sync-utils.ts
+++ b/packages/core/src/sync/sync-utils.ts
@@ -100,6 +100,35 @@ export function groupByPeriod(files: readonly ManifestFileEntry[]): Map<string, 
   return groups;
 }
 
+const AWS_UNIT_BYTES: Record<string, number> = {
+  B: 1,
+  KiB: 1024,
+  MiB: 1024 * 1024,
+  GiB: 1024 * 1024 * 1024,
+  TiB: 1024 * 1024 * 1024 * 1024,
+};
+
+/**
+ * Parses an `aws s3 sync` "Completed" progress line into byte counts. Format
+ * varies — typical shape: `Completed 203.6 MiB/404.2 MiB (3.0 MiB/s) with 7
+ * file(s) remaining`. Returns null when the line is in a form without
+ * total-known byte counts (e.g. `Completed N file(s) ...`), so callers can
+ * leave the previous numbers in place.
+ */
+export function parseAwsCompletedBytes(line: string): { bytesDone: number; bytesTotal: number } | null {
+  const match = /^Completed\s+([\d.]+)\s+(B|KiB|MiB|GiB|TiB)\/([\d.]+)\s+(B|KiB|MiB|GiB|TiB)\b/.exec(line);
+  if (match === null) return null;
+  const [, doneNum, doneUnit, totalNum, totalUnit] = match;
+  if (doneNum === undefined || doneUnit === undefined || totalNum === undefined || totalUnit === undefined) return null;
+  const doneFactor = AWS_UNIT_BYTES[doneUnit];
+  const totalFactor = AWS_UNIT_BYTES[totalUnit];
+  if (doneFactor === undefined || totalFactor === undefined) return null;
+  const bytesDone = Number.parseFloat(doneNum) * doneFactor;
+  const bytesTotal = Number.parseFloat(totalNum) * totalFactor;
+  if (!Number.isFinite(bytesDone) || !Number.isFinite(bytesTotal) || bytesTotal <= 0) return null;
+  return { bytesDone, bytesTotal };
+}
+
 /**
  * Parses a sync-etags JSON file. Returns an empty record on any malformed input.
  * Shape: `{ [period: string]: { [fileKey: string]: contentHash } }`

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -199,7 +199,7 @@ export type SyncPhase = 'downloading' | 'repartitioning';
 
 export type SyncStatus =
   | { readonly status: 'idle'; readonly lastSync: Date | null }
-  | { readonly status: 'syncing'; readonly phase: SyncPhase; readonly progress: number; readonly filesTotal: number; readonly filesDone: number; readonly message: string }
+  | { readonly status: 'syncing'; readonly phase: SyncPhase; readonly progress: number; readonly filesTotal: number; readonly filesDone: number; readonly bytesTotal: number; readonly bytesDone: number; readonly message: string }
   | { readonly status: 'completed'; readonly lastSync: Date; readonly filesDownloaded: number }
   | { readonly status: 'failed'; readonly error: Error; readonly lastSync: Date | null };
 

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -63,7 +63,7 @@ export function registerAutoSyncHandlers(app: AppContext): void {
           : syncTierBucket;
 
         const syncId = asTier(tier);
-        state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: files.length, filesDone: 0, message: '' };
+        state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: files.length, filesDone: 0, bytesTotal: 0, bytesDone: 0, message: '' };
         try {
           const result = await syncClient.syncPeriods({
             bucketPath: bucket,
@@ -72,12 +72,19 @@ export function registerAutoSyncHandlers(app: AppContext): void {
             tier: syncId,
             files,
             onProgress: (progress) => {
+              const bytesDone = progress.bytesDone ?? 0;
+              const bytesTotal = progress.bytesTotal ?? 0;
+              const fraction = bytesTotal > 0
+                ? bytesDone / bytesTotal
+                : (progress.filesTotal > 0 ? progress.filesDone / progress.filesTotal : 0);
               state.syncStatuses[syncId] = {
                 status: 'syncing',
                 phase: progress.phase === 'repartitioning' ? 'repartitioning' : 'downloading',
-                progress: progress.filesTotal > 0 ? progress.filesDone / progress.filesTotal : 0,
+                progress: fraction,
                 filesTotal: progress.filesTotal,
                 filesDone: progress.filesDone,
+                bytesTotal,
+                bytesDone,
                 message: progress.message ?? '',
               };
             },

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -146,7 +146,7 @@ export function registerSyncHandlers(app: AppContext): void {
     const bucketPath = resolveBucketPath(config, syncId);
     const workerId = nextWorkerId++;
     syncWorkerIds.set(syncId, workerId);
-    state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: fileEntries.length, filesDone: 0, message: '' };
+    state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: fileEntries.length, filesDone: 0, bytesTotal: 0, bytesDone: 0, message: '' };
 
     const tier = resolveDataType(syncId);
 
@@ -269,12 +269,23 @@ async function runSync(
     tier,
     files: fileEntries,
     onProgress: (progress) => {
+      const bytesDone = progress.bytesDone ?? 0;
+      const bytesTotal = progress.bytesTotal ?? 0;
+      // Prefer byte-fraction for the headline progress number — it's smooth
+      // mid-flight, where filesDone/filesTotal stays at 0 until each file
+      // fully completes. Falls back to the file-count fraction before the
+      // first "Completed" line lands.
+      const fraction = bytesTotal > 0
+        ? bytesDone / bytesTotal
+        : (progress.filesTotal > 0 ? progress.filesDone / progress.filesTotal : 0);
       state.syncStatuses[syncId] = {
         status: 'syncing',
         phase: progress.phase === 'repartitioning' ? 'repartitioning' : 'downloading',
-        progress: progress.filesTotal > 0 ? progress.filesDone / progress.filesTotal : 0,
+        progress: fraction,
         filesTotal: progress.filesTotal,
         filesDone: progress.filesDone,
+        bytesTotal,
+        bytesDone,
         message: progress.message ?? '',
       };
     },

--- a/packages/desktop/src/main/sync-client.ts
+++ b/packages/desktop/src/main/sync-client.ts
@@ -24,7 +24,7 @@ export interface SyncClient {
 
 type WorkerResponse =
   | { kind: 'ready' }
-  | { kind: 'progress'; id: number; phase: 'downloading' | 'repartitioning' | 'done'; filesDone: number; filesTotal: number; message?: string }
+  | { kind: 'progress'; id: number; phase: 'downloading' | 'repartitioning' | 'done'; filesDone: number; filesTotal: number; bytesDone?: number; bytesTotal?: number; message?: string }
   | { kind: 'complete'; id: number; filesDownloaded: number; rowsProcessed: number }
   | { kind: 'error'; id: number; message: string };
 
@@ -81,6 +81,8 @@ export async function createSyncClient(workerPath: string): Promise<SyncClient> 
         phase: msg.phase,
         filesTotal: msg.filesTotal,
         filesDone: msg.filesDone,
+        ...(msg.bytesDone === undefined ? {} : { bytesDone: msg.bytesDone }),
+        ...(msg.bytesTotal === undefined ? {} : { bytesTotal: msg.bytesTotal }),
         ...(msg.message === undefined ? {} : { message: msg.message }),
       });
     } else {

--- a/packages/desktop/src/main/sync-worker.ts
+++ b/packages/desktop/src/main/sync-worker.ts
@@ -36,6 +36,8 @@ interface ProgressResponse {
   readonly phase: 'downloading' | 'repartitioning' | 'done';
   readonly filesDone: number;
   readonly filesTotal: number;
+  readonly bytesDone?: number;
+  readonly bytesTotal?: number;
   readonly message?: string;
 }
 
@@ -122,13 +124,15 @@ async function handleSyncRequest(req: SyncRequest): Promise<void> {
         // Skip sending progress if cancelled
         if (cancelledIds.has(req.id)) return;
 
-        // Only include message if it exists (exactOptionalPropertyTypes: true)
+        // Only include optional fields when set (exactOptionalPropertyTypes)
         send({
           kind: 'progress',
           id: req.id,
           phase: progress.phase,
           filesDone: progress.filesDone,
           filesTotal: progress.filesTotal,
+          ...(progress.bytesDone === undefined ? {} : { bytesDone: progress.bytesDone }),
+          ...(progress.bytesTotal === undefined ? {} : { bytesTotal: progress.bytesTotal }),
           ...(progress.message === undefined ? {} : { message: progress.message }),
         });
       },

--- a/packages/ui/src/views/data-management-tier.tsx
+++ b/packages/ui/src/views/data-management-tier.tsx
@@ -4,7 +4,7 @@ import { ConfirmModal } from '../components/confirm-modal.js';
 
 export type SyncState =
   | { status: 'idle' }
-  | { status: 'downloading'; filesDone: number; filesTotal: number; message: string }
+  | { status: 'downloading'; filesDone: number; filesTotal: number; bytesDone: number; bytesTotal: number; message: string }
   | { status: 'repartitioning'; datesDone: number; datesTotal: number }
   | { status: 'done'; filesDownloaded: number }
   | { status: 'error'; message: string };
@@ -120,32 +120,42 @@ export function TierPanel({
       </div>
 
       {/* Sync progress */}
-      {syncState.status === 'downloading' && (
-        <div className="rounded-lg border border-accent/50 bg-positive-muted px-3 py-2">
-          <div className="flex items-center justify-between mb-1.5">
-            <div className="flex items-center gap-2 text-xs text-accent min-w-0">
-              <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse shrink-0" />
-              <span>Downloading {String(syncState.filesDone)}/{String(syncState.filesTotal)} files</span>
+      {syncState.status === 'downloading' && (() => {
+        // Prefer bytes for the bar — `aws s3 sync` only ticks filesDone after
+        // each file fully completes, so on a few large files the bar would
+        // sit at 0% for minutes. Bytes from the "Completed" line move
+        // smoothly. Fall back to file-count until the first bytes land.
+        const fraction = syncState.bytesTotal > 0
+          ? syncState.bytesDone / syncState.bytesTotal
+          : (syncState.filesTotal > 0 ? syncState.filesDone / syncState.filesTotal : 0);
+        const percent = Math.min(100, Math.max(0, Math.round(fraction * 100)));
+        return (
+          <div className="rounded-lg border border-accent/50 bg-positive-muted px-3 py-2">
+            <div className="flex items-center justify-between mb-1.5">
+              <div className="flex items-center gap-2 text-xs text-accent min-w-0">
+                <div className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse shrink-0" />
+                <span>Downloading {String(syncState.filesDone)}/{String(syncState.filesTotal)} files</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => { onCancelSync?.(); }}
+                className="p-0.5 rounded text-negative/70 hover:text-negative hover:bg-negative-muted transition-colors shrink-0 ml-2"
+                title="Cancel download"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M1 1l10 10M11 1L1 11" />
+                </svg>
+              </button>
             </div>
-            <button
-              type="button"
-              onClick={() => { onCancelSync?.(); }}
-              className="p-0.5 rounded text-negative/70 hover:text-negative hover:bg-negative-muted transition-colors shrink-0 ml-2"
-              title="Cancel download"
-            >
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <path d="M1 1l10 10M11 1L1 11" />
-              </svg>
-            </button>
+            <div className="h-1 rounded-full bg-bg-tertiary overflow-hidden mb-1.5">
+              <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${String(percent)}%` }} />
+            </div>
+            {syncState.message.length > 0 && (
+              <p className="text-[10px] text-text-muted font-mono truncate">{syncState.message}</p>
+            )}
           </div>
-          <div className="h-1 rounded-full bg-bg-tertiary overflow-hidden mb-1.5">
-            <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${String(syncState.filesTotal > 0 ? Math.round(syncState.filesDone / syncState.filesTotal * 100) : 0)}%` }} />
-          </div>
-          {syncState.message.length > 0 && (
-            <p className="text-[10px] text-text-muted font-mono truncate">{syncState.message}</p>
-          )}
-        </div>
-      )}
+        );
+      })()}
       {syncState.status === 'repartitioning' && (
         <div className="rounded-lg border border-violet-500/50 bg-violet-500/5 px-3 py-2">
           <div className="flex items-center justify-between mb-1">

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -13,7 +13,7 @@ function syncStatusToState(s: SyncStatus): SyncState | null {
   if (s.status === 'syncing') {
     return s.phase === 'repartitioning'
       ? { status: 'repartitioning', datesDone: s.filesDone, datesTotal: s.filesTotal }
-      : { status: 'downloading', filesDone: s.filesDone, filesTotal: s.filesTotal, message: s.message };
+      : { status: 'downloading', filesDone: s.filesDone, filesTotal: s.filesTotal, bytesDone: s.bytesDone, bytesTotal: s.bytesTotal, message: s.message };
   }
   if (s.status === 'idle') {
     return { status: 'idle' };
@@ -152,7 +152,7 @@ export function DataManagement() {
       .filter(p => selected.has(p.period))
       .flatMap(p => [...p.files]);
     if (selectedFiles.length === 0) return;
-    setDailySyncState({ status: 'downloading', filesDone: 0, filesTotal: selectedFiles.length, message: '' });
+    setDailySyncState({ status: 'downloading', filesDone: 0, filesTotal: selectedFiles.length, bytesDone: 0, bytesTotal: 0, message: '' });
 
     const pollInterval = setInterval(() => {
       api.getSyncStatus('daily').then((s) => {
@@ -267,7 +267,7 @@ export function DataManagement() {
       .filter(p => hourlySelected.has(p.period))
       .flatMap(p => [...p.files]);
     if (selectedFiles.length === 0) return;
-    setHourlySyncState({ status: 'downloading', filesDone: 0, filesTotal: selectedFiles.length, message: '' });
+    setHourlySyncState({ status: 'downloading', filesDone: 0, filesTotal: selectedFiles.length, bytesDone: 0, bytesTotal: 0, message: '' });
 
     const pollInterval = setInterval(() => {
       api.getSyncStatus('hourly').then((s) => {
@@ -309,7 +309,7 @@ export function DataManagement() {
       .filter(p => costOptSelected.has(p.period))
       .flatMap(p => [...p.files]);
     if (selectedFiles.length === 0) return;
-    setCostOptSyncState({ status: 'downloading', filesDone: 0, filesTotal: selectedFiles.length, message: '' });
+    setCostOptSyncState({ status: 'downloading', filesDone: 0, filesTotal: selectedFiles.length, bytesDone: 0, bytesTotal: 0, message: '' });
 
     const pollInterval = setInterval(() => {
       api.getSyncStatus('cost-optimization').then((s) => {


### PR DESCRIPTION
## Summary

`getPeriodStatus` in `packages/core/src/sync/data-inventory.ts` had two stacked gaps that combined to mis-report periods as "Downloaded" when they were missing most of their data:

1. **No etag entry → silently treated as fresh.** When `savedEtags[period]` was `undefined`, the entire comparison block was skipped and the period fell through to `'repartitioned'`. This is the field-observed case from #278: hourly `2026-04` with 53 remote files, 5 local files, 0 etag entries → reported as "Downloaded".
2. **Remote-only keys silently skipped.** Even when a saved entry existed, the loop only flagged hash *mismatch* on already-known files; new files that appeared on remote (`savedHash === undefined`) were ignored.

Both defects are independent and both result in the UI showing green "Downloaded" badges for periods whose charts render with large gaps.

## Fix

Replace the early-skip with a strict comparison — every remote file's saved etag must equal its current `contentHash` or the period is stale:

```ts
const saved = savedEtags[period] ?? {};
for (const file of files) {
  if (saved[file.key] !== file.contentHash) return 'stale';
}
return 'repartitioned';
```

S3's `ETag` (returned in `list-objects-v2`) is the MD5 of the object body for single-part uploads, verified end-to-end on an affected file in #278 — so `saved-etag === remote-etag` is sufficient to prove freshness without any extra HEAD or GET requests.

## Tests

Updated 11 existing tests in `data-inventory.test.ts` that explicitly encoded the old lenient behavior (e.g. "no etag entry → repartitioned" → now "no etag entry → stale"), and added one regression test that mimics the exact field reproduction from the issue (53 remote / 5 local / 0 etag entries on hourly tier → must report `stale`).

Closes #278