### PR TITLE
Hour-level drag-zoom and dashboard interaction polish

### DIFF
--- a/packages/core/src/__tests__/identifier-validator.test.ts
+++ b/packages/core/src/__tests__/identifier-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assertDateString, validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
+import { assertDateString, assertHourString, validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId } from '../types/branded.js';
 
@@ -105,6 +105,34 @@ describe('assertDateString', () => {
   it('rejects SQL injection attempts', () => {
     expect(() => { assertDateString("2026-01-01' OR 1=1 --"); }).toThrow(SecurityError);
     expect(() => { assertDateString("2026-01-01'; DROP TABLE cost_base; --"); }).toThrow(SecurityError);
+  });
+});
+
+describe('assertHourString', () => {
+  it('accepts valid YYYY-MM-DD HH:00:00 timestamps', () => {
+    expect(() => { assertHourString('2026-04-30 00:00:00'); }).not.toThrow();
+    expect(() => { assertHourString('2026-04-30 14:00:00'); }).not.toThrow();
+    expect(() => { assertHourString('2026-04-30 23:00:00'); }).not.toThrow();
+    expect(() => { assertHourString('2025-12-31 09:00:00'); }).not.toThrow();
+  });
+
+  it('rejects non-zero minutes or seconds', () => {
+    expect(() => { assertHourString('2026-04-30 14:30:00'); }).toThrow(SecurityError);
+    expect(() => { assertHourString('2026-04-30 14:00:01'); }).toThrow(SecurityError);
+    expect(() => { assertHourString('2026-04-30 14:00'); }).toThrow(SecurityError);
+  });
+
+  it('rejects out-of-range hours and dates', () => {
+    expect(() => { assertHourString('2026-04-30 24:00:00'); }).toThrow(SecurityError);
+    expect(() => { assertHourString('2026-04-30 99:00:00'); }).toThrow(SecurityError);
+    expect(() => { assertHourString('2026-13-30 14:00:00'); }).toThrow(SecurityError);
+    expect(() => { assertHourString('2026-04-32 14:00:00'); }).toThrow(SecurityError);
+  });
+
+  it('rejects SQL injection attempts', () => {
+    expect(() => { assertHourString("2026-04-30 14:00:00' OR 1=1 --"); }).toThrow(SecurityError);
+    expect(() => { assertHourString("2026-04-30 14:00:00'; DROP TABLE cost_base; --"); }).toThrow(SecurityError);
+    expect(() => { assertHourString(''); }).toThrow(SecurityError);
   });
 });
 

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { buildCostQuery, buildTrendQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource, computePeriodsInRange } from '../query/builder.js';
+import { buildCostQuery, buildDailyCostsQuery, buildTrendQuery, buildMissingTagsQuery, buildNonResourceCostQuery, buildEntityDetailQuery, buildSource, computePeriodsInRange } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
-import { asDimensionId, asDateString, asDollars, asEntityRef, asTagValue } from '../types/branded.js';
+import { asDimensionId, asDateString, asDollars, asEntityRef, asHourString, asTagValue } from '../types/branded.js';
 
 const dimensions: DimensionsConfig = {
   builtIn: [
@@ -284,5 +284,105 @@ describe('buildEntityDetailQuery', () => {
     expect(params).toContain('core-banking');
     expect(sql).toContain('usage_date');
     expect(sql).toContain('service');
+  });
+});
+
+describe('hour-bounded date ranges', () => {
+  const hourRange = {
+    start: asDateString('2026-04-30'),
+    end: asDateString('2026-04-30'),
+    startHour: asHourString('2026-04-30 14:00:00'),
+    endHour: asHourString('2026-04-30 17:00:00'),
+  };
+
+  it('buildCostQuery filters on usage_hour and forces the hourly tier', () => {
+    const { sql, params } = buildCostQuery(
+      {
+        groupBy: asDimensionId('service'),
+        dateRange: hourRange,
+        filters: {},
+        granularity: 'hourly',
+      },
+      { dataDir: '/data', dimensions },
+    );
+    expect(sql).toContain('usage_hour BETWEEN');
+    expect(sql).toContain('::TIMESTAMP');
+    expect(sql).not.toContain('usage_date BETWEEN');
+    expect(sql).toContain("'/data/aws/raw/hourly-2026-04/*.parquet'");
+    expect(params).toContain('2026-04-30 14:00:00');
+    expect(params).toContain('2026-04-30 17:00:00');
+  });
+
+  it('buildDailyCostsQuery filters on usage_hour and groups by hour', () => {
+    const { sql } = buildDailyCostsQuery(
+      {
+        groupBy: asDimensionId('service'),
+        dateRange: hourRange,
+        filters: {},
+        granularity: 'hourly',
+      },
+      { dataDir: '/data', dimensions },
+    );
+    expect(sql).toContain('usage_hour BETWEEN');
+    expect(sql).toContain("strftime(usage_hour, '%Y-%m-%d %H:00')");
+    expect(sql).not.toContain('usage_date BETWEEN');
+  });
+
+  it('buildEntityDetailQuery filters on usage_hour when hour bounds are set', () => {
+    const { sql, params } = buildEntityDetailQuery(
+      {
+        entity: asEntityRef('core-banking'),
+        dimension: asDimensionId('tag_org_team'),
+        dateRange: hourRange,
+        filters: {},
+        granularity: 'hourly',
+      },
+      { dataDir: '/data', dimensions },
+    );
+    expect(sql).toContain('usage_hour BETWEEN');
+    expect(params).toContain('2026-04-30 14:00:00');
+    expect(params).toContain('2026-04-30 17:00:00');
+  });
+
+  it('promotes daily-only callers (missing tags) to hourly tier when hour bounds are set', () => {
+    const { sql } = buildMissingTagsQuery(
+      {
+        dateRange: hourRange,
+        filters: {},
+        minCost: asDollars(0),
+        tagDimension: asDimensionId('tag_org_team'),
+      },
+      { dataDir: '/data', dimensions },
+    );
+    expect(sql).toContain('usage_hour BETWEEN');
+    expect(sql).toContain("'/data/aws/raw/hourly-2026-04/*.parquet'");
+  });
+
+  it('promotes non-resource cost to hourly tier when hour bounds are set', () => {
+    const { sql } = buildNonResourceCostQuery(
+      {
+        dateRange: hourRange,
+        filters: {},
+        minCost: asDollars(0),
+        tagDimension: asDimensionId('tag_org_team'),
+      },
+      { dataDir: '/data', dimensions },
+    );
+    expect(sql).toContain('usage_hour BETWEEN');
+    expect(sql).toContain("'/data/aws/raw/hourly-2026-04/*.parquet'");
+  });
+
+  it('falls back to date filter when hour bounds are not set', () => {
+    const { sql } = buildCostQuery(
+      {
+        groupBy: asDimensionId('service'),
+        dateRange: { start: asDateString('2026-04-01'), end: asDateString('2026-04-30') },
+        filters: {},
+        granularity: 'daily',
+      },
+      { dataDir: '/data', dimensions },
+    );
+    expect(sql).toContain('usage_date BETWEEN');
+    expect(sql).not.toContain('usage_hour BETWEEN');
   });
 });

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -324,7 +324,8 @@ describe('hour-bounded date ranges', () => {
       { dataDir: '/data', dimensions },
     );
     expect(sql).toContain('usage_hour BETWEEN');
-    expect(sql).toContain("strftime(usage_hour, '%Y-%m-%d %H:00')");
+    // Mid-hour fee timestamps round to nearest hour (see buildDailyCostsQuery).
+    expect(sql).toContain("strftime(date_trunc('hour', usage_hour + INTERVAL '30 minutes'), '%Y-%m-%d %H:00')");
     expect(sql).not.toContain('usage_date BETWEEN');
   });
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -6,7 +6,7 @@ import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
-import { assertDateString, SecurityError } from './identifier-validator.js';
+import { assertDateString, assertHourString, SecurityError } from './identifier-validator.js';
 
 function assertFiniteNumber(value: number, name: string): void {
   if (!Number.isFinite(value) || value < 0) {
@@ -409,9 +409,47 @@ function resolveQueryPeriods(
   return required.filter(p => availablePeriods.includes(p));
 }
 
+interface DateRangeLike {
+  readonly start: string;
+  readonly end: string;
+  readonly startHour?: string | undefined;
+  readonly endHour?: string | undefined;
+}
+
+/** True when the range has both hour bounds set. Hour bounds are an additive
+ *  refinement on top of the day-level start/end; they only kick in for
+ *  hourly-tier queries (the daily Parquet files don't have usage_hour). */
+function hasHourBounds(dateRange: DateRangeLike): boolean {
+  return dateRange.startHour !== undefined && dateRange.endHour !== undefined;
+}
+
+/** When hour bounds are present, the query must read from the hourly tier so
+ *  that usage_hour is available to filter on. Promote the requested tier
+ *  accordingly. */
+function effectiveTier(requestedTier: string, dateRange: DateRangeLike): string {
+  return hasHourBounds(dateRange) ? 'hourly' : requestedTier;
+}
+
+/** WHERE expression for the date range. With hour bounds set we filter at the
+ *  hour level (inclusive on both ends) — `usage_hour BETWEEN startHour AND endHour`.
+ *  Without them we keep the cheaper day-level filter. Both forms use parameter
+ *  placeholders so untrusted values stay out of the SQL string. */
+function buildDateRangeWhere(qb: QueryBuilder, dateRange: DateRangeLike): string {
+  if (dateRange.startHour !== undefined && dateRange.endHour !== undefined) {
+    assertHourString(dateRange.startHour);
+    assertHourString(dateRange.endHour);
+    const sh = qb.addParam(dateRange.startHour);
+    const eh = qb.addParam(dateRange.endHour);
+    return `usage_hour BETWEEN ${sh}::TIMESTAMP AND ${eh}::TIMESTAMP`;
+  }
+  const s = qb.addParam(dateRange.start);
+  const e = qb.addParam(dateRange.end);
+  return `usage_date BETWEEN ${s} AND ${e}`;
+}
+
 interface CommonQueryArgs {
   readonly filters: FilterMap;
-  readonly dateRange: { readonly start: string; readonly end: string };
+  readonly dateRange: DateRangeLike;
 }
 
 interface CommonQuerySetup {
@@ -444,14 +482,18 @@ function setupQuery(
   const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
   const costMetric = costScope?.costMetric ?? 'unblended';
 
-  if (materializedSource !== undefined) {
+  // The materialized base table is built at daily tier and lacks usage_hour,
+  // so it can't satisfy hour-bounded queries. Fall through to a fresh hourly
+  // Parquet read in that case.
+  if (materializedSource !== undefined && !hasHourBounds(params.dateRange)) {
     return { qb, filterClauses, exclusionClauses: [], source: materializedSource, costMetric };
   }
 
   const exclusionClauses = costScope === undefined ? [] : buildExclusionClauses(costScope.rules, dimensions, accountReverseMap, qb);
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
-  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, ...extraSourceOpts });
+  const resolvedTier = effectiveTier(tier, params.dateRange);
+  const source = buildSource({ dataDir, tier: resolvedTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, ...extraSourceOpts });
   return { qb, filterClauses, exclusionClauses, source, costMetric };
 }
 
@@ -465,10 +507,8 @@ export function buildCostQuery(
   const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, costTier, opts);
   const groupByResolved = resolveField(params.groupBy, opts.dimensions);
 
-  const startDatePlaceholder = qb.addParam(params.dateRange.start);
-  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
+    buildDateRangeWhere(qb, params.dateRange),
     ...filterClauses,
     ...exclusionClauses,
   ];
@@ -637,10 +677,8 @@ export function buildMissingTagsQuery(
   const hasRawColumn = tagDim?.accountTagFallback !== undefined && opts.orgAccountsPath !== undefined;
   const tagCheckField = hasRawColumn ? `raw_${tagResolved.rawField}` : tagResolved.rawField;
 
-  const startDatePlaceholder = qb.addParam(params.dateRange.start);
-  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
+    buildDateRangeWhere(qb, params.dateRange),
     `line_item_type IN ('Usage', 'DiscountedUsage')`,
     `resource_id IS NOT NULL AND resource_id != ''`,
     ...filterClauses,
@@ -709,10 +747,8 @@ export function buildNonResourceCostQuery(
 ): ParameterizedQuery {
   const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, 'daily', opts);
 
-  const startDatePlaceholder = qb.addParam(params.dateRange.start);
-  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
+    buildDateRangeWhere(qb, params.dateRange),
     `(line_item_type NOT IN ('Usage', 'DiscountedUsage') OR resource_id IS NULL OR resource_id = '')`,
     ...filterClauses,
     ...exclusionClauses,
@@ -739,18 +775,17 @@ export function buildDailyCostsQuery(
   opts: QueryContextOptions,
 ): ParameterizedQuery {
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
+  const resolvedTier = effectiveTier(dailyTier, params.dateRange);
   const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dailyTier, opts);
   const groupByResolved = resolveField(params.groupBy, opts.dimensions);
 
-  const startDatePlaceholder = qb.addParam(params.dateRange.start);
-  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
+    buildDateRangeWhere(qb, params.dateRange),
     ...filterClauses,
     ...exclusionClauses,
   ];
 
-  const dateExpr = dailyTier === 'hourly'
+  const dateExpr = resolvedTier === 'hourly'
     ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 
@@ -774,6 +809,7 @@ export function buildEntityDetailQuery(
 ): ParameterizedQuery {
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
+  const resolvedTier = effectiveTier(tier, params.dateRange);
   const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, tier, opts);
   const dimResolved = resolveField(params.dimension, opts.dimensions);
 
@@ -792,10 +828,8 @@ export function buildEntityDetailQuery(
     return `${dimResolved.fieldExpr} = ${entityPlaceholder}`;
   })();
 
-  const startDatePlaceholder = qb.addParam(params.dateRange.start);
-  const endDatePlaceholder = qb.addParam(params.dateRange.end);
   const whereConditions = [
-    `usage_date BETWEEN ${startDatePlaceholder} AND ${endDatePlaceholder}`,
+    buildDateRangeWhere(qb, params.dateRange),
     entityClause,
     ...filterClauses,
     ...exclusionClauses,
@@ -803,7 +837,7 @@ export function buildEntityDetailQuery(
 
   // Group by hour for hourly tier so the entity detail histogram doesn't
   // collapse 24 hourly rows into one date row.
-  const groupKey = tier === 'hourly'
+  const groupKey = resolvedTier === 'hourly'
     ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -785,8 +785,11 @@ export function buildDailyCostsQuery(
     ...exclusionClauses,
   ];
 
+  // Round CUR's mid-hour fee timestamps (SavingsPlanFee, RIFee, Tax, etc.)
+  // to the nearest hour boundary so they land in a single bucket alongside
+  // hour-aligned Usage rows instead of polluting the histogram.
   const dateExpr = resolvedTier === 'hourly'
-    ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
+    ? "strftime(date_trunc('hour', usage_hour + INTERVAL '30 minutes'), '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 
   const sql = `
@@ -836,9 +839,10 @@ export function buildEntityDetailQuery(
   ];
 
   // Group by hour for hourly tier so the entity detail histogram doesn't
-  // collapse 24 hourly rows into one date row.
+  // collapse 24 hourly rows into one date row. Mid-hour fee timestamps are
+  // rounded to the nearest hour boundary (see buildDailyCostsQuery comment).
   const groupKey = resolvedTier === 'hourly'
-    ? "strftime(usage_hour, '%Y-%m-%d %H:00')"
+    ? "strftime(date_trunc('hour', usage_hour + INTERVAL '30 minutes'), '%Y-%m-%d %H:00')"
     : 'usage_date::VARCHAR';
 
   const sql = `

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -159,6 +159,25 @@ export function assertDateString(value: string): void {
   }
 }
 
+/**
+ * Pattern for valid YYYY-MM-DD HH:00:00 hour strings.
+ */
+const HOUR_STRING_PATTERN = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):00:00$/;
+
+/**
+ * Validate that a string is a well-formed YYYY-MM-DD HH:00:00 hour timestamp.
+ * Throws SecurityError if the format is invalid, preventing SQL injection
+ * via hour values interpolated into queries.
+ */
+export function assertHourString(value: string): void {
+  if (!HOUR_STRING_PATTERN.test(value)) {
+    throw new SecurityError(
+      `Invalid hour string "${value}" - must be YYYY-MM-DD HH:00:00 format. ` +
+      `This prevents SQL injection via untrusted hour values.`
+    );
+  }
+}
+
 export function validateTablePath(tablePath: string): void {
   // Extract the tier and period from the path
   // Expected formats:

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -14,7 +14,7 @@ export type { QueryContextOptions, BuildSourceOptions } from './builder.js';
 
 export { costExprFor } from './cost-metric.js';
 
-export { assertDateString, validateColumnName, validateTablePath, SecurityError } from './identifier-validator.js';
+export { assertDateString, assertHourString, validateColumnName, validateTablePath, SecurityError } from './identifier-validator.js';
 
 export type { ParameterizedQuery } from './parameterized.js';
 export { QueryBuilder } from './parameterized.js';

--- a/packages/core/src/types/branded.ts
+++ b/packages/core/src/types/branded.ts
@@ -6,6 +6,7 @@ export type TagValue = Brand<string, 'TagValue'>;
 export type BucketPath = Brand<string, 'BucketPath'>;
 export type Dollars = Brand<number, 'Dollars'>;
 export type DateString = Brand<string, 'DateString'>;
+export type HourString = Brand<string, 'HourString'>;
 
 export function asDimensionId(value: string): DimensionId {
   return value as DimensionId;
@@ -29,6 +30,10 @@ export function asDollars(value: number): Dollars {
 
 export function asDateString(value: string): DateString {
   return value as DateString;
+}
+
+export function asHourString(value: string): HourString {
+  return value as HourString;
 }
 
 export function tagColumnName(tagName: string): string {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,6 +5,7 @@ export type {
   BucketPath,
   Dollars,
   DateString,
+  HourString,
 } from './branded.js';
 export {
   asDimensionId,
@@ -13,6 +14,7 @@ export {
   asBucketPath,
   asDollars,
   asDateString,
+  asHourString,
   tagColumnName,
 } from './branded.js';
 

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -1,10 +1,20 @@
-import type { DateString, DimensionId, Dollars, EntityRef, TagValue } from './branded.js';
+import type { DateString, DimensionId, Dollars, EntityRef, HourString, TagValue } from './branded.js';
 
 export type Granularity = 'daily' | 'hourly';
 
+/**
+ * A date range. `start`/`end` are always present and authoritative for whole-day
+ * filters. When the user has dragged into a sub-day window on an hourly chart,
+ * `startHour`/`endHour` (inclusive on both ends, in `YYYY-MM-DD HH:00:00` form)
+ * refine the window to a specific range of hours; query builders use
+ * `usage_hour BETWEEN startHour AND endHour` instead of the day-level filter
+ * when the granularity is hourly and both fields are set.
+ */
 export interface DateRange {
   readonly start: DateString;
   readonly end: DateString;
+  readonly startHour?: HourString | undefined;
+  readonly endHour?: HourString | undefined;
 }
 
 export type FilterMap = Readonly<Partial<Record<DimensionId, readonly TagValue[]>>>;

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -397,10 +397,12 @@ export function registerExplorerHandlers(app: AppContext): void {
     `.trim();
 
     // Bucket width matches the queried tier — daily rows group per day,
-    // hourly rows group per hour. Without this the hourly-tier histogram
-    // would collapse back to daily bars and hide the whole point of
-    // switching granularity.
-    const bucketExpr = qc.tier === 'hourly' ? 'usage_hour' : 'usage_date';
+    // hourly rows group per hour. CUR line items like SavingsPlanFee, RIFee,
+    // Refund and Tax carry a precise mid-hour timestamp; we shift by 30
+    // minutes before truncating so a fee at 11:56:32 lands in the 12:00
+    // bucket instead of either getting its own bar (no truncation) or being
+    // stuck in 11:00 (plain truncation).
+    const bucketExpr = qc.tier === 'hourly' ? `date_trunc('hour', usage_hour + INTERVAL '30 minutes')` : 'usage_date';
     const dailySql = `
       SELECT
         ${bucketExpr}::VARCHAR AS date,

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 import {
   asDimensionId,
   asDateString,
+  assertHourString,
   buildSource,
   buildRuleMatchExpr,
   buildAliasSqlCase,
@@ -58,12 +59,32 @@ function toIsoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-function resolveDateRange(raw: { start?: string; end?: string } | undefined): { startStr: string; endStr: string; windowDays: number } {
+interface ResolvedDateRange {
+  readonly startStr: string;
+  readonly endStr: string;
+  readonly windowDays: number;
+  readonly startHour?: string;
+  readonly endHour?: string;
+}
+
+function resolveDateRange(raw: { start?: string | undefined; end?: string | undefined; startHour?: string | undefined; endHour?: string | undefined } | undefined): ResolvedDateRange {
   const start = parseDate(raw?.start);
   const end = parseDate(raw?.end);
   if (start !== null && end !== null && start.getTime() <= end.getTime()) {
     const days = Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1;
-    return { startStr: toIsoDate(start), endStr: toIsoDate(end), windowDays: days };
+    const base = { startStr: toIsoDate(start), endStr: toIsoDate(end), windowDays: days };
+    // Hour bounds are an additive refinement from drag-zoom on the histogram.
+    // Validate up front so a malformed value can't reach the SQL builder.
+    if (typeof raw?.startHour === 'string' && typeof raw.endHour === 'string') {
+      try {
+        assertHourString(raw.startHour);
+        assertHourString(raw.endHour);
+        return { ...base, startHour: raw.startHour, endHour: raw.endHour };
+      } catch {
+        // fall through to day-only range
+      }
+    }
+    return base;
   }
   const latestDate = new Date(Date.now() - DEFAULT_LAG_DAYS * 86_400_000);
   const fallbackEnd = toIsoDate(latestDate);
@@ -219,6 +240,8 @@ interface BuildFreshSourceOptions {
   readonly params: ExplorerBaseParams;
   readonly startStr: string;
   readonly endStr: string;
+  readonly startHour?: string;
+  readonly endHour?: string;
   readonly tier: 'daily' | 'hourly';
   readonly periods: readonly string[];
   readonly dimensions: DimensionsConfig;
@@ -227,7 +250,7 @@ interface BuildFreshSourceOptions {
 }
 
 async function buildFreshSource(opts: BuildFreshSourceOptions): Promise<{ source: string; whereStr: string }> {
-  const { app, params, startStr, endStr, tier, periods, dimensions, filterPredicate, accountReverseMap } = opts;
+  const { app, params, startStr, endStr, startHour, endHour, tier, periods, dimensions, filterPredicate, accountReverseMap } = opts;
   const { ctx, getCostScope, getOrgAccountsPath, getAvailableColumns } = app;
   const orgPath = await getOrgAccountsPath();
   const availableColumns = await getAvailableColumns(tier);
@@ -239,8 +262,16 @@ async function buildFreshSource(opts: BuildFreshSourceOptions): Promise<{ source
   const source = buildSource({ dataDir: ctx.dataDir, tier, dimensions, orgAccountsPath: orgPath, periods, costMetric: metric, availableColumns, costPerspective: perspective });
   const exclusions = buildExclusionClauses(costScope, dimensions, accountReverseMap);
 
+  // When the histogram drag-zoom emits hour bounds, swap the day-level
+  // BETWEEN for an hour-level filter so the rest of the Explorer (overview,
+  // table, sample rows) matches what the user dragged. usage_hour only exists
+  // on the hourly tier — caller forces tier='hourly' in that case.
+  const dateClause = startHour !== undefined && endHour !== undefined && tier === 'hourly'
+    ? `usage_hour BETWEEN TIMESTAMP '${startHour}' AND TIMESTAMP '${endHour}'`
+    : `usage_date BETWEEN '${startStr}' AND '${endStr}'`;
+
   const whereClauses: string[] = [
-    `usage_date BETWEEN '${startStr}' AND '${endStr}'`,
+    dateClause,
     ...(filterPredicate === null ? [] : [`(${filterPredicate})`]),
     ...exclusions,
   ];
@@ -249,8 +280,12 @@ async function buildFreshSource(opts: BuildFreshSourceOptions): Promise<{ source
 
 async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams): Promise<QueryContext> {
   const { ctx, getQueryDimensions, getAccountMap } = app;
-  const { startStr, endStr, windowDays } = resolveDateRange(params.dateRange);
-  const tier: 'daily' | 'hourly' = params.granularity === 'hourly' ? 'hourly' : 'daily';
+  const { startStr, endStr, windowDays, startHour, endHour } = resolveDateRange(params.dateRange);
+  // Hour bounds (sub-day drag-zoom) require the hourly tier — that's where
+  // usage_hour lives. Promote tier when present, regardless of what
+  // params.granularity says.
+  const requestedTier: 'daily' | 'hourly' = params.granularity === 'hourly' ? 'hourly' : 'daily';
+  const tier: 'daily' | 'hourly' = (startHour !== undefined && endHour !== undefined) ? 'hourly' : requestedTier;
 
   const available = await listLocalMonths(ctx.dataDir, tier);
   const required = computePeriodsInRange({ start: startStr, end: endStr });
@@ -277,7 +312,10 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
   // slim schema (no description, usage_amount, list_cost) that Explorer's
   // aggregated table and sample rows need.
   const { source, whereStr } = await buildFreshSource({
-    app, params, startStr, endStr, tier, periods, dimensions, filterPredicate, accountReverseMap,
+    app, params, startStr, endStr,
+    ...(startHour !== undefined ? { startHour } : {}),
+    ...(endHour !== undefined ? { endHour } : {}),
+    tier, periods, dimensions, filterPredicate, accountReverseMap,
   });
   return { empty: false, source, whereStr, ...shared };
 }

--- a/packages/ui/src/__tests__/drag-select.test.ts
+++ b/packages/ui/src/__tests__/drag-select.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pixelToIndex, bucketKeyToDate, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { pixelToIndex, bucketKeyToDate, computeBucketedHourRange, normalizeHourKey, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 
 describe('pixelToIndex', () => {
   it('maps the left edge to index 0', () => {
@@ -45,6 +45,58 @@ describe('bucketKeyToDate', () => {
   it('returns short input unchanged', () => {
     expect(bucketKeyToDate('')).toBe('');
     expect(bucketKeyToDate('2026')).toBe('2026');
+  });
+});
+
+describe('normalizeHourKey', () => {
+  it('canonicalizes "YYYY-MM-DD HH:MM" to "YYYY-MM-DD HH:00:00"', () => {
+    expect(normalizeHourKey('2026-04-30 14:00')).toBe('2026-04-30 14:00:00');
+    expect(normalizeHourKey('2026-04-30 00:00')).toBe('2026-04-30 00:00:00');
+  });
+
+  it('preserves already-canonical hour keys', () => {
+    expect(normalizeHourKey('2026-04-30 14:00:00')).toBe('2026-04-30 14:00:00');
+  });
+
+  it('returns null for date-only or malformed strings', () => {
+    expect(normalizeHourKey('2026-04-30')).toBeNull();
+    expect(normalizeHourKey('')).toBeNull();
+    expect(normalizeHourKey('garbage')).toBeNull();
+  });
+});
+
+describe('computeBucketedHourRange', () => {
+  const hourBars = [
+    { date: '2026-04-30 14:00' },
+    { date: '2026-04-30 15:00' },
+    { date: '2026-04-30 16:00' },
+    { date: '2026-04-30 17:00' },
+    { date: '2026-04-30 18:00' },
+  ];
+
+  it('returns the picked hour range when dragging in the middle', () => {
+    const range = computeBucketedHourRange(hourBars, 0, 3, '2026-04-30 18:00');
+    // start = first bar, end = (next bar's hour) - 1 = 17:00 - 1 wait actually
+    // for indices 0..3 inclusive, next bar is index 4 (18:00); end = 18:00 - 1 = 17:00
+    expect(range).toEqual({ startHour: '2026-04-30 14:00:00', endHour: '2026-04-30 17:00:00' });
+  });
+
+  it('drag inside a single hour bucket yields a single-hour range', () => {
+    const range = computeBucketedHourRange(hourBars, 1, 1, '2026-04-30 18:00');
+    expect(range).toEqual({ startHour: '2026-04-30 15:00:00', endHour: '2026-04-30 15:00:00' });
+  });
+
+  it('drag covering the last bar uses fallback for the end hour', () => {
+    const range = computeBucketedHourRange(hourBars, 3, 4, '2026-04-30 18:00');
+    expect(range).toEqual({ startHour: '2026-04-30 17:00:00', endHour: '2026-04-30 18:00:00' });
+  });
+
+  it('returns null for non-hourly bar keys', () => {
+    const range = computeBucketedHourRange(
+      [{ date: '2026-04-30' }, { date: '2026-05-01' }],
+      0, 1, '2026-04-30 23:00',
+    );
+    expect(range).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -104,7 +104,7 @@ function BubbleChartInner({
   const tickColor = 'var(--color-text-muted)';
 
   return (
-    <div className="relative">
+    <div className="relative" onMouseLeave={handleMouseLeave}>
       <svg width={width} height={height} aria-label="Cost trend bubble chart: x-axis shows percent change, y-axis shows absolute delta, bubble size represents current cost">
         <Group left={MARGIN.left} top={MARGIN.top}>
           <GridRows

--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -20,16 +20,23 @@ interface BubbleChartProps {
   readonly data: readonly TrendRow[];
   readonly logScale?: number | undefined;
   readonly onEntityClick: (entity: EntityRef) => void;
+  readonly externalHoveredName?: string | null | undefined;
+  readonly onEntityHover?: ((name: string | null) => void) | undefined;
 }
 
 function BubbleChartInner({
   data,
   logScale,
   onEntityClick,
+  externalHoveredName,
+  onEntityHover,
   width,
   height,
 }: BubbleChartProps & { readonly width: number; readonly height: number }) {
-  const [hoveredEntity, setHoveredEntity] = useState<EntityRef | null>(null);
+  const [localHovered, setLocalHovered] = useState<EntityRef | null>(null);
+  const hoveredEntity: EntityRef | null = (externalHoveredName ?? null) === null
+    ? localHovered
+    : (externalHoveredName as EntityRef | null);
   const {
     showTooltip,
     hideTooltip,
@@ -48,15 +55,26 @@ function BubbleChartInner({
         tooltipLeft: coords.x,
         tooltipTop: coords.y,
       });
-      setHoveredEntity(row.entity);
+      // SVG mousemove fires every frame; only push to global focus when the
+      // pointed-at bubble actually changes, otherwise sibling charts thrash
+      // (the pie's HOVER reducer was firing 60 times/s and visibly flickered).
+      setLocalHovered(prev => {
+        if (prev === row.entity) return prev;
+        onEntityHover?.(row.entity);
+        return row.entity;
+      });
     },
-    [showTooltip],
+    [showTooltip, onEntityHover],
   );
 
   const handleMouseLeave = useCallback(() => {
     hideTooltip();
-    setHoveredEntity(null);
-  }, [hideTooltip]);
+    setLocalHovered(prev => {
+      if (prev === null) return prev;
+      onEntityHover?.(null);
+      return null;
+    });
+  }, [hideTooltip, onEntityHover]);
 
   const innerWidth = width - MARGIN.left - MARGIN.right;
   const innerHeight = height - MARGIN.top - MARGIN.bottom;
@@ -226,7 +244,7 @@ function BubbleChartInner({
   );
 }
 
-export function BubbleChart({ data, logScale, onEntityClick }: BubbleChartProps) {
+export function BubbleChart({ data, logScale, onEntityClick, externalHoveredName, onEntityHover }: BubbleChartProps) {
   return (
     <div className="h-[350px] w-full rounded-xl border border-border bg-bg-secondary/50">
       <ParentSize>
@@ -235,6 +253,8 @@ export function BubbleChart({ data, logScale, onEntityClick }: BubbleChartProps)
             data={data}
             logScale={logScale}
             onEntityClick={onEntityClick}
+            externalHoveredName={externalHoveredName}
+            onEntityHover={onEntityHover}
             width={width}
             height={height}
           />

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { CalendarIcon, ChevronDown } from 'lucide-react';
-import type { DateString } from '@costgoblin/core/browser';
+import type { DateString, HourString } from '@costgoblin/core/browser';
 import { DEFAULT_LAG_DAYS, asDateString } from '@costgoblin/core/browser';
 import { daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getLastQuarter, getYTD, getLastYear } from '../lib/dates.js';
 import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
@@ -58,6 +58,8 @@ const ALL_PRESETS = PRESETS.flatMap(s => s.items);
 export interface DateRange {
   start: DateString;
   end: DateString;
+  startHour?: HourString | undefined;
+  endHour?: HourString | undefined;
 }
 
 interface DateRangePickerProps {
@@ -94,7 +96,22 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
     return preferred;
   }
 
+  const hasHourBounds = value.startHour !== undefined && value.endHour !== undefined;
+
+  function formatHourBound(hour: HourString): string {
+    // "2026-04-30 14:00:00" → "Apr 30 14:00"
+    const s = String(hour);
+    const date = new Date(`${s.slice(0, 10)}T${s.slice(11, 16)}:00`);
+    if (Number.isNaN(date.getTime())) return s;
+    const month = date.toLocaleString('en-US', { month: 'short' });
+    return `${month} ${String(date.getDate())} ${s.slice(11, 16)}`;
+  }
+
   function getActiveLabel(): string {
+    if (hasHourBounds && value.startHour !== undefined && value.endHour !== undefined) {
+      const base = `${formatHourBound(value.startHour)} → ${formatHourBound(value.endHour)}`;
+      return compareEnabled === true ? `${base} vs prev` : base;
+    }
     let label: string | undefined;
     for (const preset of ALL_PRESETS) {
       const range = getPresetRange(preset);
@@ -109,22 +126,32 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
 
   function handlePreset(preset: Preset) {
     const range = getPresetRange(preset);
+    // Picking a preset is an explicit "back to whole-day mode" gesture —
+    // don't carry a previous drag's hour bounds onto the new window.
     onChange(range, resolveGranularity(range, preset.granularity));
     setShowCustom(false);
     setOpen(false);
   }
 
   function handleCustomRange(range: DateRange) {
+    // Same intent as a preset: editing the calendar picks whole days, so any
+    // active hour bounds no longer apply.
     onChange(range, resolveGranularity(range, granularity));
   }
 
   function handleGranularityToggle(next: Granularity) {
     if (next === granularity) return;
     if (next === 'hourly' && !hourlyAvailable) return;
-    onChange(value, next);
+    // Switching to Daily clears hour bounds; switching to Hourly leaves the
+    // current day-level range alone (the user can drag-zoom from there).
+    const cleared: DateRange = next === 'daily'
+      ? { start: value.start, end: value.end }
+      : value;
+    onChange(cleared, next);
   }
 
   function isActivePreset(preset: Preset): boolean {
+    if (hasHourBounds) return false;
     const range = getPresetRange(preset);
     return value.start === range.start && value.end === range.end && granularity === resolveGranularity(range, preset.granularity);
   }
@@ -245,7 +272,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
                         selected={new Date(value.start + 'T00:00:00')}
                         onSelect={(date) => {
                           if (date) {
-                            handleCustomRange({ ...value, start: asDateString(date.toISOString().slice(0, 10)) });
+                            handleCustomRange({ start: asDateString(date.toISOString().slice(0, 10)), end: value.end });
                           }
                         }}
                         disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
@@ -272,7 +299,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
                         selected={new Date(value.end + 'T00:00:00')}
                         onSelect={(date) => {
                           if (date) {
-                            handleCustomRange({ ...value, end: asDateString(date.toISOString().slice(0, 10)) });
+                            handleCustomRange({ start: value.start, end: asDateString(date.toISOString().slice(0, 10)) });
                           }
                         }}
                         disabled={(date) => date.toISOString().slice(0, 10) > latestDate}

--- a/packages/ui/src/components/pie-chart.tsx
+++ b/packages/ui/src/components/pie-chart.tsx
@@ -93,7 +93,10 @@ function PieChartInner({
   }, [onSliceHover]);
 
   return (
-    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col h-full">
+    <div
+      className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col h-full"
+      onMouseLeave={handleMouseLeave}
+    >
       <div className="flex items-center justify-between mb-3">
         {dimensions !== undefined && dimensions.length > 0 && onDimensionChange !== undefined ? (
           <select

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -170,10 +170,15 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
   }, [hoveredSegment]);
 
   // Surface the local hover to the widget host so it can lift it into the
-  // global cross-chart focus. Mirror of the pie chart's onSliceHover.
+  // global cross-chart focus. Mirror of the pie chart's onSliceHover. The
+  // callback is held in a ref so an unstable parent reference can't retrigger
+  // the effect on every render — that path is an infinite-update loop when
+  // the parent's dispatch causes any re-render.
+  const onSegmentHoverRef = useRef(onSegmentHover);
+  onSegmentHoverRef.current = onSegmentHover;
   useEffect(() => {
-    onSegmentHover?.(hoveredSegment);
-  }, [hoveredSegment, onSegmentHover]);
+    onSegmentHoverRef.current?.(hoveredSegment);
+  }, [hoveredSegment]);
 
   const allKeys = new Set<string>();
   for (const day of days) {

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -4,6 +4,7 @@ import { formatDollars } from './format.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
 import { usePalette } from '../hooks/use-palette.js';
 import { useBarDragSelect } from '../hooks/use-bar-drag-select.js';
+import { formatBucketKey } from '../lib/drag-select.js';
 
 export interface BarDay {
   readonly date: string;
@@ -109,8 +110,7 @@ function BarColumn({ day, segments, segTotal, barPct, highlightedGroup, palette,
     <div
       className="group relative flex-1 min-w-0"
       style={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}
-      onMouseEnter={() => { setHoveredDay(day.date); }}
-      onMouseLeave={() => { setHoveredDay(null); setHoveredSegment(null); }}
+      onMouseEnter={() => { setHoveredDay(day.date); setHoveredSegment(null); }}
     >
       <div
         className="w-full overflow-hidden rounded-t-sm"
@@ -139,12 +139,20 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
   const highlightRef = useRef<HTMLDivElement>(null);
   const barsRef = useRef<HTMLDivElement>(null);
 
-  const { isDragging, overlay, handleMouseDown } = useBarDragSelect({
+  const { isDragging, overlay, selection, handleMouseDown } = useBarDragSelect({
     containerRef: barsRef,
     bucketCount: days.length,
     onRangeSelect,
     disabled: onRangeSelect === undefined || loading === true,
   });
+
+  const dragLabels = (() => {
+    if (selection === null) return null;
+    const startBar = days[selection.startIdx];
+    const endBar = days[selection.endIdx];
+    if (startBar === undefined || endBar === undefined) return null;
+    return { start: formatBucketKey(startBar.date), end: formatBucketKey(endBar.date) };
+  })();
 
   useEffect(() => {
     highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
@@ -160,6 +168,10 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
 
   const prevMax = previousTotals === undefined ? 0 : previousTotals.reduce((m, v) => Math.max(m, v), 0);
   const maxCost = Math.max(days.reduce((m, d) => Math.max(m, d.total), 0), prevMax);
+
+  // Either an external focus signal or a row the user is currently pointing at
+  // in the tooltip should fade the other series to match how pies behave.
+  const focusedKey = highlightedGroup ?? hoveredSegment;
 
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-5 py-4 flex flex-col h-full overflow-hidden">
@@ -208,7 +220,11 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
         const minChartHeight = expanded ? 360 : 180;
         const ticks = [1, 0.75, 0.5, 0.25, 0];
         return (
-        <div className="relative flex-1 pb-7" style={{ minHeight: `${String(minChartHeight)}px` }}>
+        <div
+          className="relative flex-1 pb-7"
+          style={{ minHeight: `${String(minChartHeight)}px` }}
+          onMouseLeave={() => { setHoveredDay(null); setHoveredSegment(null); }}
+        >
           {/* Y axis ticks */}
           <div className="absolute left-0 top-0 bottom-7 w-10">
             {ticks.map(pct => (
@@ -252,7 +268,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
               .sort((a, b) => b.value - a.value);
             const segTotal = segs.reduce((sum, s) => sum + s.value, 0);
             return (
-              <div className={`pointer-events-none absolute top-0 bottom-0 z-20 ${onLeft ? 'right-0 mr-1' : 'left-12 ml-1'}`}>
+              <div className={`absolute top-0 bottom-0 z-20 ${onLeft ? 'right-0 mr-1' : 'left-12 ml-1'}`}>
                 <div className="rounded-lg bg-bg-secondary/95 px-4 py-3 text-[11px] text-text-primary whitespace-nowrap shadow-lg border border-border min-w-[280px] max-h-full overflow-y-auto">
                   <div className="mb-2 pb-2 border-b border-border-subtle flex flex-col gap-0.5">
                     <div className="flex items-center justify-between">
@@ -283,7 +299,13 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                         ? ((seg.value - prevVal) / prevVal) * 100
                         : undefined;
                       return (
-                        <div key={seg.key} ref={isHigh ? highlightRef : undefined} className={`flex items-center gap-2 rounded py-0.5 px-1 -mx-1 ${isHigh ? 'bg-white/10' : ''}`}>
+                        <div
+                          key={seg.key}
+                          ref={isHigh ? highlightRef : undefined}
+                          onMouseEnter={() => { setHoveredSegment(seg.key); }}
+                          onMouseLeave={() => { setHoveredSegment(null); }}
+                          className={`pointer-events-auto flex items-center gap-2 rounded py-0.5 px-1 -mx-1 cursor-default ${isHigh ? 'bg-white/10' : ''}`}
+                        >
                           <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
                           <span className={`truncate flex-1 min-w-0 ${isHigh ? 'text-text-primary font-semibold' : 'text-text-secondary'}`}>{seg.key}</span>
                           <span className={`tabular-nums shrink-0 ${isHigh ? 'font-semibold' : ''}`}>
@@ -331,7 +353,7 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                   segments={segments}
                   segTotal={segTotal}
                   barPct={barPct}
-                  highlightedGroup={highlightedGroup}
+                  highlightedGroup={focusedKey}
                   palette={palette}
                   onSegmentClick={onSegmentClick}
                   setHoveredDay={setHoveredDay}
@@ -344,6 +366,22 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
                 className="pointer-events-none absolute top-0 bottom-0 bg-accent/20 border-l border-r border-accent z-30"
                 style={{ left: overlay.left, width: overlay.width }}
               />
+            )}
+            {overlay !== null && dragLabels !== null && (
+              <>
+                <div
+                  className="pointer-events-none absolute -top-5 z-40 -translate-x-1/2 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-bg-primary shadow whitespace-nowrap tabular-nums"
+                  style={{ left: overlay.left }}
+                >
+                  {dragLabels.start}
+                </div>
+                <div
+                  className="pointer-events-none absolute -top-5 z-40 -translate-x-1/2 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-bg-primary shadow whitespace-nowrap tabular-nums"
+                  style={{ left: overlay.left + overlay.width }}
+                >
+                  {dragLabels.end}
+                </div>
+              </>
             )}
           </div>
 

--- a/packages/ui/src/components/stacked-bar-chart.tsx
+++ b/packages/ui/src/components/stacked-bar-chart.tsx
@@ -28,6 +28,11 @@ interface StackedBarChartProps {
    *  a dashed line overlay when present. */
   readonly previousTotals?: readonly number[] | undefined;
   readonly onRangeSelect?: ((startIdx: number, endIdx: number) => void) | undefined;
+  /** Fires when the focused series changes — either the user moused into a
+   *  bar segment or hovered a row in the floating tooltip. Lets the host
+   *  widget propagate to the global cross-chart focus so sibling pies dim
+   *  the same way pie→histogram already does. Called with null on leave. */
+  readonly onSegmentHover?: ((name: string | null) => void) | undefined;
 }
 
 export function bucketBars(bars: readonly BarDay[], maxBuckets: number): readonly BarDay[] {
@@ -64,12 +69,18 @@ interface BarSegmentProps {
 function BarSegment({ seg, segTotal, highlightedGroup, palette, onMouseEnter, onSegmentClick }: BarSegmentProps) {
   const pct = segTotal > 0 ? (seg.value / segTotal) * 100 : 0;
   const color = getColor(seg.colorIdx, palette);
-  const isDimmed = highlightedGroup !== null && highlightedGroup !== undefined && highlightedGroup !== seg.key;
-  const baseStyle = {
+  const isHighlighted = highlightedGroup !== null && highlightedGroup !== undefined && highlightedGroup === seg.key;
+  const isDimmed = highlightedGroup !== null && highlightedGroup !== undefined && !isHighlighted;
+  // Match the pie chart's emphasis: dimmed series fade to ~25%, the focused
+  // one stays at full opacity with a subtle brightness boost and a thin white
+  // outline inset so it reads as "selected" the way a pie slice does on hover.
+  const baseStyle: React.CSSProperties = {
     height: `${String(pct)}%`,
     backgroundColor: color,
-    opacity: isDimmed ? 0.25 : 0.85,
-    transition: 'opacity 0.15s',
+    opacity: isDimmed ? 0.25 : isHighlighted ? 1 : 0.85,
+    filter: isHighlighted ? 'brightness(1.2)' : 'none',
+    boxShadow: isHighlighted ? 'inset 0 0 0 1.5px rgba(255,255,255,0.85)' : 'none',
+    transition: 'opacity 0.15s, filter 0.15s, box-shadow 0.15s',
   };
   if (onSegmentClick !== undefined) {
     return (
@@ -132,7 +143,7 @@ function BarColumn({ day, segments, segTotal, barPct, highlightedGroup, palette,
   );
 }
 
-export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading, onSegmentClick, previousTotals, onRangeSelect }: StackedBarChartProps) {
+export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expanded, onExpandToggle, title, loading, onSegmentClick, previousTotals, onRangeSelect, onSegmentHover }: StackedBarChartProps) {
   const { palette } = usePalette();
   const [hoveredDay, setHoveredDay] = useState<string | null>(null);
   const [hoveredSegment, setHoveredSegment] = useState<string | null>(null);
@@ -157,6 +168,12 @@ export function StackedBarChart({ days, highlightedGroup, tab, onTabChange, expa
   useEffect(() => {
     highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
   }, [hoveredSegment]);
+
+  // Surface the local hover to the widget host so it can lift it into the
+  // global cross-chart focus. Mirror of the pie chart's onSliceHover.
+  useEffect(() => {
+    onSegmentHover?.(hoveredSegment);
+  }, [hoveredSegment, onSegmentHover]);
 
   const allKeys = new Set<string>();
   for (const day of days) {

--- a/packages/ui/src/components/top-n-bar-chart.tsx
+++ b/packages/ui/src/components/top-n-bar-chart.tsx
@@ -80,7 +80,11 @@ function TopNBarChartInner({
   }, [onBarHover]);
 
   return (
-    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col" style={{ height: CHART_HEIGHT }}>
+    <div
+      className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col"
+      style={{ height: CHART_HEIGHT }}
+      onMouseLeave={handleLeave}
+    >
       <div className="flex items-center justify-between mb-3">
         {dimensions !== undefined && dimensions.length > 0 && onDimensionChange !== undefined ? (
           <select

--- a/packages/ui/src/components/treemap-chart.tsx
+++ b/packages/ui/src/components/treemap-chart.tsx
@@ -146,7 +146,11 @@ function TreemapInner({
 
 export function TreemapChart({ data, title, subtitle, height = 320, onCellClick, onCellHover, externalHoveredName, previousCosts }: TreemapChartProps) {
   return (
-    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col" style={{ height }}>
+    <div
+      className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4 flex flex-col"
+      style={{ height }}
+      onMouseLeave={() => { onCellHover?.(null); }}
+    >
       {(title !== undefined || subtitle !== undefined) && (
         <div className="flex items-center justify-between mb-2">
           {title !== undefined && <h3 className="text-sm font-medium text-text-secondary">{title}</h3>}

--- a/packages/ui/src/hooks/use-bar-drag-select.ts
+++ b/packages/ui/src/hooks/use-bar-drag-select.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
-import { pixelToIndex } from '../lib/drag-select.js';
+import { pixelRangeToBars, pixelToIndex } from '../lib/drag-select.js';
 
 interface DragState {
   startX: number;
@@ -71,10 +71,8 @@ export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSe
       const maxX = Math.max(drag.startX, x);
       setOverlay({ left: minX, width: maxX - minX });
       const count = bucketCountRef.current;
-      setSelection({
-        startIdx: pixelToIndex(minX, drag.rect.width, count),
-        endIdx: pixelToIndex(maxX, drag.rect.width, count),
-      });
+      const range = pixelRangeToBars(minX, maxX, drag.rect.width, count);
+      if (range !== null) setSelection(range);
     };
     const handleUp = () => {
       const drag = dragRef.current;
@@ -84,9 +82,8 @@ export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSe
       // Sub-4px drags are treated as plain clicks so bar hover/click still works.
       if (maxX - minX >= MIN_DRAG_PX) {
         const count = bucketCountRef.current;
-        const startIdx = pixelToIndex(minX, drag.rect.width, count);
-        const endIdx = pixelToIndex(maxX, drag.rect.width, count);
-        if (startIdx <= endIdx) onRangeSelectRef.current?.(startIdx, endIdx);
+        const range = pixelRangeToBars(minX, maxX, drag.rect.width, count);
+        if (range !== null) onRangeSelectRef.current?.(range.startIdx, range.endIdx);
       }
       dragRef.current = null;
       setOverlay(null);

--- a/packages/ui/src/hooks/use-bar-drag-select.ts
+++ b/packages/ui/src/hooks/use-bar-drag-select.ts
@@ -19,9 +19,18 @@ interface UseBarDragSelectOptions {
   readonly disabled?: boolean | undefined;
 }
 
+interface DragSelection {
+  readonly startIdx: number;
+  readonly endIdx: number;
+}
+
 interface UseBarDragSelectResult {
   readonly isDragging: boolean;
   readonly overlay: OverlayRect | null;
+  /** Bar indices currently under the drag overlay, mirrored from the same
+   *  pixelToIndex math used at mouse-up. Lets callers display the
+   *  start/end-of-period labels live while the user is still dragging. */
+  readonly selection: DragSelection | null;
   readonly handleMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -30,6 +39,7 @@ const MIN_DRAG_PX = 4;
 export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSelectResult {
   const { containerRef, bucketCount, onRangeSelect, disabled } = options;
   const [overlay, setOverlay] = useState<OverlayRect | null>(null);
+  const [selection, setSelection] = useState<DragSelection | null>(null);
   const dragRef = useRef<DragState | null>(null);
   const bucketCountRef = useRef(bucketCount);
   const onRangeSelectRef = useRef(onRangeSelect);
@@ -46,6 +56,8 @@ export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSe
     const startX = event.clientX - rect.left;
     dragRef.current = { startX, currentX: startX, rect };
     setOverlay({ left: startX, width: 0 });
+    const startIdx = pixelToIndex(startX, rect.width, bucketCount);
+    setSelection({ startIdx, endIdx: startIdx });
     event.preventDefault();
   }, [containerRef, bucketCount, disabled]);
 
@@ -58,6 +70,11 @@ export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSe
       const minX = Math.min(drag.startX, x);
       const maxX = Math.max(drag.startX, x);
       setOverlay({ left: minX, width: maxX - minX });
+      const count = bucketCountRef.current;
+      setSelection({
+        startIdx: pixelToIndex(minX, drag.rect.width, count),
+        endIdx: pixelToIndex(maxX, drag.rect.width, count),
+      });
     };
     const handleUp = () => {
       const drag = dragRef.current;
@@ -73,11 +90,13 @@ export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSe
       }
       dragRef.current = null;
       setOverlay(null);
+      setSelection(null);
     };
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       dragRef.current = null;
       setOverlay(null);
+      setSelection(null);
     };
     window.addEventListener('mousemove', handleMove);
     window.addEventListener('mouseup', handleUp);
@@ -89,5 +108,5 @@ export function useBarDragSelect(options: UseBarDragSelectOptions): UseBarDragSe
     };
   }, []);
 
-  return { isDragging: overlay !== null, overlay, handleMouseDown };
+  return { isDragging: overlay !== null, overlay, selection, handleMouseDown };
 }

--- a/packages/ui/src/hooks/use-cost-focus.ts
+++ b/packages/ui/src/hooks/use-cost-focus.ts
@@ -28,6 +28,7 @@ export function costFocusReducer(state: CostFocusState, action: CostFocusAction)
       return { ...state, environment: action.env };
 
     case 'HOVER':
+      if (state.hoveredEntity === action.entity && state.hoveredDimension === action.dimension) return state;
       return { ...state, hoveredEntity: action.entity, hoveredDimension: action.dimension };
 
     case 'TOGGLE_EXPAND':

--- a/packages/ui/src/hooks/use-widget-query.ts
+++ b/packages/ui/src/hooks/use-widget-query.ts
@@ -96,7 +96,7 @@ export function useDailyWidgetQuery({
     () => specGroupBy === undefined
       ? Promise.resolve(null)
       : fetchDailyWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity),
-    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
@@ -134,7 +134,7 @@ export function useCostWidgetQuery({
     () => specGroupBy === undefined
       ? Promise.resolve(null)
       : fetchCostsWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity),
-    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, fk, granularity, api],
+    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
   );
 
   const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;

--- a/packages/ui/src/lib/drag-select.ts
+++ b/packages/ui/src/lib/drag-select.ts
@@ -16,6 +16,28 @@ export function bucketKeyToDate(key: string): string {
   return key.length >= 10 ? key.slice(0, 10) : key;
 }
 
+/** Human-readable label for a bar's time bucket. Hourly bucket keys carry an
+ *  `HH:MM` suffix (e.g. "2026-05-01 21:00") and we surface that; daily keys
+ *  collapse to date-only ("May 1"). Used for the live drag-zoom edge labels
+ *  so the user can see the period before releasing the mouse. */
+export function formatBucketKey(key: string): string {
+  if (key.length === 0) return '';
+  const datePart = key.slice(0, 10);
+  const [yearStr, monthStr, dayStr] = datePart.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return key;
+  const d = new Date(year, month - 1, day);
+  const dateLabel = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  // "YYYY-MM-DD HH:MM" or "YYYY-MM-DD HH:MM:SS"
+  if (key.length >= 16 && key[10] === ' ') {
+    const hour = key.slice(11, 16);
+    return `${dateLabel} ${hour}`;
+  }
+  return dateLabel;
+}
+
 export function shouldAutoSwitchToHourly(
   startDate: string,
   endDate: string,

--- a/packages/ui/src/lib/drag-select.ts
+++ b/packages/ui/src/lib/drag-select.ts
@@ -54,3 +54,49 @@ export function computeBucketedRange(
   if (endDate < startDate) endDate = startDate;
   return { startDate, endDate };
 }
+
+/** Normalize an hourly bucket key like "2026-04-30 14:00" or "2026-04-30 14:00:00"
+ *  to the canonical `YYYY-MM-DD HH:00:00` HourString form used by the query
+ *  layer. Missing seconds are zero-padded; anything that isn't an hourly key
+ *  falls through (caller should treat that as not-hourly). */
+export function normalizeHourKey(key: string): string | null {
+  // Match "YYYY-MM-DD HH:MM" or "YYYY-MM-DD HH:MM:SS"
+  const m = /^(\d{4}-\d{2}-\d{2}) (\d{2}):(\d{2})(?::\d{2})?$/.exec(key);
+  if (m === null) return null;
+  const date = m[1];
+  const hour = m[2];
+  return `${String(date)} ${String(hour)}:00:00`;
+}
+
+/** Same as `computeBucketedRange` but for hourly bars. Each bar's `date` is an
+ *  hour-bucket key (e.g. "2026-04-30 14:00"). With `bucketBars` collapsing
+ *  multiple hours per visual bar, the chunk's first bar gives the start hour;
+ *  the next bar's hour minus one gives the end hour, and the last bar falls
+ *  back to the visible range end. Inclusive on both ends. Returns null when
+ *  the bars don't carry hourly keys. */
+export function computeBucketedHourRange(
+  bars: readonly BucketLike[],
+  startIdx: number,
+  endIdx: number,
+  fallbackEndHour: string,
+): { startHour: string; endHour: string } | null {
+  const startBar = bars[startIdx];
+  const endBar = bars[endIdx];
+  if (startBar === undefined || endBar === undefined) return null;
+  const startHour = normalizeHourKey(startBar.date);
+  if (startHour === null) return null;
+  const nextBar = bars[endIdx + 1];
+  let endHour: string;
+  if (nextBar !== undefined) {
+    const nextHour = normalizeHourKey(nextBar.date);
+    if (nextHour === null) return null;
+    const d = new Date(nextHour.replace(' ', 'T') + 'Z');
+    d.setUTCHours(d.getUTCHours() - 1);
+    endHour = `${d.toISOString().slice(0, 10)} ${String(d.getUTCHours()).padStart(2, '0')}:00:00`;
+  } else {
+    const fallback = normalizeHourKey(fallbackEndHour);
+    endHour = fallback ?? startHour;
+  }
+  if (endHour < startHour) endHour = startHour;
+  return { startHour, endHour };
+}

--- a/packages/ui/src/lib/drag-select.ts
+++ b/packages/ui/src/lib/drag-select.ts
@@ -12,6 +12,41 @@ export function pixelToIndex(x: number, containerWidth: number, bucketCount: num
   return idx;
 }
 
+/** Map a drag overlay onto bar indices by majority coverage: a bar is included
+ *  only if more than half of its width is under the overlay. This means the
+ *  user can intentionally overshoot on either edge (start the drag inside the
+ *  bar before the period and end inside the bar after) and the boundary bars
+ *  drop out instead of being captured.
+ *
+ *  When the drag is so narrow that no bar is majority-covered (typically a
+ *  small drag inside a single wide bar), fall back to the bar under the drag
+ *  midpoint so single-hour selections still work. */
+export function pixelRangeToBars(
+  minX: number,
+  maxX: number,
+  containerWidth: number,
+  bucketCount: number,
+): { startIdx: number; endIdx: number } | null {
+  if (bucketCount <= 0 || containerWidth <= 0) return null;
+  const slot = containerWidth / bucketCount;
+  const half = slot / 2;
+  let startIdx = -1;
+  let endIdx = -1;
+  for (let i = 0; i < bucketCount; i++) {
+    const left = i * slot;
+    const right = left + slot;
+    const overlap = Math.max(0, Math.min(maxX, right) - Math.max(minX, left));
+    if (overlap > half) {
+      if (startIdx === -1) startIdx = i;
+      endIdx = i;
+    }
+  }
+  if (startIdx >= 0) return { startIdx, endIdx };
+  const mid = (minX + maxX) / 2;
+  const idx = pixelToIndex(mid, containerWidth, bucketCount);
+  return { startIdx: idx, endIdx: idx };
+}
+
 export function bucketKeyToDate(key: string): string {
   return key.length >= 10 ? key.slice(0, 10) : key;
 }

--- a/packages/ui/src/lib/palette.ts
+++ b/packages/ui/src/lib/palette.ts
@@ -1,19 +1,54 @@
+// Curated colors for the first N series in any chart. Sized at 16 so that the
+// common case (a stacked bar broken down by a single dimension) gets distinct,
+// designer-picked hues. Anything beyond falls back to algorithmic generation
+// below — which never collides because the golden-angle step ensures every
+// new hue is maximally distant from prior ones.
 export const PALETTE_STANDARD: readonly string[] = [
   '#10b981', '#06b6d4', '#f59e0b', '#8b5cf6',
   '#f43e5c', '#3b82f6', '#f97316', '#14b8a6',
+  '#a855f7', '#ec4899', '#22d3ee', '#84cc16',
+  '#eab308', '#6366f1', '#ef4444', '#0ea5e9',
 ];
 
+// Okabe-Ito palette extended with safe variants. Each row is one "family":
+// keeping families together so adjacent indices in a small chart still read as
+// distinct hues to a colorblind viewer.
 export const PALETTE_COLORBLIND: readonly string[] = [
   '#0072B2', '#E69F00', '#009E73', '#CC79A7',
-  '#56B4E9', '#D55E00', '#F0E442',
+  '#56B4E9', '#D55E00', '#F0E442', '#000000',
+  '#5DADE2', '#F1948A', '#48C9B0', '#AF7AC5',
+  '#F39C12', '#1F618D', '#7FB3D5', '#A9DFBF',
 ];
 
 const PALETTE_FALLBACK = '#374151';
 
+// Golden-angle step in degrees. Each subsequent index advances the hue by this
+// amount mod 360, which is the irrational sweet spot that maximizes visual
+// separation between colors regardless of how many we end up generating.
+const GOLDEN_ANGLE = 137.508;
+
 export type PaletteType = 'standard' | 'colorblind';
 
+/** Extended HSL fallback for indices past the curated palette. Deterministic
+ *  for a given (index, palette.length) so the same series always gets the
+ *  same color across renders. Uses the curated palette length as the rotation
+ *  start so the first generated hue doesn't collide with the last curated one. */
+function generateColor(index: number, paletteLength: number): string {
+  const hue = ((index - paletteLength) * GOLDEN_ANGLE) % 360;
+  const positiveHue = hue < 0 ? hue + 360 : hue;
+  // Alternate slightly between two lightness/saturation pairs so neighbouring
+  // generated colors don't all read as the same brightness.
+  const isOdd = (index - paletteLength) % 2 === 1;
+  const saturation = isOdd ? 55 : 65;
+  const lightness = isOdd ? 60 : 50;
+  return `hsl(${positiveHue.toFixed(1)}, ${String(saturation)}%, ${String(lightness)}%)`;
+}
+
 export function getColor(index: number, palette: readonly string[] = PALETTE_STANDARD): string {
-  return palette[index % palette.length] ?? PALETTE_FALLBACK;
+  if (index < 0) return PALETTE_FALLBACK;
+  const curated = palette[index];
+  if (curated !== undefined) return curated;
+  return generateColor(index, palette.length);
 }
 
 export function getActivePalette(type: PaletteType = 'standard'): readonly string[] {

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { asDateString, asTagValue } from '@costgoblin/core/browser';
+import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser';
 import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
@@ -50,7 +50,30 @@ function priorityFor(d: Dimension): number {
   return 4;
 }
 
+function formatHour(d: Date): string {
+  return `${d.toISOString().slice(0, 10)} ${String(d.getUTCHours()).padStart(2, '0')}:00:00`;
+}
+
 function previousRangeFor(dr: DateRange): DateRange {
+  // Sub-day window (drag-zoom into hours): shift back by the same hour duration
+  // so the comparison is apples-to-apples (4 hours vs the prior 4 hours), not
+  // 4 hours vs the 1–2 calendar days that contain them.
+  if (dr.startHour !== undefined && dr.endHour !== undefined) {
+    const startMs = new Date(`${String(dr.startHour).slice(0, 10)}T${String(dr.startHour).slice(11, 19)}Z`).getTime();
+    const endMs = new Date(`${String(dr.endHour).slice(0, 10)}T${String(dr.endHour).slice(11, 19)}Z`).getTime();
+    const hourMs = 60 * 60 * 1000;
+    const durationHours = Math.round((endMs - startMs) / hourMs) + 1;
+    const prevEndMs = startMs - hourMs;
+    const prevStartMs = prevEndMs - (durationHours - 1) * hourMs;
+    const prevStartHour = formatHour(new Date(prevStartMs));
+    const prevEndHour = formatHour(new Date(prevEndMs));
+    return {
+      start: asDateString(prevStartHour.slice(0, 10)),
+      end: asDateString(prevEndHour.slice(0, 10)),
+      startHour: asHourString(prevStartHour),
+      endHour: asHourString(prevEndHour),
+    };
+  }
   const periodDays = daysBetween(dr.start, dr.end);
   const prevEnd = new Date(new Date(dr.start).getTime() - 24 * 60 * 60 * 1000);
   const prevStart = new Date(prevEnd.getTime() - (periodDays - 1) * 24 * 60 * 60 * 1000);

--- a/packages/ui/src/views/data-management-tier.tsx
+++ b/packages/ui/src/views/data-management-tier.tsx
@@ -183,6 +183,31 @@ export function TierPanel({
         </div>
       )}
 
+      {/* Local periods */}
+      {downloadedPeriods.length > 0 && (
+        <div className="rounded-lg border border-border overflow-hidden">
+          <div className="border-b border-border px-3 py-2">
+            <span className="text-xs font-medium text-text-secondary">Downloaded</span>
+          </div>
+          <div className="max-h-48 overflow-y-auto divide-y divide-border-subtle">
+            {downloadedPeriods.map(p => (
+              <div key={p.period} className="flex items-center gap-2 px-3 py-1.5 text-xs">
+                <div className="h-1.5 w-1.5 rounded-full bg-accent" />
+                <span className="text-text-primary w-16">{formatPeriod(p.period)}</span>
+                <span className="text-text-muted tabular-nums ml-auto mr-2">{formatBytes(p.totalSize)}</span>
+                <button
+                  type="button"
+                  onClick={() => { setPendingDelete(p.period); }}
+                  className="text-text-muted hover:text-negative transition-colors"
+                >
+                  &#10005;
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Missing / stale periods */}
       {missingPeriods.length > 0 && (
         <div className="rounded-lg border border-border overflow-hidden">
@@ -218,31 +243,6 @@ export function TierPanel({
               </button>
             </div>
           )}
-        </div>
-      )}
-
-      {/* Local periods */}
-      {downloadedPeriods.length > 0 && (
-        <div className="rounded-lg border border-border overflow-hidden">
-          <div className="border-b border-border px-3 py-2">
-            <span className="text-xs font-medium text-text-secondary">Downloaded</span>
-          </div>
-          <div className="max-h-48 overflow-y-auto divide-y divide-border-subtle">
-            {downloadedPeriods.map(p => (
-              <div key={p.period} className="flex items-center gap-2 px-3 py-1.5 text-xs">
-                <div className="h-1.5 w-1.5 rounded-full bg-accent" />
-                <span className="text-text-primary w-16">{formatPeriod(p.period)}</span>
-                <span className="text-text-muted tabular-nums ml-auto mr-2">{formatBytes(p.totalSize)}</span>
-                <button
-                  type="button"
-                  onClick={() => { setPendingDelete(p.period); }}
-                  className="text-text-muted hover:text-negative transition-colors"
-                >
-                  &#10005;
-                </button>
-              </div>
-            ))}
-          </div>
         </div>
       )}
 

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { DataInventoryResult, CostGoblinConfig, SyncStatus } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -79,19 +79,53 @@ export function DataManagement() {
   const [autoSyncInterval, setAutoSyncInterval] = useState(24 * 60);
   const [autoSyncIntervalLoaded, setAutoSyncIntervalLoaded] = useState(false);
 
+  // Track the previous server-side status per tier so the poller can detect a
+  // syncing→completed/failed transition. Without it, a background auto-sync that
+  // finishes between two ticks leaves the React state pinned to the last
+  // 'syncing' value (the mapper used to return null for completed/failed,
+  // skipping the setter entirely) and the inventory was never refreshed.
+  const prevServerStatusRef = useRef<Record<'daily' | 'hourly' | 'cost-optimization', SyncStatus['status'] | null>>({
+    daily: null,
+    hourly: null,
+    'cost-optimization': null,
+  });
+
   useEffect(() => {
     let cancelled = false;
-    function applyStatus(tier: 'daily' | 'hourly' | 'cost-optimization', setter: (s: SyncState) => void) {
+    function applyStatus(
+      tier: 'daily' | 'hourly' | 'cost-optimization',
+      setter: (s: SyncState) => void,
+      bumpRefresh: () => void,
+    ) {
       api.getSyncStatus(tier).then(s => {
         if (cancelled) return;
-        const mapped = syncStatusToState(s);
-        if (mapped !== null) setter(mapped);
+        const prev = prevServerStatusRef.current[tier];
+        prevServerStatusRef.current[tier] = s.status;
+
+        if (s.status === 'syncing') {
+          const mapped = syncStatusToState(s);
+          if (mapped !== null) setter(mapped);
+          return;
+        }
+        // Only react to terminal states when we directly observed the
+        // syncing→terminal transition in this session — otherwise a leftover
+        // 'completed' from a prior session would keep flashing the "synced N
+        // files" message every time the user opens this page.
+        if (prev !== 'syncing') return;
+        if (s.status === 'completed') {
+          setter({ status: 'done', filesDownloaded: s.filesDownloaded });
+          bumpRefresh();
+        } else if (s.status === 'failed') {
+          setter({ status: 'error', message: s.error.message });
+        } else {
+          setter({ status: 'idle' });
+        }
       }).catch(() => undefined);
     }
     function tick() {
-      applyStatus('daily', setDailySyncState);
-      applyStatus('hourly', setHourlySyncState);
-      applyStatus('cost-optimization', setCostOptSyncState);
+      applyStatus('daily', setDailySyncState, () => { setDailyRefreshKey(k => k + 1); });
+      applyStatus('hourly', setHourlySyncState, () => { setHourlyRefreshKey(k => k + 1); });
+      applyStatus('cost-optimization', setCostOptSyncState, () => { setCostOptRefreshKey(k => k + 1); });
     }
     tick();
     const timer = setInterval(tick, 2_000);

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -7,7 +7,7 @@ import type {
   EntityDetailResult,
   FilterMap,
 } from '@costgoblin/core/browser';
-import { asDateString, asDimensionId, asEntityRef, asTagValue } from '@costgoblin/core/browser';
+import { asDateString, asDimensionId, asEntityRef, asHourString, asTagValue } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -21,7 +21,7 @@ import type { PieSlice } from '../components/pie-chart.js';
 import { StackedBarChart, bucketBars } from '../components/stacked-bar-chart.js';
 import type { BarDay, HistogramTab } from '../components/stacked-bar-chart.js';
 import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension } from '../lib/dimensions.js';
-import { computeBucketedRange, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { computeBucketedHourRange, computeBucketedRange, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 
 interface EntityDetailProps {
   entity: string;
@@ -215,6 +215,24 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const barDays = bucketBars(dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null), 170);
 
   const handleHistogramRangeSelect = useCallback((startIdx: number, endIdx: number) => {
+    if (granularity === 'hourly') {
+      // Hourly bars carry "YYYY-MM-DD HH:00" keys — preserve the hour info so
+      // the rest of the page (totals, pies, breakdown) filters on the same
+      // sub-day window the user dragged across.
+      const fallbackEndHour = `${String(dateRange.end)} 23:00:00`;
+      const hourRange = computeBucketedHourRange(barDays, startIdx, endIdx, fallbackEndHour);
+      if (hourRange === null) return;
+      const startDate = hourRange.startHour.slice(0, 10);
+      const endDate = hourRange.endHour.slice(0, 10);
+      setDateRange({
+        start: asDateString(startDate),
+        end: asDateString(endDate),
+        startHour: asHourString(hourRange.startHour),
+        endHour: asHourString(hourRange.endHour),
+      });
+      setHourlyHint(false);
+      return;
+    }
     const range = computeBucketedRange(barDays, startIdx, endIdx, dateRange.end);
     if (range === null) return;
     const { startDate, endDate } = range;

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -95,7 +95,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
     columnOrder: [],
   });
 
-  const dateRangeKey = `${dateRange.start}_${dateRange.end}`;
+  const dateRangeKey = `${dateRange.start}_${dateRange.end}_${String(dateRange.startHour ?? '')}_${String(dateRange.endHour ?? '')}`;
   const entityFilter: FilterMap = { [asDimensionId(dimension)]: [asTagValue(entity)] };
   const filterKey = JSON.stringify(entityFilter);
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -13,7 +13,7 @@ import type {
   ExplorerSort,
   Granularity,
 } from '@costgoblin/core/browser';
-import { asDateString } from '@costgoblin/core/browser';
+import { asDateString, asHourString } from '@costgoblin/core/browser';
 import type { SortingState } from '@tanstack/react-table';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
@@ -26,7 +26,7 @@ import { DateRangePicker, getDefaultDateRange } from '../components/date-range-p
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { getDimensionId } from '../lib/dimensions.js';
-import { bucketKeyToDate, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { bucketKeyToDate, normalizeHourKey, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import type { TableColumn } from '../lib/table-types.js';
 
 const DEBOUNCE_MS = 250;
@@ -392,6 +392,21 @@ export function ExplorerView(): React.JSX.Element {
     const startBar = dailyTotals[startIdx];
     const endBar = dailyTotals[endIdx];
     if (startBar === undefined || endBar === undefined) return;
+    if (granularity === 'hourly') {
+      // Each bar is one hour bucket — keep the hour info so the rest of
+      // the Explorer (overview totals, table) filters on the same window.
+      const startHour = normalizeHourKey(startBar.date);
+      const endHour = normalizeHourKey(endBar.date);
+      if (startHour === null || endHour === null) return;
+      setDateRange({
+        start: asDateString(startHour.slice(0, 10)),
+        end: asDateString(endHour.slice(0, 10)),
+        startHour: asHourString(startHour),
+        endHour: asHourString(endHour),
+      });
+      setHourlyHint(false);
+      return;
+    }
     const startDate = bucketKeyToDate(startBar.date);
     const endDate = bucketKeyToDate(endBar.date);
     setDateRange({ start: asDateString(startDate), end: asDateString(endDate) });

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -26,7 +26,7 @@ import { DateRangePicker, getDefaultDateRange } from '../components/date-range-p
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { getDimensionId } from '../lib/dimensions.js';
-import { bucketKeyToDate, normalizeHourKey, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
+import { bucketKeyToDate, formatBucketKey, normalizeHourKey, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import type { TableColumn } from '../lib/table-types.js';
 
 const DEBOUNCE_MS = 250;
@@ -643,12 +643,20 @@ const Y_TICKS = [1, 0.75, 0.5, 0.25, 0] as const;
 function Histogram({ days, loading, onRangeSelect }: HistogramProps): React.JSX.Element {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const barsRef = useRef<HTMLDivElement>(null);
-  const { isDragging, overlay, handleMouseDown } = useBarDragSelect({
+  const { isDragging, overlay, selection, handleMouseDown } = useBarDragSelect({
     containerRef: barsRef,
     bucketCount: days.length,
     onRangeSelect,
     disabled: onRangeSelect === undefined || loading,
   });
+
+  const dragLabels = (() => {
+    if (selection === null) return null;
+    const startBar = days[selection.startIdx];
+    const endBar = days[selection.endIdx];
+    if (startBar === undefined || endBar === undefined) return null;
+    return { start: formatBucketKey(startBar.date), end: formatBucketKey(endBar.date) };
+  })();
 
   if (loading) {
     return <CoinRainLoader height={CHART_HEIGHT} count={6} />;
@@ -746,6 +754,22 @@ function Histogram({ days, loading, onRangeSelect }: HistogramProps): React.JSX.
               className="pointer-events-none absolute top-0 bottom-0 bg-accent/20 border-l border-r border-accent z-30"
               style={{ left: overlay.left, width: overlay.width }}
             />
+          )}
+          {overlay !== null && dragLabels !== null && (
+            <>
+              <div
+                className="pointer-events-none absolute -top-5 z-40 -translate-x-1/2 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-bg-primary shadow whitespace-nowrap tabular-nums"
+                style={{ left: overlay.left }}
+              >
+                {dragLabels.start}
+              </div>
+              <div
+                className="pointer-events-none absolute -top-5 z-40 -translate-x-1/2 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-bg-primary shadow whitespace-nowrap tabular-nums"
+                style={{ left: overlay.left + overlay.width }}
+              >
+                {dragLabels.end}
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -8,6 +8,7 @@ import type { DimensionId, TrendResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
+import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 
 const DEFAULT_DELTA_THRESHOLD = asDollars(50);
 const DEFAULT_PERCENT_THRESHOLD = 5;
@@ -25,6 +26,8 @@ export function BubbleWidget({
   onEntityClick,
 }: WidgetCommonProps) {
   const api = useCostApi();
+  const focus = useCostFocus();
+  const dispatch = useCostFocusDispatch();
   const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'bubble' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
@@ -65,6 +68,8 @@ export function BubbleWidget({
         data={data}
         logScale={spec.logScale}
         onEntityClick={(entity) => { onEntityClick?.(entity, effectiveGroupBy); }}
+        externalHoveredName={focus.hoveredDimension === effectiveGroupBy ? focus.hoveredEntity : null}
+        onEntityHover={(name) => { dispatch({ type: 'HOVER', entity: name, dimension: effectiveGroupBy }); }}
       />
     </div>
   );

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -41,7 +41,7 @@ export function BubbleWidget({
           deltaThreshold: DEFAULT_DELTA_THRESHOLD,
           percentThreshold: DEFAULT_PERCENT_THRESHOLD,
         }),
-    [effectiveGroupBy, dateRange.start, dateRange.end, fk, api],
+    [effectiveGroupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, api],
   );
 
   const data = useMemo(

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -81,7 +81,7 @@ export function LineWidget({
     () => compareEnabled && effectiveGroupBy !== undefined
       ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 
   const series = useMemo(

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -4,7 +4,7 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { StackedBarChart, bucketBars, type BarDay } from '../components/stacked-bar-chart.js';
 import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser';
-import { useCostFocus } from '../hooks/use-cost-focus.js';
+import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
@@ -56,6 +56,7 @@ export function StackedBarWidget({
 }: WidgetCommonProps) {
   const api = useCostApi();
   const focus = useCostFocus();
+  const dispatch = useCostFocusDispatch();
   const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
@@ -136,15 +137,25 @@ export function StackedBarWidget({
     title = <GroupByTitle dimensions={dimensions} currentGroupBy={activeGroupBy} onGroupByChange={setGroupByOverride} label={label} />;
   }
 
+  // Cross-chart focus is dimension-scoped: only honour an external hover when
+  // it came from a chart grouped by the same dimension as us. Otherwise the
+  // histogram would dim every bar when the user hovered, say, a Team slice.
+  const externalHighlight = activeGroupBy !== undefined && focus.hoveredDimension === activeGroupBy
+    ? focus.hoveredEntity
+    : null;
+
   return (
     <StackedBarChart
       days={loading ? [] : barDays}
-      highlightedGroup={focus.hoveredEntity}
+      highlightedGroup={externalHighlight}
       title={title}
       loading={loading}
       onSegmentClick={activeGroupBy === undefined ? undefined : (name) => { onSetFilter(activeGroupBy, asTagValue(name)); }}
       previousTotals={compareEnabled ? previousTotals : undefined}
       onRangeSelect={onDateRangeChange === undefined ? undefined : handleRangeSelect}
+      onSegmentHover={activeGroupBy === undefined ? undefined : (name) => {
+        dispatch({ type: 'HOVER', entity: name, dimension: activeGroupBy });
+      }}
     />
   );
 }

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -74,7 +74,7 @@ export function StackedBarWidget({
     () => compareEnabled && effectiveGroupBy !== undefined
       ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 
   const barDays = useMemo(
@@ -83,7 +83,7 @@ export function StackedBarWidget({
       const filled = granularity === 'daily' ? fillDateRange(raw, dateRange.start, dateRange.end) : raw;
       return bucketBars(filled, MAX_BARS);
     },
-    [dailyResult, granularity, dateRange.start, dateRange.end],
+    [dailyResult, granularity, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour],
   );
 
   const prevHasCoverage = prevQuery.status === 'success' && prevQuery.data !== null && hasSufficientDailyCoverage(prevQuery.data, previousDateRange);

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -3,13 +3,13 @@ import { useDailyWidgetQuery } from '../hooks/use-widget-query.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { StackedBarChart, bucketBars, type BarDay } from '../components/stacked-bar-chart.js';
-import { asDateString, asTagValue } from '@costgoblin/core/browser';
+import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser';
 import { useCostFocus } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
-import { computeBucketedRange } from '../lib/drag-select.js';
+import { computeBucketedHourRange, computeBucketedRange } from '../lib/drag-select.js';
 
 const MAX_BARS = 170;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -105,13 +105,25 @@ export function StackedBarWidget({
 
   const handleRangeSelect = useCallback((startIdx: number, endIdx: number) => {
     if (onDateRangeChange === undefined) return;
+    if (granularity === 'hourly') {
+      const fallbackEndHour = `${String(dateRange.end)} 23:00:00`;
+      const hourRange = computeBucketedHourRange(barDays, startIdx, endIdx, fallbackEndHour);
+      if (hourRange === null) return;
+      onDateRangeChange({
+        start: asDateString(hourRange.startHour.slice(0, 10)),
+        end: asDateString(hourRange.endHour.slice(0, 10)),
+        startHour: asHourString(hourRange.startHour),
+        endHour: asHourString(hourRange.endHour),
+      });
+      return;
+    }
     const range = computeBucketedRange(barDays, startIdx, endIdx, dateRange.end);
     if (range === null) return;
     onDateRangeChange({
       start: asDateString(range.startDate),
       end: asDateString(range.endDate),
     });
-  }, [barDays, dateRange.end, onDateRangeChange]);
+  }, [barDays, dateRange.end, granularity, onDateRangeChange]);
 
   if (spec.type !== 'stackedBar') return null;
 

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -25,11 +25,11 @@ export function SummaryWidget({
 
   const cur = useQuery<CostResult | null>(
     () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity }) : Promise.resolve(null),
-    [isSummary, groupBy, dateRange.start, dateRange.end, fk, granularity, api],
+    [isSummary, groupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
   );
   const prev = useQuery<CostResult | null>(
     () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity }) : Promise.resolve(null),
-    [isSummary, compareEnabled, groupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [isSummary, compareEnabled, groupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 
   if (!isSummary) return null;

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -100,7 +100,7 @@ export function TableWidget({
 
   const overviewQuery = useQuery(
     () => api.queryExplorerOverview({ filters: explorerFilters, dateRange, granularity }),
-    [fk, dateRange.start, dateRange.end, granularity, api],
+    [fk, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, granularity, api],
   );
 
   const tagColumns = overviewQuery.status === 'success' ? overviewQuery.data.tagColumns : [];
@@ -130,7 +130,7 @@ export function TableWidget({
       ...(sort === undefined ? {} : { sort }),
       rowLimit: ROW_LIMIT,
     }),
-    [fk, dateRange.start, dateRange.end, granularity, groupByKey, sort?.column, sort?.direction, api],
+    [fk, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, granularity, groupByKey, sort?.column, sort?.direction, api],
   );
 
   const prevDataQuery = useQuery(
@@ -144,7 +144,7 @@ export function TableWidget({
           rowLimit: ROW_LIMIT,
         })
       : Promise.resolve(null),
-    [compareEnabled, fk, previousDateRange.start, previousDateRange.end, granularity, groupByKey, api],
+    [compareEnabled, fk, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, granularity, groupByKey, api],
   );
 
   const prevCostMap = useMemo(() => {

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -58,7 +58,7 @@ export function TopNBarWidget({
     () => compareEnabled && effectiveGroupBy !== undefined
       ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 
   const bars = useMemo(

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -53,7 +53,7 @@ export function TreemapWidget({
     () => compareEnabled && effectiveGroupBy !== undefined
       ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 
   const cells = useMemo(


### PR DESCRIPTION
Closes #280.

Started as hour-level date ranges so the histogram drag-zoom can land on a sub-day window, then expanded into related UX polish that surfaced once that feature actually worked end-to-end.

## Hour-level drag-zoom (#280)
- New \`HourString\` brand (\`YYYY-MM-DD HH:00:00\`) + \`assertHourString\` SQL-injection guard. \`DateRange\` extended with optional \`startHour\`/\`endHour\` as an additive refinement on the day-level start/end.
- Query builders pick \`usage_hour BETWEEN ::TIMESTAMP\` when hour bounds are set, and the read is promoted to the hourly Parquet tier so the column exists. Applied across \`buildCostQuery\`, \`buildDailyCostsQuery\`, \`buildEntityDetailQuery\`, \`buildMissingTagsQuery\`, \`buildNonResourceCostQuery\`. The materialized base table (daily-tier only) is bypassed when hour bounds are set.
- Explorer's \`prepareQueryContext\` / \`buildFreshSource\` now also honour hour bounds and force the hourly tier — without this, drag-zoom on the Explorer histogram silently re-fetched whole-day data.
- Mid-hour CUR fee timestamps (SavingsPlanFee, RIFee, Tax, Refund) round to the nearest hour bucket so they no longer get their own \`11:56\` bar in the histogram.
- New \`computeBucketedHourRange\` and \`normalizeHourKey\`. \`StackedBarWidget\`, \`EntityDetail\`, and \`Explorer\` drag handlers branch on granularity and emit hour bounds for hourly bars.
- Picker shows \`Apr 30 14:00 → Apr 30 17:00\` in the trigger label when bounds are present; preset / custom-calendar / Daily-toggle clear them.
- Every widget's \`useQuery\` dep array now watches \`startHour\`/\`endHour\` so a drag that stays within the same calendar-day pair still triggers a refetch (\`use-widget-query.ts\`, \`stacked-bar\`, \`summary\`, \`table\`, \`bubble\`, \`top-n-bar\`, \`treemap\`, \`line\`, \`entity-detail\`'s \`dateRangeKey\`).
- Compare-to-previous: \`previousRangeFor\` propagates hour bounds (subtracts by hour duration) so a 4-hour current period compares to the prior 4 hours instead of the prior 2 calendar days.

## Drag-zoom UX
- Live edge labels at the overlay boundaries during drag — hourly buckets show \`May 1 14:00\`, daily ones show \`May 1\` — so the user can see the window before releasing.
- Majority-coverage selection rule: a bar is included only if more than half of it is under the overlay, so deliberate overshoot on the start/end no longer captures boundary bars. Falls back to the bar at the drag midpoint when the drag is too narrow.

## Cross-chart hover sync
- Histogram and bubble charts now broadcast hover into \`useCostFocus\` (filtered by dimension) and read it back, matching what pie / top-n-bar / treemap already did. Hovering an AmazonRDS slice highlights the same series in the histogram and AWS Service bubble; hovering an histogram segment or tooltip row does the reverse.
- Bubble flicker fix: only dispatch \`HOVER\` when the pointed-at bubble actually changes (was firing on every visx mousemove tick, ~60/s).
- Stuck-hover hardening: every chart's outer card has an \`onMouseLeave\` that clears the focus, in addition to per-element handlers — protects against missed leaves from layout shifts on hover or fast edge exits.
- Histogram's focused segment now has full opacity + brightness boost + thin inset white outline so it reads as "selected" instead of just being slightly less faded than its dimmed peers.
- Hovering a row in the histogram tooltip propagates the same focus signal as hovering a segment in a bar.

## Other polish
- 16-color curated palette per theme (was 8) plus a deterministic golden-angle HSL fallback for indices past the curated range, so charts with 50+ services no longer have the 1st and 9th rendering in the same green.
- Data Management: list "Downloaded" tier above "Available", and have the 2-second sync-status poller transition to \`done\` (with file count) and refresh inventory when it observes an auto-sync \`syncing → completed\` transition. Previously the React state was pinned to the last \`syncing\` value because the mapper returned null for terminal states.

## Tests
- \`assertHourString\` happy/sad/SQL-injection paths.
- \`computeBucketedHourRange\` and \`normalizeHourKey\` boundary cases.
- One builder test per affected category asserting that hour bounds switch all five builders to \`usage_hour\` + hourly tier and that builders without hour bounds keep the day-level filter.

## Out of scope
- Custom hour entry in the picker (drag-on-histogram remains the only way to set sub-day windows).
- "Last N hours" presets.
- \`buildTrendQuery\` and \`buildMaterializeBaseQuery\` left alone — trend's previous-period concept doesn't fit cleanly with sub-day windows; the materialize warmup uses an internally-computed daily range that never carries hour bounds.