### PR TITLE
Org Tree Visual Editor with Drag-and-Drop

### DIFF
--- a/packages/core/src/__tests__/org-tree-edit.test.ts
+++ b/packages/core/src/__tests__/org-tree-edit.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pathsEqual,
+  isPathDescendantOf,
+  getNodeAtPath,
+  updateNodeAtPath,
+  removeNodeAtPath,
+  insertNodeAtPath,
+  moveNode,
+  appendChild,
+} from '../models/org-tree-edit.js';
+import type { OrgNode } from '../types/config.js';
+
+const tree: readonly OrgNode[] = [
+  {
+    name: 'engineering',
+    virtual: true,
+    children: [
+      { name: 'platform', children: [{ name: 'backend' }, { name: 'frontend' }] },
+      { name: 'data', children: [{ name: 'analytics' }] },
+    ],
+  },
+  { name: 'growth' },
+];
+
+describe('pathsEqual', () => {
+  it('compares paths', () => {
+    expect(pathsEqual([0, 1], [0, 1])).toBe(true);
+    expect(pathsEqual([], [])).toBe(true);
+    expect(pathsEqual([0, 1], [0, 2])).toBe(false);
+    expect(pathsEqual([0], [0, 0])).toBe(false);
+  });
+});
+
+describe('isPathDescendantOf', () => {
+  it('true for self and descendants', () => {
+    expect(isPathDescendantOf([0, 1], [0, 1])).toBe(true);
+    expect(isPathDescendantOf([0, 1, 2], [0, 1])).toBe(true);
+  });
+
+  it('false for non-descendants', () => {
+    expect(isPathDescendantOf([0], [0, 1])).toBe(false);
+    expect(isPathDescendantOf([1], [0])).toBe(false);
+  });
+});
+
+describe('getNodeAtPath', () => {
+  it('returns the node at the path', () => {
+    expect(getNodeAtPath(tree, [0])?.name).toBe('engineering');
+    expect(getNodeAtPath(tree, [0, 0, 1])?.name).toBe('frontend');
+  });
+
+  it('returns undefined for invalid path', () => {
+    expect(getNodeAtPath(tree, [9])).toBeUndefined();
+    expect(getNodeAtPath(tree, [0, 9])).toBeUndefined();
+    expect(getNodeAtPath(tree, [1, 0])).toBeUndefined();
+  });
+});
+
+describe('updateNodeAtPath', () => {
+  it('renames a leaf', () => {
+    const next = updateNodeAtPath(tree, [0, 0, 0], (n) => ({ ...n, name: 'api' }));
+    expect(getNodeAtPath(next, [0, 0, 0])?.name).toBe('api');
+    expect(getNodeAtPath(tree, [0, 0, 0])?.name).toBe('backend');
+  });
+
+  it('returns the same tree on invalid path', () => {
+    const next = updateNodeAtPath(tree, [9], (n) => n);
+    expect(next).toBe(tree);
+  });
+});
+
+describe('removeNodeAtPath', () => {
+  it('removes a root node', () => {
+    const next = removeNodeAtPath(tree, [1]);
+    expect(next).toHaveLength(1);
+    expect(next[0]?.name).toBe('engineering');
+  });
+
+  it('removes a deeply nested node', () => {
+    const next = removeNodeAtPath(tree, [0, 0, 1]);
+    expect(getNodeAtPath(next, [0, 0])?.children).toHaveLength(1);
+    expect(getNodeAtPath(next, [0, 0, 0])?.name).toBe('backend');
+  });
+
+  it('no-op on invalid path', () => {
+    expect(removeNodeAtPath(tree, [])).toBe(tree);
+    expect(removeNodeAtPath(tree, [9])).toEqual(tree);
+  });
+});
+
+describe('insertNodeAtPath', () => {
+  it('inserts at root', () => {
+    const next = insertNodeAtPath(tree, [], 1, { name: 'new' });
+    expect(next.map(n => n.name)).toEqual(['engineering', 'new', 'growth']);
+  });
+
+  it('inserts as a child', () => {
+    const next = insertNodeAtPath(tree, [0, 0], 0, { name: 'first' });
+    const platformChildren = getNodeAtPath(next, [0, 0])?.children ?? [];
+    expect(platformChildren.map(n => n.name)).toEqual(['first', 'backend', 'frontend']);
+  });
+
+  it('clamps to bounds', () => {
+    const next = insertNodeAtPath(tree, [], 100, { name: 'last' });
+    expect(next[next.length - 1]?.name).toBe('last');
+  });
+});
+
+describe('moveNode', () => {
+  it('moves across parents', () => {
+    const next = moveNode(tree, [0, 0, 0], [0, 1], 0);
+    expect(getNodeAtPath(next, [0, 0])?.children).toHaveLength(1);
+    expect(getNodeAtPath(next, [0, 1, 0])?.name).toBe('backend');
+  });
+
+  it('reorders within the same parent', () => {
+    const next = moveNode(tree, [0, 0, 0], [0, 0], 2);
+    const platformChildren = getNodeAtPath(next, [0, 0])?.children ?? [];
+    expect(platformChildren.map(n => n.name)).toEqual(['frontend', 'backend']);
+  });
+
+  it('refuses to move a node into its own subtree', () => {
+    const next = moveNode(tree, [0], [0, 0], 0);
+    expect(next).toBe(tree);
+  });
+
+  it('moves a root node into a child position', () => {
+    const next = moveNode(tree, [1], [0], 0);
+    expect(next).toHaveLength(1);
+    expect(getNodeAtPath(next, [0, 0])?.name).toBe('growth');
+  });
+});
+
+describe('appendChild', () => {
+  it('appends at root', () => {
+    const { tree: next, path } = appendChild(tree, [], { name: 'ml' });
+    expect(path).toEqual([2]);
+    expect(getNodeAtPath(next, [2])?.name).toBe('ml');
+  });
+
+  it('appends as a child of an internal node', () => {
+    const { tree: next, path } = appendChild(tree, [0, 0], { name: 'shared' });
+    expect(path).toEqual([0, 0, 2]);
+    expect(getNodeAtPath(next, [0, 0, 2])?.name).toBe('shared');
+  });
+
+  it('appends as the first child of a leaf', () => {
+    const { tree: next, path } = appendChild(tree, [1], { name: 'sub' });
+    expect(path).toEqual([1, 0]);
+    expect(getNodeAtPath(next, [1, 0])?.name).toBe('sub');
+  });
+});

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,4 +4,5 @@ export { validateViews } from './views-validator.js';
 export { validateCostScope } from './cost-scope-validator.js';
 export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './views-serialize.js';
 export { costScopeToYaml } from './cost-scope-serialize.js';
+export { orgTreeToYaml } from './org-tree-serialize.js';
 export { BUILTIN_EXCLUSION_RULES, DEFAULT_COST_SCOPE, mergeBuiltInExclusionRules } from './cost-scope-seed.js';

--- a/packages/core/src/config/org-tree-serialize.ts
+++ b/packages/core/src/config/org-tree-serialize.ts
@@ -1,0 +1,23 @@
+import type { OrgNode, OrgTreeConfig } from '../types/config.js';
+
+/** YAML-ready shape for a single org tree node. Keeps keys in a stable order so
+ *  round-tripping a config doesn't produce noisy diffs. */
+function nodeToYaml(node: OrgNode): Record<string, unknown> {
+  const out: Record<string, unknown> = { name: node.name };
+
+  if (node.virtual === true) {
+    out['virtual'] = true;
+  }
+
+  if (node.children !== undefined && node.children.length > 0) {
+    out['children'] = node.children.map(nodeToYaml);
+  }
+
+  return out;
+}
+
+export function orgTreeToYaml(config: OrgTreeConfig): { tree: unknown[] } {
+  return {
+    tree: config.tree.map(nodeToYaml),
+  };
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -5,3 +5,14 @@ export {
   getAllLeafValues,
   findUnassignedValues,
 } from './org-tree.js';
+export {
+  pathsEqual,
+  isPathDescendantOf,
+  getNodeAtPath,
+  updateNodeAtPath,
+  removeNodeAtPath,
+  insertNodeAtPath,
+  moveNode,
+  appendChild,
+} from './org-tree-edit.js';
+export type { NodePath } from './org-tree-edit.js';

--- a/packages/core/src/models/org-tree-edit.ts
+++ b/packages/core/src/models/org-tree-edit.ts
@@ -1,0 +1,132 @@
+import type { OrgNode } from '../types/config.js';
+
+/** Path to a node = sibling indices from root. `[0, 2, 1]` means
+ *  `tree[0].children[2].children[1]`. */
+export type NodePath = readonly number[];
+
+export function pathsEqual(a: NodePath, b: NodePath): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** True if `descendant` is `ancestor` itself or any node beneath it. Used to
+ *  prevent dropping a node into its own subtree. */
+export function isPathDescendantOf(descendant: NodePath, ancestor: NodePath): boolean {
+  if (descendant.length < ancestor.length) return false;
+  for (let i = 0; i < ancestor.length; i++) {
+    if (descendant[i] !== ancestor[i]) return false;
+  }
+  return true;
+}
+
+function getNode(tree: readonly OrgNode[], path: NodePath): OrgNode | undefined {
+  let current: readonly OrgNode[] | undefined = tree;
+  let node: OrgNode | undefined;
+  for (const idx of path) {
+    if (current === undefined || idx < 0 || idx >= current.length) return undefined;
+    node = current[idx];
+    current = node?.children;
+  }
+  return node;
+}
+
+export function getNodeAtPath(tree: readonly OrgNode[], path: NodePath): OrgNode | undefined {
+  return getNode(tree, path);
+}
+
+export function updateNodeAtPath(
+  tree: readonly OrgNode[],
+  path: NodePath,
+  updater: (node: OrgNode) => OrgNode,
+): readonly OrgNode[] {
+  if (path.length === 0) return tree;
+  const [index, ...rest] = path;
+  if (index === undefined || index < 0 || index >= tree.length) return tree;
+  return tree.map((node, idx) => {
+    if (idx !== index) return node;
+    if (rest.length === 0) return updater(node);
+    if (node.children === undefined) return node;
+    return { ...node, children: updateNodeAtPath(node.children, rest, updater) };
+  });
+}
+
+export function removeNodeAtPath(tree: readonly OrgNode[], path: NodePath): readonly OrgNode[] {
+  if (path.length === 0) return tree;
+  if (path.length === 1) {
+    const idx = path[0];
+    if (idx === undefined || idx < 0 || idx >= tree.length) return tree;
+    return [...tree.slice(0, idx), ...tree.slice(idx + 1)];
+  }
+  const parentPath = path.slice(0, -1);
+  const lastIdx = path[path.length - 1];
+  if (lastIdx === undefined) return tree;
+  return updateNodeAtPath(tree, parentPath, (parent) => {
+    const children = parent.children ?? [];
+    if (lastIdx < 0 || lastIdx >= children.length) return parent;
+    return { ...parent, children: [...children.slice(0, lastIdx), ...children.slice(lastIdx + 1)] };
+  });
+}
+
+/** Insert `node` as a child of the node at `parentPath` at position `insertIdx`.
+ *  `parentPath = []` inserts into the root array. */
+export function insertNodeAtPath(
+  tree: readonly OrgNode[],
+  parentPath: NodePath,
+  insertIdx: number,
+  node: OrgNode,
+): readonly OrgNode[] {
+  if (parentPath.length === 0) {
+    const clamped = Math.max(0, Math.min(insertIdx, tree.length));
+    return [...tree.slice(0, clamped), node, ...tree.slice(clamped)];
+  }
+  return updateNodeAtPath(tree, parentPath, (parent) => {
+    const children = parent.children ?? [];
+    const clamped = Math.max(0, Math.min(insertIdx, children.length));
+    return { ...parent, children: [...children.slice(0, clamped), node, ...children.slice(clamped)] };
+  });
+}
+
+/** Move the node at `fromPath` to be a child of `toParentPath` at index
+ *  `toIdx`. No-op if the move would put a node inside its own subtree. */
+export function moveNode(
+  tree: readonly OrgNode[],
+  fromPath: NodePath,
+  toParentPath: NodePath,
+  toIdx: number,
+): readonly OrgNode[] {
+  if (isPathDescendantOf(toParentPath, fromPath)) return tree;
+  const node = getNode(tree, fromPath);
+  if (node === undefined) return tree;
+
+  const removed = removeNodeAtPath(tree, fromPath);
+
+  const fromParent = fromPath.slice(0, -1);
+  const fromIdx = fromPath[fromPath.length - 1];
+  let adjustedIdx = toIdx;
+  if (pathsEqual(fromParent, toParentPath) && fromIdx !== undefined && toIdx > fromIdx) {
+    adjustedIdx = toIdx - 1;
+  }
+  return insertNodeAtPath(removed, toParentPath, adjustedIdx, node);
+}
+
+/** Append `node` as the last child of the node at `parentPath`, returning the
+ *  new tree and the path of the inserted node. `parentPath = []` appends at
+ *  root. */
+export function appendChild(
+  tree: readonly OrgNode[],
+  parentPath: NodePath,
+  node: OrgNode,
+): { tree: readonly OrgNode[]; path: NodePath } {
+  if (parentPath.length === 0) {
+    return { tree: [...tree, node], path: [tree.length] };
+  }
+  const parent = getNode(tree, parentPath);
+  const childCount = parent?.children?.length ?? 0;
+  return {
+    tree: insertNodeAtPath(tree, parentPath, childCount, node),
+    path: [...parentPath, childCount],
+  };
+}

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -100,6 +100,7 @@ export interface CostApi {
   getConfig(): Promise<CostGoblinConfig>;
   getDimensions(): Promise<Dimension[]>;
   getOrgTree(): Promise<OrgNode[]>;
+  saveOrgTree(tree: readonly OrgNode[]): Promise<void>;
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult>;
   syncPeriods(files: readonly { key: string; contentHash: string; size: number }[], syncId?: string): Promise<{ filesDownloaded: number; rowsProcessed: number }>;
   cancelSync(syncId?: string): Promise<void>;

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -155,6 +155,7 @@ export interface AppContext {
   readonly runPreparedQuery: (sql: string, params: readonly unknown[], materialized?: boolean) => Promise<RawRow[]>;
   readonly invalidateConfig: () => void;
   readonly invalidateDimensions: () => void;
+  readonly invalidateOrgTree: () => void;
   readonly invalidateViews: () => void;
   readonly invalidateCostScope: () => void;
   readonly invalidateColumnCache: () => void;
@@ -518,6 +519,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
       state.dimensions = null; state.accountMap = null; state.accountReverseMap = null; state.regionMap = null; state.orgAccountsPath = null;
       void materializedBase.drop((s) => ctx.db.runQuery(s), () => { resultCache.clear(); }).then(() => { void warmupBase(); });
     },
+    invalidateOrgTree: () => { state.orgTree = null; },
     invalidateViews: () => { state.views = null; },
     invalidateCostScope: () => {
       state.costScope = null;

--- a/packages/desktop/src/main/handlers/org-tree.ts
+++ b/packages/desktop/src/main/handlers/org-tree.ts
@@ -1,0 +1,15 @@
+import { ipcMain } from 'electron';
+import { writeFile } from 'node:fs/promises';
+import { stringify } from 'yaml';
+import { validateOrgTree, orgTreeToYaml } from '@costgoblin/core';
+import type { AppContext } from './context.js';
+
+export function registerOrgTreeHandlers(app: AppContext): void {
+  const { ctx, invalidateOrgTree } = app;
+
+  ipcMain.handle('org-tree:save', async (_event, raw: unknown): Promise<void> => {
+    const validated = validateOrgTree({ tree: raw });
+    await writeFile(ctx.orgTreePath, stringify(orgTreeToYaml(validated)));
+    invalidateOrgTree();
+  });
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -13,6 +13,7 @@ import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
 import { registerDebugHandlers } from './handlers/debug.js';
 import { registerMcpHandlers } from './handlers/mcp-handler.js';
+import { registerOrgTreeHandlers } from './handlers/org-tree.js';
 
 export type { AppContext, IpcContext } from './handlers/context.js';
 
@@ -32,6 +33,7 @@ export function registerIpcHandlers(ctx: IpcContext): AppContext {
   registerExplorerHandlers(app);
   registerDebugHandlers(app);
   registerMcpHandlers(app);
+  registerOrgTreeHandlers(app);
 
   app.warmupBase();
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -121,6 +121,9 @@ const api: CostApi = {
   getOrgTree(): Promise<OrgNode[]> {
     return invoke<OrgNode[]>('config:org-tree');
   },
+  saveOrgTree(tree: readonly OrgNode[]): Promise<void> {
+    return invoke<undefined>('org-tree:save', tree).then(() => undefined);
+  },
   getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]> {
     return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange, opts, origin);
   },

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -194,6 +194,8 @@ const orgTree: OrgNode[] = [
 ];
 
 export class MockCostApi implements CostApi {
+  private currentOrgTree: OrgNode[] = orgTree;
+
   queryCosts(): Promise<CostResult> { return Promise.resolve(costResult); }
   queryDailyCosts(): Promise<DailyCostsResult> {
     const days = Array.from({ length: 30 }, (_, i) => {
@@ -232,7 +234,11 @@ export class MockCostApi implements CostApi {
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
   getConfig(): Promise<CostGoblinConfig> { return Promise.resolve(config); }
   getDimensions(): Promise<Dimension[]> { return Promise.resolve(mockDimensions); }
-  getOrgTree(): Promise<OrgNode[]> { return Promise.resolve(orgTree); }
+  getOrgTree(): Promise<OrgNode[]> { return Promise.resolve(this.currentOrgTree); }
+  saveOrgTree(tree: readonly OrgNode[]): Promise<void> {
+    this.currentOrgTree = [...tree];
+    return Promise.resolve();
+  }
   getFilterValues(): Promise<{ value: string; label: string; count: number }[]> { return Promise.resolve([]); }
   getDataInventory(): Promise<DataInventoryResult> { return Promise.resolve({ periods: [], totalRemoteSize: 0, totalLocalPeriods: 0, totalRemotePeriods: 0, local: { periods: [], diskBytes: 0, oldestPeriod: null, newestPeriod: null } }); }
   syncPeriods(): Promise<{ filesDownloaded: number; rowsProcessed: number }> { return Promise.resolve({ filesDownloaded: 0, rowsProcessed: 0 }); }

--- a/packages/ui/src/components/org-tree-editor.tsx
+++ b/packages/ui/src/components/org-tree-editor.tsx
@@ -1,0 +1,604 @@
+import { useEffect, useRef, useState } from 'react';
+import { GripVertical, Check, X, Plus, Trash2, ChevronRight, ChevronDown, Folder, FileText, Layers } from 'lucide-react';
+import type { OrgNode } from '@costgoblin/core/browser';
+import {
+  findUnassignedValues,
+  pathsEqual,
+  isPathDescendantOf,
+  getNodeAtPath,
+  updateNodeAtPath,
+  removeNodeAtPath,
+  insertNodeAtPath,
+  moveNode,
+  appendChild,
+  type NodePath,
+} from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
+import { useQuery } from '../hooks/use-query.js';
+import { CoinRainLoader } from './coin-rain-loader.js';
+import { ConfirmModal } from './confirm-modal.js';
+
+interface EditingNode {
+  readonly path: NodePath;
+  readonly name: string;
+  readonly virtual: boolean;
+}
+
+interface OrgTreeEditorProps {
+  readonly onClose?: () => void;
+}
+
+/** What's being dragged. Tree nodes carry a path; unassigned entities carry
+ *  the entity name so we can append a new leaf when dropped. */
+type DragRef =
+  | { readonly source: 'tree'; readonly path: NodePath }
+  | { readonly source: 'unassigned'; readonly entityName: string };
+
+/** Where a drop will land, used purely for visual feedback. */
+type DropTarget =
+  | { readonly kind: 'into'; readonly path: NodePath }
+  | { readonly kind: 'before'; readonly path: NodePath };
+
+function dropTargetEqual(a: DropTarget | null, b: DropTarget | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.kind === b.kind && pathsEqual(a.path, b.path);
+}
+
+function NodeIcon({ virtual, isLeaf }: Readonly<{ virtual: boolean; isLeaf: boolean }>): React.JSX.Element {
+  if (virtual) return <Folder className="h-3.5 w-3.5 text-accent" aria-label="Virtual node" />;
+  if (isLeaf) return <FileText className="h-3.5 w-3.5 text-text-muted" aria-label="Leaf entity" />;
+  return <Layers className="h-3.5 w-3.5 text-text-secondary" aria-label="Parent node" />;
+}
+
+function InlineNodeEditor({ initial, onSave, onCancel }: Readonly<{
+  initial: { name: string; virtual: boolean };
+  onSave: (next: { name: string; virtual: boolean }) => void;
+  onCancel: () => void;
+}>): React.JSX.Element {
+  const [name, setName] = useState(initial.name);
+  const [virtual, setVirtual] = useState(initial.virtual);
+  const trimmed = name.trim();
+  const canSave = trimmed.length > 0;
+
+  function commit(): void {
+    if (!canSave) return;
+    onSave({ name: trimmed, virtual });
+  }
+
+  return (
+    <>
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => { setName(e.target.value); }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') { e.preventDefault(); commit(); }
+          else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+        }}
+        className="flex-1 min-w-0 bg-bg-primary border border-border rounded px-2 py-1 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
+        placeholder="Node name"
+        autoFocus
+      />
+      <label className="flex items-center gap-1.5 text-xs text-text-secondary cursor-pointer">
+        <input
+          type="checkbox"
+          checked={virtual}
+          onChange={(e) => { setVirtual(e.target.checked); }}
+          className="cursor-pointer"
+        />
+        <span>Virtual</span>
+      </label>
+      <button
+        type="button"
+        onClick={commit}
+        disabled={!canSave}
+        className="rounded p-1 bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        title="Save (Enter)"
+      >
+        <Check className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="rounded p-1 bg-bg-secondary text-text-secondary hover:bg-bg-tertiary transition-colors"
+        title="Cancel (Esc)"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </>
+  );
+}
+
+interface NodeViewProps {
+  readonly node: OrgNode;
+  readonly depth: number;
+  readonly path: NodePath;
+  readonly draggedItem: DragRef | null;
+  readonly dropTarget: DropTarget | null;
+  readonly editingNode: EditingNode | null;
+  readonly onDragStart: (path: NodePath) => void;
+  readonly onDragOverInto: (path: NodePath) => void;
+  readonly onDragOverBefore: (path: NodePath) => void;
+  readonly onDragLeave: () => void;
+  readonly onDropInto: (path: NodePath) => void;
+  readonly onDropBefore: (path: NodePath) => void;
+  readonly onDragEnd: () => void;
+  readonly onStartEdit: (path: NodePath, name: string, virtual: boolean) => void;
+  readonly onSaveEdit: (next: { name: string; virtual: boolean }) => void;
+  readonly onCancelEdit: () => void;
+  readonly onAddChild: (parentPath: NodePath) => void;
+  readonly onDelete: (path: NodePath) => void;
+}
+
+function NodeView(props: NodeViewProps): React.JSX.Element {
+  const { node, depth, path, draggedItem, dropTarget, editingNode } = props;
+  const [collapsed, setCollapsed] = useState(false);
+
+  const hasChildren = node.children !== undefined && node.children.length > 0;
+  const isVirtual = node.virtual === true;
+  const isLeaf = !hasChildren && !isVirtual;
+
+  const isDragging = draggedItem?.source === 'tree' && pathsEqual(draggedItem.path, path);
+  const isDropInto = dropTarget?.kind === 'into' && pathsEqual(dropTarget.path, path);
+  const isDropBefore = dropTarget?.kind === 'before' && pathsEqual(dropTarget.path, path);
+  const isEditing = editingNode !== null && pathsEqual(editingNode.path, path);
+
+  // Decide whether the drag is in the top or bottom band of the row. Top band
+  // → drop *before* this node; bottom band on a virtual node → drop *into* it
+  // as a new child; bottom band on a leaf → drop *before the next sibling*.
+  function handleDragOver(e: React.DragEvent): void {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const offset = e.clientY - rect.top;
+    if (offset < rect.height / 3) {
+      props.onDragOverBefore(path);
+    } else if (isVirtual) {
+      props.onDragOverInto(path);
+    } else {
+      const lastIdx = path[path.length - 1] ?? 0;
+      props.onDragOverBefore([...path.slice(0, -1), lastIdx + 1]);
+    }
+  }
+
+  function handleDrop(e: React.DragEvent): void {
+    e.preventDefault();
+    e.stopPropagation();
+    if (dropTarget === null) return;
+    if (dropTarget.kind === 'into') props.onDropInto(dropTarget.path);
+    else props.onDropBefore(dropTarget.path);
+  }
+
+  return (
+    <div className="flex flex-col">
+      {isDropBefore && <div className="h-0.5 bg-accent rounded-full mx-2" style={{ marginLeft: `${String(depth * 1.5 + 0.5)}rem` }} />}
+      <div
+        className={`group flex items-center gap-2 py-1.5 px-2 rounded transition-colors ${
+          isDragging ? 'opacity-40' : ''
+        } ${
+          isDropInto ? 'bg-accent/15 ring-1 ring-accent/40' : 'hover:bg-bg-tertiary/30'
+        }`}
+        style={{ paddingLeft: `${String(depth * 1.5 + 0.5)}rem` }}
+        draggable={!isEditing}
+        onDragStart={(e) => {
+          e.stopPropagation();
+          props.onDragStart(path);
+        }}
+        onDragOver={handleDragOver}
+        onDragLeave={(e) => { e.stopPropagation(); props.onDragLeave(); }}
+        onDrop={handleDrop}
+        onDragEnd={(e) => { e.stopPropagation(); props.onDragEnd(); }}
+      >
+        <GripVertical className="h-3.5 w-3.5 text-text-muted cursor-grab active:cursor-grabbing flex-shrink-0" />
+
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => { setCollapsed(v => !v); }}
+            className="text-text-muted hover:text-text-primary transition-colors flex-shrink-0"
+            aria-label={collapsed ? 'Expand' : 'Collapse'}
+          >
+            {collapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+          </button>
+        ) : (
+          <span className="w-3.5 flex-shrink-0" />
+        )}
+
+        <NodeIcon virtual={isVirtual} isLeaf={isLeaf} />
+
+        {isEditing ? (
+          <InlineNodeEditor
+            initial={{ name: editingNode.name, virtual: editingNode.virtual }}
+            onSave={props.onSaveEdit}
+            onCancel={props.onCancelEdit}
+          />
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => { props.onStartEdit(path, node.name, isVirtual); }}
+              className="text-sm text-text-primary font-medium hover:text-accent transition-colors text-left truncate"
+            >
+              {node.name}
+            </button>
+            {isVirtual && (
+              <span className="rounded-full border border-accent/50 bg-accent/10 px-2 py-0.5 text-[10px] text-accent flex-shrink-0">
+                virtual
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => { props.onDelete(path); }}
+              className="ml-auto rounded p-1 text-text-muted opacity-0 group-hover:opacity-100 hover:bg-negative/10 hover:text-negative transition-all"
+              title="Delete node"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+      </div>
+
+      {hasChildren && !collapsed && (
+        <div className="flex flex-col">
+          {node.children.map((child, idx) => (
+            <NodeView
+              key={`${child.name}-${String(idx)}`}
+              {...props}
+              node={child}
+              depth={depth + 1}
+              path={[...path, idx]}
+            />
+          ))}
+        </div>
+      )}
+
+      {isVirtual && !collapsed && (
+        <button
+          type="button"
+          onClick={() => { props.onAddChild(path); }}
+          className="flex items-center gap-2 py-1 px-2 text-xs text-text-muted hover:text-accent hover:bg-bg-tertiary/30 transition-colors rounded"
+          style={{ paddingLeft: `${String((depth + 1) * 1.5 + 0.5)}rem` }}
+        >
+          <Plus className="h-3 w-3" />
+          <span>Add child node</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function UnassignedEntityView({ entityName, isDragging, onDragStart, onDragEnd }: Readonly<{
+  entityName: string;
+  isDragging: boolean;
+  onDragStart: (entityName: string) => void;
+  onDragEnd: () => void;
+}>): React.JSX.Element {
+  return (
+    <div
+      className={`flex items-center gap-2 py-1.5 px-2 rounded transition-colors ${
+        isDragging ? 'opacity-40' : 'hover:bg-bg-tertiary/30'
+      }`}
+      draggable
+      onDragStart={(e) => { e.stopPropagation(); onDragStart(entityName); }}
+      onDragEnd={(e) => { e.stopPropagation(); onDragEnd(); }}
+    >
+      <GripVertical className="h-3.5 w-3.5 text-text-muted cursor-grab active:cursor-grabbing flex-shrink-0" />
+      <FileText className="h-3.5 w-3.5 text-text-muted" />
+      <span className="text-sm text-text-primary font-medium truncate">{entityName}</span>
+      <span className="rounded-full border border-yellow-500/50 bg-yellow-500/10 px-2 py-0.5 text-[10px] text-yellow-600 dark:text-yellow-400 flex-shrink-0">
+        unassigned
+      </span>
+    </div>
+  );
+}
+
+export function OrgTreeEditor({ onClose }: OrgTreeEditorProps): React.JSX.Element {
+  const api = useCostApi();
+  const treeQuery = useQuery(() => api.getOrgTree(), []);
+  const dimensionsQuery = useQuery(() => api.getDimensions(), []);
+
+  const [tree, setTree] = useState<readonly OrgNode[] | null>(null);
+  const initialRef = useRef<readonly OrgNode[] | null>(null);
+
+  const [discardConfirm, setDiscardConfirm] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<NodePath | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveInProgress, setSaveInProgress] = useState(false);
+
+  const [draggedItem, setDraggedItem] = useState<DragRef | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+  const [editingNode, setEditingNode] = useState<EditingNode | null>(null);
+
+  const ownerDimension = dimensionsQuery.status === 'success'
+    ? dimensionsQuery.data.find(d => 'concept' in d && d.concept === 'owner')
+    : undefined;
+  const ownerDimensionId = ownerDimension !== undefined
+    ? ('tagName' in ownerDimension ? ownerDimension.tagName : ownerDimension.name)
+    : undefined;
+
+  const allValuesQuery = useQuery(
+    async () => {
+      if (ownerDimensionId === undefined) return [];
+      const result = await api.getFilterValues(ownerDimensionId, {});
+      return result.map(v => v.value);
+    },
+    [ownerDimensionId],
+  );
+
+  const unassignedValues = tree !== null && allValuesQuery.status === 'success'
+    ? findUnassignedValues(tree, allValuesQuery.data)
+    : [];
+
+  useEffect(() => {
+    if (treeQuery.status === 'success' && tree === null) {
+      const loaded = treeQuery.data;
+      setTree(loaded);
+      initialRef.current = loaded;
+    }
+  }, [treeQuery, tree]);
+
+  const isDirty = tree !== null && initialRef.current !== null &&
+    JSON.stringify(tree) !== JSON.stringify(initialRef.current);
+
+  useUnsavedChanges(isDirty, 'Org tree editor');
+
+  function setDropTargetIfChanged(next: DropTarget | null): void {
+    setDropTarget(prev => (dropTargetEqual(prev, next) ? prev : next));
+  }
+
+  function requestClose(): void {
+    if (isDirty) setDiscardConfirm(true);
+    else onClose?.();
+  }
+
+  async function handleSave(): Promise<void> {
+    if (tree === null) return;
+    setSaveInProgress(true);
+    setSaveError(null);
+    try {
+      await api.saveOrgTree(tree);
+      initialRef.current = tree;
+      setSaveInProgress(false);
+      onClose?.();
+    } catch (err: unknown) {
+      setSaveInProgress(false);
+      setSaveError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  function isValidTreeMove(fromPath: NodePath, target: DropTarget): boolean {
+    if (target.kind === 'into') {
+      return !isPathDescendantOf(target.path, fromPath);
+    }
+    const parentPath = target.path.slice(0, -1);
+    return !isPathDescendantOf(parentPath, fromPath);
+  }
+
+  function handleDragOverInto(path: NodePath): void {
+    if (draggedItem === null) return;
+    if (draggedItem.source === 'tree' && !isValidTreeMove(draggedItem.path, { kind: 'into', path })) return;
+    setDropTargetIfChanged({ kind: 'into', path });
+  }
+
+  function handleDragOverBefore(path: NodePath): void {
+    if (draggedItem === null) return;
+    if (draggedItem.source === 'tree' && !isValidTreeMove(draggedItem.path, { kind: 'before', path })) return;
+    setDropTargetIfChanged({ kind: 'before', path });
+  }
+
+  function handleDropInto(targetPath: NodePath): void {
+    if (draggedItem === null || tree === null) { resetDrag(); return; }
+    if (draggedItem.source === 'unassigned') {
+      const { tree: next } = appendChild(tree, targetPath, { name: draggedItem.entityName });
+      setTree(next);
+    } else {
+      const target = getNodeAtPath(tree, targetPath);
+      const childCount = target?.children?.length ?? 0;
+      setTree(moveNode(tree, draggedItem.path, targetPath, childCount));
+    }
+    resetDrag();
+  }
+
+  function handleDropBefore(targetPath: NodePath): void {
+    if (draggedItem === null || tree === null) { resetDrag(); return; }
+    const parentPath = targetPath.slice(0, -1);
+    const insertIdx = targetPath[targetPath.length - 1] ?? 0;
+    if (draggedItem.source === 'unassigned') {
+      setTree(insertNodeAtPath(tree, parentPath, insertIdx, { name: draggedItem.entityName }));
+    } else {
+      setTree(moveNode(tree, draggedItem.path, parentPath, insertIdx));
+    }
+    resetDrag();
+  }
+
+  function resetDrag(): void {
+    setDraggedItem(null);
+    setDropTarget(null);
+  }
+
+  function handleSaveEdit(next: { name: string; virtual: boolean }): void {
+    if (tree === null || editingNode === null) return;
+    setTree(updateNodeAtPath(tree, editingNode.path, (node) => {
+      // OrgNode.virtual is `true | undefined`; toggling off must omit the key.
+      if (next.virtual) return { ...node, name: next.name, virtual: true };
+      return node.children === undefined
+        ? { name: next.name }
+        : { name: next.name, children: node.children };
+    }));
+    setEditingNode(null);
+  }
+
+  function handleAddChild(parentPath: NodePath): void {
+    if (tree === null) return;
+    const { tree: next, path } = appendChild(tree, parentPath, { name: 'New node', virtual: true });
+    setTree(next);
+    setEditingNode({ path, name: 'New node', virtual: true });
+  }
+
+  function handleDelete(path: NodePath): void {
+    if (tree === null) return;
+    setTree(removeNodeAtPath(tree, path));
+    setDeleteConfirm(null);
+    if (editingNode !== null && pathsEqual(editingNode.path, path)) setEditingNode(null);
+  }
+
+  if (treeQuery.status === 'loading' || tree === null) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <CoinRainLoader />
+      </div>
+    );
+  }
+
+  if (treeQuery.status === 'error') {
+    return (
+      <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3 text-sm text-negative">
+        Failed to load org tree: {treeQuery.error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-text-primary">Organization Tree Editor</h2>
+          <p className="text-xs text-text-muted mt-1">
+            Drag nodes to rearrange. Drop into a virtual folder, or between siblings to reorder.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={requestClose}
+            disabled={saveInProgress}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors disabled:opacity-50"
+          >
+            {isDirty ? 'Cancel' : 'Close'}
+          </button>
+          <button
+            type="button"
+            onClick={() => { handleSave().catch(() => undefined); }}
+            disabled={!isDirty || saveInProgress}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-white bg-accent hover:bg-accent-hover transition-colors disabled:opacity-40"
+          >
+            {saveInProgress ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {saveError !== null && (
+        <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3 text-sm text-negative">
+          Failed to save: {saveError}
+        </div>
+      )}
+
+      <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+        <div className="p-3">
+          {tree.length > 0 ? (
+            <>
+              {tree.map((node, idx) => (
+                <NodeView
+                  key={`${node.name}-${String(idx)}`}
+                  node={node}
+                  depth={0}
+                  path={[idx]}
+                  draggedItem={draggedItem}
+                  dropTarget={dropTarget}
+                  editingNode={editingNode}
+                  onDragStart={(path) => { setDraggedItem({ source: 'tree', path }); }}
+                  onDragOverInto={handleDragOverInto}
+                  onDragOverBefore={handleDragOverBefore}
+                  onDragLeave={() => { setDropTarget(null); }}
+                  onDropInto={handleDropInto}
+                  onDropBefore={handleDropBefore}
+                  onDragEnd={resetDrag}
+                  onStartEdit={(path, name, virtual) => { setEditingNode({ path, name, virtual }); }}
+                  onSaveEdit={handleSaveEdit}
+                  onCancelEdit={() => { setEditingNode(null); }}
+                  onAddChild={handleAddChild}
+                  onDelete={(path) => { setDeleteConfirm(path); }}
+                />
+              ))}
+              <button
+                type="button"
+                onClick={() => { handleAddChild([]); }}
+                className="flex items-center gap-2 py-2 px-2 text-xs text-text-muted hover:text-accent hover:bg-bg-tertiary/30 transition-colors rounded mt-2"
+              >
+                <Plus className="h-3 w-3" />
+                <span>Add root node</span>
+              </button>
+            </>
+          ) : (
+            <div className="p-5 text-center">
+              <p className="text-sm text-text-muted mb-3">
+                No organizational tree configured. Add nodes to get started.
+              </p>
+              <button
+                type="button"
+                onClick={() => { handleAddChild([]); }}
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm text-white bg-accent hover:bg-accent-hover transition-colors rounded-md"
+              >
+                <Plus className="h-4 w-4" />
+                <span>Add first node</span>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {ownerDimensionId !== undefined && unassignedValues.length > 0 && (
+        <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+          <div className="p-3">
+            <div className="flex items-center gap-2 mb-2">
+              <h3 className="text-sm font-semibold text-text-primary">Unassigned Entities</h3>
+              <span className="rounded-full bg-yellow-500/10 border border-yellow-500/30 px-2 py-0.5 text-[10px] text-yellow-600 dark:text-yellow-400">
+                {unassignedValues.length}
+              </span>
+            </div>
+            <p className="text-xs text-text-muted mb-3">
+              Drag entities below into the tree to organize them.
+            </p>
+            <div className="flex flex-col gap-0.5">
+              {unassignedValues.map(entityName => (
+                <UnassignedEntityView
+                  key={entityName}
+                  entityName={entityName}
+                  isDragging={draggedItem?.source === 'unassigned' && draggedItem.entityName === entityName}
+                  onDragStart={(name) => { setDraggedItem({ source: 'unassigned', entityName: name }); }}
+                  onDragEnd={resetDrag}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {discardConfirm && (
+        <ConfirmModal
+          title="Discard changes?"
+          message="You have unsaved changes to the org tree. Discard them and close the editor?"
+          confirmLabel="Discard"
+          cancelLabel="Keep editing"
+          destructive
+          onConfirm={() => { setDiscardConfirm(false); onClose?.(); }}
+          onCancel={() => { setDiscardConfirm(false); }}
+        />
+      )}
+
+      {deleteConfirm !== null && (
+        <ConfirmModal
+          title="Delete node?"
+          message={`Remove "${getNodeAtPath(tree, deleteConfirm)?.name ?? ''}" and all its descendants from the tree?`}
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+          destructive
+          onConfirm={() => { handleDelete(deleteConfirm); }}
+          onCancel={() => { setDeleteConfirm(null); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/hooks/use-click-outside-dismiss.ts
+++ b/packages/ui/src/hooks/use-click-outside-dismiss.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+/** Click outside the container fires `onCancel`. If `isDirty`, it instead
+ *  flips `setDiscardConfirm(true)` so the caller can render a confirm modal.
+ *  Suppressed while `discardConfirm` is already true so the modal's own
+ *  outside-clicks don't recurse. */
+export function useClickOutsideDismiss(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  onCancel: () => void,
+  isDirty: boolean,
+  discardConfirm: boolean,
+  setDiscardConfirm: (v: boolean) => void,
+): void {
+  useEffect(() => {
+    function onDocClick(e: MouseEvent): void {
+      if (containerRef.current === null) return;
+      if (!(e.target instanceof Node)) return;
+      if (containerRef.current.contains(e.target)) return;
+      if (discardConfirm) return;
+      if (isDirty) { setDiscardConfirm(true); }
+      else { onCancel(); }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => { document.removeEventListener('mousedown', onDocClick); };
+  }, [containerRef, onCancel, isDirty, discardConfirm, setDiscardConfirm]);
+}

--- a/packages/ui/src/views/data-management-org.tsx
+++ b/packages/ui/src/views/data-management-org.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
+import { OrgTreeEditor } from '../components/org-tree-editor.js';
 
 type OrgSyncState =
   | { status: 'idle' }
@@ -352,6 +353,32 @@ export function OrgAccountsSection({ profile }: Readonly<{ profile: string | nul
           onConfirm={() => { handleClear().catch(() => undefined); }}
           onCancel={() => { setShowClearConfirm(false); }}
         />
+      )}
+    </div>
+  );
+}
+
+export function OrgTreeSection(): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3">
+        <button
+          type="button"
+          onClick={() => { setExpanded(v => !v); }}
+          className="flex items-center gap-2 flex-1 text-left hover:bg-bg-tertiary/30 transition-colors rounded -mx-1 px-1"
+        >
+          <div className="h-2 w-2 rounded-full bg-accent" />
+          <span className="text-sm font-medium text-text-primary">Organizational Hierarchy Editor</span>
+          <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-border p-4">
+          <OrgTreeEditor onClose={() => { setExpanded(false); }} />
+        </div>
       )}
     </div>
   );

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -4,7 +4,7 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
 import { SetupWizard } from './setup-wizard.js';
-import { OrgAccountsSection } from './data-management-org.js';
+import { OrgAccountsSection, OrgTreeSection } from './data-management-org.js';
 import { SsmParameterSection } from './data-management-ssm.js';
 import { TierPanel, type SyncState } from './data-management-tier.js';
 import { SsoLoginButton } from '../components/sso-login-button.js';
@@ -466,6 +466,9 @@ export function DataManagement() {
 
       {/* Account mapping */}
       <OrgAccountsSection profile={awsProfile} />
+
+      {/* Org Tree Editor */}
+      <OrgTreeSection />
 
       {/* Region names enrichment — independent of Org sync */}
       <SsmParameterSection profile={awsProfile} />

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -20,30 +20,10 @@ function migrateLocked(cfg: DimensionsConfig): { config: DimensionsConfig; chang
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { useQuery } from '../hooks/use-query.js';
+import { useClickOutsideDismiss } from '../hooks/use-click-outside-dismiss.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
 import { AliasSuggestions } from '../components/alias-suggestions.js';
-
-function useClickOutsideDismiss(
-  containerRef: React.RefObject<HTMLDivElement | null>,
-  onCancel: () => void,
-  isDirty: boolean,
-  discardConfirm: boolean,
-  setDiscardConfirm: (v: boolean) => void,
-): void {
-  useEffect(() => {
-    function onDocClick(e: MouseEvent): void {
-      if (containerRef.current === null) return;
-      if (!(e.target instanceof Node)) return;
-      if (containerRef.current.contains(e.target)) return;
-      if (discardConfirm) return;
-      if (isDirty) { setDiscardConfirm(true); }
-      else { onCancel(); }
-    }
-    document.addEventListener('mousedown', onDocClick);
-    return () => { document.removeEventListener('mousedown', onDocClick); };
-  }, [containerRef, onCancel, isDirty, discardConfirm, setDiscardConfirm]);
-}
 
 /** Drag/drop is now indexed by position in the unified `order` array,
  *  not by (type, index) into the split built-in/tag arrays. Keeps a single


### PR DESCRIPTION
## Summary

Replace the YAML-only org tree editing with a visual editor inside the Data Management view.

- Add / rename / delete nodes (virtual folders or leaf entities)
- Drag-and-drop between any parents — drop on a virtual folder to nest, drop between siblings to reorder
- Owner-tag values not present in the tree show in an "Unassigned" panel and can be dragged onto the tree
- Inline rename with Enter / Escape; trash icon appears on hover
- `useUnsavedChanges` integration so navigating away with a dirty tree prompts before discarding

Tree mutations live in `core/models/org-tree-edit.ts` as pure helpers (insert / remove / move / append / paths equality), unit-tested without React.