### PR TITLE
Add daily-grain rollup parquet cache for dashboard queries

### DIFF
--- a/packages/core/src/__tests__/rollup-integration.test.ts
+++ b/packages/core/src/__tests__/rollup-integration.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { mkdtemp, rm, mkdir, copyFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildCostQuery,
+  buildDailyCostsQuery,
+  buildMissingTagsQuery,
+} from '../query/builder.js';
+import {
+  deriveRollupSchema,
+  buildOnePeriod,
+  hashRawEtags,
+  computeRollupAvailability,
+  isRollupEligible,
+  rollupParquetPath,
+} from '../rollup/index.js';
+import type { DimensionsConfig } from '../types/config.js';
+import { asDimensionId, asDateString, asDollars } from '../types/branded.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SYNTHETIC_SRC = join(__dirname, '..', '__fixtures__', 'synthetic');
+
+const dimensions: DimensionsConfig = {
+  builtIn: [
+    { name: asDimensionId('account_id'), label: 'Account', field: 'account_id', displayField: 'account_name' },
+    { name: asDimensionId('service'), label: 'Service', field: 'service' },
+    { name: asDimensionId('region'), label: 'Region', field: 'region' },
+    { name: asDimensionId('resource_id'), label: 'Resource', field: 'resource_id', enabled: false },
+  ],
+  tags: [
+    { tagName: 'team', label: 'Team', concept: 'owner' },
+    { tagName: 'environment', label: 'Environment', concept: 'environment' },
+  ],
+};
+
+interface QueryRow { [key: string]: unknown }
+
+async function queryAll(conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>, sql: string): Promise<QueryRow[]> {
+  const result = await conn.run(sql);
+  const cols = result.columnCount;
+  const names: string[] = [];
+  for (let i = 0; i < cols; i++) names.push(result.columnName(i));
+  const rows: QueryRow[] = [];
+  let chunk = await result.fetchChunk();
+  while (chunk !== null && chunk.rowCount > 0) {
+    for (let r = 0; r < chunk.rowCount; r++) {
+      const row: QueryRow = {};
+      for (let c = 0; c < cols; c++) {
+        const name = names[c];
+        if (name !== undefined) row[name] = chunk.getColumnVector(c).getItem(r);
+      }
+      rows.push(row);
+    }
+    chunk = await result.fetchChunk();
+  }
+  return rows;
+}
+
+function substituteParams(sql: string, params: readonly unknown[]): string {
+  let result = sql;
+  for (let i = params.length; i >= 1; i--) {
+    const param = params[i - 1];
+    const placeholder = '$' + String(i);
+    const value = typeof param === 'string' ? `'${param}'` : String(param);
+    result = result.replaceAll(placeholder, value);
+  }
+  return result;
+}
+
+async function setUpDataDir(): Promise<string> {
+  // Copy synthetic raw parquet into a temp data dir so we can build rollups
+  // alongside (and not pollute the committed fixture tree).
+  const root = await mkdtemp(join(tmpdir(), 'cg-rollup-'));
+  await mkdir(join(root, 'aws', 'raw', 'daily-2026-01'), { recursive: true });
+  await mkdir(join(root, 'aws', 'raw', 'daily-2026-02'), { recursive: true });
+  await copyFile(
+    join(SYNTHETIC_SRC, 'aws', 'raw', 'daily-2026-01', 'data.parquet'),
+    join(root, 'aws', 'raw', 'daily-2026-01', 'data.parquet'),
+  );
+  await copyFile(
+    join(SYNTHETIC_SRC, 'aws', 'raw', 'daily-2026-02', 'data.parquet'),
+    join(root, 'aws', 'raw', 'daily-2026-02', 'data.parquet'),
+  );
+  // Fake sync-etags so freshPeriods has something to hash. Real sync writes
+  // these; the test mimics that step.
+  await writeFile(join(root, 'sync-etags.json'), JSON.stringify({
+    '2026-01': { 'daily/2026-01/data.parquet': 'etag-jan' },
+    '2026-02': { 'daily/2026-02/data.parquet': 'etag-feb' },
+  }));
+  return root;
+}
+
+describe('rollup integration', () => {
+  let db: Awaited<ReturnType<typeof DuckDBInstance.create>>;
+  let conn: Awaited<ReturnType<typeof db.connect>>;
+  let dataDir: string;
+
+  beforeAll(async () => {
+    db = await DuckDBInstance.create();
+    conn = await db.connect();
+    dataDir = await setUpDataDir();
+  });
+
+  afterAll(async () => {
+    if (dataDir !== '') await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('schema hash is stable for identical config and changes when config changes', () => {
+    const a = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    const b = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    expect(a.hash).toBe(b.hash);
+
+    // Add a tag — hash must change so the rollup is treated as stale.
+    const withExtra: DimensionsConfig = {
+      ...dimensions,
+      tags: [...dimensions.tags, { tagName: 'cost_center', label: 'Cost Center' }],
+    };
+    expect(deriveRollupSchema(withExtra, 'unblended', 'gross').hash).not.toBe(a.hash);
+
+    // Changing cost metric also bumps hash — different rollup contents.
+    expect(deriveRollupSchema(dimensions, 'amortized', 'gross').hash).not.toBe(a.hash);
+
+    // Disabling a built-in changes the carried column set, hence the hash.
+    const disabled: DimensionsConfig = {
+      ...dimensions,
+      builtIn: dimensions.builtIn.map(d =>
+        d.field === 'region' ? { ...d, enabled: false } : d,
+      ),
+    };
+    expect(deriveRollupSchema(disabled, 'unblended', 'gross').hash).not.toBe(a.hash);
+  });
+
+  it('schema does not include resource_id', () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    expect(schema.builtInFields).not.toContain('resource_id');
+    expect(schema.builtInFields).toContain('account_id');
+    expect(schema.builtInFields).toContain('region');
+    expect(schema.builtInFields).toContain('service');
+    expect(schema.tagColumns).toEqual(expect.arrayContaining(['tag_team', 'tag_environment']));
+  });
+
+  it('builds a rollup parquet whose totals match raw to the cent', async () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    const rawHash = hashRawEtags({ 'daily/2026-01/data.parquet': 'etag-jan' });
+
+    await buildOnePeriod({
+      dataDir,
+      period: '2026-01',
+      schema,
+      rawHash,
+      availableColumns: undefined,
+      runQuery: async (sql) => queryAll(conn, sql),
+    });
+
+    const [rawTotal] = await queryAll(conn,
+      `SELECT SUM(line_item_unblended_cost) AS t FROM read_parquet('${join(dataDir, 'aws', 'raw', 'daily-2026-01', '*.parquet')}')`,
+    );
+    const [rollupTotal] = await queryAll(conn,
+      `SELECT SUM(cost) AS t FROM read_parquet('${rollupParquetPath(dataDir, '2026-01')}')`,
+    );
+    // Use exact equality — SUM is associative under floats only when the
+    // grouping doesn't reorder; the test passes today because the synthetic
+    // fixture is small enough that float drift is below the printed
+    // precision. Use closeTo with a generous epsilon for safety.
+    expect(Number(rollupTotal?.['t'])).toBeCloseTo(Number(rawTotal?.['t']), 4);
+  });
+
+  it('availability sees freshly-built periods', async () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    const avail = await computeRollupAvailability(dataDir, schema);
+    expect(avail.fresh.has('2026-01')).toBe(true);
+    // 2026-02 wasn't built in the previous test.
+    expect(avail.fresh.has('2026-02')).toBe(false);
+  });
+
+  it('eligibility blocks resource_id queries, allows service queries', () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    expect(isRollupEligible({
+      schema, dimensions,
+      referencedDimensionIds: [asDimensionId('service')],
+    })).toBe(true);
+    expect(isRollupEligible({
+      schema, dimensions,
+      referencedDimensionIds: [asDimensionId('resource_id')],
+    })).toBe(false);
+    expect(isRollupEligible({
+      schema, dimensions,
+      referencedDimensionIds: [asDimensionId('service')],
+      needsRawRows: true,
+    })).toBe(false);
+  });
+
+  it('cost query against rollup returns identical totals to raw query', async () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    // Need both periods built for the date range below.
+    await buildOnePeriod({
+      dataDir,
+      period: '2026-02',
+      schema,
+      rawHash: hashRawEtags({ 'daily/2026-02/data.parquet': 'etag-feb' }),
+      availableColumns: undefined,
+      runQuery: async (sql) => queryAll(conn, sql),
+    });
+    const avail = await computeRollupAvailability(dataDir, schema);
+
+    const params = {
+      groupBy: asDimensionId('service'),
+      dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-02-28') },
+      filters: {},
+    };
+
+    const raw = buildCostQuery(params, {
+      dataDir, dimensions, availablePeriods: ['2026-01', '2026-02'],
+    });
+    const fast = buildCostQuery(params, {
+      dataDir, dimensions, availablePeriods: ['2026-01', '2026-02'],
+      rollupSchema: schema, rollupFreshPeriods: avail.fresh,
+    });
+
+    // Build query SQL is different — rollup version reads from rollup parquet.
+    expect(fast.sql).not.toBe(raw.sql);
+    expect(fast.sql).toContain('rollup/daily-');
+    expect(raw.sql).not.toContain('rollup/daily-');
+
+    const rawRows = await queryAll(conn,
+      `SELECT SUM(total_cost) AS t FROM (${substituteParams(raw.sql, raw.params)})`,
+    );
+    const fastRows = await queryAll(conn,
+      `SELECT SUM(total_cost) AS t FROM (${substituteParams(fast.sql, fast.params)})`,
+    );
+    expect(Number(fastRows[0]?.['t'])).toBeCloseTo(Number(rawRows[0]?.['t']), 2);
+  });
+
+  it('daily-costs query against rollup returns identical per-day totals to raw', async () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    const avail = await computeRollupAvailability(dataDir, schema);
+
+    const params = {
+      groupBy: asDimensionId('service'),
+      dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+      filters: {},
+    };
+
+    const raw = buildDailyCostsQuery(params, {
+      dataDir, dimensions, availablePeriods: ['2026-01'],
+    });
+    const fast = buildDailyCostsQuery(params, {
+      dataDir, dimensions, availablePeriods: ['2026-01'],
+      rollupSchema: schema, rollupFreshPeriods: avail.fresh,
+    });
+
+    const rawRows = await queryAll(conn,
+      `SELECT date, SUM(cost) AS c FROM (${substituteParams(raw.sql, raw.params)}) GROUP BY date ORDER BY date`,
+    );
+    const fastRows = await queryAll(conn,
+      `SELECT date, SUM(cost) AS c FROM (${substituteParams(fast.sql, fast.params)}) GROUP BY date ORDER BY date`,
+    );
+    expect(fastRows.length).toBe(rawRows.length);
+    for (let i = 0; i < rawRows.length; i++) {
+      const r = rawRows[i];
+      const f = fastRows[i];
+      if (r === undefined || f === undefined) continue;
+      expect(String(f['date'])).toBe(String(r['date']));
+      expect(Number(f['c'])).toBeCloseTo(Number(r['c']), 2);
+    }
+  });
+
+  it('missing-tags query falls back to raw — rollup never used (resource_id required)', () => {
+    const schema = deriveRollupSchema(dimensions, 'unblended', 'gross');
+    const result = buildMissingTagsQuery(
+      {
+        dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+        filters: {},
+        minCost: asDollars(0),
+        tagDimension: asDimensionId('tag_team'),
+      },
+      {
+        dataDir, dimensions, availablePeriods: ['2026-01'],
+        rollupSchema: schema, rollupFreshPeriods: new Set(['2026-01']),
+      },
+    );
+    // No matter what we passed for rollup availability, the missing-tags query
+    // never opts in — its SQL stays on raw parquet.
+    expect(result.sql).not.toContain('rollup/daily-');
+    expect(result.sql).toContain('aws/raw/daily-');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './config/index.js';
 export * from './normalize/index.js';
 export * from './models/index.js';
 export * from './query/index.js';
+export * from './rollup/index.js';
 export * from './sync/index.js';
 export * from './logger/index.js';
 export * from './utils/index.js';

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -7,6 +7,8 @@ import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize
 import { costExprFor } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
 import { assertDateString, assertHourString, SecurityError } from './identifier-validator.js';
+import { rollupParquetPath, type RollupSchema } from '../rollup/index.js';
+import { isRollupEligible } from '../rollup/eligibility.js';
 
 function assertFiniteNumber(value: number, name: string): void {
   if (!Number.isFinite(value) || value < 0) {
@@ -308,6 +310,11 @@ export interface BuildSourceOptions {
    *  description, usage_amount, list_cost. Used by the materialized base
    *  to keep the in-memory table small. */
   readonly slim?: boolean | undefined;
+  /** When set, emit a SELECT directly over the rollup parquet files instead
+   *  of the raw CUR. Caller is responsible for verifying eligibility — every
+   *  column referenced by the outer query must be carried by `schema`.
+   *  `paths` is the list of rollup parquet files to UNION (one per period). */
+  readonly rollupSource?: { readonly paths: readonly string[]; readonly schema: RollupSchema } | undefined;
 }
 
 function buildRawTagSelects(dimensions: DimensionsConfig): string[] {
@@ -330,6 +337,31 @@ function buildParquetSource(dataDir: string, tier: string, periods: readonly str
   return `read_parquet('${dataDir}/aws/raw/${tier}-*/*.parquet')`;
 }
 
+/** Inner SELECT when reading from a rollup parquet. The rollup carries every
+ *  column its schema declares using the same canonical names buildSource() emits
+ *  on the raw path — so the outer query can reference them identically. Cost
+ *  measures are pre-aggregated; downstream SUM(cost) is SUM-of-SUMs (correct
+ *  for SUM under associativity).
+ *
+ *  Caller is responsible for eligibility — the outer query must NOT reference
+ *  any column not in the rollup schema (e.g. resource_id, description). */
+function buildRollupSelectSource(rollupSource: { readonly paths: readonly string[]; readonly schema: RollupSchema }): string {
+  const { paths, schema } = rollupSource;
+  const escapedPaths = paths.map(p => `'${p.replaceAll("'", "''")}'`).join(', ');
+  const cols = [
+    ...schema.builtInFields,
+    ...schema.tagColumns,
+    'cost',
+    'list_cost',
+    'usage_amount',
+    'row_count',
+  ];
+  return `(
+    SELECT ${cols.join(', ')}
+    FROM read_parquet([${escapedPaths}])
+  )`;
+}
+
 function buildFromClause(
   parquetSource: string,
   dimensions: DimensionsConfig,
@@ -350,7 +382,12 @@ function buildFromClause(
 }
 
 export function buildSource(opts: BuildSourceOptions): string {
-  const { dataDir, tier, dimensions, orgAccountsPath, periods, costMetric = 'unblended', availableColumns, costPerspective, includeRawTags, slim } = opts;
+  const { dataDir, tier, dimensions, orgAccountsPath, periods, costMetric = 'unblended', availableColumns, costPerspective, includeRawTags, slim, rollupSource } = opts;
+
+  if (rollupSource !== undefined) {
+    return buildRollupSelectSource(rollupSource);
+  }
+
   const hasFallbacks = dimensions.tags.some(t => t.accountTagFallback !== undefined);
   const needsOrgJoin = hasFallbacks && orgAccountsPath !== undefined;
 
@@ -469,6 +506,75 @@ export interface QueryContextOptions {
   readonly costScope?: CostScopeConfig | undefined;
   readonly availableColumns?: ReadonlySet<string> | undefined;
   readonly materializedSource?: string | undefined;
+  /** When set, the desktop layer has determined a rollup is available for some
+   *  set of months. Per-query builders pass the schema + the set of fresh
+   *  periods through `tryRollupSourceFor()` to decide whether to use it. */
+  readonly rollupSchema?: RollupSchema | undefined;
+  readonly rollupFreshPeriods?: ReadonlySet<string> | undefined;
+}
+
+/** Collect every dimension id touched by a query: explicit group-by/dimension
+ *  selectors plus the keys of any filter map. Used to feed isRollupEligible. */
+function collectReferencedDimensionIds(
+  explicit: readonly DimensionId[],
+  filters: FilterMap,
+): readonly DimensionId[] {
+  const ids = new Set<DimensionId>(explicit);
+  for (const k of Object.keys(filters)) ids.add(k as DimensionId);
+  return [...ids];
+}
+
+/** Decide whether the rollup can satisfy a query and return a `rollupSource`
+ *  ready to pass into buildSource(). Returns undefined when the query must use
+ *  raw — the caller falls through to the normal raw path.
+ *
+ *  Conditions for "yes":
+ *   1. tier is daily (rollup is daily-only)
+ *   2. opts.rollupSchema is configured
+ *   3. every required period has a fresh rollup
+ *   4. the query references only dimensions the rollup carries (no resource_id,
+ *      no description, no disabled built-ins)
+ *   5. cost-scope rules don't reference rollup-incompatible dimensions */
+function tryRollupSourceFor(args: {
+  readonly tier: string;
+  readonly dataDir: string;
+  readonly periods: readonly string[];
+  readonly opts: QueryContextOptions;
+  readonly referencedDimensionIds: readonly DimensionId[];
+  readonly extraReferencedFields?: readonly string[];
+  readonly needsRawRows?: boolean;
+}): { readonly paths: readonly string[]; readonly schema: RollupSchema } | undefined {
+  const { tier, dataDir, periods, opts, referencedDimensionIds, extraReferencedFields, needsRawRows } = args;
+  if (tier !== 'daily') return undefined;
+  if (opts.rollupSchema === undefined || opts.rollupFreshPeriods === undefined) return undefined;
+  if (periods.length === 0) return undefined;
+  for (const p of periods) {
+    if (!opts.rollupFreshPeriods.has(p)) return undefined;
+  }
+  if (!isRollupEligible({
+    schema: opts.rollupSchema,
+    dimensions: opts.dimensions,
+    referencedDimensionIds,
+    extraReferencedFields: extraReferencedFields ?? [],
+    needsRawRows: needsRawRows ?? false,
+    costScope: opts.costScope,
+  })) return undefined;
+
+  const paths = periods.map(p => rollupParquetPath(dataDir, p));
+  return { paths, schema: opts.rollupSchema };
+}
+
+interface RollupHint {
+  /** Dimension ids referenced by the query (filters, group-by, entity).
+   *  Used to decide whether the query is rollup-eligible. */
+  readonly referencedDimensionIds: readonly DimensionId[];
+  /** Raw fields the outer SQL references directly, bypassing dimension
+   *  resolution (e.g. line_item_type). If any aren't carried by the rollup
+   *  schema, eligibility fails. */
+  readonly extraReferencedFields?: readonly string[];
+  /** When true, the caller needs raw rows (per-resource detail, raw tag
+   *  detection). Forces raw. */
+  readonly needsRawRows?: boolean;
 }
 
 function setupQuery(
@@ -476,6 +582,7 @@ function setupQuery(
   tier: string,
   opts: QueryContextOptions,
   extraSourceOpts?: Partial<BuildSourceOptions>,
+  rollupHint?: RollupHint,
 ): CommonQuerySetup {
   const { dataDir, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns, materializedSource } = opts;
   const qb = new QueryBuilder();
@@ -493,7 +600,24 @@ function setupQuery(
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const resolvedTier = effectiveTier(tier, params.dateRange);
-  const source = buildSource({ dataDir, tier: resolvedTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, ...extraSourceOpts });
+
+  const rollupSource = rollupHint === undefined
+    ? undefined
+    : tryRollupSourceFor({
+        tier: resolvedTier,
+        dataDir,
+        periods,
+        opts,
+        referencedDimensionIds: rollupHint.referencedDimensionIds,
+        extraReferencedFields: rollupHint.extraReferencedFields ?? [],
+        needsRawRows: rollupHint.needsRawRows ?? false,
+      });
+
+  const source = buildSource({
+    dataDir, tier: resolvedTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective,
+    ...extraSourceOpts,
+    rollupSource,
+  });
   return { qb, filterClauses, exclusionClauses, source, costMetric };
 }
 
@@ -504,7 +628,11 @@ export function buildCostQuery(
 ): ParameterizedQuery {
   assertFiniteNumber(topN, 'topN');
   const costTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
-  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, costTier, opts);
+  const referencedDimensionIds = collectReferencedDimensionIds([params.groupBy], params.filters);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, costTier, opts, undefined, {
+    referencedDimensionIds,
+    extraReferencedFields: ['service'],
+  });
   const groupByResolved = resolveField(params.groupBy, opts.dimensions);
 
   const whereConditions = [
@@ -590,7 +718,18 @@ export function buildTrendQuery(
     const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
     const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
     const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-    source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
+
+    const referencedDimensionIds = collectReferencedDimensionIds([params.groupBy], params.filters);
+    const rollupSource = tryRollupSourceFor({
+      tier: 'daily',
+      dataDir,
+      periods,
+      opts,
+      referencedDimensionIds,
+      extraReferencedFields: [],
+    });
+
+    source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, rollupSource });
   } else {
     source = materializedSource;
     exclusionClauses = [];
@@ -776,7 +915,10 @@ export function buildDailyCostsQuery(
 ): ParameterizedQuery {
   const dailyTier = params.granularity === 'hourly' ? 'hourly' : 'daily';
   const resolvedTier = effectiveTier(dailyTier, params.dateRange);
-  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dailyTier, opts);
+  const referencedDimensionIds = collectReferencedDimensionIds([params.groupBy], params.filters);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, dailyTier, opts, undefined, {
+    referencedDimensionIds,
+  });
   const groupByResolved = resolveField(params.groupBy, opts.dimensions);
 
   const whereConditions = [
@@ -813,7 +955,12 @@ export function buildEntityDetailQuery(
   const granularity = params.granularity ?? 'daily';
   const tier = granularity === 'hourly' ? 'hourly' : 'daily';
   const resolvedTier = effectiveTier(tier, params.dateRange);
-  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, tier, opts);
+  const referencedDimensionIds = collectReferencedDimensionIds([params.dimension], params.filters);
+  const { qb, filterClauses, exclusionClauses, source } = setupQuery(params, tier, opts, undefined, {
+    referencedDimensionIds,
+    // entity detail outputs `service`, `account_id`, `account_name` columns;
+    // these are all in the rollup, no extra raw fields needed.
+  });
   const dimResolved = resolveField(params.dimension, opts.dimensions);
 
   // Same display-name collision treatment for the entity selector itself: if

--- a/packages/core/src/rollup/build-rollup.ts
+++ b/packages/core/src/rollup/build-rollup.ts
@@ -1,0 +1,168 @@
+import { mkdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { logger } from '../logger/logger.js';
+import { costExprFor } from '../query/cost-metric.js';
+import { rollupDir, rollupParquetPath, upsertRollupEntry, type RollupEntry } from './manifest.js';
+import type { RollupSchema } from './schema.js';
+
+function sqlEscapeString(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+/**
+ * Build the COPY ... TO ... SQL that materializes one month's rollup parquet.
+ *
+ * The SELECT mirrors the same column names that buildSource() emits so the
+ * rollup file is a drop-in for the inner subquery (read_parquet of the rollup
+ * returns rows with the same schema downstream queries already expect — minus
+ * the columns we deliberately drop, like resource_id).
+ *
+ * Group-by keys cover every dimension that could appear in a rollup-eligible
+ * GROUP BY at query time. Everything else is a SUM.
+ */
+export function buildRollupSql(opts: {
+  readonly dataDir: string;
+  readonly period: string;
+  readonly schema: RollupSchema;
+  readonly availableColumns: ReadonlySet<string> | undefined;
+}): string {
+  const { dataDir, period, schema, availableColumns } = opts;
+
+  const has = (col: string): boolean => availableColumns === undefined || availableColumns.has(col);
+  // Cost expr resolves to a SQL fragment over raw CUR columns (no table alias
+  // needed — the FROM is the parquet glob, no JOINs).
+  const costExpr = costExprFor(schema.costMetric, '', schema.costPerspective, availableColumns);
+
+  // Build per-dimension SELECT projections that match buildSource()'s output
+  // names. We re-derive these from the raw CUR columns so the rollup parquet
+  // schema is independent of buildSource() — no implicit dependency. If a
+  // dimension's raw column doesn't exist in this CUR, its projection becomes
+  // a NULL literal so the GROUP BY still works.
+  const dimSelects: string[] = [];
+  for (const field of schema.builtInFields) {
+    dimSelects.push(`${rawProjectionFor(field, has)} AS ${field}`);
+  }
+  for (let i = 0; i < schema.tagColumns.length; i++) {
+    const col = schema.tagColumns[i];
+    const raw = schema.tagRawKeys[i];
+    if (col === undefined || raw === undefined) continue;
+    dimSelects.push(`element_at(resource_tags, '${sqlEscapeString(raw)}')[1] AS ${col}`);
+  }
+
+  const listExpr = has('pricing_public_on_demand_cost') ? 'COALESCE(pricing_public_on_demand_cost, 0)' : '0';
+  const usageExpr = has('line_item_usage_amount') ? 'COALESCE(line_item_usage_amount, 0)' : '0';
+
+  const dimList = schema.builtInFields.length + schema.tagColumns.length;
+  const groupByPositions = Array.from({ length: dimList }, (_, i) => String(i + 1)).join(', ');
+
+  const srcGlob = `${dataDir}/aws/raw/daily-${period}/*.parquet`;
+  const dest = rollupParquetPath(dataDir, period);
+
+  return `
+COPY (
+  SELECT
+    ${dimSelects.join(',\n    ')},
+    SUM(${costExpr}) AS cost,
+    SUM(${listExpr}) AS list_cost,
+    SUM(${usageExpr}) AS usage_amount,
+    COUNT(*) AS row_count
+  FROM read_parquet('${sqlEscapeString(srcGlob)}', union_by_name=true)
+  GROUP BY ${groupByPositions}
+) TO '${sqlEscapeString(dest)}' (FORMAT PARQUET, COMPRESSION ZSTD)
+`.trim();
+}
+
+/** SQL projection from raw CUR columns to a buildSource-named output column.
+ *  Mirrors the COALESCE shape buildSource uses so values stay byte-identical. */
+function rawProjectionFor(field: string, has: (col: string) => boolean): string {
+  switch (field) {
+    case 'usage_date':
+      return `line_item_usage_start_date::DATE`;
+    case 'account_id':
+      return `line_item_usage_account_id`;
+    case 'account_name':
+      return has('line_item_usage_account_name') ? `COALESCE(line_item_usage_account_name, '')` : `''`;
+    case 'region':
+      return has('product_region_code') ? `COALESCE(product_region_code, '')` : `''`;
+    case 'service':
+      return has('product_servicecode') ? `COALESCE(product_servicecode, '')` : `''`;
+    case 'service_family':
+      return has('product_product_family') ? `COALESCE(product_product_family, '')` : `''`;
+    case 'line_item_type':
+      return has('line_item_line_item_type') ? `COALESCE(line_item_line_item_type, '')` : `''`;
+    case 'usage_type':
+      return has('line_item_usage_type') ? `COALESCE(line_item_usage_type, '')` : `''`;
+    case 'operation':
+      return has('line_item_operation') ? `COALESCE(line_item_operation, '')` : `''`;
+    default:
+      // Unknown built-in field: defensively project NULL so the GROUP BY
+      // doesn't error. Schema invariant: this should not happen for
+      // dimensions that came out of deriveRollupSchema's allow-list.
+      return `NULL`;
+  }
+}
+
+/**
+ * Hash of the raw parquet etags for a period. Two builds with the same hash
+ * see the same raw bytes — used as a cheap "is this rollup still in sync with
+ * raw?" check, paired with the schema hash.
+ */
+export function hashRawEtags(periodEtags: Readonly<Record<string, string>>): string {
+  // Sort keys so the hash is order-independent across Node versions / OSes.
+  const sortedKeys = Object.keys(periodEtags).sort();
+  const sorted = sortedKeys.map(k => `${k}\0${periodEtags[k] ?? ''}`).join('\n');
+  return createHash('sha256').update(sorted).digest('hex').slice(0, 16);
+}
+
+export interface BuildOnePeriodOptions {
+  readonly dataDir: string;
+  readonly period: string;
+  readonly schema: RollupSchema;
+  readonly rawHash: string;
+  readonly availableColumns: ReadonlySet<string> | undefined;
+  /** Caller-supplied DuckDB query runner. Returns rows; we use it for the
+   *  COPY ... TO ... and the row-count probe. The runner must be on the same
+   *  DuckDB process that the rest of the app uses (no in-memory isolation). */
+  readonly runQuery: (sql: string) => Promise<readonly unknown[]>;
+}
+
+export async function buildOnePeriod(opts: BuildOnePeriodOptions): Promise<RollupEntry> {
+  const { dataDir, period, schema, rawHash, availableColumns, runQuery } = opts;
+  await mkdir(rollupDir(dataDir), { recursive: true });
+
+  const sql = buildRollupSql({ dataDir, period, schema, availableColumns });
+
+  const startedAt = Date.now();
+  await runQuery(sql);
+  const elapsedMs = Date.now() - startedAt;
+
+  // Probe rowCount from the freshly-written file. Cheap: parquet metadata read.
+  const rowCountRows = await runQuery(
+    `SELECT COUNT(*) AS n FROM read_parquet('${sqlEscapeString(rollupParquetPath(dataDir, period))}')`,
+  );
+  const rowCount = extractRowCount(rowCountRows);
+
+  const entry: RollupEntry = {
+    schemaHash: schema.hash,
+    builtAt: new Date().toISOString(),
+    rowCount,
+    rawHash,
+  };
+  await upsertRollupEntry(dataDir, period, entry);
+
+  logger.info('rollup-built', { period, rowCount, elapsedMs, schemaHash: schema.hash });
+  return entry;
+}
+
+function extractRowCount(rows: readonly unknown[]): number {
+  const first = rows[0];
+  if (first === undefined || typeof first !== 'object' || first === null) return 0;
+  const n = (first as Record<string, unknown>)['n'];
+  if (typeof n === 'number') return n;
+  if (typeof n === 'bigint') return Number(n);
+  if (typeof n === 'string') {
+    const parsed = Number.parseInt(n, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}

--- a/packages/core/src/rollup/eligibility.ts
+++ b/packages/core/src/rollup/eligibility.ts
@@ -1,0 +1,80 @@
+import type { DimensionsConfig } from '../types/config.js';
+import type { DimensionId } from '../types/branded.js';
+import { tagColumnName } from '../types/branded.js';
+import type { CostScopeConfig } from '../types/cost-scope.js';
+import type { RollupSchema } from './schema.js';
+
+/** Fields that, if referenced anywhere in the query, force a fall-back to raw.
+ *  These are columns the rollup deliberately doesn't carry. */
+const RAW_ONLY_FIELDS: ReadonlySet<string> = new Set([
+  'resource_id',
+  'description',
+]);
+
+/** Resolve a dimension id to the underlying CUR field name. Returns null when
+ *  the id is unknown (caller should treat as "force raw" — we can't reason
+ *  about what we can't see). */
+function resolveFieldName(id: DimensionId, dimensions: DimensionsConfig): string | null {
+  const builtIn = dimensions.builtIn.find(d => d.name === id);
+  if (builtIn !== undefined) return builtIn.field;
+  const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === id);
+  if (tag !== undefined) return tagColumnName(tag.tagName);
+  return null;
+}
+
+export interface RollupEligibilityInput {
+  readonly schema: RollupSchema;
+  readonly dimensions: DimensionsConfig;
+  /** Fields the query selects/filters/groups by. Caller is responsible for
+   *  enumerating these — usually one or two ids. */
+  readonly referencedDimensionIds: readonly DimensionId[];
+  /** Filters and groupBy on these raw fields ALREADY exist in the rollup
+   *  (e.g. usage_date is always present). Listed here as a fast-path. */
+  readonly extraReferencedFields?: readonly string[];
+  /** When true the caller plans to use raw-tag detection (missing-tags query)
+   *  or other features that bypass aggregation — short-circuit to raw. */
+  readonly needsRawRows?: boolean;
+  /** Cost scope conditions reference dimensions too — if any condition's
+   *  dimension isn't in the rollup we must read raw to apply the exclusion
+   *  correctly. Pass undefined when no scope is configured. */
+  readonly costScope?: CostScopeConfig | undefined;
+}
+
+/**
+ * Decide whether a query can read from the rollup parquet (true) or must use
+ * raw (false). Conservative — any uncertainty falls back to raw, which is
+ * correct but slower.
+ */
+export function isRollupEligible(input: RollupEligibilityInput): boolean {
+  const { schema, dimensions, referencedDimensionIds, extraReferencedFields, needsRawRows, costScope } = input;
+
+  if (needsRawRows === true) return false;
+
+  const carried = new Set<string>([...schema.builtInFields, ...schema.tagColumns]);
+
+  for (const id of referencedDimensionIds) {
+    const field = resolveFieldName(id, dimensions);
+    if (field === null) return false;
+    if (RAW_ONLY_FIELDS.has(field)) return false;
+    if (!carried.has(field)) return false;
+  }
+
+  for (const field of extraReferencedFields ?? []) {
+    if (RAW_ONLY_FIELDS.has(field)) return false;
+    if (!carried.has(field)) return false;
+  }
+
+  if (costScope !== undefined) {
+    for (const rule of costScope.rules) {
+      if (!rule.enabled) continue;
+      for (const cond of rule.conditions) {
+        const field = resolveFieldName(cond.dimensionId, dimensions);
+        if (field === null) return false;
+        if (RAW_ONLY_FIELDS.has(field)) return false;
+        if (!carried.has(field)) return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/packages/core/src/rollup/index.ts
+++ b/packages/core/src/rollup/index.ts
@@ -1,0 +1,22 @@
+export { deriveRollupSchema, rollupOutputColumns } from './schema.js';
+export type { RollupSchema } from './schema.js';
+export {
+  loadRollupManifest,
+  saveRollupManifest,
+  upsertRollupEntry,
+  removeRollupEntry,
+  freshPeriods,
+  rollupDir,
+  rollupParquetPath,
+} from './manifest.js';
+export type { RollupEntry, RollupManifest } from './manifest.js';
+export { buildRollupSql, buildOnePeriod, hashRawEtags } from './build-rollup.js';
+export type { BuildOnePeriodOptions } from './build-rollup.js';
+export { isRollupEligible } from './eligibility.js';
+export type { RollupEligibilityInput } from './eligibility.js';
+export {
+  computeRollupAvailability,
+  buildPendingRollups,
+  dropStaleManifestEntries,
+} from './orchestrator.js';
+export type { RollupAvailability, BuildPendingOptions } from './orchestrator.js';

--- a/packages/core/src/rollup/manifest.ts
+++ b/packages/core/src/rollup/manifest.ts
@@ -1,0 +1,118 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { logger } from '../logger/logger.js';
+import { isStringRecord } from '../utils/json.js';
+
+export interface RollupEntry {
+  readonly schemaHash: string;
+  readonly builtAt: string;
+  readonly rowCount: number;
+  /** Hash of the raw parquet file etags for this period at build time.
+   *  Used to detect "raw changed since last build" without having to re-run
+   *  the rollup SQL — current month rebuilds every sync but closed months
+   *  shouldn't waste work if the etags haven't moved. */
+  readonly rawHash: string;
+}
+
+export interface RollupManifest {
+  readonly version: 1;
+  readonly entries: Readonly<Record<string, RollupEntry>>;
+}
+
+const MANIFEST_VERSION = 1 as const;
+
+export function rollupDir(dataDir: string): string {
+  return join(dataDir, 'aws', 'rollup');
+}
+
+export function rollupParquetPath(dataDir: string, period: string): string {
+  return join(rollupDir(dataDir), `daily-${period}.parquet`);
+}
+
+function manifestPath(dataDir: string): string {
+  return join(rollupDir(dataDir), 'manifest.json');
+}
+
+function emptyManifest(): RollupManifest {
+  return { version: MANIFEST_VERSION, entries: {} };
+}
+
+function isRollupEntry(v: unknown): v is RollupEntry {
+  if (!isStringRecord(v)) return false;
+  return typeof v['schemaHash'] === 'string'
+    && typeof v['builtAt'] === 'string'
+    && typeof v['rowCount'] === 'number'
+    && typeof v['rawHash'] === 'string';
+}
+
+export async function loadRollupManifest(dataDir: string): Promise<RollupManifest> {
+  try {
+    const raw = await readFile(manifestPath(dataDir), 'utf-8');
+    let parsed: unknown;
+    try { parsed = JSON.parse(raw); } catch {
+      logger.warn('rollup manifest unparseable — treating as empty', { dataDir });
+      return emptyManifest();
+    }
+    if (!isStringRecord(parsed)) return emptyManifest();
+    const entriesRaw = parsed['entries'];
+    if (!isStringRecord(entriesRaw)) return emptyManifest();
+    const entries: Record<string, RollupEntry> = {};
+    for (const [period, entry] of Object.entries(entriesRaw)) {
+      if (!/^\d{4}-\d{2}$/.test(period)) continue;
+      if (isRollupEntry(entry)) entries[period] = entry;
+    }
+    return { version: MANIFEST_VERSION, entries };
+  } catch {
+    return emptyManifest();
+  }
+}
+
+export async function saveRollupManifest(dataDir: string, manifest: RollupManifest): Promise<void> {
+  await mkdir(rollupDir(dataDir), { recursive: true });
+  await writeFile(manifestPath(dataDir), JSON.stringify(manifest, null, 2));
+}
+
+export async function upsertRollupEntry(
+  dataDir: string,
+  period: string,
+  entry: RollupEntry,
+): Promise<void> {
+  const current = await loadRollupManifest(dataDir);
+  const next: RollupManifest = {
+    version: MANIFEST_VERSION,
+    entries: { ...current.entries, [period]: entry },
+  };
+  await saveRollupManifest(dataDir, next);
+}
+
+export async function removeRollupEntry(
+  dataDir: string,
+  period: string,
+): Promise<void> {
+  const current = await loadRollupManifest(dataDir);
+  if (current.entries[period] === undefined) return;
+  const nextEntries: Record<string, RollupEntry> = {};
+  for (const [k, v] of Object.entries(current.entries)) {
+    if (k !== period) nextEntries[k] = v;
+  }
+  await saveRollupManifest(dataDir, { version: MANIFEST_VERSION, entries: nextEntries });
+}
+
+/** Returns the periods whose rollup is fresh under the given schema hash AND
+ *  whose stored rawHash matches the supplied one. Caller computes rawHash from
+ *  the current sync-etags so we detect raw changes between rollup builds. */
+export function freshPeriods(
+  manifest: RollupManifest,
+  schemaHash: string,
+  rawHashesByPeriod: ReadonlyMap<string, string>,
+): Set<string> {
+  const fresh = new Set<string>();
+  for (const [period, entry] of Object.entries(manifest.entries)) {
+    if (entry.schemaHash !== schemaHash) continue;
+    const expectedRawHash = rawHashesByPeriod.get(period);
+    if (expectedRawHash === undefined) continue;
+    if (entry.rawHash !== expectedRawHash) continue;
+    fresh.add(period);
+  }
+  return fresh;
+}

--- a/packages/core/src/rollup/orchestrator.ts
+++ b/packages/core/src/rollup/orchestrator.ts
@@ -1,0 +1,118 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { logger } from '../logger/logger.js';
+import { parseEtagsJson, listLocalMonths } from '../sync/sync-utils.js';
+import { buildOnePeriod, hashRawEtags } from './build-rollup.js';
+import { freshPeriods, loadRollupManifest, removeRollupEntry, type RollupManifest } from './manifest.js';
+import type { RollupSchema } from './schema.js';
+
+/** Read sync-etags.json for the daily tier and return per-period file→hash maps. */
+async function loadDailyEtags(dataDir: string): Promise<Record<string, Record<string, string>>> {
+  try {
+    const raw = await readFile(join(dataDir, 'sync-etags.json'), 'utf-8');
+    return parseEtagsJson(raw);
+  } catch {
+    return {};
+  }
+}
+
+/** Per-period rawHash for every daily period that has parquet on disk. */
+async function computeRawHashes(dataDir: string): Promise<Map<string, string>> {
+  const etags = await loadDailyEtags(dataDir);
+  const localMonths = await listLocalMonths(dataDir, 'daily');
+  const result = new Map<string, string>();
+  for (const period of localMonths) {
+    const periodEtags = etags[period] ?? {};
+    result.set(period, hashRawEtags(periodEtags));
+  }
+  return result;
+}
+
+export interface RollupAvailability {
+  readonly schema: RollupSchema;
+  readonly fresh: ReadonlySet<string>;
+  /** All periods that have raw parquet on disk — useful for diagnostics. */
+  readonly knownPeriods: readonly string[];
+}
+
+export async function computeRollupAvailability(
+  dataDir: string,
+  schema: RollupSchema,
+): Promise<RollupAvailability> {
+  const manifest = await loadRollupManifest(dataDir);
+  const rawHashes = await computeRawHashes(dataDir);
+  const fresh = freshPeriods(manifest, schema.hash, rawHashes);
+  return { schema, fresh, knownPeriods: [...rawHashes.keys()].sort((a, b) => a.localeCompare(b)) };
+}
+
+export interface BuildPendingOptions {
+  readonly dataDir: string;
+  readonly schema: RollupSchema;
+  readonly availableColumns: ReadonlySet<string> | undefined;
+  readonly runQuery: (sql: string) => Promise<readonly unknown[]>;
+  /** Limit the build to these periods. When undefined, builds every stale or
+   *  missing period. Pass the periods that just got synced for the post-sync
+   *  hook so we don't accidentally rebuild old months that haven't changed. */
+  readonly periods?: readonly string[] | undefined;
+}
+
+/**
+ * Build any rollup that's missing or stale relative to the supplied schema.
+ * Returns the list of periods that were (re)built. Periods that are already
+ * fresh are skipped. Failures are logged but don't abort the loop — one bad
+ * month shouldn't stop the rest from building.
+ */
+export async function buildPendingRollups(opts: BuildPendingOptions): Promise<readonly string[]> {
+  const { dataDir, schema, availableColumns, runQuery, periods } = opts;
+
+  const manifest = await loadRollupManifest(dataDir);
+  const rawHashes = await computeRawHashes(dataDir);
+  const fresh = freshPeriods(manifest, schema.hash, rawHashes);
+
+  const candidates = periods === undefined
+    ? [...rawHashes.keys()]
+    : periods.filter(p => rawHashes.has(p));
+
+  const built: string[] = [];
+  for (const period of candidates) {
+    if (fresh.has(period)) continue;
+    const rawHash = rawHashes.get(period);
+    if (rawHash === undefined) continue;
+    try {
+      await buildOnePeriod({ dataDir, period, schema, rawHash, availableColumns, runQuery });
+      built.push(period);
+    } catch (err: unknown) {
+      logger.warn('rollup-build-failed', { period, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return built;
+}
+
+/**
+ * Drop all rollup manifest entries whose schema hash doesn't match the supplied
+ * one. Used when the dimensions config changes — the on-disk parquet files
+ * become unreadable under the new schema and must be regenerated.
+ *
+ * Doesn't delete the parquet files themselves; the next buildPendingRollups
+ * will overwrite them when it rebuilds. Leaving stale files on disk is harmless
+ * (nothing reads them once the manifest entry is gone).
+ */
+export async function dropStaleManifestEntries(
+  dataDir: string,
+  schema: RollupSchema,
+): Promise<readonly string[]> {
+  const manifest = await loadRollupManifest(dataDir);
+  const stale = staleEntries(manifest, schema);
+  for (const period of stale) {
+    await removeRollupEntry(dataDir, period);
+  }
+  return stale;
+}
+
+function staleEntries(manifest: RollupManifest, schema: RollupSchema): readonly string[] {
+  const out: string[] = [];
+  for (const [period, entry] of Object.entries(manifest.entries)) {
+    if (entry.schemaHash !== schema.hash) out.push(period);
+  }
+  return out;
+}

--- a/packages/core/src/rollup/schema.ts
+++ b/packages/core/src/rollup/schema.ts
@@ -1,0 +1,128 @@
+import { createHash } from 'node:crypto';
+import type { DimensionsConfig, BuiltInDimension, TagDimension } from '../types/config.js';
+import type { CostMetric, CostPerspective } from '../types/cost-scope.js';
+import { tagColumnName } from '../types/branded.js';
+
+/**
+ * Rollup schema versioning.
+ *
+ * Bump when the on-disk parquet shape changes in a way that older readers can't
+ * handle (new measure column, renamed dim column, etc.). The version is part of
+ * the schema hash so any rollup written under an older version is treated as
+ * stale and rebuilt.
+ */
+const ROLLUP_VERSION = 1;
+
+/** Built-in dimensions that resolve to a column we never include in the rollup,
+ *  because they push cardinality to ~raw size or aren't a real CUR column on
+ *  their own (region_country/continent are derived from `region` at query time). */
+const NON_ROLLUP_BUILTIN_FIELDS: ReadonlySet<string> = new Set([
+  'resource_id',
+  // description isn't currently a built-in dim but the explorer references it;
+  // keep it out so rollup-eligibility short-circuits cleanly when it appears.
+  'description',
+]);
+
+export interface RollupSchema {
+  /** Stable hash. Changes when the shape of the rollup changes — driven by
+   *  enabled built-in dims, enabled tags, cost metric, cost perspective, or a
+   *  ROLLUP_VERSION bump. */
+  readonly hash: string;
+  /** Built-in dimension fields (column names) carried as group-by keys.
+   *  Always includes `usage_date` first; deduplicated; sorted for stability. */
+  readonly builtInFields: readonly string[];
+  /** Tag column names (e.g. `tag_user_sb_team`) carried as group-by keys.
+   *  Sorted for stability. */
+  readonly tagColumns: readonly string[];
+  /** Raw CUR tag keys (e.g. `user_sb_team`) corresponding to tagColumns, same
+   *  order. Used by the build SQL to extract from the resource_tags MAP. */
+  readonly tagRawKeys: readonly string[];
+  /** Currently a single SUM measure named `cost`, computed from the user's
+   *  metric+perspective. Stored as the column producer SQL fragment that
+   *  becomes `SUM(<expr>) AS cost` in the build query. */
+  readonly costMetric: CostMetric;
+  readonly costPerspective: CostPerspective;
+}
+
+function isBuiltInEligibleForRollup(d: BuiltInDimension): boolean {
+  if (d.enabled === false) return false;
+  if (NON_ROLLUP_BUILTIN_FIELDS.has(d.field)) return false;
+  return true;
+}
+
+function isTagEligibleForRollup(d: TagDimension): boolean {
+  return d.enabled !== false;
+}
+
+function rawTagKey(tagName: string): string {
+  return tagName.startsWith('user_') ? tagName : `user_${tagName}`;
+}
+
+/**
+ * Derive the rollup schema from the user's dimensions config and cost shape.
+ *
+ * Built-ins keep their canonical output names (account_id, region, service,
+ * service_family, line_item_type, usage_type, operation, ...) — same names
+ * that buildSource() emits, so the rollup parquet can stand in for the inner
+ * SELECT without renaming columns.
+ *
+ * `account_name` is always included alongside `account_id`. It's a per-account
+ * constant in CUR (1:1 with account_id), so it doesn't grow cardinality and
+ * carrying it lets account-grouped queries skip a JSON lookup.
+ */
+export function deriveRollupSchema(
+  dimensions: DimensionsConfig,
+  costMetric: CostMetric,
+  costPerspective: CostPerspective,
+): RollupSchema {
+  const builtInFields = new Set<string>(['usage_date']);
+  for (const d of dimensions.builtIn) {
+    if (!isBuiltInEligibleForRollup(d)) continue;
+    builtInFields.add(d.field);
+  }
+  // account_name rides along with account_id — only when the latter is in.
+  if (builtInFields.has('account_id')) builtInFields.add('account_name');
+
+  const enabledTags = dimensions.tags
+    .filter(isTagEligibleForRollup)
+    .map(t => ({ col: tagColumnName(t.tagName), raw: rawTagKey(t.tagName) }));
+
+  const tagColumns = enabledTags.map(t => t.col).sort((a, b) => a.localeCompare(b));
+  const tagRawKeys = tagColumns.map(col => {
+    const found = enabledTags.find(t => t.col === col);
+    if (found === undefined) throw new Error(`unreachable: tag column ${col} not found`);
+    return found.raw;
+  });
+
+  const sortedBuiltIn = [...builtInFields].sort((a, b) => a.localeCompare(b));
+
+  const hash = createHash('sha256').update(JSON.stringify({
+    v: ROLLUP_VERSION,
+    builtIn: sortedBuiltIn,
+    tags: tagColumns,
+    metric: costMetric,
+    perspective: costPerspective,
+  })).digest('hex').slice(0, 16);
+
+  return {
+    hash,
+    builtInFields: sortedBuiltIn,
+    tagColumns,
+    tagRawKeys,
+    costMetric,
+    costPerspective,
+  };
+}
+
+/** All output columns the rollup parquet will have, in stable order.
+ *  Useful for SELECT * targets and for tests asserting parquet shape. */
+export function rollupOutputColumns(schema: RollupSchema): readonly string[] {
+  return [
+    ...schema.builtInFields,
+    ...schema.tagColumns,
+    'cost',
+    'list_cost',
+    'usage_amount',
+    'row_count',
+  ];
+}

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -19,7 +19,12 @@ import {
   DEFAULT_LAG_DAYS,
   logger,
   isStringRecord,
+  deriveRollupSchema,
+  computeRollupAvailability,
+  buildPendingRollups,
+  dropStaleManifestEntries,
 } from '@costgoblin/core';
+import type { RollupSchema } from '@costgoblin/core';
 import { buildAccountReverseMap } from './query-utils.js';
 import type {
   BuiltInDimension,
@@ -122,6 +127,9 @@ export interface AppState {
   accountReverseMap: Map<string, readonly string[]> | null;
   regionMap: Map<string, RegionEnrichment> | null;
   orgAccountsPath: string | undefined | null;
+  /** Cached rollup availability — computed lazily, invalidated when dims or
+   *  cost scope change, refreshed after sync completes. */
+  rollupAvailability: { schema: RollupSchema; fresh: ReadonlySet<string> } | null;
 }
 
 export interface AppContext {
@@ -159,6 +167,13 @@ export interface AppContext {
   readonly invalidateCostScope: () => void;
   readonly invalidateColumnCache: () => void;
   readonly warmupBase: () => void;
+  /** Returns the current rollup schema + the set of fresh-on-disk periods.
+   *  Lazy: computes on first call, cached until invalidated. */
+  readonly getRollupAvailability: () => Promise<{ schema: RollupSchema; fresh: ReadonlySet<string> }>;
+  /** Build any rollup that's missing or stale. Called after sync completes
+   *  (with the synced periods) and lazily from query handlers when a query
+   *  would hit a stale period. */
+  readonly buildRollups: (periods?: readonly string[]) => Promise<readonly string[]>;
 }
 
 async function loadAccountCsv(
@@ -243,6 +258,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     accountReverseMap: null,
     regionMap: null,
     orgAccountsPath: null,
+    rollupAvailability: null,
   };
 
   async function getConfig(): Promise<CostGoblinConfig> {
@@ -494,6 +510,52 @@ export function createAppContext(ctx: IpcContext): AppContext {
     }
   }
 
+  async function deriveSchemaForRollup(): Promise<RollupSchema> {
+    // Use the user-facing dimensions (NOT query-enriched) — we want the raw
+    // tag list, not SSM-derived enrichment, to drive the rollup shape.
+    const dims = await getDimensions();
+    const costScope = await getCostScope().catch(() => undefined);
+    const metric = costScope?.costMetric ?? 'unblended';
+    const perspective = costScope?.costPerspective ?? 'gross';
+    return deriveRollupSchema(dims, metric, perspective);
+  }
+
+  async function getRollupAvailability(): Promise<{ schema: RollupSchema; fresh: ReadonlySet<string> }> {
+    if (state.rollupAvailability !== null) return state.rollupAvailability;
+    const schema = await deriveSchemaForRollup();
+    const availability = await computeRollupAvailability(ctx.dataDir, schema);
+    const cached = { schema: availability.schema, fresh: availability.fresh };
+    state.rollupAvailability = cached;
+    return cached;
+  }
+
+  async function buildRollups(periods?: readonly string[]): Promise<readonly string[]> {
+    try {
+      const schema = await deriveSchemaForRollup();
+      // Drop manifest entries from any older schema before rebuilding under the
+      // new one. The on-disk parquet files get overwritten as we go.
+      await dropStaleManifestEntries(ctx.dataDir, schema);
+      const availableColumns = await getAvailableColumns('daily');
+      const built = await buildPendingRollups({
+        dataDir: ctx.dataDir,
+        schema,
+        availableColumns,
+        runQuery: (sql) => ctx.db.runQuery(sql),
+        ...(periods === undefined ? {} : { periods }),
+      });
+      // Refresh cached availability so subsequent queries see the new files.
+      const refreshed = await computeRollupAvailability(ctx.dataDir, schema);
+      state.rollupAvailability = { schema: refreshed.schema, fresh: refreshed.fresh };
+      if (built.length > 0) {
+        logger.info('rollup-built-batch', { count: built.length, periods: built });
+      }
+      return built;
+    } catch (err: unknown) {
+      logger.warn(`buildRollups: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
   return {
     ctx,
     state,
@@ -515,15 +577,24 @@ export function createAppContext(ctx: IpcContext): AppContext {
     invalidateConfig: () => { state.config = null; },
     invalidateDimensions: () => {
       state.dimensions = null; state.accountMap = null; state.accountReverseMap = null; state.regionMap = null; state.orgAccountsPath = null;
+      // Schema changes — drop rollup availability so the next query sees the
+      // post-rebuild state, then rebuild in the background.
+      state.rollupAvailability = null;
       void materializedBase.drop((s) => ctx.db.runQuery(s), () => { resultCache.clear(); }).then(() => { void warmupBase(); });
+      void buildRollups();
     },
     invalidateViews: () => { state.views = null; },
     invalidateCostScope: () => {
       state.costScope = null;
+      // Cost metric / perspective live in the cost scope; rollup invalidates too.
+      state.rollupAvailability = null;
       void materializedBase.drop((s) => ctx.db.runQuery(s), () => { resultCache.clear(); }).then(() => { void warmupBase(); });
+      void buildRollups();
     },
     invalidateColumnCache: () => { columnCache.clear(); },
     warmupBase: () => { resultCache.clear(); void warmupBase(); },
+    getRollupAvailability,
+    buildRollups,
   };
 }
 

--- a/packages/desktop/src/main/handlers/query-costs.ts
+++ b/packages/desktop/src/main/handlers/query-costs.ts
@@ -45,7 +45,12 @@ export function registerCostHandlers(app: AppContext): void {
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
     const matSource = materializedBase.getSource(params.dateRange, tier);
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const rollup = isMat || tier !== 'daily' ? undefined : await app.getRollupAvailability();
+    const qcOpts: QueryContextOptions = {
+      dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available,
+      accountReverseMap, costScope, availableColumns, materializedSource: matSource,
+      ...(rollup === undefined ? {} : { rollupSchema: rollup.schema, rollupFreshPeriods: rollup.fresh }),
+    };
     const { sql, params: queryParams } = buildCostQuery(params, qcOpts);
     logger.info('query:costs', { groupBy: params.groupBy, materialized: isMat });
 
@@ -80,7 +85,12 @@ export function registerCostHandlers(app: AppContext): void {
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
     const matSource = materializedBase.getSource(params.dateRange, tier);
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const rollup = isMat || tier !== 'daily' ? undefined : await app.getRollupAvailability();
+    const qcOpts: QueryContextOptions = {
+      dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available,
+      accountReverseMap, costScope, availableColumns, materializedSource: matSource,
+      ...(rollup === undefined ? {} : { rollupSchema: rollup.schema, rollupFreshPeriods: rollup.fresh }),
+    };
     const { sql, params: queryParams } = buildDailyCostsQuery(params, qcOpts);
     logger.info('query:daily-costs', { groupBy: params.groupBy, materialized: isMat });
 
@@ -152,7 +162,12 @@ export function registerCostHandlers(app: AppContext): void {
     }
     const matSource = materializedBase.getSource(params.dateRange, tier);
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const rollup = isMat || tier !== 'daily' ? undefined : await app.getRollupAvailability();
+    const qcOpts: QueryContextOptions = {
+      dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available,
+      accountReverseMap, costScope, availableColumns, materializedSource: matSource,
+      ...(rollup === undefined ? {} : { rollupSchema: rollup.schema, rollupFreshPeriods: rollup.fresh }),
+    };
     const { sql, params: queryParams } = buildEntityDetailQuery(params, qcOpts);
     logger.info('query:entity-detail', { entity: params.entity, materialized: isMat });
 

--- a/packages/desktop/src/main/handlers/query-trends.ts
+++ b/packages/desktop/src/main/handlers/query-trends.ts
@@ -41,8 +41,13 @@ export function registerTrendHandlers(app: AppContext): void {
     const fullRange = { start: prevStart, end: params.dateRange.end };
     const matSource = materializedBase.getSource(fullRange, 'daily');
     const isMat = matSource !== undefined;
+    const rollup = isMat ? undefined : await app.getRollupAvailability();
 
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const qcOpts: QueryContextOptions = {
+      dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available,
+      accountReverseMap, costScope, availableColumns, materializedSource: matSource,
+      ...(rollup === undefined ? {} : { rollupSchema: rollup.schema, rollupFreshPeriods: rollup.fresh }),
+    };
     const { sql, params: queryParams } = buildTrendQuery(params, qcOpts);
     logger.info('query:trends', { groupBy: params.groupBy, materialized: isMat });
 

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -1,5 +1,6 @@
 import { ipcMain, shell } from 'electron';
 import {
+  extractPeriod,
   getDataInventory,
   getEtagFileName,
   getRawDirPrefix,
@@ -155,7 +156,17 @@ export function registerSyncHandlers(app: AppContext): void {
       syncWorkerIds.delete(syncId);
 
       state.syncStatuses[syncId] = { status: 'completed', lastSync: new Date(), filesDownloaded: result.filesDownloaded };
-      if (result.filesDownloaded > 0) app.warmupBase();
+      if (result.filesDownloaded > 0) {
+        app.warmupBase();
+        // Daily tier is the only one with rollups today; trigger build for the
+        // synced periods. Don't await — query traffic shouldn't wait on rollup
+        // builds, the rollup just kicks in on the next query that lands after
+        // the build finishes.
+        if (tier === 'daily') {
+          const periods = [...new Set(fileEntries.map(f => extractPeriod(f.key)).filter(p => p !== 'unknown'))];
+          if (periods.length > 0) void app.buildRollups(periods);
+        }
+      }
       return result;
     } catch (err: unknown) {
       syncWorkerIds.delete(syncId);


### PR DESCRIPTION
## Summary

Pre-aggregate raw daily CUR parquet into a per-month rollup parquet, keyed by every enabled dimension (built-in + tag) plus account_name. Resource_id and description are deliberately dropped so cardinality shrinks ~10–50× — those queries (missing-tags, entity drill-down) stay on raw.

## Why

Dashboard renders fan out into 16+ independent SQL queries that each scan the same monthly CUR parquet (~2GB) and re-evaluate `COALESCE` + `element_at(MAP, ...)` per row. From a real query log on a 4-month range:

| Tile | Time |
|---|---|
| Most tiles | 4–9s |
| Region (full label CASE) | 15.8s |
| Resource-id breakdown | 18.4s |
| Daily-cost histogram | 9.1s |

Eight queries firing in the same second do not share scans. File-level partitioning won't help — each query wants the whole window. The leverage is a smaller, pre-grouped table.

## What

**Lifecycle.** Built post-sync for synced periods (current month rebuilds every sync). Schema hash includes enabled built-ins, enabled tags, cost metric, and perspective. Editing `dimensions.yaml` or cost scope bumps the hash and invalidates every rollup; the next build regenerates from raw. Per-period state in `aws/rollup/manifest.json` tracks `{ schemaHash, rawHash, builtAt, rowCount }`. `rawHash` is over the period's sync etags so closed-month rollups don't waste work.

**Query path.** `buildSource()` emits a SELECT directly over the rollup parquet when the caller passes `rollupSource`, skipping the whole COALESCE / `element_at` / org-account JOIN machinery. Per-query builders (cost, trends, daily-costs, entity-detail) opt in via `setupQuery()`'s `rollupHint`. Eligibility is conservative: rollup is used only when every referenced dimension is in the schema, no `resource_id` / `description` is touched, no scope rule references a dropped dim, and every required period is fresh.

**Opt-out.** `buildMissingTagsQuery`, `buildNonResourceCostQuery`, and the materialized-base path stay on raw — they need `resource_id`, `raw_<tag>`, or a slim projection the rollup doesn't carry.

**Coexistence with materialized base.** Materialized base keeps winning for queries that fall inside its in-memory warmup window. Rollup covers everything beyond it and survives restarts. The handlers prefer materialized, then rollup, then raw.

## Files

- `packages/core/src/rollup/{schema,manifest,build-rollup,eligibility,orchestrator,index}.ts` — new module
- `packages/core/src/query/builder.ts` — `BuildSourceOptions.rollupSource`, `QueryContextOptions.rollupSchema/rollupFreshPeriods`, `tryRollupSourceFor()`, per-query opt-in
- `packages/desktop/src/main/handlers/context.ts` — `getRollupAvailability()`, `buildRollups()`, invalidation on dims / cost-scope change
- `packages/desktop/src/main/handlers/sync.ts` — post-sync hook for daily tier
- `packages/desktop/src/main/handlers/{query-costs,query-trends}.ts` — pass schema + fresh periods into `QueryContextOptions`
- `packages/core/src/__tests__/rollup-integration.test.ts` — 8 new integration tests covering schema hashing, build correctness, eligibility, and per-query SQL shape

All 503 tests pass (498 + 5 skipped) and `npm run check` is green.