### PR TITLE
Tag DB queries with widget/view origin in debug panel

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -103,7 +103,7 @@ export interface CostApi {
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult>;
   syncPeriods(files: readonly { key: string; contentHash: string; size: number }[], syncId?: string): Promise<{ filesDownloaded: number; rowsProcessed: number }>;
   cancelSync(syncId?: string): Promise<void>;
-  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]>;
+  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]>;
   deleteLocalPeriod(period: string, tier?: DataTier): Promise<void>;
   openDataFolder(): Promise<void>;
   ssoLogin(profile: string): Promise<void>;

--- a/packages/core/src/types/explorer.ts
+++ b/packages/core/src/types/explorer.ts
@@ -40,6 +40,8 @@ export interface ExplorerBaseParams {
    *  meaningful when the CUR includes `line_item_net_*` columns —
    *  capabilities probe tells the UI whether to show the toggle. */
   readonly costPerspective?: CostPerspective;
+  /** Debug-only: tag identifying which widget/view fired this query. */
+  readonly origin?: string | undefined;
 }
 
 export type ExplorerOverviewParams = ExplorerBaseParams;
@@ -165,4 +167,5 @@ export interface ExplorerFilterValuesParams {
   readonly applyCostScope?: boolean;
   readonly costMetric?: CostMetric;
   readonly costPerspective?: CostPerspective;
+  readonly origin?: string | undefined;
 }

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -25,6 +25,9 @@ export interface CostQueryParams {
   readonly filters: FilterMap;
   readonly granularity?: Granularity | undefined;
   readonly orgNodeValues?: readonly string[] | undefined;
+  /** Debug-only: tag identifying which widget/view fired this query,
+   *  surfaced in the query log. Not used by SQL builders. */
+  readonly origin?: string | undefined;
 }
 
 export interface CostRow {
@@ -47,6 +50,7 @@ export interface TrendQueryParams {
   readonly filters: FilterMap;
   readonly deltaThreshold: Dollars;
   readonly percentThreshold: number;
+  readonly origin?: string | undefined;
 }
 
 export interface TrendRow {
@@ -69,6 +73,7 @@ export interface MissingTagsParams {
   readonly filters: FilterMap;
   readonly minCost: Dollars;
   readonly tagDimension: DimensionId;
+  readonly origin?: string | undefined;
 }
 
 /**
@@ -133,6 +138,7 @@ export interface EntityDetailParams {
   readonly dateRange: DateRange;
   readonly filters: FilterMap;
   readonly granularity?: Granularity | undefined;
+  readonly origin?: string | undefined;
 }
 
 export interface DailyCost {
@@ -164,6 +170,7 @@ export interface DailyCostsParams {
   readonly filters: FilterMap;
   readonly groupBy: DimensionId;
   readonly granularity?: Granularity | undefined;
+  readonly origin?: string | undefined;
 }
 
 export interface DailyCostDay {

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import { originStore } from '../query-log.js';
 import {
   asDimensionId,
   asDateString,
@@ -411,7 +412,7 @@ export function registerExplorerHandlers(app: AppContext): void {
   // Histogram + totals. Depends on filters/range/granularity/scope/metric/
   // perspective — NOT on sort. Kept separate from the rows query so that
   // clicking a column header doesn't wipe the histogram.
-  ipcMain.handle('explorer:query-overview', async (_event, payload: unknown): Promise<ExplorerOverviewResult> => {
+  ipcMain.handle('explorer:query-overview', (_event, payload: unknown): Promise<ExplorerOverviewResult> => originStore.run((payload as ExplorerOverviewParams).origin ?? null, async () => {
     const params = payload as ExplorerOverviewParams;
     const qc = await prepareQueryContext(app, params);
 
@@ -489,10 +490,10 @@ export function registerExplorerHandlers(app: AppContext): void {
       totalCost,
       tagColumns: qc.tagColumns,
     };
-  });
+  }));
 
   // Sample rows. Depends on everything the overview does PLUS sort + rowLimit.
-  ipcMain.handle('explorer:query-rows', async (_event, payload: unknown): Promise<ExplorerRowsResult> => {
+  ipcMain.handle('explorer:query-rows', (_event, payload: unknown): Promise<ExplorerRowsResult> => originStore.run((payload as ExplorerRowsParams).origin ?? null, async () => {
     const params = payload as ExplorerRowsParams;
     const qc = await prepareQueryContext(app, params);
     const rowLimit = clampRowLimit(params.rowLimit);
@@ -555,9 +556,9 @@ export function registerExplorerHandlers(app: AppContext): void {
     }
 
     return { sampleRows, tagColumns: qc.tagColumns };
-  });
+  }));
 
-  ipcMain.handle('explorer:query-aggregated-table', async (_event, payload: unknown): Promise<AggregatedTableResult> => {
+  ipcMain.handle('explorer:query-aggregated-table', (_event, payload: unknown): Promise<AggregatedTableResult> => originStore.run((payload as AggregatedTableParams).origin ?? null, async () => {
     const params = payload as AggregatedTableParams;
     const qc = await prepareQueryContext(app, params);
     const rowLimit = clampRowLimit(params.rowLimit);
@@ -633,9 +634,9 @@ export function registerExplorerHandlers(app: AppContext): void {
     });
 
     return { rows: resultRows, totalRows, tagColumns: qc.tagColumns };
-  });
+  }));
 
-  ipcMain.handle('explorer:filter-values', async (_event, payload: unknown): Promise<ExplorerFilterValue[]> => {
+  ipcMain.handle('explorer:filter-values', (_event, payload: unknown): Promise<ExplorerFilterValue[]> => originStore.run((payload as ExplorerFilterValuesParams).origin ?? null, async () => {
     const params = payload as ExplorerFilterValuesParams;
     const dimId = params.dimensionId;
 
@@ -695,5 +696,5 @@ export function registerExplorerHandlers(app: AppContext): void {
         rows: toNum(r['row_count']),
       };
     });
-  });
+  }));
 }

--- a/packages/desktop/src/main/handlers/query-costs.ts
+++ b/packages/desktop/src/main/handlers/query-costs.ts
@@ -29,11 +29,12 @@ import {
   resolveAvailablePeriods,
   resolveEntityName,
 } from './query-utils.js';
+import { originStore } from '../query-log.js';
 
 export function registerCostHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getOrgTreeConfig, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
 
-  ipcMain.handle('query:costs', async (_event, params: CostQueryParams): Promise<CostResult> => {
+  ipcMain.handle('query:costs', (_event, params: CostQueryParams): Promise<CostResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
@@ -67,9 +68,9 @@ export function registerCostHandlers(app: AppContext): void {
     }
 
     return result;
-  });
+  }));
 
-  ipcMain.handle('query:daily-costs', async (_event, params: DailyCostsParams): Promise<DailyCostsResult> => {
+  ipcMain.handle('query:daily-costs', (_event, params: DailyCostsParams): Promise<DailyCostsResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountReverseMap = await getAccountReverseMap();
     const orgPath = await getOrgAccountsPath();
@@ -127,9 +128,9 @@ export function registerCostHandlers(app: AppContext): void {
       });
 
     return { days, groups: [...groupSet], totalCost: asDollars(totalCost) };
-  });
+  }));
 
-  ipcMain.handle('query:entity-detail', async (_event, params: EntityDetailParams): Promise<EntityDetailResult> => {
+  ipcMain.handle('query:entity-detail', (_event, params: EntityDetailParams): Promise<EntityDetailResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
@@ -165,5 +166,5 @@ export function registerCostHandlers(app: AppContext): void {
         name: resolveEntityName(s.name, accountMap),
       })),
     };
-  });
+  }));
 }

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -12,6 +12,7 @@ import {
   toNum,
   toStr,
 } from './query-utils.js';
+import { originStore } from '../query-log.js';
 
 function resolveFieldExpr(
   dimensionId: string,
@@ -116,7 +117,7 @@ function mergeAccountRows(
 export function registerFilterHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
 
-  ipcMain.handle('query:filter-values', async (_event, dimensionId: string, filterEntries: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> => {
+  ipcMain.handle('query:filter-values', (_event, dimensionId: string, filterEntries: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]> => originStore.run(origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
@@ -174,5 +175,5 @@ export function registerFilterHandlers(app: AppContext): void {
       const rawVal = toStr(r['val']);
       return { value: rawVal, label: rawVal, count: toNum(r['total_cost']) };
     });
-  });
+  }));
 }

--- a/packages/desktop/src/main/handlers/query-recommendations.ts
+++ b/packages/desktop/src/main/handlers/query-recommendations.ts
@@ -20,11 +20,12 @@ import {
   toNum,
   toStr,
 } from './query-utils.js';
+import { originStore } from '../query-log.js';
 
 export function registerRecommendationHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getConfig, getCostScope, getAvailableColumns, runQuery, runPreparedQuery, materializedBase } = app;
 
-  ipcMain.handle('query:missing-tags', async (_event, params: MissingTagsParams): Promise<MissingTagsResult> => {
+  ipcMain.handle('query:missing-tags', (_event, params: MissingTagsParams): Promise<MissingTagsResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
@@ -67,9 +68,9 @@ export function registerRecommendationHandlers(app: AppContext): void {
         accountName: resolveEntityName(r.accountId, accountMap) || r.accountName,
       })),
     };
-  });
+  }));
 
-  ipcMain.handle('query:savings', async (): Promise<SavingsResult> => {
+  ipcMain.handle('query:savings', (): Promise<SavingsResult> => originStore.run('savings', async () => {
     const config = await getConfig();
     const provider = config.providers[0];
     if (provider?.sync.costOptimization === undefined) {
@@ -131,5 +132,5 @@ export function registerRecommendationHandlers(app: AppContext): void {
     });
 
     return { recommendations, totalMonthlySavings: asDollars(totalSavings) };
-  });
+  }));
 }

--- a/packages/desktop/src/main/handlers/query-trends.ts
+++ b/packages/desktop/src/main/handlers/query-trends.ts
@@ -17,11 +17,12 @@ import {
   resolveAvailablePeriods,
   resolveEntityName,
 } from './query-utils.js';
+import { originStore } from '../query-log.js';
 
 export function registerTrendHandlers(app: AppContext): void {
   const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
 
-  ipcMain.handle('query:trends', async (_event, params: TrendQueryParams): Promise<TrendResult> => {
+  ipcMain.handle('query:trends', (_event, params: TrendQueryParams): Promise<TrendResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
@@ -56,5 +57,5 @@ export function registerTrendHandlers(app: AppContext): void {
       };
     }
     return result;
-  });
+  }));
 }

--- a/packages/desktop/src/main/query-log.ts
+++ b/packages/desktop/src/main/query-log.ts
@@ -1,6 +1,12 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { RawRow } from './duckdb-client.js';
 
 export type QueryStatus = 'queued' | 'running' | 'success' | 'error';
+
+/** Per-IPC-call origin tag (e.g. "pie:service"). Set by handlers via
+ *  `originStore.run(origin, fn)` so QueryLog.start can attach it without
+ *  threading origin through every helper signature. */
+export const originStore = new AsyncLocalStorage<string | null>();
 
 export interface QueryLogEntry {
   readonly id: number;
@@ -13,6 +19,7 @@ export interface QueryLogEntry {
   readonly error: string | null;
   readonly materialized: boolean;
   readonly cached: boolean;
+  readonly origin: string | null;
 }
 
 interface InternalEntry {
@@ -27,6 +34,7 @@ interface InternalEntry {
   error: string | null;
   materialized: boolean;
   cached: boolean;
+  origin: string | null;
 }
 
 const MAX_ENTRIES = 200;
@@ -49,6 +57,7 @@ export class QueryLog {
       error: null,
       materialized,
       cached: false,
+      origin: originStore.getStore() ?? null,
     });
     if (this.entries.length > MAX_ENTRIES) {
       this.entries = this.entries.slice(-MAX_ENTRIES);
@@ -92,6 +101,7 @@ export class QueryLog {
       error: e.error,
       materialized: e.materialized,
       cached: e.cached,
+      origin: e.origin,
     }));
   }
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -54,6 +54,9 @@ interface DebugQueryLogEntry {
   readonly durationMs: number | null;
   readonly rowCount: number | null;
   readonly error: string | null;
+  readonly materialized: boolean;
+  readonly cached: boolean;
+  readonly origin: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,8 +121,8 @@ const api: CostApi = {
   getOrgTree(): Promise<OrgNode[]> {
     return invoke<OrgNode[]>('config:org-tree');
   },
-  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }): Promise<{ value: string; label: string; count: number }[]> {
-    return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange, opts);
+  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]> {
+    return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange, opts, origin);
   },
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult> {
     return invoke<DataInventoryResult>('data:inventory', tier);

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -15,6 +15,11 @@ const perfEnabled = globalThis.costgoblinPerf !== undefined;
 const isDev = globalThis.costgoblinDebug.isDev();
 const renderTimings: RenderTiming[] = [];
 
+function formatMemory(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(2)} GB`;
+  return `${String(mb)} MB`;
+}
+
 function useMemoryMB(): number {
   const [mb, setMb] = useState(0);
   useEffect(() => {
@@ -506,6 +511,9 @@ function AppShell(): React.JSX.Element {
     api.clearAllCaches()
       .catch(() => undefined)
       .finally(() => {
+        // Wipe the debug panel's query log too — after clearing the cache,
+        // only the queries that the refresh triggers are interesting.
+        globalThis.costgoblinDebug.clearLog().catch(() => undefined);
         setClearingCache(false);
         setRefreshNonce(n => n + 1);
       });
@@ -671,7 +679,7 @@ function AppShell(): React.JSX.Element {
             <span className="text-sm font-bold text-accent tracking-wider leading-tight">CostGoblin</span>
             <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
               {appVersion !== '' && <span>v{appVersion}</span>}
-              {isDev && memoryMB > 0 && <span>{memoryMB} MB</span>}
+              {isDev && memoryMB > 0 && <span>{formatMemory(memoryMB)}</span>}
             </div>
           </div>
           <nav className="flex items-center justify-end gap-1 [-webkit-app-region:no-drag]" aria-label="Sync and settings">

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -366,7 +366,7 @@ async function prewarmDimensions(
   let done = 0;
   setSplashStep(`Loading dimensions 0/${String(dims.length)}...`);
   await Promise.all(dims.map(async (dim) => {
-    await api.getFilterValues(dimId(dim), {}, range).catch(() => undefined);
+    await api.getFilterValues(dimId(dim), {}, range, undefined, `splash:warmup:${dimId(dim)}`).catch(() => undefined);
     done++;
     setSplashStep(`Loading dimensions ${String(done)}/${String(dims.length)}...`);
   }));

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -17,7 +17,8 @@ function serializeLog(entries: DebugQueryLogEntry[]): string {
     const status = labels[e.status] ?? e.status;
     const duration = e.durationMs === null ? '...' : formatDuration(e.durationMs);
     const rows = e.rowCount === null ? '' : `${String(e.rowCount)} rows`;
-    const header = `[${status}] ${formatTimestamp(e.startedAt)}  ${duration}  ${rows}`;
+    const origin = e.origin === null ? '' : `  origin=${e.origin}`;
+    const header = `[${status}] ${formatTimestamp(e.startedAt)}  ${duration}  ${rows}${origin}`;
     const error = e.error === null ? '' : `\nError: ${e.error}`;
     return `${header}\n${e.sql}${error}`;
   }).join('\n\n---\n\n');
@@ -26,6 +27,17 @@ function serializeLog(entries: DebugQueryLogEntry[]): string {
 function sqlPreview(sql: string): string {
   const oneLine = sql.replaceAll(/\s+/g, ' ').trim();
   return oneLine.length > 100 ? `${oneLine.slice(0, 100)}...` : oneLine;
+}
+
+type QuerySource = 'rollup' | 'raw' | null;
+
+/** Infer the on-disk source the query reads from. CACHE / MEM are set on the
+ *  entry directly; ROLLUP / RAW we infer by looking for the path markers in
+ *  the SQL since those flags are not plumbed through. */
+function detectSource(sql: string): QuerySource {
+  if (sql.includes('/aws/rollup/')) return 'rollup';
+  if (sql.includes('/aws/raw/')) return 'raw';
+  return null;
 }
 
 function StatusDot({ status }: Readonly<{ status: DebugQueryLogEntry['status'] }>): React.JSX.Element {
@@ -76,6 +88,12 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
             {entry.materialized && !entry.cached && (
               <span className="text-[10px] font-medium px-1 rounded bg-positive/15 text-positive">MEM</span>
             )}
+            {!entry.cached && !entry.materialized && (() => {
+              const src = detectSource(entry.sql);
+              if (src === 'rollup') return <span className="text-[10px] font-medium px-1 rounded bg-warning/15 text-warning">ROLLUP</span>;
+              if (src === 'raw') return <span className="text-[10px] font-medium px-1 rounded bg-text-muted/15 text-text-secondary">RAW</span>;
+              return null;
+            })()}
             <span className="text-xs text-text-muted">
               {(() => { if (entry.durationMs !== null) { return formatDuration(entry.durationMs); } return entry.status === 'queued' ? 'queued' : '...'; })()}
             </span>
@@ -91,6 +109,9 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
           )}
           {entry.error !== null && (
             <span className="text-[10px] text-negative truncate">{entry.error}</span>
+          )}
+          {entry.origin !== null && (
+            <span className="ml-auto text-[10px] font-mono text-text-muted truncate" title={entry.origin}>{entry.origin}</span>
           )}
         </div>
       </button>

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -182,13 +182,18 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
 
   const runningCount = visible.filter(e => e.status === 'running').length;
   const queuedCount = visible.filter(e => e.status === 'queued').length;
-  const sorted = [...visible].reverse().sort((a, b) => {
+  // Sort: running first (so the active spinner stays visible), then queued,
+  // then completed entries by duration DESC so the slowest queries float to
+  // the top where they're easiest to spot.
+  const sorted = [...visible].sort((a, b) => {
     const rank = (s: DebugQueryLogEntry['status']): number => {
       if (s === 'running') return 0;
       if (s === 'queued') return 1;
       return 2;
     };
-    return rank(a.status) - rank(b.status);
+    const rankDiff = rank(a.status) - rank(b.status);
+    if (rankDiff !== 0) return rankDiff;
+    return (b.durationMs ?? 0) - (a.durationMs ?? 0);
   });
 
   return (

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -142,8 +142,14 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
   );
 }
 
+/** Sentinel value used in the origin dropdown — `<select>` only accepts
+ *  strings, so we encode "no origin" as this token and treat empty string
+ *  ('') as the "all" choice. */
+const NO_ORIGIN = '__no_origin__';
+
 export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): React.JSX.Element {
   const [entries, setEntries] = useState<DebugQueryLogEntry[]>([]);
+  const [originFilter, setOriginFilter] = useState('');
   const inFlightCount = useDebugBadge();
 
   useEffect(() => {
@@ -158,9 +164,25 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
     return () => { cancelled = true; clearInterval(timer); };
   }, []);
 
-  const runningCount = entries.filter(e => e.status === 'running').length;
-  const queuedCount = entries.filter(e => e.status === 'queued').length;
-  const sorted = [...entries].reverse().sort((a, b) => {
+  // Count queries per origin (incl. a bucket for entries with no origin) so
+  // the dropdown can show counts and sort by frequency.
+  const originCounts = new Map<string, number>();
+  for (const e of entries) {
+    const key = e.origin ?? NO_ORIGIN;
+    originCounts.set(key, (originCounts.get(key) ?? 0) + 1);
+  }
+  const originOptions = [...originCounts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+
+  const visible = originFilter === ''
+    ? entries
+    : entries.filter(e => (e.origin ?? NO_ORIGIN) === originFilter);
+
+  const runningCount = visible.filter(e => e.status === 'running').length;
+  const queuedCount = visible.filter(e => e.status === 'queued').length;
+  const sorted = [...visible].reverse().sort((a, b) => {
     const rank = (s: DebugQueryLogEntry['status']): number => {
       if (s === 'running') return 0;
       if (s === 'queued') return 1;
@@ -170,21 +192,30 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
   });
 
   return (
-    <div className="fixed top-[4.5rem] right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col">
+    <div className="fixed top-[5.5rem] right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0 [-webkit-app-region:no-drag]">
         <div className="flex items-center gap-3">
           <h2 className="text-sm font-semibold text-text-primary">Query Log</h2>
-          <span className="text-xs text-text-muted">
-            {String(entries.length)} queries
-            {(runningCount > 0 || queuedCount > 0) && (
-              <span className="ml-1">
-                {runningCount > 0 && <span className="text-accent">{String(runningCount)} running</span>}
-                {runningCount > 0 && queuedCount > 0 && <span className="text-text-muted">, </span>}
-                {queuedCount > 0 && <span className="text-warning">{String(queuedCount)} queued</span>}
-              </span>
-            )}
-          </span>
+          <select
+            value={originFilter}
+            onChange={(e) => { setOriginFilter(e.target.value); }}
+            className="text-xs bg-bg-tertiary text-text-secondary border border-border rounded px-2 py-1 hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
+          >
+            <option value="">all ({String(entries.length)})</option>
+            {originOptions.map(([origin, count]) => (
+              <option key={origin} value={origin}>
+                {origin === NO_ORIGIN ? '(no origin)' : origin} ({String(count)})
+              </option>
+            ))}
+          </select>
+          {(runningCount > 0 || queuedCount > 0) && (
+            <span className="text-xs text-text-muted">
+              {runningCount > 0 && <span className="text-accent">{String(runningCount)} running</span>}
+              {runningCount > 0 && queuedCount > 0 && <span className="text-text-muted">, </span>}
+              {queuedCount > 0 && <span className="text-warning">{String(queuedCount)} queued</span>}
+            </span>
+          )}
           {inFlightCount > 0 && (
             <span className="text-xs text-text-muted" title="Total IPC calls in-flight (includes config, sync, and other non-SQL calls)">
               <span className="text-accent">{String(inFlightCount)}</span> IPC in-flight

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -12,6 +12,7 @@ declare global {
     readonly error: string | null;
     readonly materialized: boolean;
     readonly cached: boolean;
+    readonly origin: string | null;
   }
 
   interface DebugApi {

--- a/packages/ui/src/components/entity-popup.tsx
+++ b/packages/ui/src/components/entity-popup.tsx
@@ -59,6 +59,7 @@ export function EntityPopup({
         dimension: asDimensionId(dimension),
         dateRange: getDateRange(),
         filters: {},
+        origin: 'entity-popup',
       }),
     [entity, dimension, api],
   );

--- a/packages/ui/src/hooks/use-widget-query.ts
+++ b/packages/ui/src/hooks/use-widget-query.ts
@@ -31,13 +31,14 @@ async function fetchDailyWithFallback(
   dateRange: DateRange,
   filters: FilterMap,
   granularity: Granularity,
+  origin: string,
 ): Promise<DailyQueryResult> {
-  const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+  const primary = await api.queryDailyCosts({ groupBy: specGroupBy, dateRange, filters, granularity, origin });
   if (fallbackDims.length === 0 || primary.groups.length > 1) {
     return { result: primary, groupBy: specGroupBy };
   }
   for (const dim of fallbackDims) {
-    const result = await api.queryDailyCosts({ groupBy: dim, dateRange, filters, granularity });
+    const result = await api.queryDailyCosts({ groupBy: dim, dateRange, filters, granularity, origin: `${origin}/fallback` });
     if (result.groups.length > 1) return { result, groupBy: dim };
   }
   return { result: primary, groupBy: specGroupBy };
@@ -50,13 +51,14 @@ async function fetchCostsWithFallback(
   dateRange: DateRange,
   filters: FilterMap,
   granularity: Granularity,
+  origin: string,
 ): Promise<CostQueryResult> {
-  const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity });
+  const primary = await api.queryCosts({ groupBy: specGroupBy, dateRange, filters, granularity, origin });
   if (fallbackDims.length === 0 || primary.rows.length > 1) {
     return { result: primary, groupBy: specGroupBy };
   }
   for (const dim of fallbackDims) {
-    const result = await api.queryCosts({ groupBy: dim, dateRange, filters, granularity });
+    const result = await api.queryCosts({ groupBy: dim, dateRange, filters, granularity, origin: `${origin}/fallback` });
     if (result.rows.length > 1) return { result, groupBy: dim };
   }
   return { result: primary, groupBy: specGroupBy };
@@ -68,6 +70,7 @@ interface WidgetQueryArgs {
   readonly granularity: Granularity;
   readonly globalFilters: FilterMap;
   readonly specFilters: WidgetFilterOverlay | undefined;
+  readonly origin: string;
 }
 
 interface DailyWidgetQueryResult {
@@ -83,6 +86,7 @@ export function useDailyWidgetQuery({
   granularity,
   globalFilters,
   specFilters,
+  origin,
 }: WidgetQueryArgs): DailyWidgetQueryResult {
   const api = useCostApi();
   const filters = mergeFilters(globalFilters, specFilters);
@@ -95,8 +99,8 @@ export function useDailyWidgetQuery({
   const query = useQuery<DailyQueryResult | null>(
     () => specGroupBy === undefined
       ? Promise.resolve(null)
-      : fetchDailyWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity),
-    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
+      : fetchDailyWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity, origin),
+    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api, origin],
   );
 
   const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;
@@ -121,6 +125,7 @@ export function useCostWidgetQuery({
   granularity,
   globalFilters,
   specFilters,
+  origin,
 }: WidgetQueryArgs): CostWidgetQueryResult {
   const api = useCostApi();
   const filters = mergeFilters(globalFilters, specFilters);
@@ -133,8 +138,8 @@ export function useCostWidgetQuery({
   const query = useQuery<CostQueryResult | null>(
     () => specGroupBy === undefined
       ? Promise.resolve(null)
-      : fetchCostsWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity),
-    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
+      : fetchCostsWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity, origin),
+    [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api, origin],
   );
 
   const activeGroupBy = query.status === 'success' && query.data !== null ? query.data.groupBy : specGroupBy;

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -638,7 +638,7 @@ export function CostScopeView(): React.JSX.Element {
     async function fetchDimValues(d: typeof dimensions[number]): Promise<[string, readonly string[]]> {
       const id = getDimensionId(d);
       try {
-        const vals = await api.getFilterValues(id, {}, undefined, { bypassCostScope: true });
+        const vals = await api.getFilterValues(id, {}, undefined, { bypassCostScope: true }, `cost-scope:${id}`);
         return [id, vals.map(v => v.value)];
       } catch {
         return [id, []];

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -102,6 +102,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
         filters: {},
         deltaThreshold: asDollars(state.deltaThreshold),
         percentThreshold: state.percentThreshold,
+        origin: `trends:${String(activeDimensionId)}`,
       });
     },
     [activeDimensionId, state.dateRange.start, state.dateRange.end, state.deltaThreshold, state.percentThreshold, api],

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -175,7 +175,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     for (const dim of dimensions) {
       const dimId = getDimensionId(dim);
       if (filterCacheRef.current.has(dimId)) continue;
-      api.getFilterValues(dimId, {}, dateRange).then(values => {
+      api.getFilterValues(dimId, {}, dateRange, undefined, `filter-bar:prefetch:${dimId}`).then(values => {
         filterCacheRef.current.set(dimId, values);
       }).catch(() => undefined);
     }
@@ -225,7 +225,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     }
     const plain: Record<string, readonly string[]> = {};
     for (const [k, v] of Object.entries(currentFilters)) if (v !== undefined) plain[k] = v;
-    return api.getFilterValues(dimensionId, plain, dateRange);
+    return api.getFilterValues(dimensionId, plain, dateRange, undefined, `filter-bar:${dimensionId}`);
   }
 
   return (

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -152,6 +152,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
       dateRange,
       filters: {},
       granularity,
+      origin: 'entity-detail:summary',
     }),
     [entity, dimension, dateRangeKey, granularity, api],
   );
@@ -184,19 +185,19 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
 
   // Pie queries — same as overview but scoped to this entity via filter
   const pie1Query = useQuery(
-    () => api.queryCosts({ groupBy: effectivePie1, dateRange, filters: entityFilter, granularity }),
+    () => api.queryCosts({ groupBy: effectivePie1, dateRange, filters: entityFilter, granularity, origin: `entity-detail:pie1:${String(effectivePie1)}` }),
     [effectivePie1, dateRangeKey, filterKey, granularity, api],
   );
   const pie1Slices = costRowsToSlices(pie1Query.status === 'success' ? pie1Query.data : null);
 
   const pie2Query = useQuery(
-    () => api.queryCosts({ groupBy: effectivePie2, dateRange, filters: entityFilter, granularity }),
+    () => api.queryCosts({ groupBy: effectivePie2, dateRange, filters: entityFilter, granularity, origin: `entity-detail:pie2:${String(effectivePie2)}` }),
     [effectivePie2, dateRangeKey, filterKey, granularity, api],
   );
   const pie2Slices = costRowsToSlices(pie2Query.status === 'success' ? pie2Query.data : null);
 
   const pie3Query = useQuery(
-    () => api.queryCosts({ groupBy: effectivePie3, dateRange, filters: entityFilter, granularity }),
+    () => api.queryCosts({ groupBy: effectivePie3, dateRange, filters: entityFilter, granularity, origin: `entity-detail:pie3:${String(effectivePie3)}` }),
     [effectivePie3, dateRangeKey, filterKey, granularity, api],
   );
   const pie3Slices = costRowsToSlices(pie3Query.status === 'success' ? pie3Query.data : null);
@@ -209,7 +210,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   })();
 
   const dailyQuery = useQuery(
-    () => api.queryDailyCosts({ groupBy: histogramDimId, dateRange, filters: entityFilter, granularity }),
+    () => api.queryDailyCosts({ groupBy: histogramDimId, dateRange, filters: entityFilter, granularity, origin: `entity-detail:histogram:${String(histogramDimId)}` }),
     [histogramDimId, dateRangeKey, filterKey, granularity, api],
   );
   const barDays = bucketBars(dailyCostsToBarDays(dailyQuery.status === 'success' ? dailyQuery.data : null), 170);

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -218,6 +218,7 @@ export function ExplorerView(): React.JSX.Element {
       applyCostScope: scope,
       costMetric: metric,
       costPerspective: perspective,
+      origin: 'explorer:overview',
     })
       .then(data => {
         if (reqId !== overviewReqIdRef.current) return;
@@ -250,6 +251,7 @@ export function ExplorerView(): React.JSX.Element {
       costMetric: metric,
       costPerspective: perspective,
       ...(s === undefined ? {} : { sort: s }),
+      origin: 'explorer:rows',
     })
       .then(data => {
         if (reqId !== rowsReqIdRef.current) return;
@@ -472,6 +474,7 @@ export function ExplorerView(): React.JSX.Element {
             applyCostScope,
             costMetric,
             costPerspective,
+            origin: `explorer:filter-values:${dimId}`,
           })}
         />
         {activeFilterCount > 0 && (

--- a/packages/ui/src/views/missing-tags.tsx
+++ b/packages/ui/src/views/missing-tags.tsx
@@ -226,6 +226,7 @@ export function MissingTags({ onEntityClick }: MissingTagsProps = {}) {
         filters: {},
         minCost: asDollars(minCost),
         tagDimension: activeTagId,
+        origin: `findings:missing-tags:${String(activeTagId)}`,
       });
     },
     [activeTagId, minCost, dateRange.start, dateRange.end, api],

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -43,6 +43,7 @@ export function BubbleWidget({
           filters,
           deltaThreshold: DEFAULT_DELTA_THRESHOLD,
           percentThreshold: DEFAULT_PERCENT_THRESHOLD,
+          origin: `bubble:${String(effectiveGroupBy)}`,
         }),
     [effectiveGroupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, api],
   );

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -43,7 +43,7 @@ export function BubbleWidget({
           filters,
           deltaThreshold: DEFAULT_DELTA_THRESHOLD,
           percentThreshold: DEFAULT_PERCENT_THRESHOLD,
-          origin: `bubble:${String(effectiveGroupBy)}`,
+          origin: `widget:bubble:${String(effectiveGroupBy)}`,
         }),
     [effectiveGroupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, api],
   );

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -60,7 +60,7 @@ export function HeatmapWidget({
     granularity,
     globalFilters,
     specFilters: spec.filters,
-    origin: `heatmap:${String(effectiveGroupBy ?? '')}`,
+    origin: `widget:heatmap:${String(effectiveGroupBy ?? '')}`,
   });
 
   const { cells, groups, dates } = useMemo(

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -60,6 +60,7 @@ export function HeatmapWidget({
     granularity,
     globalFilters,
     specFilters: spec.filters,
+    origin: `heatmap:${String(effectiveGroupBy ?? '')}`,
   });
 
   const { cells, groups, dates } = useMemo(

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -69,7 +69,7 @@ export function LineWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
-  const origin = `line:${String(effectiveGroupBy ?? '')}`;
+  const origin = `widget:line:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -69,19 +69,21 @@ export function LineWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
+  const origin = `line:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
     specFilters: spec.filters,
+    origin,
   });
 
   const prevQuery = useQuery<DailyCostsResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
+      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );
 
   const series = useMemo(

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -47,19 +47,21 @@ export function PieWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
+  const origin = `pie:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
     specFilters: spec.filters,
+    origin,
   });
 
   const prevQuery = useQuery<CostResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api, origin],
   );
 
   const slices = useMemo(

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -47,7 +47,7 @@ export function PieWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
-  const origin = `pie:${String(effectiveGroupBy ?? '')}`;
+  const origin = `widget:pie:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -63,19 +63,21 @@ export function StackedBarWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
+  const origin = `stackedBar:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
     specFilters: spec.filters,
+    origin,
   });
 
   const prevQuery = useQuery<DailyCostsResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
+      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );
 
   const barDays = useMemo(

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -63,7 +63,7 @@ export function StackedBarWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
-  const origin = `stackedBar:${String(effectiveGroupBy ?? '')}`;
+  const origin = `widget:stackedBar:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -24,11 +24,11 @@ export function SummaryWidget({
   const fk = filtersKey(filters);
 
   const cur = useQuery<CostResult | null>(
-    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity }) : Promise.resolve(null),
+    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity, origin: 'summary:total' }) : Promise.resolve(null),
     [isSummary, groupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
   );
   const prev = useQuery<CostResult | null>(
-    () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity }) : Promise.resolve(null),
+    () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity, origin: 'summary:total/prev' }) : Promise.resolve(null),
     [isSummary, compareEnabled, groupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -24,11 +24,11 @@ export function SummaryWidget({
   const fk = filtersKey(filters);
 
   const cur = useQuery<CostResult | null>(
-    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity, origin: 'summary:total' }) : Promise.resolve(null),
+    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity, origin: 'widget:summary:total' }) : Promise.resolve(null),
     [isSummary, groupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
   );
   const prev = useQuery<CostResult | null>(
-    () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity, origin: 'summary:total/prev' }) : Promise.resolve(null),
+    () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity, origin: 'widget:summary:total/prev' }) : Promise.resolve(null),
     [isSummary, compareEnabled, groupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -99,7 +99,7 @@ export function TableWidget({
   const [enabledColumns, setEnabledColumns] = useState(specEnabled);
 
   const overviewQuery = useQuery(
-    () => api.queryExplorerOverview({ filters: explorerFilters, dateRange, granularity, origin: 'table:overview' }),
+    () => api.queryExplorerOverview({ filters: explorerFilters, dateRange, granularity, origin: 'widget:table:overview' }),
     [fk, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, granularity, api],
   );
 
@@ -129,7 +129,7 @@ export function TableWidget({
       groupByColumns,
       ...(sort === undefined ? {} : { sort }),
       rowLimit: ROW_LIMIT,
-      origin: 'table:rows',
+      origin: 'widget:table:rows',
     }),
     [fk, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, granularity, groupByKey, sort?.column, sort?.direction, api],
   );
@@ -143,7 +143,7 @@ export function TableWidget({
           applyCostScope: true,
           groupByColumns,
           rowLimit: ROW_LIMIT,
-          origin: 'table:rows/prev',
+          origin: 'widget:table:rows/prev',
         })
       : Promise.resolve(null),
     [compareEnabled, fk, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, granularity, groupByKey, api],
@@ -247,7 +247,7 @@ export function TableWidget({
       groupByColumns: allDimKeys,
       rowLimit: 100,
       rowFilters: row.values,
-      origin: 'table:expand',
+      origin: 'widget:table:expand',
     });
     return result.rows;
   }, [api, explorerFilters, dateRange, granularity, allColumnSpecs]);

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -99,7 +99,7 @@ export function TableWidget({
   const [enabledColumns, setEnabledColumns] = useState(specEnabled);
 
   const overviewQuery = useQuery(
-    () => api.queryExplorerOverview({ filters: explorerFilters, dateRange, granularity }),
+    () => api.queryExplorerOverview({ filters: explorerFilters, dateRange, granularity, origin: 'table:overview' }),
     [fk, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, granularity, api],
   );
 
@@ -129,6 +129,7 @@ export function TableWidget({
       groupByColumns,
       ...(sort === undefined ? {} : { sort }),
       rowLimit: ROW_LIMIT,
+      origin: 'table:rows',
     }),
     [fk, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, granularity, groupByKey, sort?.column, sort?.direction, api],
   );
@@ -142,6 +143,7 @@ export function TableWidget({
           applyCostScope: true,
           groupByColumns,
           rowLimit: ROW_LIMIT,
+          origin: 'table:rows/prev',
         })
       : Promise.resolve(null),
     [compareEnabled, fk, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, granularity, groupByKey, api],
@@ -245,6 +247,7 @@ export function TableWidget({
       groupByColumns: allDimKeys,
       rowLimit: 100,
       rowFilters: row.values,
+      origin: 'table:expand',
     });
     return result.rows;
   }, [api, explorerFilters, dateRange, granularity, allColumnSpecs]);

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -46,7 +46,7 @@ export function TopNBarWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
-  const origin = `topNBar:${String(effectiveGroupBy ?? '')}`;
+  const origin = `widget:topNBar:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -46,19 +46,21 @@ export function TopNBarWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
+  const origin = `topNBar:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
     specFilters: spec.filters,
+    origin,
   });
 
   const prevQuery = useQuery<CostResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );
 
   const bars = useMemo(

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -41,7 +41,7 @@ export function TreemapWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
-  const origin = `treemap:${String(effectiveGroupBy ?? '')}`;
+  const origin = `widget:treemap:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -41,19 +41,21 @@ export function TreemapWidget({
   const filters = mergeFilters(globalFilters, spec.filters);
   const fk = filtersKey(filters);
 
+  const origin = `treemap:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
     specGroupBy: effectiveGroupBy,
     dateRange,
     granularity,
     globalFilters,
     specFilters: spec.filters,
+    origin,
   });
 
   const prevQuery = useQuery<CostResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity })
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
-    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
+    [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );
 
   const cells = useMemo(


### PR DESCRIPTION
Closes #295.

## Summary

- Adds an **origin tag** (e.g. `pie:service`, `bubble:user_sb_team`, `summary:total`) to every query that surfaces in the query debug panel — so you can tell at a glance which widget / view fired which SQL.
- Adds **ROLLUP** / **RAW** source badges alongside the existing **CACHE** / **MEM** badges, inferred from the SQL's path (`/aws/rollup/` vs `/aws/raw/`).

## Implementation

- **Core types**: optional `origin?: string` on `CostQueryParams`, `DailyCostsParams`, `TrendQueryParams`, `MissingTagsParams`, `EntityDetailParams`, `ExplorerBaseParams`, `ExplorerFilterValuesParams`. Trailing optional `origin?: string` on `getFilterValues`.
- **Main process**: `QueryLog` gains an `AsyncLocalStorage<string | null>` `originStore`. Each query IPC handler wraps its body in `originStore.run(params.origin ?? null, ...)` so any nested `runPreparedQuery` — including the cached path — inherits the origin via async-context propagation. `QueryLog.start` reads from the store.
- **Preload + renderer types**: `origin: string | null` on `DebugQueryLogEntry`.
- **UI call sites**: every widget passes its origin (`pie:<dim>`, `stackedBar:<dim>`, `summary:total`, `bubble:<dim>`, etc.) with `/prev` on previous-period queries and `/fallback` on auto-fallback dim choices. Views tag with `trends:<dim>`, `entity-detail:summary` / `pie1/2/3` / `histogram`, `findings:missing-tags:<dim>`, `explorer:overview/rows/filter-values:<dim>`, `table:overview/rows/expand`, `filter-bar:<dim>`, `cost-scope:<dim>`, `splash:warmup:<dim>`.
- **DebugPanel**: origin renders right-aligned on the second info line of each row. Exported / copied log includes `origin=...` in the header.

## Notes

- ROLLUP badge only appears once the daily-rollup baseline ships (tracked in #294). Today, source detection falls through to RAW for queries that read parquet directly. CACHE and MEM are already plumbed via explicit flags and unchanged.
- Explorer with `applyCostScope: false` keeps using raw parquet — origin tagging is independent of source selection.
- 30 files changed, +132 / −55. 490 tests + lint + tsc green.