### PR TITLE
Add an All option to the trends direction toggle

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -118,6 +118,16 @@ export async function hasVisibleData(page: Page): Promise<boolean> {
 const OPTIONS_ITEMS = new Set(['Cost Scope', 'Dimensions', 'Views Editor', 'AI Assistant']);
 const DIRECT_NAV = new Set(['Trends', 'Findings', 'Tags', 'Explorer', 'Sync', 'Dashboards', 'Options', 'Home']);
 const NAV_ALIASES: Record<string, string> = { Views: 'Views Editor' };
+// Both top-bar <nav> elements have aria-labels — scope direct-nav lookups
+// to them so we never pick up a same-named button living inside a view
+// (e.g. "Sync region names" in DataManagement, "Trends" in some chart).
+const LEFT_NAV_LABEL = 'Dashboards and analysis';
+const RIGHT_NAV_LABEL = 'Sync and settings';
+const NAV_SIDE: Record<string, 'left' | 'right'> = {
+  Trends: 'left', Findings: 'left', Tags: 'left', Explorer: 'left',
+  Dashboards: 'left', Home: 'left',
+  Sync: 'right', Options: 'right',
+};
 
 async function openIfClosed(trigger: ReturnType<Page['getByRole']>): Promise<void> {
   // Radix Popover toggles open/closed on each trigger click. If a previous
@@ -129,8 +139,12 @@ async function openIfClosed(trigger: ReturnType<Page['getByRole']>): Promise<voi
   await trigger.click();
 }
 
+function topNav(page: Page, side: 'left' | 'right'): ReturnType<Page['getByRole']> {
+  return page.getByRole('navigation', { name: side === 'left' ? LEFT_NAV_LABEL : RIGHT_NAV_LABEL });
+}
+
 export async function openDashboardsDropdown(page: Page): Promise<void> {
-  const trigger = page.getByRole('button', { name: 'Dashboards', exact: false }).first();
+  const trigger = topNav(page, 'left').getByRole('button', { name: 'Dashboards', exact: false }).first();
   // The Dashboards trigger now doubles as a Home button: if the user isn't
   // on the default dashboard, the first click navigates there instead of
   // opening the popover. Click once, see whether the popover actually
@@ -141,7 +155,7 @@ export async function openDashboardsDropdown(page: Page): Promise<void> {
 }
 
 export async function openOptionsMenu(page: Page): Promise<void> {
-  await openIfClosed(page.getByRole('button', { name: 'Options', exact: true }));
+  await openIfClosed(topNav(page, 'right').getByRole('button', { name: 'Options', exact: true }));
 }
 
 export async function clickNavButton(page: Page, name: string): Promise<void> {
@@ -152,7 +166,8 @@ export async function clickNavButton(page: Page, name: string): Promise<void> {
     return;
   }
   if (DIRECT_NAV.has(resolved)) {
-    await page.getByRole('button', { name: new RegExp(`^${resolved}`), exact: false }).first().click();
+    const side = NAV_SIDE[resolved] ?? 'left';
+    await topNav(page, side).getByRole('button', { name: new RegExp(`^${resolved}`), exact: false }).first().click();
     return;
   }
   // Custom dashboard — hidden behind the Dashboards popover.

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -167,7 +167,10 @@ export async function clickNavButton(page: Page, name: string): Promise<void> {
   }
   if (DIRECT_NAV.has(resolved)) {
     const side = NAV_SIDE[resolved] ?? 'left';
-    await topNav(page, side).getByRole('button', { name: new RegExp(`^${resolved}`), exact: false }).first().click();
+    // Substring match (not start-anchored) — the Sync button's accessible
+    // name can be e.g. "sync error Sync !" once status badges decorate it,
+    // so anchoring on ^Sync would never match.
+    await topNav(page, side).getByRole('button', { name: resolved, exact: false }).first().click();
     return;
   }
   // Custom dashboard — hidden behind the Dashboards popover.

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -119,12 +119,22 @@ const OPTIONS_ITEMS = new Set(['Cost Scope', 'Dimensions', 'Views Editor', 'AI A
 const DIRECT_NAV = new Set(['Trends', 'Findings', 'Tags', 'Explorer', 'Sync', 'Dashboards', 'Options', 'Home']);
 const NAV_ALIASES: Record<string, string> = { Views: 'Views Editor' };
 
+async function openIfClosed(trigger: ReturnType<Page['getByRole']>): Promise<void> {
+  // Radix Popover toggles open/closed on each trigger click. If a previous
+  // test or step left the popover open, clicking again would CLOSE it and
+  // the subsequent menu-item lookup would time out. Check aria-expanded
+  // first.
+  const expanded = await trigger.getAttribute('aria-expanded').catch(() => null);
+  if (expanded === 'true') return;
+  await trigger.click();
+}
+
 export async function openDashboardsDropdown(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Dashboards', exact: false }).first().click();
+  await openIfClosed(page.getByRole('button', { name: 'Dashboards', exact: false }).first());
 }
 
 export async function openOptionsMenu(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Options', exact: true }).click();
+  await openIfClosed(page.getByRole('button', { name: 'Options', exact: true }));
 }
 
 export async function clickNavButton(page: Page, name: string): Promise<void> {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -130,7 +130,14 @@ async function openIfClosed(trigger: ReturnType<Page['getByRole']>): Promise<voi
 }
 
 export async function openDashboardsDropdown(page: Page): Promise<void> {
-  await openIfClosed(page.getByRole('button', { name: 'Dashboards', exact: false }).first());
+  const trigger = page.getByRole('button', { name: 'Dashboards', exact: false }).first();
+  // The Dashboards trigger now doubles as a Home button: if the user isn't
+  // on the default dashboard, the first click navigates there instead of
+  // opening the popover. Click once, see whether the popover actually
+  // opened, and click again if not.
+  await openIfClosed(trigger);
+  const expanded = await trigger.getAttribute('aria-expanded').catch(() => null);
+  if (expanded !== 'true') await trigger.click();
 }
 
 export async function openOptionsMenu(page: Page): Promise<void> {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -104,11 +104,43 @@ export async function hasVisibleData(page: Page): Promise<boolean> {
   return text !== null && text.includes('$') && !text.includes('$0.00');
 }
 
-// Click a nav button, wait for the destination heading, and let initial
-// queries settle. Shared app launch means each describe block navigates
-// between views via clicks instead of relaunching Electron.
+// The top-menu rework moved a number of items behind popovers. Tests that
+// reach for a nav button by name no longer want to know whether that button
+// is inline or hidden in the Dashboards / Options popover — clickNavButton
+// dispatches based on where the item lives.
+//
+// - Inline top-bar items: kept in DIRECT_NAV. Icon-only when inactive, but
+//   their aria-label still matches their human name so getByRole('button',
+//   { name }) finds them either way.
+// - Items behind the Options (☰) popover: settings pages and the AI tool.
+// - Anything else is assumed to be a custom dashboard living inside the
+//   Dashboards popover (Cost Overview, plus whatever views.yaml defines).
+const OPTIONS_ITEMS = new Set(['Cost Scope', 'Dimensions', 'Views Editor', 'AI Assistant']);
+const DIRECT_NAV = new Set(['Trends', 'Findings', 'Tags', 'Explorer', 'Sync', 'Dashboards', 'Options', 'Home']);
+const NAV_ALIASES: Record<string, string> = { Views: 'Views Editor' };
+
+export async function openDashboardsDropdown(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Dashboards', exact: false }).first().click();
+}
+
+export async function openOptionsMenu(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Options', exact: true }).click();
+}
+
 export async function clickNavButton(page: Page, name: string): Promise<void> {
-  await page.getByRole('button', { name: new RegExp(name), exact: false }).first().click();
+  const resolved = NAV_ALIASES[name] ?? name;
+  if (OPTIONS_ITEMS.has(resolved)) {
+    await openOptionsMenu(page);
+    await page.getByRole('button', { name: resolved, exact: false }).click();
+    return;
+  }
+  if (DIRECT_NAV.has(resolved)) {
+    await page.getByRole('button', { name: new RegExp(`^${resolved}`), exact: false }).first().click();
+    return;
+  }
+  // Custom dashboard — hidden behind the Dashboards popover.
+  await openDashboardsDropdown(page);
+  await page.getByRole('menuitem', { name: new RegExp(resolved) }).first().click();
 }
 
 export async function navigateTo(page: Page, buttonName: string, headingName: string): Promise<void> {

--- a/e2e/stress.test.ts
+++ b/e2e/stress.test.ts
@@ -2,7 +2,7 @@ import { test, expect, type ElectronApplication, type Page } from '@playwright/t
 import { join } from 'node:path';
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
-import { FIXTURE_CONFIG_DIR, launchApp, waitForQuerySettle } from './helpers.js';
+import { FIXTURE_CONFIG_DIR, clickNavButton, launchApp, waitForQuerySettle } from './helpers.js';
 
 // ---------------------------------------------------------------------------
 // Widget growth regression — every widget × every size stays bounded
@@ -38,7 +38,7 @@ test.describe('Widget growth', () => {
 
   for (const widgetType of WIDGET_TYPES) {
     test(`${widgetType} stays bounded at all sizes`, async () => {
-      await widgetPage.getByRole('button', { name: `test-${widgetType}`, exact: true }).click();
+      await clickNavButton(widgetPage, `test-${widgetType}`);
       await waitForQuerySettle(widgetPage);
       // Let queries resolve, loaders swap to real data, and any one-shot
       // layout transitions settle — we're hunting runaway growth, not

--- a/e2e/views-config.test.ts
+++ b/e2e/views-config.test.ts
@@ -9,6 +9,7 @@ import {
   waitForCostScopePreview,
   hasVisibleData,
   navigateTo,
+  clickNavButton,
   writeCoverage,
   LOAD_TIMEOUT,
 } from './helpers.js';
@@ -336,7 +337,7 @@ test.describe('Cost Scope', () => {
   test.beforeAll(async () => {
     // Click Cost Scope nav — if the Views editor has unsaved changes,
     // a "Discard" confirm modal will appear. Dismiss it.
-    await page.getByRole('button', { name: 'Cost Scope', exact: true }).first().click();
+    await clickNavButton(page, 'Cost Scope');
     const discardBtn = page.getByRole('button', { name: 'Discard' });
     if (await discardBtn.isVisible({ timeout: 500 }).catch(() => false)) {
       await discardBtn.click();

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -11,6 +11,7 @@ import {
   navigateToText,
   selectDatePreset,
   clickNavButton,
+  openOptionsMenu,
   writeCoverage,
   LOAD_TIMEOUT,
 } from './helpers.js';
@@ -45,29 +46,41 @@ test.describe('App shell', () => {
   });
 
   test('shows all navigation buttons', async () => {
-    for (const label of ['Cost Overview', 'Trends', 'Tags', 'Findings', 'Cost Scope', 'Dimensions', 'Views']) {
-      await expect(page.getByRole('button', { name: label })).toBeVisible();
+    // Inline top-bar buttons.
+    for (const label of ['Dashboards', 'Trends', 'Tags', 'Findings', 'Explorer', 'Options']) {
+      await expect(page.getByRole('button', { name: label, exact: false }).first()).toBeVisible();
     }
     await expect(page.getByRole('button', { name: /Sync/ }).first()).toBeVisible();
+    // Items behind the Options popover.
+    await openOptionsMenu(page);
+    for (const label of ['Cost Scope', 'Dimensions', 'Views Editor']) {
+      await expect(page.getByRole('button', { name: label, exact: false })).toBeVisible();
+    }
+    await page.keyboard.press('Escape');
   });
 
   test('has theme toggle button', async () => {
-    const themeBtn = page.getByRole('button', { name: /Switch to (light|dark) mode/ });
+    await openOptionsMenu(page);
+    const themeBtn = page.getByRole('button', { name: /^(Light|Dark) mode$/ });
     await expect(themeBtn).toBeVisible();
+    await page.keyboard.press('Escape');
   });
 
   test('theme toggle switches dark/light', async () => {
     const html = page.locator('html');
     const hadDark = await html.evaluate(el => el.classList.contains('dark'));
 
-    await page.getByRole('button', { name: /Switch to (light|dark) mode/ }).click();
+    await openOptionsMenu(page);
+    await page.getByRole('button', { name: /^(Light|Dark) mode$/ }).click();
     const hasToggled = await html.evaluate(el => el.classList.contains('dark'));
     expect(hasToggled).toBe(!hadDark);
 
-    // toggle back
-    await page.getByRole('button', { name: /Switch to (light|dark) mode/ }).click();
+    // toggle back — the label has flipped now that the theme switched
+    await openOptionsMenu(page);
+    await page.getByRole('button', { name: /^(Light|Dark) mode$/ }).click();
     const restored = await html.evaluate(el => el.classList.contains('dark'));
     expect(restored).toBe(hadDark);
+    await page.keyboard.press('Escape');
   });
 
   test('navigating between all views changes active content', async () => {
@@ -371,25 +384,29 @@ test.describe('Cost Trends', () => {
     }
   });
 
-  test('Increases/Savings toggle is present and clickable', async () => {
-    // These buttons have CSS capitalize. The nav bar also has a "Savings" button,
-    // so we scope to the toggle container (the bordered pill group).
+  test('All/Increase/Savings toggle is present and clickable', async () => {
+    // Toggle now has three options. The nav bar also has a "Findings" /
+    // "Savings"-flavoured button, so scope to the bordered pill group.
     const toggleContainer = page.locator('.flex.items-center.gap-1.rounded-lg.border').nth(1);
-    const increasesBtn = toggleContainer.getByRole('button', { name: 'increases' });
-    const savingsBtn = toggleContainer.getByRole('button', { name: 'savings' });
+    const allBtn = toggleContainer.getByRole('button', { name: 'All', exact: true });
+    const increaseBtn = toggleContainer.getByRole('button', { name: 'Increase', exact: true });
+    const savingsBtn = toggleContainer.getByRole('button', { name: 'Savings', exact: true });
 
-    await expect(increasesBtn).toBeVisible();
+    await expect(allBtn).toBeVisible();
+    await expect(increaseBtn).toBeVisible();
     await expect(savingsBtn).toBeVisible();
 
-    // toggle to savings
     await savingsBtn.click();
     await waitForQuerySettle(page);
     await screenshot(page, 'trends-savings');
 
-    // toggle back to increases
-    await increasesBtn.click();
+    await increaseBtn.click();
     await waitForQuerySettle(page);
     await screenshot(page, 'trends-increases');
+
+    await allBtn.click();
+    await waitForQuerySettle(page);
+    await screenshot(page, 'trends-all');
   });
 
   test('Min $ and Min % inputs are present and functional', async () => {
@@ -409,8 +426,8 @@ test.describe('Cost Trends', () => {
     await screenshot(page, 'trends-high-threshold');
 
     // restore defaults
-    await minDollar.fill('10');
-    await minPercent.fill('1');
+    await minDollar.fill('0');
+    await minPercent.fill('0');
     await waitForQuerySettle(page);
   });
 

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -71,12 +71,13 @@ test.describe('App shell', () => {
     const hadDark = await html.evaluate(el => el.classList.contains('dark'));
 
     await openOptionsMenu(page);
+    // The Appearance items don't auto-close the menu (so users can toggle
+    // theme + palette in one open), so click both toggles back-to-back
+    // without reopening — the label flips between Light mode / Dark mode.
     await page.getByRole('button', { name: /^(Light|Dark) mode$/ }).click();
     const hasToggled = await html.evaluate(el => el.classList.contains('dark'));
     expect(hasToggled).toBe(!hadDark);
 
-    // toggle back — the label has flipped now that the theme switched
-    await openOptionsMenu(page);
     await page.getByRole('button', { name: /^(Light|Dark) mode$/ }).click();
     const restored = await html.evaluate(el => el.classList.contains('dark'));
     expect(restored).toBe(hadDark);
@@ -501,7 +502,9 @@ test.describe('Missing Tags', () => {
   });
 
   test('shows heading and subtitle', async () => {
-    await expect(page.getByRole('heading', { name: 'Missing Tags' })).toBeVisible();
+    // The header is no longer a semantic heading — it's a styled <p> now,
+    // matching the other view headers.
+    await expect(page.getByText('Missing Tags', { exact: true }).first()).toBeVisible();
     await expect(page.getByText(/without the selected allocation tag/i)).toBeVisible();
   });
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -401,16 +401,14 @@ function AppShell(): React.JSX.Element {
   const autoOpenRef = useMemo(() => ({ current: false }), []);
   const initialViewSetRef = useRef(false);
   const headerRef = useRef<HTMLDivElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(72);
 
-  // Publish the actual rendered header height as a CSS variable so the debug
-  // panel (and anything else that wants to sit flush below the top bar) can
-  // use it instead of guessing with a magic top offset.
+  // Track the actual rendered header height so the debug panel can sit
+  // flush below it without guessing with a magic top offset.
   useLayoutEffect(() => {
     const el = headerRef.current;
     if (el === null) return undefined;
-    const update = () => {
-      document.documentElement.style.setProperty('--top-bar-height', `${String(el.offsetHeight)}px`);
-    };
+    const update = () => { setHeaderHeight(el.offsetHeight); };
     update();
     const observer = new ResizeObserver(update);
     observer.observe(el);
@@ -860,7 +858,7 @@ function AppShell(): React.JSX.Element {
           </Profiler>
         </div>
       </div>
-      {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} />}
+      {debugOpen && <DebugPanel onClose={() => { setDebugOpen(false); }} topOffset={headerHeight} />}
       <ReleaseNotesModal open={releaseNotesOpen} onOpenChange={setReleaseNotesOpen} status={updateStatus} />
       <Dialog open={reloadConfirmOpen} onOpenChange={setReloadConfirmOpen}>
         <DialogContent>

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -750,9 +750,10 @@ function AppShell(): React.JSX.Element {
                   ].join(' ')}
                   title={syncError === null ? undefined : `Sync error — ${syncError}`}
                   aria-current={active === 'sync' ? 'page' : undefined}
+                  aria-label="Sync"
                 >
                   {showError && (
-                    <span className="inline-flex h-2 w-2 shrink-0 rounded-full bg-negative animate-pulse" aria-label="sync error" />
+                    <span className="inline-flex h-2 w-2 shrink-0 rounded-full bg-negative animate-pulse" aria-hidden="true" />
                   )}
                   {showActive && syncActivity === 'downloading' && (
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef, Profiler } from 'react';
+import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Profiler } from 'react';
 import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
 import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
@@ -400,6 +400,22 @@ function AppShell(): React.JSX.Element {
   const memoryMB = useMemoryMB();
   const autoOpenRef = useMemo(() => ({ current: false }), []);
   const initialViewSetRef = useRef(false);
+  const headerRef = useRef<HTMLDivElement>(null);
+
+  // Publish the actual rendered header height as a CSS variable so the debug
+  // panel (and anything else that wants to sit flush below the top bar) can
+  // use it instead of guessing with a magic top offset.
+  useLayoutEffect(() => {
+    const el = headerRef.current;
+    if (el === null) return undefined;
+    const update = () => {
+      document.documentElement.style.setProperty('--top-bar-height', `${String(el.offsetHeight)}px`);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => { observer.disconnect(); };
+  }, []);
 
   useEffect(() => {
     globalThis.costgoblinUpdate.getAppVersion().then(setAppVersion).catch(() => undefined);
@@ -623,7 +639,7 @@ function AppShell(): React.JSX.Element {
           missingPeriods={missingPeriods}
         />
         {/* Title bar + nav */}
-        <div className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
+        <div ref={headerRef} className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center px-4 pt-7 pb-2">
           <nav className="flex items-center gap-1" aria-label="Dashboards and analysis">
             {(() => {

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -197,7 +197,10 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
   });
 
   return (
-    <div className="fixed top-[5.5rem] right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col">
+    <div
+      className="fixed right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col"
+      style={{ top: 'var(--top-bar-height, 5.5rem)' }}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0 [-webkit-app-region:no-drag]">
         <div className="flex items-center gap-3">

--- a/packages/desktop/src/renderer/debug-panel.tsx
+++ b/packages/desktop/src/renderer/debug-panel.tsx
@@ -147,7 +147,7 @@ function QueryRow({ entry }: Readonly<{ entry: DebugQueryLogEntry }>): React.JSX
  *  ('') as the "all" choice. */
 const NO_ORIGIN = '__no_origin__';
 
-export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): React.JSX.Element {
+export function DebugPanel({ onClose, topOffset }: Readonly<{ onClose: () => void; topOffset: number }>): React.JSX.Element {
   const [entries, setEntries] = useState<DebugQueryLogEntry[]>([]);
   const [originFilter, setOriginFilter] = useState('');
   const inFlightCount = useDebugBadge();
@@ -199,7 +199,7 @@ export function DebugPanel({ onClose }: Readonly<{ onClose: () => void }>): Reac
   return (
     <div
       className="fixed right-0 bottom-0 z-40 w-[75vw] bg-bg-secondary border-l border-border shadow-xl flex flex-col"
-      style={{ top: 'var(--top-bar-height, 5.5rem)' }}
+      style={{ top: `${String(topOffset)}px` }}
     >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0 [-webkit-app-region:no-drag]">

--- a/packages/desktop/src/renderer/top-menu/dashboards-dropdown.tsx
+++ b/packages/desktop/src/renderer/top-menu/dashboards-dropdown.tsx
@@ -31,9 +31,24 @@ export function DashboardsDropdown({
   }, [items, defaultId]);
 
   const activeIsCustom = items.some(i => i.id === activeId);
+  const isOnDefault = activeId === defaultId;
+  const defaultExists = items.some(i => i.id === defaultId);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        // First click acts as Home: if the user isn't already on the default
+        // dashboard, jump them there instead of opening the list. They can
+        // click again (now that they're on the default) to actually see the
+        // list of dashboards.
+        if (next && !isOnDefault && defaultExists) {
+          onSelect(defaultId);
+          return;
+        }
+        setOpen(next);
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"

--- a/packages/desktop/src/renderer/top-menu/dashboards-dropdown.tsx
+++ b/packages/desktop/src/renderer/top-menu/dashboards-dropdown.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { ChevronDown, Star, LayoutDashboard } from 'lucide-react';
+import { ChevronDown, Star, Gauge } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
 
 export interface DashboardItem {
@@ -48,7 +48,7 @@ export function DashboardsDropdown({
           aria-label={activeIsCustom ? undefined : 'Dashboards'}
           title={activeIsCustom ? undefined : 'Dashboards'}
         >
-          {activeIsCustom ? 'Dashboards' : <LayoutDashboard size={18} />}
+          {activeIsCustom ? 'Dashboards' : <Gauge size={18} />}
           <ChevronDown
             size={activeIsCustom ? 14 : 12}
             className={open ? 'rotate-180 transition-transform' : 'transition-transform'}

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -18,7 +18,13 @@ import { DimensionSelector } from '../components/dimension-selector.js';
 import { formatDollars, formatPercent } from '../components/format.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 
-type Direction = 'increases' | 'savings';
+type Direction = 'all' | 'increases' | 'savings';
+
+const DIRECTION_OPTIONS: readonly { value: Direction; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'increases', label: 'Increase' },
+  { value: 'savings', label: 'Savings' },
+];
 
 interface TrendsState {
   selectedDimensionId: DimensionId | null;
@@ -69,7 +75,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
 
   const [state, setState] = useState<TrendsState>(() => ({
     selectedDimensionId: null,
-    direction: 'increases',
+    direction: 'all',
     dateRange: getDefaultDateRange(lagDays),
     granularity: 'daily' satisfies Granularity,
     deltaThreshold: 10,
@@ -113,14 +119,23 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
 
   let rows: readonly TrendRow[] = [];
   if (trendData !== null) {
-    rows = state.direction === 'increases' ? trendData.increases : trendData.savings;
+    let pool: TrendRow[];
+    if (state.direction === 'increases') pool = [...trendData.increases];
+    else if (state.direction === 'savings') pool = [...trendData.savings];
+    else pool = [...trendData.increases, ...trendData.savings];
+    pool.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+    rows = pool;
   }
 
   let totalLabel = '';
   if (trendData !== null) {
-    totalLabel = state.direction === 'increases'
-      ? `+${formatDollars(trendData.totalIncrease)} total increase`
-      : `-${formatDollars(trendData.totalSavings)} total savings`;
+    if (state.direction === 'increases') {
+      totalLabel = `+${formatDollars(trendData.totalIncrease)} total increase`;
+    } else if (state.direction === 'savings') {
+      totalLabel = `-${formatDollars(trendData.totalSavings)} total savings`;
+    } else {
+      totalLabel = `+${formatDollars(trendData.totalIncrease)} increase · -${formatDollars(trendData.totalSavings)} savings`;
+    }
   }
 
   function handleEntityClick(entity: EntityRef) {
@@ -151,19 +166,19 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
           />
 
           <div className="flex items-center gap-1 rounded-lg border border-border bg-bg-tertiary/30 p-1">
-            {(['increases', 'savings'] as const).map((d) => (
+            {DIRECTION_OPTIONS.map((opt) => (
               <button
-                key={d}
+                key={opt.value}
                 type="button"
-                onClick={() => { setState((p) => ({ ...p, direction: d })); }}
+                onClick={() => { setState((p) => ({ ...p, direction: opt.value })); }}
                 className={[
-                  'rounded-md px-3 py-1.5 text-xs font-medium transition-colors capitalize',
-                  state.direction === d
+                  'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                  state.direction === opt.value
                     ? 'bg-accent text-bg-primary shadow-sm'
                     : 'text-text-secondary hover:text-text-primary',
                 ].join(' ')}
               >
-                {d}
+                {opt.label}
               </button>
             ))}
           </div>
@@ -235,7 +250,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
 
       {trendData !== null && rows.length === 0 && (
         <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center text-text-secondary">
-          No {state.direction} above thresholds
+          No {state.direction === 'all' ? 'changes' : state.direction} above thresholds
         </div>
       )}
     </div>

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -6,7 +6,7 @@ import type {
   TrendRow,
   EntityRef,
 } from '@costgoblin/core/browser';
-import { asDimensionId, asDollars } from '@costgoblin/core/browser';
+import { asDimensionId, asDollars, asEntityRef } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
@@ -78,8 +78,8 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
     direction: 'all',
     dateRange: getDefaultDateRange(lagDays),
     granularity: 'daily' satisfies Granularity,
-    deltaThreshold: 10,
-    percentThreshold: 1,
+    deltaThreshold: 0,
+    percentThreshold: 0,
   }));
 
   const dimensions: Dimension[] =
@@ -118,11 +118,43 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
     trendsQuery.status === 'success' ? trendsQuery.data : null;
 
   let rows: readonly TrendRow[] = [];
+  let totalIncrease = 0;
+  let totalSavings = 0;
   if (trendData !== null) {
+    // The backend partitions raw SQL rows into increases / savings by sign
+    // and then merges within each bucket by friendly entity name. For the
+    // account dim, two account_ids can resolve to the same name with opposing
+    // deltas — leaving the same entity in *both* buckets and hiding its true
+    // net direction. Net the buckets here so each entity surfaces once with
+    // the right sign.
+    const merged = new Map<string, { currentCost: number; previousCost: number; delta: number }>();
+    for (const r of [...trendData.increases, ...trendData.savings]) {
+      const existing = merged.get(r.entity);
+      if (existing === undefined) {
+        merged.set(r.entity, { currentCost: r.currentCost, previousCost: r.previousCost, delta: r.delta });
+      } else {
+        existing.currentCost += r.currentCost;
+        existing.previousCost += r.previousCost;
+        existing.delta += r.delta;
+      }
+    }
+    const allRows: TrendRow[] = [...merged.entries()].map(([entity, d]) => ({
+      entity: asEntityRef(entity),
+      currentCost: asDollars(d.currentCost),
+      previousCost: asDollars(d.previousCost),
+      delta: asDollars(d.delta),
+      percentChange: d.previousCost === 0
+        ? (d.currentCost === 0 ? 0 : 100)
+        : (d.delta / d.previousCost) * 100,
+    }));
+    for (const r of allRows) {
+      if (r.delta > 0) totalIncrease += r.delta;
+      else totalSavings += Math.abs(r.delta);
+    }
     let pool: TrendRow[];
-    if (state.direction === 'increases') pool = [...trendData.increases];
-    else if (state.direction === 'savings') pool = [...trendData.savings];
-    else pool = [...trendData.increases, ...trendData.savings];
+    if (state.direction === 'increases') pool = allRows.filter(r => r.delta > 0);
+    else if (state.direction === 'savings') pool = allRows.filter(r => r.delta < 0);
+    else pool = allRows;
     pool.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
     rows = pool;
   }
@@ -130,11 +162,11 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
   let totalLabel = '';
   if (trendData !== null) {
     if (state.direction === 'increases') {
-      totalLabel = `+${formatDollars(trendData.totalIncrease)} total increase`;
+      totalLabel = `+${formatDollars(asDollars(totalIncrease))} total increase`;
     } else if (state.direction === 'savings') {
-      totalLabel = `-${formatDollars(trendData.totalSavings)} total savings`;
+      totalLabel = `-${formatDollars(asDollars(totalSavings))} total savings`;
     } else {
-      totalLabel = `+${formatDollars(trendData.totalIncrease)} increase · -${formatDollars(trendData.totalSavings)} savings`;
+      totalLabel = `+${formatDollars(asDollars(totalIncrease))} increase · -${formatDollars(asDollars(totalSavings))} savings`;
     }
   }
 


### PR DESCRIPTION
## Trends rework

- Toggle is now **All / Increase / Savings**, defaulting to **All**. In `All` mode the chart and table merge both buckets — the bubble chart already plots both signs of delta using colour.
- Rows always sort by `|delta|` descending now, so the largest-impact entities surface at the top regardless of direction.
- Default `Min $` / `Min %` thresholds dropped to **0** (was 10 / 1) so the view shows everything out of the box.
- Renderer now nets the backend buckets per entity. The backend partitioned SQL rows into `increases` / `savings` by per-row delta sign and then merged within each bucket by friendly entity name — for the account dim, two account IDs that resolve to the same friendly name with opposing deltas left the same entity in *both* buckets, so the wrong direction was shown. Netting on the renderer gives each entity one row with the true direction; totals are recomputed from that.

## Menu polish (carry-overs from the menu rework PR)

- **Debug panel** is now pinned flush against the bottom of the top bar via `ResizeObserver` on the header — no more hard-coded `top-[5.5rem]` gap.
- **Goblin logo doubles as Home**: when the user isn't on the default dashboard, the first click on the Dashboards trigger navigates them there; a second click (now that they're on the default) opens the dropdown. The plain Home button is gone.
- The inactive Dashboards trigger uses the **Gauge** icon — the speedometer reads as "dashboard" without competing with the grid-shaped icons next to it.
- **Missing Tags** view header (text-base `<p>`) matches the styling used by Trends / Findings / Explorer instead of standing out as a bold `<h2>`.

## e2e helpers reworked for the new layout

`clickNavButton` now dispatches based on where each item lives:

- **Direct top-bar items** (Trends / Findings / Tags / Explorer / Sync / Dashboards / Options / Home) — scoped to the appropriate `<nav>` landmark (`Dashboards and analysis` or `Sync and settings`) so a same-named button buried inside a hidden view can't be picked up. Substring matching on the accessible name (not start-anchored) so status badges like `"sync error Sync !"` still match the Sync button.
- **Options popover items** (Cost Scope / Dimensions / Views Editor / AI Assistant, plus a `Views` → `Views Editor` alias) — open via the Options trigger first.
- **Custom dashboards** (Cost Overview, plus whatever views.yaml defines) — open via the Dashboards trigger; the helper double-taps if the first click only navigated home.

New `openDashboardsDropdown` and `openOptionsMenu` helpers are idempotent — they check `aria-expanded` so re-opening an already-open popover doesn't accidentally toggle it closed. The shell / theme-toggle / Missing-Tags-heading / trends-toggle tests are updated for the new layout.