### PR TITLE
Fall back to full download when differential update fails

### DIFF
--- a/packages/desktop/src/__tests__/update-manager.test.ts
+++ b/packages/desktop/src/__tests__/update-manager.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EventEmitter } from 'node:events';
+import type { UpdateStatus } from '@costgoblin/core/browser';
+
+interface MockAutoUpdater extends EventEmitter {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  disableDifferentialDownload: boolean;
+  downloadUpdate: ReturnType<typeof vi.fn>;
+  checkForUpdates: ReturnType<typeof vi.fn>;
+  quitAndInstall: ReturnType<typeof vi.fn>;
+}
+
+const { mockUpdater } = await vi.hoisted(async () => {
+  const { EventEmitter: NodeEventEmitter } = await import('node:events');
+  const e = new NodeEventEmitter() as MockAutoUpdater;
+  e.autoDownload = true;
+  e.autoInstallOnAppQuit = true;
+  e.disableDifferentialDownload = false;
+  e.downloadUpdate = vi.fn(() => Promise.resolve([]));
+  e.checkForUpdates = vi.fn(() => Promise.resolve(null));
+  e.quitAndInstall = vi.fn();
+  return { mockUpdater: e };
+});
+
+vi.mock('electron-updater', () => ({
+  default: { autoUpdater: mockUpdater },
+}));
+
+const AVAILABLE_INFO = { version: '0.2.1', releaseDate: '2026-05-18', releaseNotes: '' };
+const NEXT_INFO = { version: '0.2.2', releaseDate: '2026-05-20', releaseNotes: '' };
+
+async function freshManager(): Promise<{
+  init: () => void;
+  statuses: UpdateStatus[];
+}> {
+  vi.resetModules();
+  mockUpdater.removeAllListeners();
+  mockUpdater.disableDifferentialDownload = false;
+  mockUpdater.downloadUpdate.mockClear();
+  mockUpdater.downloadUpdate.mockResolvedValue([]);
+
+  const mod = await import('../main/update-manager.js');
+  const statuses: UpdateStatus[] = [];
+  mod.onStatusChanged(s => statuses.push(s));
+  return { init: mod.initAutoUpdater, statuses };
+}
+
+function flushImmediate(): Promise<void> {
+  return new Promise(resolve => { setImmediate(resolve); });
+}
+
+describe('update-manager differential download fallback', () => {
+  beforeEach(() => {
+    mockUpdater.removeAllListeners();
+    mockUpdater.disableDifferentialDownload = false;
+    mockUpdater.downloadUpdate.mockClear();
+  });
+
+  it('retries with full download when differential fails mid-stream', async () => {
+    const { init, statuses } = await freshManager();
+    init();
+
+    mockUpdater.emit('update-available', AVAILABLE_INFO);
+    mockUpdater.emit('download-progress', { percent: 90 });
+    mockUpdater.emit('error', new Error('block 42 not found in cache'));
+
+    // Retry is scheduled via setImmediate so electron-updater can clear its
+    // internal downloadPromise via the chained .finally. A synchronous retry
+    // would hit the "already in progress" guard and return the rejected
+    // promise — so this ordering matters.
+    expect(mockUpdater.downloadUpdate).not.toHaveBeenCalled();
+
+    await flushImmediate();
+
+    expect(mockUpdater.disableDifferentialDownload).toBe(true);
+    expect(mockUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+
+    const last = statuses.at(-1);
+    expect(last?.state).toBe('downloading');
+    if (last?.state === 'downloading') {
+      expect(last.percent).toBe(0);
+    }
+  });
+
+  it('surfaces the error if the retry also fails', async () => {
+    const { init, statuses } = await freshManager();
+    init();
+
+    mockUpdater.emit('update-available', AVAILABLE_INFO);
+    mockUpdater.emit('download-progress', { percent: 90 });
+    mockUpdater.emit('error', new Error('first failure'));
+    await flushImmediate();
+
+    // Second failure during the full-download retry
+    mockUpdater.emit('download-progress', { percent: 60 });
+    mockUpdater.emit('error', new Error('second failure'));
+    await flushImmediate();
+
+    expect(mockUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+    const last = statuses.at(-1);
+    expect(last?.state).toBe('error');
+    if (last?.state === 'error') {
+      expect(last.error).toBe('second failure');
+    }
+  });
+
+  it('does not retry errors fired outside the downloading state', async () => {
+    const { init, statuses } = await freshManager();
+    init();
+
+    mockUpdater.emit('error', new Error('check failed'));
+    await flushImmediate();
+
+    expect(mockUpdater.downloadUpdate).not.toHaveBeenCalled();
+    expect(mockUpdater.disableDifferentialDownload).toBe(false);
+    const last = statuses.at(-1);
+    expect(last?.state).toBe('error');
+  });
+
+  it('resets the retry budget for each new update-available', async () => {
+    const { init } = await freshManager();
+    init();
+
+    mockUpdater.emit('update-available', AVAILABLE_INFO);
+    mockUpdater.emit('download-progress', { percent: 90 });
+    mockUpdater.emit('error', new Error('first version failed'));
+    await flushImmediate();
+
+    expect(mockUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdater.disableDifferentialDownload).toBe(true);
+
+    // A new version surfaces — we should try differential again first.
+    mockUpdater.emit('update-available', NEXT_INFO);
+    expect(mockUpdater.disableDifferentialDownload).toBe(false);
+
+    mockUpdater.emit('download-progress', { percent: 90 });
+    mockUpdater.emit('error', new Error('next version also failed'));
+    await flushImmediate();
+
+    expect(mockUpdater.downloadUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdater.disableDifferentialDownload).toBe(true);
+  });
+
+  it('surfaces a synchronous downloadUpdate rejection from the retry', async () => {
+    const { init, statuses } = await freshManager();
+    init();
+
+    mockUpdater.downloadUpdate.mockRejectedValueOnce(new Error('immediate failure'));
+
+    mockUpdater.emit('update-available', AVAILABLE_INFO);
+    mockUpdater.emit('download-progress', { percent: 90 });
+    mockUpdater.emit('error', new Error('differential failed'));
+
+    await flushImmediate();
+    await flushImmediate();
+
+    const last = statuses.at(-1);
+    expect(last?.state).toBe('error');
+    if (last?.state === 'error') {
+      expect(last.error).toBe('immediate failure');
+    }
+  });
+});

--- a/packages/desktop/src/main/update-manager.ts
+++ b/packages/desktop/src/main/update-manager.ts
@@ -80,14 +80,22 @@ export function initAutoUpdater(): void {
     // blockmap from the previously installed version doesn't reconstruct
     // cleanly against the new zip. Fall back to a full download once
     // before surfacing the error.
+    //
+    // electron-updater emits 'error' synchronously from inside the
+    // download promise's .catch, BEFORE the chained .finally clears its
+    // internal downloadPromise. A synchronous retry here would hit the
+    // "already in progress" guard and return the same rejected promise.
+    // Defer with setImmediate so the .finally runs first.
     if (currentStatus.state === 'downloading' && !hasTriedFullDownload && currentInfo !== null) {
       logger.warn('Differential download failed, retrying with full download', { error: err.message });
       hasTriedFullDownload = true;
       updater.disableDifferentialDownload = true;
       setStatus({ state: 'downloading', percent: 0, info: currentInfo });
-      autoUpdater.downloadUpdate().catch((retryErr: unknown) => {
-        const message = retryErr instanceof Error ? retryErr.message : String(retryErr);
-        setStatus({ state: 'error', error: message });
+      setImmediate(() => {
+        autoUpdater.downloadUpdate().catch((retryErr: unknown) => {
+          const message = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          setStatus({ state: 'error', error: message });
+        });
       });
       return;
     }

--- a/packages/desktop/src/main/update-manager.ts
+++ b/packages/desktop/src/main/update-manager.ts
@@ -42,6 +42,7 @@ function toUpdateInfo(info: { version: string; releaseDate: string; releaseNotes
 }
 
 let currentInfo: UpdateInfo | null = null;
+let hasTriedFullDownload = false;
 
 export function initAutoUpdater(): void {
   const updater = autoUpdater;
@@ -54,6 +55,8 @@ export function initAutoUpdater(): void {
 
   updater.on('update-available', (info) => {
     currentInfo = toUpdateInfo(info);
+    hasTriedFullDownload = false;
+    updater.disableDifferentialDownload = false;
     setStatus({ state: 'available', info: currentInfo });
   });
 
@@ -73,6 +76,21 @@ export function initAutoUpdater(): void {
   });
 
   updater.on('error', (err) => {
+    // Differential download can hang or fail mid-stream when the cached
+    // blockmap from the previously installed version doesn't reconstruct
+    // cleanly against the new zip. Fall back to a full download once
+    // before surfacing the error.
+    if (currentStatus.state === 'downloading' && !hasTriedFullDownload && currentInfo !== null) {
+      logger.warn('Differential download failed, retrying with full download', { error: err.message });
+      hasTriedFullDownload = true;
+      updater.disableDifferentialDownload = true;
+      setStatus({ state: 'downloading', percent: 0, info: currentInfo });
+      autoUpdater.downloadUpdate().catch((retryErr: unknown) => {
+        const message = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        setStatus({ state: 'error', error: message });
+      });
+      return;
+    }
     setStatus({ state: 'error', error: err.message });
   });
 


### PR DESCRIPTION
## Summary

`electron-updater` defaults to **differential downloads**: it diffs the new release's blockmap against the previously installed version's blockmap and patches only the differing blocks via HTTP Range requests. When that path stalls or fails mid-stream — flaky Range request, blockmap mismatch, corrupted cached zip — the user sees the download halt at some high percent and the dialog silently closes on the error event. (This is what just happened with the v0.2.1 update: the download hung at 90% three attempts in a row, and the workaround was to manually `rm -rf ~/Library/Caches/costgoblin-updater`.)

## Change

`packages/desktop/src/main/update-manager.ts` now retries once with full download on the first error during an active download:

- On the `error` event, if we were in `downloading` state and haven't tried full mode yet, flip `updater.disableDifferentialDownload = true`, reset progress to 0, and call `downloadUpdate()` again.
- A second failure surfaces the error to the renderer as before.
- The flag (and `hasTriedFullDownload`) is reset on every new `update-available` event so future updates still try the smaller differential path first.

Net effect: the smart/small path stays the default, but a flaky differential download no longer leaves the user stranded — the app transparently re-downloads the full ~155 MB zip and proceeds to install.

## Why the retry runs via `setImmediate`

Reading `node_modules/electron-updater/out/AppUpdater.js:435-475`, the relevant sequence on download failure is:

```js
this.downloadPromise = this.doDownloadUpdate(...)
    .catch((e) => { throw errorHandler(e); })   // emits 'error' synchronously
    .finally(() => { this.downloadPromise = null; });  // clears AFTER catch
```

A synchronous `downloadUpdate()` call from inside our error handler would hit the `if (this.downloadPromise != null) return this.downloadPromise` guard at line 442 and return the same rejected promise — so the retry would never actually start a fresh download. Deferring with `setImmediate` lets the chained `.finally` run first.

## Tests

`packages/desktop/src/__tests__/update-manager.test.ts` mocks `electron-updater` with an `EventEmitter` and pins the state machine:

- Retry does **not** fire synchronously during the `error` event (the `setImmediate` ordering is asserted, not just the eventual behavior — this is the regression that would have shipped without it)
- `disableDifferentialDownload` is set to `true` before the retry call
- A second failure during the retry surfaces as `error`
- Errors fired outside the `downloading` state do not trigger a retry
- The retry budget resets on every new `update-available`