### PR TITLE
Make virtual org departments filter-aware + tighten the model

### DIFF
--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -46,7 +46,7 @@ describe('loadOrgTree', () => {
 
     const sre = company?.children?.[2];
     expect(sre?.name).toBe('SRE');
-    expect(sre?.virtual).toBeUndefined();
+    expect(sre?.virtual).toBe(true);
     expect(sre?.children).toHaveLength(2);
   });
 });
@@ -77,9 +77,56 @@ describe('validateDimensions', () => {
 
 describe('validateOrgTree', () => {
   it('validates nested structure', () => {
-    const tree = validateOrgTree({
+    const { config, migrations } = validateOrgTree({
       tree: [{ name: 'Root', virtual: true, children: [{ name: 'leaf' }] }],
     });
-    expect(tree.tree[0]?.children?.[0]?.name).toBe('leaf');
+    expect(config.tree[0]?.children?.[0]?.name).toBe('leaf');
+    expect(migrations.promotedToVirtual).toEqual([]);
+    expect(migrations.wrappedRoots).toBe(false);
+    expect(migrations.addedEmptyRoot).toBe(false);
+  });
+
+  it('synthesizes a root when the tree is empty', () => {
+    const { config, migrations } = validateOrgTree({ tree: [] });
+    expect(config.tree).toHaveLength(1);
+    expect(config.tree[0]?.name).toBe('Organization');
+    expect(config.tree[0]?.virtual).toBe(true);
+    expect(migrations.addedEmptyRoot).toBe(true);
+  });
+
+  it('wraps multiple roots under a synthetic root', () => {
+    const { config, migrations } = validateOrgTree({
+      tree: [
+        { name: 'Engineering', virtual: true, children: [{ name: 'backend' }] },
+        { name: 'Sales', virtual: true, children: [{ name: 'east' }] },
+      ],
+    });
+    expect(config.tree).toHaveLength(1);
+    expect(config.tree[0]?.name).toBe('Organization');
+    expect(config.tree[0]?.children).toHaveLength(2);
+    expect(migrations.wrappedRoots).toBe(true);
+  });
+
+  it('wraps a single non-virtual root under the synthetic root', () => {
+    const { config, migrations } = validateOrgTree({
+      tree: [{ name: 'single-team' }],
+    });
+    expect(config.tree[0]?.name).toBe('Organization');
+    expect(config.tree[0]?.children?.[0]?.name).toBe('single-team');
+    expect(migrations.wrappedRoots).toBe(true);
+  });
+
+  it('auto-promotes a node that has children but no virtual flag', () => {
+    const { config, migrations } = validateOrgTree({
+      tree: [{
+        name: 'Root',
+        virtual: true,
+        children: [{ name: 'SRE', children: [{ name: 'sre-emea' }, { name: 'sre-us' }] }],
+      }],
+    });
+    const sre = config.tree[0]?.children?.[0];
+    expect(sre?.name).toBe('SRE');
+    expect(sre?.virtual).toBe(true);
+    expect(migrations.promotedToVirtual).toEqual(['SRE']);
   });
 });

--- a/packages/core/src/__tests__/org-tree-filter.test.ts
+++ b/packages/core/src/__tests__/org-tree-filter.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { expandOrgFilters } from '../models/org-tree-filter.js';
+import { asDimensionId, asTagValue } from '../types/branded.js';
+import type { OrgNode } from '../types/config.js';
+
+const ownerDim = asDimensionId('tag_owner');
+const accountDim = asDimensionId('account_id');
+
+const tree: readonly OrgNode[] = [{
+  name: 'Organization',
+  virtual: true,
+  children: [
+    { name: 'engineering', virtual: true, children: [{ name: 'backend' }, { name: 'frontend' }] },
+    { name: 'data', virtual: true, children: [{ name: 'analytics' }] },
+    { name: 'lone-team' },
+  ],
+}];
+
+describe('expandOrgFilters', () => {
+  it('expands a virtual department to its descendant leaves', () => {
+    const out = expandOrgFilters({ [ownerDim]: [asTagValue('engineering')] }, ownerDim, tree);
+    expect(out[ownerDim]).toEqual(['backend', 'frontend']);
+  });
+
+  it('passes leaf values through unchanged', () => {
+    const filters = { [ownerDim]: [asTagValue('backend'), asTagValue('lone-team')] };
+    const out = expandOrgFilters(filters, ownerDim, tree);
+    expect(out).toBe(filters);
+  });
+
+  it('mixes leaves and virtuals correctly', () => {
+    const out = expandOrgFilters(
+      { [ownerDim]: [asTagValue('engineering'), asTagValue('lone-team')] },
+      ownerDim,
+      tree,
+    );
+    expect(out[ownerDim]).toEqual(['backend', 'frontend', 'lone-team']);
+  });
+
+  it('dedupes when virtuals overlap with picked leaves', () => {
+    const out = expandOrgFilters(
+      { [ownerDim]: [asTagValue('engineering'), asTagValue('backend')] },
+      ownerDim,
+      tree,
+    );
+    expect(out[ownerDim]).toEqual(['backend', 'frontend']);
+  });
+
+  it('passes unknown values through (defensive)', () => {
+    const out = expandOrgFilters(
+      { [ownerDim]: [asTagValue('not-in-tree')] },
+      ownerDim,
+      tree,
+    );
+    expect(out[ownerDim]).toEqual(['not-in-tree']);
+  });
+
+  it('expands the synthetic root to every leaf', () => {
+    const out = expandOrgFilters(
+      { [ownerDim]: [asTagValue('Organization')] },
+      ownerDim,
+      tree,
+    );
+    expect(new Set(out[ownerDim])).toEqual(new Set(['backend', 'frontend', 'analytics', 'lone-team']));
+  });
+
+  it('leaves filters for other dimensions untouched', () => {
+    const filters = {
+      [ownerDim]: [asTagValue('engineering')],
+      [accountDim]: [asTagValue('111111111111')],
+    };
+    const out = expandOrgFilters(filters, ownerDim, tree);
+    expect(out[accountDim]).toBe(filters[accountDim]);
+  });
+
+  it('returns the input unchanged when ownerDimensionId is undefined', () => {
+    const filters = { [ownerDim]: [asTagValue('engineering')] };
+    const out = expandOrgFilters(filters, undefined, tree);
+    expect(out).toBe(filters);
+  });
+
+  it('returns the input unchanged when owner filter is empty', () => {
+    const filters = {};
+    const out = expandOrgFilters(filters, ownerDim, tree);
+    expect(out).toBe(filters);
+  });
+});

--- a/packages/core/src/__tests__/org-tree-rollup.test.ts
+++ b/packages/core/src/__tests__/org-tree-rollup.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { applyOrgTreeRollup } from '../models/org-tree-rollup.js';
+import type { CostResult, CostRow } from '../types/query.js';
+import type { OrgNode } from '../types/config.js';
+import { asDollars, asEntityRef, asDateString } from '../types/branded.js';
+
+function row(entity: string, totalCost: number, services: Record<string, number>): CostRow {
+  return {
+    entity: asEntityRef(entity),
+    totalCost: asDollars(totalCost),
+    serviceCosts: Object.fromEntries(Object.entries(services).map(([k, v]) => [k, asDollars(v)])),
+  };
+}
+
+function result(rows: CostRow[]): CostResult {
+  return {
+    rows,
+    totalCost: asDollars(rows.reduce((s, r) => s + r.totalCost, 0)),
+    topServices: [],
+    dateRange: { start: asDateString('2026-01-01'), end: asDateString('2026-01-31') },
+  };
+}
+
+function singleRoot(children: readonly OrgNode[]): readonly OrgNode[] {
+  return [{ name: 'Organization', virtual: true, children }];
+}
+
+describe('applyOrgTreeRollup', () => {
+  it('rolls a department into a single row summing its leaves', () => {
+    const tree = singleRoot([
+      { name: 'engineering', virtual: true, children: [{ name: 'backend' }, { name: 'frontend' }] },
+    ]);
+    const input = result([
+      row('backend', 100, { ec2: 60, s3: 40 }),
+      row('frontend', 50, { ec2: 30, s3: 20 }),
+    ]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    expect(out.rows).toHaveLength(1);
+    expect(out.rows[0]?.entity).toBe('engineering');
+    expect(out.rows[0]?.totalCost).toBe(150);
+    expect(out.rows[0]?.serviceCosts).toEqual({ ec2: asDollars(90), s3: asDollars(60) });
+    expect(out.rows[0]?.isVirtual).toBe(true);
+  });
+
+  it('emits leaves placed directly under the root as raw rows', () => {
+    const tree = singleRoot([{ name: 'backend' }, { name: 'frontend' }]);
+    const input = result([
+      row('backend', 100, { ec2: 100 }),
+      row('frontend', 50, { ec2: 50 }),
+    ]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    expect(out.rows).toHaveLength(2);
+    expect(out.rows.find(r => r.entity === 'backend')?.totalCost).toBe(100);
+    expect(out.rows.find(r => r.entity === 'frontend')?.totalCost).toBe(50);
+    expect(out.rows.every(r => r.isVirtual === undefined)).toBe(true);
+  });
+
+  it('mixes departments and leaves at the top level', () => {
+    const tree = singleRoot([
+      { name: 'engineering', virtual: true, children: [{ name: 'backend' }, { name: 'frontend' }] },
+      { name: 'lone-team' },
+    ]);
+    const input = result([
+      row('backend', 100, {}),
+      row('frontend', 50, {}),
+      row('lone-team', 25, {}),
+    ]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    expect(out.rows).toHaveLength(2);
+    expect(out.rows.find(r => r.entity === 'engineering')?.totalCost).toBe(150);
+    expect(out.rows.find(r => r.entity === 'lone-team')?.totalCost).toBe(25);
+  });
+
+  it('passes through unassigned leaves not under any department', () => {
+    const tree = singleRoot([
+      { name: 'engineering', virtual: true, children: [{ name: 'backend' }] },
+    ]);
+    const input = result([
+      row('backend', 100, {}),
+      row('orphan-team', 25, {}),
+    ]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    expect(out.rows).toHaveLength(2);
+    expect(out.rows.find(r => r.entity === 'engineering')?.totalCost).toBe(100);
+    expect(out.rows.find(r => r.entity === 'orphan-team')?.totalCost).toBe(25);
+  });
+
+  it('drops a department whose descendants have no data', () => {
+    const tree = singleRoot([
+      { name: 'empty-dept', virtual: true, children: [{ name: 'missing-team' }] },
+    ]);
+    const input = result([row('other-team', 10, {})]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    expect(out.rows.find(r => r.entity === 'empty-dept')).toBeUndefined();
+    expect(out.rows.find(r => r.entity === 'other-team')?.totalCost).toBe(10);
+  });
+
+  it('flattens nested departments into their top-level ancestor', () => {
+    const tree = singleRoot([
+      {
+        name: 'engineering',
+        virtual: true,
+        children: [
+          { name: 'platform', virtual: true, children: [{ name: 'backend' }, { name: 'frontend' }] },
+          { name: 'data', virtual: true, children: [{ name: 'analytics' }] },
+        ],
+      },
+    ]);
+    const input = result([
+      row('backend', 100, {}),
+      row('frontend', 50, {}),
+      row('analytics', 75, {}),
+    ]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    expect(out.rows).toHaveLength(1);
+    expect(out.rows[0]?.entity).toBe('engineering');
+    expect(out.rows[0]?.totalCost).toBe(225);
+  });
+
+  it('does not double-count when the same leaf appears under multiple subtrees', () => {
+    const tree = singleRoot([
+      { name: 'engineering', virtual: true, children: [{ name: 'backend' }] },
+      { name: 'platform', virtual: true, children: [{ name: 'backend' }] },
+    ]);
+    const input = result([row('backend', 100, {})]);
+
+    const out = applyOrgTreeRollup(input, tree);
+
+    const eng = out.rows.find(r => r.entity === 'engineering');
+    const plat = out.rows.find(r => r.entity === 'platform');
+    expect(eng?.totalCost).toBe(100);
+    expect(plat?.totalCost).toBe(100);
+    expect(out.rows.find(r => r.entity === 'backend')).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/org-tree.test.ts
+++ b/packages/core/src/__tests__/org-tree.test.ts
@@ -30,6 +30,7 @@ const data: OrgNode = {
 
 const sre: OrgNode = {
   name: 'SRE',
+  virtual: true,
   children: [
     { name: 'sre-emea' },
     { name: 'sre-us' },
@@ -54,9 +55,9 @@ describe('getDescendantTagValues', () => {
     expect(values).toEqual(['core-banking', 'payments', 'identity', 'platform']);
   });
 
-  it('includes self for non-virtual node with children', () => {
+  it('returns descendants only for parent node (virtual by invariant)', () => {
     const values = getDescendantTagValues(sre);
-    expect(values).toEqual(['SRE', 'sre-emea', 'sre-us']);
+    expect(values).toEqual(['sre-emea', 'sre-us']);
   });
 
   it('returns all leaf values for root', () => {
@@ -64,7 +65,7 @@ describe('getDescendantTagValues', () => {
     expect(values).toContain('core-banking');
     expect(values).toContain('analytics');
     expect(values).toContain('sre-emea');
-    expect(values).toHaveLength(9);
+    expect(values).toHaveLength(8);
   });
 });
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,5 +1,6 @@
-export { loadConfig, loadDimensions, loadOrgTree, loadViews, loadCostScope } from './loader.js';
-export { validateConfig, validateDimensions, validateOrgTree, ConfigValidationError, assertObject, assertArray, assertString, assertNumber } from './validator.js';
+export { loadConfig, loadDimensions, loadOrgTree, loadOrgTreeNormalized, loadViews, loadCostScope } from './loader.js';
+export { validateConfig, validateDimensions, validateOrgTree, SYNTHETIC_ROOT_NAME, ConfigValidationError, assertObject, assertArray, assertString, assertNumber } from './validator.js';
+export type { NormalizedOrgTree, OrgTreeMigrations } from './validator.js';
 export { validateViews } from './views-validator.js';
 export { validateCostScope } from './cost-scope-validator.js';
 export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './views-serialize.js';

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -3,7 +3,7 @@ import { parse } from 'yaml';
 import type { CostGoblinConfig, DimensionsConfig, OrgTreeConfig } from '../types/index.js';
 import type { ViewsConfig } from '../types/views.js';
 import type { CostScopeConfig } from '../types/cost-scope.js';
-import { validateConfig, validateDimensions, validateOrgTree } from './validator.js';
+import { validateConfig, validateDimensions, validateOrgTree, type NormalizedOrgTree } from './validator.js';
 import { validateViews } from './views-validator.js';
 import { validateCostScope } from './cost-scope-validator.js';
 
@@ -20,11 +20,15 @@ export async function loadDimensions(path: string): Promise<DimensionsConfig> {
 }
 
 export async function loadOrgTree(path: string): Promise<OrgTreeConfig> {
+  return (await loadOrgTreeNormalized(path)).config;
+}
+
+export async function loadOrgTreeNormalized(path: string): Promise<NormalizedOrgTree> {
   let content: string;
   try {
     content = await readFile(path, 'utf-8');
   } catch {
-    return { tree: [] };
+    return validateOrgTree({ tree: [] });
   }
   const raw: unknown = parse(content);
   return validateOrgTree(raw);

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -222,27 +222,67 @@ export function validateDimensions(raw: unknown): DimensionsConfig {
   return { builtIn, tags, ...(order === undefined ? {} : { order }) };
 }
 
-function validateOrgNode(raw: unknown, path: string): OrgNode {
+export const SYNTHETIC_ROOT_NAME = 'Organization';
+
+export interface OrgTreeMigrations {
+  readonly promotedToVirtual: readonly string[];
+  readonly wrappedRoots: boolean;
+  readonly addedEmptyRoot: boolean;
+}
+
+export interface NormalizedOrgTree {
+  readonly config: OrgTreeConfig;
+  readonly migrations: OrgTreeMigrations;
+}
+
+function validateOrgNode(raw: unknown, path: string, promoted: string[]): OrgNode {
   assertObject(raw, path);
   assertString(raw['name'], `${path}.name`);
 
-  const virtual = raw['virtual'] === true || undefined;
+  const declaredVirtual = raw['virtual'] === true;
   let children: OrgNode[] | undefined;
   if (raw['children'] !== undefined) {
     assertArray(raw['children'], `${path}.children`);
-    children = raw['children'].map((c, i) => validateOrgNode(c, `${path}.children[${String(i)}]`));
+    children = raw['children'].map((c, i) => validateOrgNode(c, `${path}.children[${String(i)}]`, promoted));
   }
+
+  const hasChildren = children !== undefined && children.length > 0;
+  const virtual = declaredVirtual || hasChildren;
+  if (hasChildren && !declaredVirtual) promoted.push(raw['name']);
 
   return {
     name: raw['name'],
-    ...(virtual === undefined ? {} : { virtual }),
+    ...(virtual ? { virtual: true as const } : {}),
     ...(children === undefined ? {} : { children }),
   };
 }
 
-export function validateOrgTree(raw: unknown): OrgTreeConfig {
+export function validateOrgTree(raw: unknown): NormalizedOrgTree {
   assertObject(raw, 'orgTree');
   assertArray(raw['tree'], 'tree');
-  const tree = raw['tree'].map((node, i) => validateOrgNode(node, `tree[${String(i)}]`));
-  return { tree };
+  const promoted: string[] = [];
+  const roots = raw['tree'].map((node, i) => validateOrgNode(node, `tree[${String(i)}]`, promoted));
+
+  let tree: OrgNode[];
+  let wrappedRoots = false;
+  let addedEmptyRoot = false;
+
+  if (roots.length === 0) {
+    tree = [{ name: SYNTHETIC_ROOT_NAME, virtual: true, children: [] }];
+    addedEmptyRoot = true;
+  } else if (roots.length === 1 && roots[0]?.virtual === true) {
+    tree = roots;
+  } else {
+    tree = [{ name: SYNTHETIC_ROOT_NAME, virtual: true, children: roots }];
+    wrappedRoots = true;
+  }
+
+  return {
+    config: { tree },
+    migrations: {
+      promotedToVirtual: promoted,
+      wrappedRoots,
+      addedEmptyRoot,
+    },
+  };
 }

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -16,3 +16,5 @@ export {
   appendChild,
 } from './org-tree-edit.js';
 export type { NodePath } from './org-tree-edit.js';
+export { applyOrgTreeRollup } from './org-tree-rollup.js';
+export { expandOrgFilters, expandOrgFiltersPlain, getOwnerDimensionId } from './org-tree-filter.js';

--- a/packages/core/src/models/org-tree-filter.ts
+++ b/packages/core/src/models/org-tree-filter.ts
@@ -1,0 +1,64 @@
+import type { FilterMap } from '../types/query.js';
+import type { DimensionsConfig, OrgNode } from '../types/config.js';
+import type { DimensionId, TagValue } from '../types/branded.js';
+import { asDimensionId, asTagValue, tagColumnName } from '../types/branded.js';
+import { findNode, getDescendantTagValues } from './org-tree.js';
+
+/** Returns the DimensionId for the dimension marked `concept: 'owner'`, if any.
+ *  Only one such dimension is expected per config. */
+export function getOwnerDimensionId(dimensions: DimensionsConfig): DimensionId | undefined {
+  const tag = dimensions.tags.find(t => t.concept === 'owner');
+  return tag === undefined ? undefined : asDimensionId(tagColumnName(tag.tagName));
+}
+
+function expandOwnerValues(
+  values: readonly string[],
+  tree: readonly OrgNode[],
+): { expanded: string[]; touched: boolean } {
+  const expanded: string[] = [];
+  let touched = false;
+  for (const value of values) {
+    const node = findNode(tree, value);
+    if (node !== undefined && node.children !== undefined && node.children.length > 0) {
+      for (const desc of getDescendantTagValues(node)) expanded.push(desc);
+      touched = true;
+    } else {
+      expanded.push(value);
+    }
+  }
+  return { expanded: Array.from(new Set(expanded)), touched };
+}
+
+/** Replace any virtual-department values on the owner dimension (in the typed
+ *  `FilterMap` used by query builders) with their descendant leaf tag values.
+ *  Leaf values and unknown values pass through. */
+export function expandOrgFilters(
+  filters: FilterMap,
+  ownerDimensionId: DimensionId | undefined,
+  tree: readonly OrgNode[],
+): FilterMap {
+  if (ownerDimensionId === undefined) return filters;
+  const ownerValues = filters[ownerDimensionId];
+  if (ownerValues === undefined || ownerValues.length === 0) return filters;
+  const { expanded, touched } = expandOwnerValues(ownerValues, tree);
+  if (!touched) return filters;
+  const branded: readonly TagValue[] = expanded.map(asTagValue);
+  return { ...filters, [ownerDimensionId]: branded };
+}
+
+/** Same logic, plain-string variant used at IPC boundaries where the filter
+ *  map arrives unbranded. */
+export function expandOrgFiltersPlain(
+  filters: Readonly<Record<string, readonly string[]>>,
+  ownerDimensionId: string | undefined,
+  tree: readonly OrgNode[],
+): Record<string, readonly string[]> {
+  const out: Record<string, readonly string[]> = { ...filters };
+  if (ownerDimensionId === undefined) return out;
+  const ownerValues = filters[ownerDimensionId];
+  if (ownerValues === undefined || ownerValues.length === 0) return out;
+  const { expanded, touched } = expandOwnerValues(ownerValues, tree);
+  if (!touched) return out;
+  out[ownerDimensionId] = expanded;
+  return out;
+}

--- a/packages/core/src/models/org-tree-rollup.ts
+++ b/packages/core/src/models/org-tree-rollup.ts
@@ -1,0 +1,73 @@
+import type { CostResult, CostRow } from '../types/query.js';
+import type { OrgNode } from '../types/config.js';
+import { asDollars, asEntityRef } from '../types/branded.js';
+import { getDescendantTagValues } from './org-tree.js';
+
+function mergeDescendantCosts(
+  descendants: readonly string[],
+  entityCostMap: Map<string, CostRow>,
+  consumedEntities: Set<string>,
+): { totalCost: number; mergedServices: Record<string, number> } {
+  let totalCost = 0;
+  const mergedServices: Record<string, number> = {};
+  for (const desc of descendants) {
+    consumedEntities.add(desc);
+    const row = entityCostMap.get(desc);
+    if (row === undefined) continue;
+    totalCost += row.totalCost;
+    for (const [svc, cost] of Object.entries(row.serviceCosts)) {
+      mergedServices[svc] = (mergedServices[svc] ?? 0) + cost;
+    }
+  }
+  return { totalCost, mergedServices };
+}
+
+function makeVirtualRow(name: string, totalCost: number, mergedServices: Record<string, number>): CostRow | null {
+  if (totalCost <= 0) return null;
+  return {
+    entity: asEntityRef(name),
+    totalCost: asDollars(totalCost),
+    serviceCosts: Object.fromEntries(
+      Object.entries(mergedServices).map(([k, v]) => [k, asDollars(v)]),
+    ),
+    isVirtual: true,
+  };
+}
+
+/** Validator invariant: the tree has exactly one virtual root. We roll up at
+ *  the root's children — one row per direct child (rolled up if it has its own
+ *  children, raw cost row if it's a leaf) — so the table shows departments and
+ *  unsorted teams side by side instead of collapsing to a single "Organization"
+ *  entry. */
+export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[]): CostResult {
+  const topLevel = tree[0]?.children ?? [];
+
+  const entityCostMap = new Map<string, CostRow>();
+  for (const row of result.rows) entityCostMap.set(row.entity, row);
+
+  const rolledUpRows: CostRow[] = [];
+  const consumedEntities = new Set<string>();
+
+  for (const node of topLevel) {
+    if (node.children === undefined || node.children.length === 0) {
+      const row = entityCostMap.get(node.name);
+      if (row !== undefined) {
+        rolledUpRows.push(row);
+        consumedEntities.add(node.name);
+      }
+      continue;
+    }
+    const descendants = getDescendantTagValues(node);
+    const { totalCost, mergedServices } = mergeDescendantCosts(descendants, entityCostMap, consumedEntities);
+    const row = makeVirtualRow(node.name, totalCost, mergedServices);
+    if (row !== null) rolledUpRows.push(row);
+  }
+
+  for (const row of result.rows) {
+    if (!consumedEntities.has(row.entity) && !rolledUpRows.some(r => r.entity === row.entity)) {
+      rolledUpRows.push(row);
+    }
+  }
+
+  return { ...result, rows: rolledUpRows };
+}

--- a/packages/core/src/models/org-tree.ts
+++ b/packages/core/src/models/org-tree.ts
@@ -2,18 +2,14 @@ import type { OrgNode } from '../types/config.js';
 import type { EntityRef } from '../types/branded.js';
 import { asEntityRef } from '../types/branded.js';
 
+/** Validator invariant: a node with children is always virtual. So a leaf
+ *  (no children) is itself a tag value; a parent (always virtual) contributes
+ *  only its descendants, never its own name. */
 export function getDescendantTagValues(node: OrgNode): string[] {
-  if (node.virtual !== true && (node.children === undefined || node.children.length === 0)) {
+  if (node.children === undefined || node.children.length === 0) {
     return [node.name];
   }
-  if (node.children === undefined) {
-    return [node.name];
-  }
-  const descendants = node.children.flatMap(getDescendantTagValues);
-  if (node.virtual !== true) {
-    return [node.name, ...descendants];
-  }
-  return descendants;
+  return node.children.flatMap(getDescendantTagValues);
 }
 
 export function findNode(tree: readonly OrgNode[], name: string): OrgNode | undefined {

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,9 +1,11 @@
-import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
+import type { BuiltInDimension, DimensionsConfig, OrgNode, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
 import { tagColumnName } from '../types/branded.js';
 import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
+import { expandOrgFilters, getOwnerDimensionId } from '../models/org-tree-filter.js';
+import { findNode, getDescendantTagValues } from '../models/org-tree.js';
 import { costExprFor } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
 import { assertDateString, assertHourString, SecurityError } from './identifier-validator.js';
@@ -464,6 +466,7 @@ export interface QueryContextOptions {
   readonly dataDir: string;
   readonly dimensions: DimensionsConfig;
   readonly orgAccountsPath?: string | undefined;
+  readonly orgTree?: readonly OrgNode[] | undefined;
   readonly availablePeriods?: readonly string[] | undefined;
   readonly accountReverseMap?: ReadonlyMap<string, readonly string[]> | undefined;
   readonly costScope?: CostScopeConfig | undefined;
@@ -477,9 +480,10 @@ function setupQuery(
   opts: QueryContextOptions,
   extraSourceOpts?: Partial<BuildSourceOptions>,
 ): CommonQuerySetup {
-  const { dataDir, dimensions, orgAccountsPath, availablePeriods, accountReverseMap, costScope, availableColumns, materializedSource } = opts;
+  const { dataDir, dimensions, orgAccountsPath, orgTree, availablePeriods, accountReverseMap, costScope, availableColumns, materializedSource } = opts;
   const qb = new QueryBuilder();
-  const filterClauses = buildFilterClauses(params.filters, dimensions, accountReverseMap, qb);
+  const expandedFilters = expandOrgFilters(params.filters, getOwnerDimensionId(dimensions), orgTree ?? []);
+  const filterClauses = buildFilterClauses(expandedFilters, dimensions, accountReverseMap, qb);
   const costMetric = costScope?.costMetric ?? 'unblended';
 
   // The materialized base table is built at daily tier and lacks usage_hour,
@@ -512,11 +516,6 @@ export function buildCostQuery(
     ...filterClauses,
     ...exclusionClauses,
   ];
-
-  if (params.orgNodeValues !== undefined && params.orgNodeValues.length > 0) {
-    const placeholders = params.orgNodeValues.map(v => qb.addParam(v)).join(', ');
-    whereConditions.push(`${groupByResolved.fieldExpr} IN (${placeholders})`);
-  }
 
   const topNPlaceholder = qb.addParam(topN);
 
@@ -818,13 +817,25 @@ export function buildEntityDetailQuery(
 
   // Same display-name collision treatment for the entity selector itself: if
   // the user clicked into "sre default" we need to match every underlying id,
-  // not just one.
+  // not just one. Likewise, if the user clicked into a virtual department row
+  // (e.g. "Engineering") we expand to all descendant tag values so the SQL
+  // matches the same rows the rollup summed.
   const entityClause = (() => {
     if (dimResolved.rawField === 'account_id' && opts.accountReverseMap !== undefined) {
       const ids = opts.accountReverseMap.get(String(params.entity));
       if (ids !== undefined && ids.length > 0) {
         const placeholders = ids.map(id => qb.addParam(id)).join(', ');
         return `${dimResolved.rawField} IN (${placeholders})`;
+      }
+    }
+    const ownerDimId = getOwnerDimensionId(opts.dimensions);
+    const isOwnerDim = ownerDimId !== undefined && params.dimension === ownerDimId;
+    if (isOwnerDim && opts.orgTree !== undefined) {
+      const node = findNode(opts.orgTree, String(params.entity));
+      if (node !== undefined && node.children !== undefined && node.children.length > 0) {
+        const descendants = getDescendantTagValues(node);
+        const placeholders = descendants.map(v => qb.addParam(v)).join(', ');
+        return `${dimResolved.fieldExpr} IN (${placeholders})`;
       }
     }
     const entityPlaceholder = qb.addParam(String(params.entity));

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -67,6 +67,20 @@ export interface OrgSyncProgress {
   readonly total: number;
 }
 
+export interface OrgTreeMigrationFlags {
+  readonly promotedToVirtual: readonly string[];
+  readonly wrappedRoots: boolean;
+  readonly addedEmptyRoot: boolean;
+}
+
+/** Shape returned by the `getOrgTree` IPC method: the normalized tree plus
+ *  flags describing any silent migrations the validator performed (auto-promoting
+ *  to virtual, wrapping multi-root, etc.). The editor surfaces these as a banner. */
+export interface OrgTreeWithMigrations {
+  readonly tree: readonly OrgNode[];
+  readonly migrations: OrgTreeMigrationFlags;
+}
+
 export type Dimension = BuiltInDimension | TagDimension;
 
 export type DataTier = 'daily' | 'hourly' | 'cost-optimization';
@@ -99,12 +113,12 @@ export interface CostApi {
   getSyncStatus(syncId?: string): Promise<SyncStatus>;
   getConfig(): Promise<CostGoblinConfig>;
   getDimensions(): Promise<Dimension[]>;
-  getOrgTree(): Promise<OrgNode[]>;
+  getOrgTree(): Promise<OrgTreeWithMigrations>;
   saveOrgTree(tree: readonly OrgNode[]): Promise<void>;
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult>;
   syncPeriods(files: readonly { key: string; contentHash: string; size: number }[], syncId?: string): Promise<{ filesDownloaded: number; rowsProcessed: number }>;
   cancelSync(syncId?: string): Promise<void>;
-  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]>;
+  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number; isVirtual?: true | undefined }[]>;
   deleteLocalPeriod(period: string, tier?: DataTier): Promise<void>;
   openDataFolder(): Promise<void>;
   ssoLogin(profile: string): Promise<void>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -62,7 +62,7 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateStatus, UpdateApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, OrgTreeWithMigrations, OrgTreeMigrationFlags, UpdateInfo, UpdateStatus, UpdateApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -24,7 +24,6 @@ export interface CostQueryParams {
   readonly dateRange: DateRange;
   readonly filters: FilterMap;
   readonly granularity?: Granularity | undefined;
-  readonly orgNodeValues?: readonly string[] | undefined;
   /** Debug-only: tag identifying which widget/view fired this query,
    *  surfaced in the query log. Not used by SQL builders. */
   readonly origin?: string | undefined;

--- a/packages/desktop/src/main/handlers/config.ts
+++ b/packages/desktop/src/main/handlers/config.ts
@@ -1,14 +1,14 @@
 import { ipcMain } from 'electron';
-import { asDimensionId, isStringRecord, logger } from '@costgoblin/core';
+import { asDimensionId, isStringRecord, loadOrgTreeNormalized, logger } from '@costgoblin/core';
 import type {
   CostGoblinConfig,
   Dimension,
-  OrgNode,
+  OrgTreeWithMigrations,
 } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
 export function registerConfigHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, getOrgTreeConfig, invalidateConfig } = app;
+  const { ctx, getConfig, getDimensions, invalidateConfig } = app;
 
   ipcMain.handle('config:get', async (): Promise<CostGoblinConfig> => {
     return getConfig();
@@ -40,9 +40,14 @@ export function registerConfigHandlers(app: AppContext): void {
     return [...builtIn, ...tags];
   });
 
-  ipcMain.handle('config:org-tree', async (): Promise<OrgNode[]> => {
-    const orgTree = await getOrgTreeConfig();
-    return [...orgTree.tree];
+  ipcMain.handle('config:org-tree', async (): Promise<OrgTreeWithMigrations> => {
+    // Re-validate the YAML on every editor open so migration flags (auto-promoted
+    // nodes, wrapped roots, synthetic empty root) reflect the on-disk state and
+    // the editor's banner stays in sync. The cached `getOrgTreeConfig` returns
+    // only the normalized tree without migration info, so we go to the raw file
+    // here instead.
+    const { config, migrations } = await loadOrgTreeNormalized(ctx.orgTreePath);
+    return { tree: [...config.tree], migrations };
   });
 
   // Surgical update: rewrite ONLY the first provider's credentials.profile,

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -9,6 +9,8 @@ import {
   buildAliasSqlCase,
   computePeriodsInRange,
   DEFAULT_LAG_DAYS,
+  expandOrgFiltersPlain,
+  getOwnerDimensionId,
   isStringRecord,
   logger,
   listLocalMonths,
@@ -280,7 +282,7 @@ async function buildFreshSource(opts: BuildFreshSourceOptions): Promise<{ source
 }
 
 async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams): Promise<QueryContext> {
-  const { ctx, getQueryDimensions, getAccountMap } = app;
+  const { ctx, getQueryDimensions, getAccountMap, getOrgTreeConfig } = app;
   const { startStr, endStr, windowDays, startHour, endHour } = resolveDateRange(params.dateRange);
   // Hour bounds (sub-day drag-zoom) require the hourly tier — that's where
   // usage_hour lives. Promote tier when present, regardless of what
@@ -294,6 +296,7 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
 
   const dimensions = await getQueryDimensions();
   const accountMap = await getAccountMap();
+  const orgTreeConfig = await getOrgTreeConfig();
 
   const tagColumns: readonly ExplorerTagColumn[] = dimensions.tags.map(t => ({
     id: tagColumnName(t.tagName),
@@ -307,7 +310,8 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
   }
 
   const accountReverseMap = buildAccountReverseMap(accountMap);
-  const filterPredicate = buildExplorerFilterPredicate(params.filters, dimensions, accountReverseMap);
+  const expandedFilters = expandOrgFiltersPlain(params.filters, getOwnerDimensionId(dimensions), orgTreeConfig.tree);
+  const filterPredicate = buildExplorerFilterPredicate(expandedFilters, dimensions, accountReverseMap);
 
   // Explorer always reads Parquet directly — the materialized base uses a
   // slim schema (no description, usage_amount, list_cost) that Explorer's

--- a/packages/desktop/src/main/handlers/org-tree.ts
+++ b/packages/desktop/src/main/handlers/org-tree.ts
@@ -8,8 +8,8 @@ export function registerOrgTreeHandlers(app: AppContext): void {
   const { ctx, invalidateOrgTree } = app;
 
   ipcMain.handle('org-tree:save', async (_event, raw: unknown): Promise<void> => {
-    const validated = validateOrgTree({ tree: raw });
-    await writeFile(ctx.orgTreePath, stringify(orgTreeToYaml(validated)));
+    const { config } = validateOrgTree({ tree: raw });
+    await writeFile(ctx.orgTreePath, stringify(orgTreeToYaml(config)));
     invalidateOrgTree();
   });
 }

--- a/packages/desktop/src/main/handlers/query-costs.ts
+++ b/packages/desktop/src/main/handlers/query-costs.ts
@@ -19,9 +19,9 @@ import type {
   EntityDetailResult,
   QueryContextOptions,
 } from '@costgoblin/core';
+import { applyOrgTreeRollup } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import {
-  applyOrgTreeRollup,
   buildCostResult,
   buildEntityDetailResult,
   isOwnerGroupBy,
@@ -39,6 +39,7 @@ export function registerCostHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
     const orgPath = await getOrgAccountsPath();
+    const orgTreeConfig = await getOrgTreeConfig();
     const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const availableColumns = await getAvailableColumns(tier);
@@ -46,7 +47,7 @@ export function registerCostHandlers(app: AppContext): void {
     if (empty) return { rows: [], totalCost: asDollars(0), topServices: [], dateRange: params.dateRange };
     const matSource = materializedBase.getSource(params.dateRange, tier);
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, orgTree: orgTreeConfig.tree, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildCostQuery(params, qcOpts);
     logger.info('query:costs', { groupBy: params.groupBy, materialized: isMat });
 
@@ -60,11 +61,8 @@ export function registerCostHandlers(app: AppContext): void {
       };
     }
 
-    if (isOwnerGroupBy(params.groupBy, dimensions) && params.orgNodeValues === undefined) {
-      const orgTreeConfig = await getOrgTreeConfig();
-      if (orgTreeConfig.tree.length > 0) {
-        result = applyOrgTreeRollup(result, orgTreeConfig.tree);
-      }
+    if (isOwnerGroupBy(params.groupBy, dimensions)) {
+      result = applyOrgTreeRollup(result, orgTreeConfig.tree);
     }
 
     return result;
@@ -74,6 +72,7 @@ export function registerCostHandlers(app: AppContext): void {
     const dimensions = await getDimensions();
     const accountReverseMap = await getAccountReverseMap();
     const orgPath = await getOrgAccountsPath();
+    const orgTreeConfig = await getOrgTreeConfig();
     const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const availableColumns = await getAvailableColumns(tier);
@@ -81,7 +80,7 @@ export function registerCostHandlers(app: AppContext): void {
     if (empty) return { days: [], groups: [], totalCost: asDollars(0) };
     const matSource = materializedBase.getSource(params.dateRange, tier);
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, orgTree: orgTreeConfig.tree, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildDailyCostsQuery(params, qcOpts);
     logger.info('query:daily-costs', { groupBy: params.groupBy, materialized: isMat });
 
@@ -135,6 +134,7 @@ export function registerCostHandlers(app: AppContext): void {
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
     const orgPath = await getOrgAccountsPath();
+    const orgTreeConfig = await getOrgTreeConfig();
     const costScope = await getCostScope().catch(() => undefined);
     const tier = params.granularity === 'hourly' ? 'hourly' : 'daily';
     const availableColumns = await getAvailableColumns(tier);
@@ -153,7 +153,7 @@ export function registerCostHandlers(app: AppContext): void {
     }
     const matSource = materializedBase.getSource(params.dateRange, tier);
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, orgTree: orgTreeConfig.tree, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildEntityDetailQuery(params, qcOpts);
     logger.info('query:entity-detail', { entity: params.entity, materialized: isMat });
 

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -4,9 +4,14 @@ import {
   buildAliasSqlCase,
   buildRuleMatchExpr,
   computePeriodsInRange,
+  expandOrgFiltersPlain,
+  findNode,
+  getDescendantTagValues,
+  getOwnerDimensionId,
   tagColumnName,
   QueryBuilder,
 } from '@costgoblin/core';
+import type { OrgNode } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import {
   toNum,
@@ -102,7 +107,7 @@ function buildExclusionWhereClauses(
 function mergeAccountRows(
   rows: import('../duckdb-client.js').RawRow[],
   accountMap: Map<string, string>,
-): { value: string; label: string; count: number }[] {
+): { value: string; label: string; count: number; isVirtual?: true | undefined }[] {
   const merged = new Map<string, number>();
   for (const r of rows) {
     const rawVal = toStr(r['val']);
@@ -114,16 +119,48 @@ function mergeAccountRows(
     .sort((a, b) => b.count - a.count);
 }
 
-export function registerFilterHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
+/** Walk the org tree and emit one synthetic filter entry per virtual node,
+ *  summing the costs of its descendant leaves (looked up in `leafCosts`).
+ *  Departments with zero total are dropped — no point offering a filter that
+ *  would zero the table. */
+function synthesizeVirtualEntries(
+  tree: readonly OrgNode[],
+  leafCosts: Map<string, number>,
+): { value: string; label: string; count: number; isVirtual: true }[] {
+  const out: { value: string; label: string; count: number; isVirtual: true }[] = [];
+  function walk(node: OrgNode): void {
+    if (node.children === undefined || node.children.length === 0) return;
+    let total = 0;
+    for (const leaf of getDescendantTagValues(node)) {
+      total += leafCosts.get(leaf) ?? 0;
+    }
+    if (total > 0) {
+      out.push({ value: node.name, label: node.name, count: total, isVirtual: true });
+    }
+    for (const child of node.children) walk(child);
+  }
+  for (const node of tree) walk(node);
+  return out;
+}
 
-  ipcMain.handle('query:filter-values', (_event, dimensionId: string, filterEntries: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]> => originStore.run(origin ?? null, async () => {
+export function registerFilterHandlers(app: AppContext): void {
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getOrgTreeConfig, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
+
+  ipcMain.handle('query:filter-values', (_event, dimensionId: string, filterEntries: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number; isVirtual?: true | undefined }[]> => originStore.run(origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
+    const orgTreeConfig = await getOrgTreeConfig();
     const costScope = opts?.bypassCostScope === true
       ? undefined
       : await getCostScope().catch(() => undefined);
+
+    const ownerDimensionId = getOwnerDimensionId(dimensions);
+    const isOwnerDim = ownerDimensionId !== undefined && dimensionId === ownerDimensionId;
+
+    // Filter input may contain virtual department names (the user picked a
+    // department chip); expand them to leaves before composing the SQL.
+    const expandedFilterEntries = expandOrgFiltersPlain(filterEntries, ownerDimensionId, orgTreeConfig.tree);
 
     const qb = new QueryBuilder();
     const { fieldExpr } = resolveFieldExpr(dimensionId, dimensions);
@@ -132,7 +169,7 @@ export function registerFilterHandlers(app: AppContext): void {
       ? undefined
       : materializedBase.getSource(dateRange, 'daily');
 
-    const filterClauses = buildFilterWhereClauses(filterEntries, dimensions, accountReverseMap, qb);
+    const filterClauses = buildFilterWhereClauses(expandedFilterEntries, dimensions, accountReverseMap, qb);
     const exclusionClauses = matSource === undefined
       ? buildExclusionWhereClauses(costScope, dimensions, accountReverseMap, qb)
       : [];
@@ -156,6 +193,10 @@ export function registerFilterHandlers(app: AppContext): void {
       source = matSource;
     }
 
+    // For the owner dim we fetch un-limited values so the synthesized virtual
+    // entries can sum from a complete leaf set; cardinality is bounded by
+    // team count, not data volume.
+    const limitClause = isOwnerDim ? '' : 'LIMIT 100';
     const sql = `
       SELECT ${fieldExpr} AS val, SUM(cost) AS total_cost
       FROM ${source}
@@ -163,7 +204,7 @@ export function registerFilterHandlers(app: AppContext): void {
       GROUP BY val
       HAVING val IS NOT NULL AND val != ''
       ORDER BY total_cost DESC
-      LIMIT 100
+      ${limitClause}
     `;
 
     const params = qb.build().params;
@@ -171,9 +212,37 @@ export function registerFilterHandlers(app: AppContext): void {
     const isAccountDim = dimensionId === 'account' || dimensionId === 'account_id';
     if (isAccountDim) return mergeAccountRows(rows, accountMap);
 
-    return rows.map(r => {
+    const leafEntries = rows.map(r => {
       const rawVal = toStr(r['val']);
       return { value: rawVal, label: rawVal, count: toNum(r['total_cost']) };
     });
+
+    if (!isOwnerDim) return leafEntries;
+
+    // Synthesize one entry per virtual node, summing its descendant leaves.
+    // Hide leaves that already appear as the picked filter value's expansion —
+    // when the user has picked "Engineering" we want the chip dropdown to keep
+    // showing Engineering, not the expanded leaves.
+    const leafCosts = new Map(leafEntries.map(e => [e.value, e.count]));
+    const virtualEntries = synthesizeVirtualEntries(orgTreeConfig.tree, leafCosts);
+
+    // If the user has the owner dim filtered to a virtual node, only show the
+    // virtual node itself (so they can deselect it) and that node's children
+    // (so they can drill in by deselecting siblings).
+    const pickedOwner = filterEntries[ownerDimensionId];
+    if (pickedOwner !== undefined && pickedOwner.length === 1) {
+      const pickedNode = findNode(orgTreeConfig.tree, pickedOwner[0] ?? '');
+      if (pickedNode !== undefined && pickedNode.children !== undefined && pickedNode.children.length > 0) {
+        const childNames = new Set(pickedNode.children.map(c => c.name));
+        const filtered = [
+          ...virtualEntries.filter(e => e.value === pickedNode.name || childNames.has(e.value)),
+          ...leafEntries.filter(e => childNames.has(e.value)),
+        ];
+        return filtered.sort((a, b) => b.count - a.count).slice(0, 200);
+      }
+    }
+
+    const merged = [...virtualEntries, ...leafEntries];
+    return merged.sort((a, b) => b.count - a.count).slice(0, 200);
   }));
 }

--- a/packages/desktop/src/main/handlers/query-recommendations.ts
+++ b/packages/desktop/src/main/handlers/query-recommendations.ts
@@ -23,13 +23,14 @@ import {
 import { originStore } from '../query-log.js';
 
 export function registerRecommendationHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getConfig, getCostScope, getAvailableColumns, runQuery, runPreparedQuery, materializedBase } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getOrgTreeConfig, getConfig, getCostScope, getAvailableColumns, runQuery, runPreparedQuery, materializedBase } = app;
 
   ipcMain.handle('query:missing-tags', (_event, params: MissingTagsParams): Promise<MissingTagsResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
     const orgPath = await getOrgAccountsPath();
+    const orgTreeConfig = await getOrgTreeConfig();
     const costScope = await getCostScope().catch(() => undefined);
     const availableColumns = await getAvailableColumns('daily');
     logger.info('query:missing-tags', { tagDimension: params.tagDimension });
@@ -53,7 +54,7 @@ export function registerRecommendationHandlers(app: AppContext): void {
     }
     const matSource = materializedBase.getSource(params.dateRange, 'daily');
     const isMat = matSource !== undefined;
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, orgTree: orgTreeConfig.tree, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const resourceQuery = buildMissingTagsQuery(params, qcOpts);
     const nonResourceQuery = buildNonResourceCostQuery(params, qcOpts);
     const [resourceRows, nonResourceRows] = await Promise.all([

--- a/packages/desktop/src/main/handlers/query-trends.ts
+++ b/packages/desktop/src/main/handlers/query-trends.ts
@@ -20,13 +20,14 @@ import {
 import { originStore } from '../query-log.js';
 
 export function registerTrendHandlers(app: AppContext): void {
-  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
+  const { ctx, getQueryDimensions: getDimensions, getAccountMap, getAccountReverseMap, getOrgAccountsPath, getOrgTreeConfig, getCostScope, getAvailableColumns, runPreparedQuery, materializedBase } = app;
 
   ipcMain.handle('query:trends', (_event, params: TrendQueryParams): Promise<TrendResult> => originStore.run(params.origin ?? null, async () => {
     const dimensions = await getDimensions();
     const accountMap = await getAccountMap();
     const accountReverseMap = await getAccountReverseMap();
     const orgPath = await getOrgAccountsPath();
+    const orgTreeConfig = await getOrgTreeConfig();
     const costScope = await getCostScope().catch(() => undefined);
     const availableColumns = await getAvailableColumns('daily');
     const { available, empty } = await resolveAvailablePeriods(ctx.dataDir, 'daily', params.dateRange);
@@ -43,7 +44,7 @@ export function registerTrendHandlers(app: AppContext): void {
     const matSource = materializedBase.getSource(fullRange, 'daily');
     const isMat = matSource !== undefined;
 
-    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
+    const qcOpts: QueryContextOptions = { dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, orgTree: orgTreeConfig.tree, availablePeriods: available, accountReverseMap, costScope, availableColumns, materializedSource: matSource };
     const { sql, params: queryParams } = buildTrendQuery(params, qcOpts);
     logger.info('query:trends', { groupBy: params.groupBy, materialized: isMat });
 

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -3,7 +3,6 @@ import {
   asDollars,
   asDateString,
   computePeriodsInRange,
-  getDescendantTagValues,
   listLocalMonths,
   logger,
   tagColumnName,
@@ -22,7 +21,6 @@ import type {
   EntityDetailResult,
   DailyCost,
   DistributionSlice,
-  OrgNode,
 } from '@costgoblin/core';
 import type { RawRow } from '../duckdb-client.js';
 
@@ -384,99 +382,3 @@ export function buildEntityDetailResult(rows: RawRow[], entity: string): EntityD
   };
 }
 
-function mergeDescendantCosts(
-  descendants: readonly string[],
-  entityCostMap: Map<string, CostRow>,
-  consumedEntities: Set<string>,
-  skipName?: string,
-  baseCost?: number,
-  baseServices?: Record<string, number>,
-): { totalCost: number; mergedServices: Record<string, number> } {
-  let totalCost = baseCost ?? 0;
-  const mergedServices: Record<string, number> = baseServices === undefined
-    ? {}
-    : { ...baseServices };
-  for (const desc of descendants) {
-    if (desc === skipName) continue;
-    consumedEntities.add(desc);
-    const row = entityCostMap.get(desc);
-    if (row === undefined) continue;
-    totalCost += row.totalCost;
-    for (const [svc, cost] of Object.entries(row.serviceCosts)) {
-      mergedServices[svc] = (mergedServices[svc] ?? 0) + cost;
-    }
-  }
-  return { totalCost, mergedServices };
-}
-
-function makeVirtualRow(name: string, totalCost: number, mergedServices: Record<string, number>): CostRow | null {
-  if (totalCost <= 0) return null;
-  return {
-    entity: asEntityRef(name),
-    totalCost: asDollars(totalCost),
-    serviceCosts: Object.fromEntries(
-      Object.entries(mergedServices).map(([k, v]) => [k, asDollars(v)]),
-    ),
-    isVirtual: true,
-  };
-}
-
-function rollupVirtualNode(
-  node: OrgNode,
-  entityCostMap: Map<string, CostRow>,
-  consumedEntities: Set<string>,
-): CostRow | null {
-  const descendants = getDescendantTagValues(node);
-  const { totalCost, mergedServices } = mergeDescendantCosts(descendants, entityCostMap, consumedEntities);
-  return makeVirtualRow(node.name, totalCost, mergedServices);
-}
-
-function rollupRealNode(
-  node: OrgNode,
-  entityCostMap: Map<string, CostRow>,
-  consumedEntities: Set<string>,
-): CostRow | null {
-  const descendants = node.children === undefined ? [] : getDescendantTagValues(node);
-  for (const desc of descendants) {
-    if (desc !== node.name) consumedEntities.add(desc);
-  }
-
-  const existingRow = entityCostMap.get(node.name);
-  if (node.children === undefined || node.children.length === 0) {
-    return existingRow ?? null;
-  }
-
-  const baseCost = existingRow === undefined ? 0 : existingRow.totalCost;
-  const baseServices = existingRow === undefined
-    ? {}
-    : Object.fromEntries(Object.entries(existingRow.serviceCosts).map(([k, v]) => [k, Number(v)]));
-  const { totalCost, mergedServices } = mergeDescendantCosts(
-    descendants, entityCostMap, consumedEntities, node.name, baseCost, baseServices,
-  );
-  return makeVirtualRow(node.name, totalCost, mergedServices);
-}
-
-export function applyOrgTreeRollup(result: CostResult, tree: readonly OrgNode[]): CostResult {
-  const entityCostMap = new Map<string, CostRow>();
-  for (const row of result.rows) {
-    entityCostMap.set(row.entity, row);
-  }
-
-  const rolledUpRows: CostRow[] = [];
-  const consumedEntities = new Set<string>();
-
-  for (const node of tree) {
-    const row = node.virtual
-      ? rollupVirtualNode(node, entityCostMap, consumedEntities)
-      : rollupRealNode(node, entityCostMap, consumedEntities);
-    if (row !== null) rolledUpRows.push(row);
-  }
-
-  for (const row of result.rows) {
-    if (!consumedEntities.has(row.entity) && !rolledUpRows.some(r => r.entity === row.entity)) {
-      rolledUpRows.push(row);
-    }
-  }
-
-  return { ...result, rows: rolledUpRows };
-}

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -4,6 +4,7 @@ import type {
   Dimension,
   CostGoblinConfig,
   OrgNode,
+  OrgTreeWithMigrations,
   CostQueryParams,
   CostResult,
   DailyCostsParams,
@@ -118,14 +119,14 @@ const api: CostApi = {
   getDimensions(): Promise<Dimension[]> {
     return invoke<Dimension[]>('config:dimensions');
   },
-  getOrgTree(): Promise<OrgNode[]> {
-    return invoke<OrgNode[]>('config:org-tree');
+  getOrgTree(): Promise<OrgTreeWithMigrations> {
+    return invoke<OrgTreeWithMigrations>('config:org-tree');
   },
   saveOrgTree(tree: readonly OrgNode[]): Promise<void> {
     return invoke<undefined>('org-tree:save', tree).then(() => undefined);
   },
-  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number }[]> {
-    return invoke<{ value: string; label: string; count: number }[]>('query:filter-values', dimensionId, filters, dateRange, opts, origin);
+  getFilterValues(dimensionId: string, filters: Record<string, readonly string[]>, dateRange?: { start: string; end: string }, opts?: { bypassCostScope?: boolean }, origin?: string): Promise<{ value: string; label: string; count: number; isVirtual?: true | undefined }[]> {
+    return invoke<{ value: string; label: string; count: number; isVirtual?: true | undefined }[]>('query:filter-values', dimensionId, filters, dateRange, opts, origin);
   },
   getDataInventory(tier?: DataTier): Promise<DataInventoryResult> {
     return invoke<DataInventoryResult>('data:inventory', tier);

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -234,12 +234,27 @@ export class MockCostApi implements CostApi {
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
   getConfig(): Promise<CostGoblinConfig> { return Promise.resolve(config); }
   getDimensions(): Promise<Dimension[]> { return Promise.resolve(mockDimensions); }
-  getOrgTree(): Promise<OrgNode[]> { return Promise.resolve(this.currentOrgTree); }
+  getOrgTree(): Promise<{ tree: readonly OrgNode[]; migrations: { promotedToVirtual: readonly string[]; wrappedRoots: boolean; addedEmptyRoot: boolean } }> {
+    return Promise.resolve({
+      tree: this.currentOrgTree,
+      migrations: { promotedToVirtual: [], wrappedRoots: false, addedEmptyRoot: false },
+    });
+  }
   saveOrgTree(tree: readonly OrgNode[]): Promise<void> {
     this.currentOrgTree = [...tree];
     return Promise.resolve();
   }
-  getFilterValues(): Promise<{ value: string; label: string; count: number }[]> { return Promise.resolve([]); }
+  getFilterValues(dimensionId: string): Promise<{ value: string; label: string; count: number; isVirtual?: true | undefined }[]> {
+    if (dimensionId === 'tag_owner') {
+      return Promise.resolve([
+        { value: 'engineering', label: 'engineering', count: 12000, isVirtual: true },
+        { value: 'core-banking', label: 'core-banking', count: 4500 },
+        { value: 'payments', label: 'payments', count: 3500 },
+        { value: 'platform', label: 'platform', count: 4000, isVirtual: true },
+      ]);
+    }
+    return Promise.resolve([]);
+  }
   getDataInventory(): Promise<DataInventoryResult> { return Promise.resolve({ periods: [], totalRemoteSize: 0, totalLocalPeriods: 0, totalRemotePeriods: 0, local: { periods: [], diskBytes: 0, oldestPeriod: null, newestPeriod: null } }); }
   syncPeriods(): Promise<{ filesDownloaded: number; rowsProcessed: number }> { return Promise.resolve({ filesDownloaded: 0, rowsProcessed: 0 }); }
   cancelSync(): Promise<void> { return Promise.resolve(); }

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Folder } from 'lucide-react';
 import type { Dimension, DimensionId, FilterMap, TagValue } from '@costgoblin/core/browser';
 import { asTagValue } from '@costgoblin/core/browser';
 import { getDimensionId } from '../lib/dimensions.js';
@@ -8,6 +9,7 @@ interface FilterValue {
   value: string;
   label: string;
   count: number;
+  isVirtual?: true | undefined;
 }
 
 type DropdownState =
@@ -244,7 +246,13 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
                             onChange={() => { toggleValue(item.value); }}
                             aria-label={item.label}
                           />
-                          <span className="truncate">{item.label}</span>
+                          {item.isVirtual === true && (
+                            <Folder className="h-3 w-3 text-warning shrink-0" aria-label="Department" />
+                          )}
+                          <span className={`truncate ${item.isVirtual === true ? 'font-semibold text-warning' : ''}`}>{item.label}</span>
+                          {item.isVirtual === true && (
+                            <span className="rounded-full border border-warning/40 bg-warning/10 px-1.5 py-0 text-[9px] text-warning shrink-0">department</span>
+                          )}
                         </span>
                         <span className="flex items-center gap-1.5 shrink-0">
                           <button

--- a/packages/ui/src/components/org-tree-editor.tsx
+++ b/packages/ui/src/components/org-tree-editor.tsx
@@ -16,6 +16,7 @@ import {
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { useQuery } from '../hooks/use-query.js';
+import { getDimensionId } from '../lib/dimensions.js';
 import { CoinRainLoader } from './coin-rain-loader.js';
 import { ConfirmModal } from './confirm-modal.js';
 
@@ -313,15 +314,16 @@ export function OrgTreeEditor({ onClose }: OrgTreeEditorProps): React.JSX.Elemen
   const ownerDimension = dimensionsQuery.status === 'success'
     ? dimensionsQuery.data.find(d => 'concept' in d && d.concept === 'owner')
     : undefined;
-  const ownerDimensionId = ownerDimension !== undefined
-    ? ('tagName' in ownerDimension ? ownerDimension.tagName : ownerDimension.name)
-    : undefined;
+  const ownerDimensionId = ownerDimension !== undefined ? getDimensionId(ownerDimension) : undefined;
 
   const allValuesQuery = useQuery(
     async () => {
       if (ownerDimensionId === undefined) return [];
       const result = await api.getFilterValues(ownerDimensionId, {});
-      return result.map(v => v.value);
+      // The handler returns both leaf tag values and synthesized virtual
+      // departments. The editor's unassigned panel only cares about leaves
+      // — virtual nodes are part of the tree, not orphans.
+      return result.filter(v => v.isVirtual !== true).map(v => v.value);
     },
     [ownerDimensionId],
   );
@@ -332,11 +334,18 @@ export function OrgTreeEditor({ onClose }: OrgTreeEditorProps): React.JSX.Elemen
 
   useEffect(() => {
     if (treeQuery.status === 'success' && tree === null) {
-      const loaded = treeQuery.data;
+      const loaded = treeQuery.data.tree;
       setTree(loaded);
       initialRef.current = loaded;
     }
   }, [treeQuery, tree]);
+
+  const [migrationsDismissed, setMigrationsDismissed] = useState(false);
+  const visibleMigrations = (() => {
+    if (treeQuery.status !== 'success' || migrationsDismissed) return null;
+    const m = treeQuery.data.migrations;
+    return (m.promotedToVirtual.length > 0 || m.wrappedRoots || m.addedEmptyRoot) ? m : null;
+  })();
 
   const isDirty = tree !== null && initialRef.current !== null &&
     JSON.stringify(tree) !== JSON.stringify(initialRef.current);
@@ -492,6 +501,30 @@ export function OrgTreeEditor({ onClose }: OrgTreeEditorProps): React.JSX.Elemen
       {saveError !== null && (
         <div className="rounded-lg border border-negative/50 bg-negative-muted px-4 py-3 text-sm text-negative">
           Failed to save: {saveError}
+        </div>
+      )}
+
+      {visibleMigrations !== null && (
+        <div className="rounded-lg border border-warning/50 bg-warning-muted px-4 py-3 text-sm text-warning flex items-start justify-between gap-3">
+          <div className="flex-1">
+            <p className="font-medium mb-1">Org tree normalized on load</p>
+            <ul className="text-xs space-y-0.5">
+              {visibleMigrations.addedEmptyRoot && <li>Synthesized an "Organization" root (no tree was configured).</li>}
+              {visibleMigrations.wrappedRoots && <li>Wrapped multiple roots under a single "Organization" parent.</li>}
+              {visibleMigrations.promotedToVirtual.length > 0 && (
+                <li>Promoted to virtual departments: {visibleMigrations.promotedToVirtual.join(', ')}.</li>
+              )}
+            </ul>
+            <p className="text-xs mt-1 opacity-80">Save to persist these changes to the YAML.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => { setMigrationsDismissed(true); }}
+            className="rounded p-1 hover:bg-warning/20 transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
 

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -639,7 +639,10 @@ export function CostScopeView(): React.JSX.Element {
       const id = getDimensionId(d);
       try {
         const vals = await api.getFilterValues(id, {}, undefined, { bypassCostScope: true }, `cost-scope:${id}`);
-        return [id, vals.map(v => v.value)];
+        // Cost-scope exclusion rules apply to literal CUR row values; virtual
+        // department names don't match anything in the data, so they'd be
+        // misleading autocomplete options.
+        return [id, vals.filter(v => v.isVirtual !== true).map(v => v.value)];
       } catch {
         return [id, []];
       }


### PR DESCRIPTION
## Summary

Stacks on top of #282. The cost table already showed virtual departments as rolled-up rows when grouping by owner, but clicking a department to filter by it sent `WHERE owner='Engineering'` literally and returned zero rows — display and filter layers disagreed on what a virtual node meant. This closes the asymmetry and tightens the model.

## What changes

- **Validator enforces a single virtual root.** Multi-root configs are wrapped under a synthetic "Organization" on load; empty trees get the same synthetic root. Non-virtual nodes with children are auto-promoted to virtual, eliminating the confusing "leaf-and-parent at the same time" edge case. The editor surfaces all three migrations as a dismissible banner.
- **New `expandOrgFilters` core helper** expands virtual-department filter values to their descendant leaves. Wired through `setupQuery` so every query handler (costs, trends, daily-costs, missing-tags, entity-detail) plus the explorer and filter-values handlers get it.
- **`query:filter-values` synthesizes virtual entries** with rolled-up costs (`isVirtual: true`). The owner-dim `LIMIT 100` is dropped since cardinality is bounded by team count. When a virtual department is picked, the dropdown shows only that node + its immediate children for drill-down.
- **Entity detail handles virtual entities** by expanding to descendant leaves before applying the entity filter.
- **Filter bar renders virtual entries** with a Folder icon + "department" badge — same visual language used in the cost table.
- **`applyOrgTreeRollup` rolls up at the root's children** (departments) rather than at the root itself, so the cost table shows per-department rows instead of one big "Organization" row. `rollupRealNode` and the dead `orgNodeValues` query param are deleted.
- **Cost-scope autocomplete strips virtual entries** (exclusion rules apply to literal CUR values, so virtual names would be misleading).
- **Inherited bug fix from #282**: the editor was passing `ownerDimension.tagName` (raw `user_sb_team`) instead of the column ID (`tag_user_sb_team`) to `getFilterValues`, which made the SQL reference a non-existent column. Now using the canonical `getDimensionId` helper.

20 new tests on the rollup, validator migrations, and filter expansion. All existing tests still pass.