### PR TITLE
Account-only tag dimensions, OU Path source, segment picker, and 'unit' concept

### DIFF
--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -265,6 +265,29 @@ describe('buildSource with account tag fallback', () => {
     expect(sql).not.toContain('LEFT JOIN');
     expect(sql).not.toContain('fallback');
   });
+
+  it('reads ouPath from org-accounts when accountTagFallback is the OU Path sentinel', () => {
+    const dims: DimensionsConfig = {
+      builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
+      tags: [{ tagName: 'team', label: 'Team', accountTagFallback: '__ouPath__' }],
+    };
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
+    expect(sql).toContain('ouPath AS fallback_tag_team');
+    expect(sql).toContain('COALESCE(NULLIF(');
+  });
+
+  it('emits account-source-only column when tagName is omitted', () => {
+    const dims: DimensionsConfig = {
+      builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
+      tags: [{ label: 'Department', accountTagFallback: '__ouPath__' }],
+    };
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
+    // Column name derives from "ou_path" since no tagName was provided.
+    expect(sql).toContain('acct_tags.fallback_tag_ou_path AS tag_ou_path');
+    expect(sql).toContain('ouPath AS fallback_tag_ou_path');
+    // No resource-tag COALESCE — there is no resource tag to read.
+    expect(sql).not.toContain('element_at(cur.resource_tags');
+  });
 });
 
 describe('buildEntityDetailQuery', () => {

--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -288,6 +288,48 @@ describe('buildSource with account tag fallback', () => {
     // No resource-tag COALESCE — there is no resource tag to read.
     expect(sql).not.toContain('element_at(cur.resource_tags');
   });
+
+  it('wraps the resolved value with split_part when pathSegment is set', () => {
+    const dims: DimensionsConfig = {
+      builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
+      tags: [{
+        tagName: 'department',
+        label: 'Department',
+        accountTagFallback: '__ouPath__',
+        pathSegment: { separator: ' / ', index: 1 },
+      }],
+    };
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
+    expect(sql).toContain("split_part(COALESCE(NULLIF(element_at(cur.resource_tags, 'user_department')[1], ''), acct_tags.fallback_tag_department), ' / ', 1)");
+    expect(sql).toContain('AS tag_department');
+  });
+
+  it('segments an account-source-only column', () => {
+    const dims: DimensionsConfig = {
+      builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
+      tags: [{
+        label: 'Unit',
+        accountTagFallback: '__ouPath__',
+        pathSegment: { separator: ' / ', index: 1 },
+      }],
+    };
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
+    expect(sql).toContain("split_part(acct_tags.fallback_tag_ou_path, ' / ', 1)");
+    expect(sql).toContain('AS tag_ou_path');
+  });
+
+  it('supports negative segment indices', () => {
+    const dims: DimensionsConfig = {
+      builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id' }],
+      tags: [{
+        label: 'Environment',
+        accountTagFallback: '__ouPath__',
+        pathSegment: { separator: ' / ', index: -1 },
+      }],
+    };
+    const sql = buildSource({ dataDir: '/data', tier: 'daily', dimensions: dims, orgAccountsPath: '/org-tags.json' });
+    expect(sql).toContain("split_part(acct_tags.fallback_tag_ou_path, ' / ', -1)");
+  });
 });
 
 describe('buildEntityDetailQuery', () => {

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -177,8 +177,20 @@ function validateBuiltInDimension(dim: unknown, i: number) {
 function validateTagDimension(tag: unknown, i: number) {
   const ctx = `tags[${String(i)}]`;
   assertObject(tag, ctx);
-  assertString(tag['tagName'], `${ctx}.tagName`);
+  // tagName is optional — when omitted, the dimension is sourced purely from
+  // accountTagFallback (e.g. the OU Path sentinel).
+  const tagName = tag['tagName'] === undefined || tag['tagName'] === ''
+    ? undefined
+    : (assertString(tag['tagName'], `${ctx}.tagName`), tag['tagName']);
   assertString(tag['label'], `${ctx}.label`);
+
+  const accountTagFallback = typeof tag['accountTagFallback'] === 'string' && tag['accountTagFallback'].length > 0
+    ? tag['accountTagFallback']
+    : undefined;
+
+  if (tagName === undefined && accountTagFallback === undefined) {
+    throw new ConfigValidationError(`${ctx} must set either tagName or accountTagFallback`);
+  }
 
   const concept = tag['concept'] === undefined ? undefined : (() => {
     assertString(tag['concept'], `${ctx}.concept`);
@@ -194,13 +206,13 @@ function validateTagDimension(tag: unknown, i: number) {
   const enabled = tag['enabled'] === false ? false : undefined;
 
   return {
-    tagName: tag['tagName'],
+    ...(tagName === undefined ? {} : { tagName }),
     label: tag['label'],
     ...(concept === undefined ? {} : { concept }),
     ...(normalize === undefined ? {} : { normalize }),
     ...(separator === undefined ? {} : { separator }),
     ...(aliases === undefined ? {} : { aliases }),
-    ...(typeof tag['accountTagFallback'] === 'string' ? { accountTagFallback: tag['accountTagFallback'] } : {}),
+    ...(accountTagFallback === undefined ? {} : { accountTagFallback }),
     ...(typeof tag['missingValueTemplate'] === 'string' ? { missingValueTemplate: tag['missingValueTemplate'] } : {}),
     ...(enabled === false ? { enabled } : {}),
   };

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -194,16 +194,31 @@ function validateTagDimension(tag: unknown, i: number) {
 
   const concept = tag['concept'] === undefined ? undefined : (() => {
     assertString(tag['concept'], `${ctx}.concept`);
-    const validConcepts = new Set(['owner', 'product', 'environment']);
+    const validConcepts = new Set(['owner', 'product', 'environment', 'unit']);
     if (!validConcepts.has(tag['concept'])) {
-      throw new ConfigValidationError(`${ctx}.concept must be 'owner', 'product', or 'environment'`);
+      throw new ConfigValidationError(`${ctx}.concept must be 'owner', 'product', 'environment', or 'unit'`);
     }
-    return tag['concept'] as 'owner' | 'product' | 'environment';
+    return tag['concept'] as 'owner' | 'product' | 'environment' | 'unit';
   })();
   const normalize = validateNormalize(tag['normalize'], ctx);
   const separator = tag['separator'] === undefined ? undefined : (assertString(tag['separator'], `${ctx}.separator`), tag['separator']);
   const aliases = validateAliases(tag['aliases'], ctx);
   const enabled = tag['enabled'] === false ? false : undefined;
+
+  let pathSegment: { separator: string; index: number } | undefined;
+  if (tag['pathSegment'] !== undefined) {
+    const raw = tag['pathSegment'];
+    assertObject(raw, `${ctx}.pathSegment`);
+    assertString(raw['separator'], `${ctx}.pathSegment.separator`);
+    assertNumber(raw['index'], `${ctx}.pathSegment.index`);
+    if (raw['separator'].length === 0) {
+      throw new ConfigValidationError(`${ctx}.pathSegment.separator must be non-empty`);
+    }
+    if (!Number.isInteger(raw['index']) || raw['index'] === 0) {
+      throw new ConfigValidationError(`${ctx}.pathSegment.index must be a non-zero integer (1-based; -1 = last)`);
+    }
+    pathSegment = { separator: raw['separator'], index: raw['index'] };
+  }
 
   return {
     ...(tagName === undefined ? {} : { tagName }),
@@ -214,6 +229,7 @@ function validateTagDimension(tag: unknown, i: number) {
     ...(aliases === undefined ? {} : { aliases }),
     ...(accountTagFallback === undefined ? {} : { accountTagFallback }),
     ...(typeof tag['missingValueTemplate'] === 'string' ? { missingValueTemplate: tag['missingValueTemplate'] } : {}),
+    ...(pathSegment === undefined ? {} : { pathSegment }),
     ...(enabled === false ? { enabled } : {}),
   };
 }

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,7 +1,8 @@
 import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
-import { tagColumnName } from '../types/branded.js';
+import { tagDimColumn } from '../types/branded.js';
+import { OU_PATH_SOURCE_KEY } from '../types/config.js';
 import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor } from './cost-metric.js';
@@ -75,9 +76,9 @@ function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig)
     return { fieldExpr, rawField: builtIn.field, dim: builtIn };
   }
 
-  const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
+  const tag = dimensions.tags.find(d => tagDimColumn(d) === dimensionId);
   if (tag !== undefined) {
-    const rawField = tagColumnName(tag.tagName);
+    const rawField = tagDimColumn(tag);
     return { fieldExpr: buildAliasSqlCase(rawField, tag), rawField, dim: tag };
   }
 
@@ -270,13 +271,26 @@ function buildTagSelect(
   t: DimensionsConfig['tags'][number],
   needsOrgJoin: boolean,
 ): string {
-  const rawKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
+  const colName = tagDimColumn(t);
+  const hasResourceTag = t.tagName !== undefined && t.tagName.length > 0;
+  const hasFallback = t.accountTagFallback !== undefined;
+
+  // Account-source-only dimension: emit just the fallback column.
+  if (!hasResourceTag) {
+    if (needsOrgJoin && hasFallback) {
+      return `acct_tags.fallback_${colName} AS ${colName}`;
+    }
+    // No org join available — dimension can't resolve; emit NULL so SQL stays valid.
+    return `NULL AS ${colName}`;
+  }
+
+  const tagName = t.tagName ?? '';
+  const rawKey = tagName.startsWith('user_') ? tagName : `user_${tagName}`;
   const curKey = sqlEscapeString(rawKey);
-  const colName = tagColumnName(t.tagName);
   const tablePrefix = needsOrgJoin ? 'cur.' : '';
   const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;
 
-  if (t.accountTagFallback === undefined || !needsOrgJoin) {
+  if (!hasFallback || !needsOrgJoin) {
     return `${resourceExpr} AS ${colName}`;
   }
 
@@ -314,9 +328,10 @@ function buildRawTagSelects(dimensions: DimensionsConfig): string[] {
   const selects: string[] = [];
   for (const t of dimensions.tags) {
     if (t.accountTagFallback === undefined) continue;
+    if (t.tagName === undefined || t.tagName.length === 0) continue;
     const rawKey = t.tagName.startsWith('user_') ? t.tagName : `user_${t.tagName}`;
     const curKey = sqlEscapeString(rawKey);
-    const colName = tagColumnName(t.tagName);
+    const colName = tagDimColumn(t);
     selects.push(`element_at(cur.resource_tags, '${curKey}')[1] AS raw_${colName}`);
   }
   return selects;
@@ -338,8 +353,12 @@ function buildFromClause(
   const fallbackSelects = dimensions.tags
     .filter(t => t.accountTagFallback !== undefined)
     .map(t => {
-      const colName = tagColumnName(t.tagName);
-      const fallbackKey = sqlEscapeString(t.accountTagFallback ?? '');
+      const colName = tagDimColumn(t);
+      const fallback = t.accountTagFallback ?? '';
+      if (fallback === OU_PATH_SOURCE_KEY) {
+        return `ouPath AS fallback_${colName}`;
+      }
+      const fallbackKey = sqlEscapeString(fallback);
       return `tags->>'${fallbackKey}' AS fallback_${colName}`;
     });
   return `${parquetSource} AS cur
@@ -673,8 +692,8 @@ export function buildMissingTagsQuery(
 
   // Use the raw_ column (before COALESCE fallback) when available, so that
   // resources with only an account-level fallback are still reported as untagged.
-  const tagDim = tagResolved.dim !== null && 'tagName' in tagResolved.dim ? tagResolved.dim : undefined;
-  const hasRawColumn = tagDim?.accountTagFallback !== undefined && opts.orgAccountsPath !== undefined;
+  const tagDim = tagResolved.dim !== null && !('field' in tagResolved.dim) ? tagResolved.dim : undefined;
+  const hasRawColumn = tagDim?.accountTagFallback !== undefined && tagDim.tagName !== undefined && tagDim.tagName.length > 0 && opts.orgAccountsPath !== undefined;
   const tagCheckField = hasRawColumn ? `raw_${tagResolved.rawField}` : tagResolved.rawField;
 
   const whereConditions = [

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -272,16 +272,23 @@ function buildTagSelect(
   needsOrgJoin: boolean,
 ): string {
   const colName = tagDimColumn(t);
+  const valueExpr = buildTagValueExpr(t, needsOrgJoin, colName);
+  const wrapped = applyPathSegment(valueExpr, t.pathSegment);
+  return `${wrapped} AS ${colName}`;
+}
+
+function buildTagValueExpr(
+  t: DimensionsConfig['tags'][number],
+  needsOrgJoin: boolean,
+  colName: string,
+): string {
   const hasResourceTag = t.tagName !== undefined && t.tagName.length > 0;
   const hasFallback = t.accountTagFallback !== undefined;
 
   // Account-source-only dimension: emit just the fallback column.
   if (!hasResourceTag) {
-    if (needsOrgJoin && hasFallback) {
-      return `acct_tags.fallback_${colName} AS ${colName}`;
-    }
-    // No org join available — dimension can't resolve; emit NULL so SQL stays valid.
-    return `NULL AS ${colName}`;
+    if (needsOrgJoin && hasFallback) return `acct_tags.fallback_${colName}`;
+    return 'NULL';
   }
 
   const tagName = t.tagName ?? '';
@@ -290,9 +297,7 @@ function buildTagSelect(
   const tablePrefix = needsOrgJoin ? 'cur.' : '';
   const resourceExpr = `element_at(${tablePrefix}resource_tags, '${curKey}')[1]`;
 
-  if (!hasFallback || !needsOrgJoin) {
-    return `${resourceExpr} AS ${colName}`;
-  }
+  if (!hasFallback || !needsOrgJoin) return resourceExpr;
 
   const fallbackExpr = `acct_tags.fallback_${colName}`;
   if (t.missingValueTemplate !== undefined && t.missingValueTemplate.length > 0 && t.missingValueTemplate !== '{fallback}') {
@@ -300,9 +305,18 @@ function buildTagSelect(
     const prefix = sqlEscapeString(parts[0] ?? '');
     const suffix = sqlEscapeString(parts[1] ?? '');
     const formatted = `'${prefix}' || ${fallbackExpr} || '${suffix}'`;
-    return `COALESCE(NULLIF(${resourceExpr}, ''), ${formatted}) AS ${colName}`;
+    return `COALESCE(NULLIF(${resourceExpr}, ''), ${formatted})`;
   }
-  return `COALESCE(NULLIF(${resourceExpr}, ''), ${fallbackExpr}) AS ${colName}`;
+  return `COALESCE(NULLIF(${resourceExpr}, ''), ${fallbackExpr})`;
+}
+
+function applyPathSegment(expr: string, pathSegment: { separator: string; index: number } | undefined): string {
+  if (pathSegment === undefined) return expr;
+  const sep = sqlEscapeString(pathSegment.separator);
+  // DuckDB's split_part is 1-based and supports negative indices (-1 = last).
+  // NULLIF guards against returning the empty string when the segment index
+  // is out of range (split_part returns '' rather than NULL in that case).
+  return `NULLIF(split_part(${expr}, '${sep}', ${String(pathSegment.index)}), '')`;
 }
 
 export interface BuildSourceOptions {

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -1,5 +1,5 @@
 import type { DimensionsConfig } from '../types/config.js';
-import { tagColumnName } from '../types/branded.js';
+import { tagDimColumn } from '../types/branded.js';
 
 /**
  * Error thrown when SQL identifier validation fails.
@@ -94,7 +94,7 @@ function buildAllowedColumns(dimensions: DimensionsConfig): ReadonlySet<string> 
 
   // Add tag columns (normalized tag names)
   for (const tag of dimensions.tags) {
-    const col = tagColumnName(tag.tagName);
+    const col = tagDimColumn(tag);
     allowed.add(col);
     allowed.add(`fallback_${col}`);
   }

--- a/packages/core/src/types/branded.ts
+++ b/packages/core/src/types/branded.ts
@@ -39,3 +39,15 @@ export function asHourString(value: string): HourString {
 export function tagColumnName(tagName: string): string {
   return `tag_${tagName.replaceAll(/[^a-zA-Z0-9]/g, '_')}`;
 }
+
+/** Returns the SQL column name for a tag dimension. When the dimension has no
+ *  resource `tagName` (account-only dimension), the column name is derived
+ *  from the account-level source: `tag_ou_path` for the OU Path sentinel, or
+ *  a slugified `accountTagFallback`. */
+export function tagDimColumn(t: { readonly tagName?: string | undefined; readonly accountTagFallback?: string | undefined }): string {
+  if (t.tagName !== undefined && t.tagName.length > 0) return tagColumnName(t.tagName);
+  const fallback = t.accountTagFallback;
+  if (fallback === '__ouPath__') return tagColumnName('ou_path');
+  if (fallback !== undefined && fallback.length > 0) return tagColumnName(fallback);
+  return tagColumnName('unknown');
+}

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -70,8 +70,18 @@ export interface BuiltInDimension {
   readonly useRegionNames?: boolean | undefined;
 }
 
+/** Sentinel value usable wherever an account-level tag key is expected
+ *  (`TagDimension.accountTagFallback`, `BuiltInDimension.accountNameFromTag`)
+ *  to mean "use the account's OU Path from the AWS Organizations sync"
+ *  instead of an account-level tag value. */
+export const OU_PATH_SOURCE_KEY = '__ouPath__';
+
 export interface TagDimension {
-  readonly tagName: string;
+  /** Resource tag key (without the `user_` prefix). When omitted, the
+   *  dimension is sourced purely from `accountTagFallback` (which may be
+   *  the OU Path sentinel) — useful for account-level concepts like
+   *  Department/BU that don't appear on individual resources. */
+  readonly tagName?: string | undefined;
   readonly label: string;
   readonly concept?: ConceptType | undefined;
   readonly normalize?: NormalizationRule | undefined;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -2,7 +2,7 @@ import type { BucketPath, DimensionId } from './branded.js';
 
 export type NormalizationRule = 'lowercase' | 'uppercase' | 'lowercase-kebab' | 'lowercase-underscore' | 'camelCase';
 
-export type ConceptType = 'owner' | 'product' | 'environment';
+export type ConceptType = 'owner' | 'product' | 'environment' | 'unit';
 
 export interface ProviderConfig {
   readonly name: string;
@@ -89,6 +89,12 @@ export interface TagDimension {
   readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
   readonly accountTagFallback?: string | undefined;
   readonly missingValueTemplate?: string | undefined;
+  /** When set, the resolved value is split by `separator` and only the
+   *  `index`-th part (1-based; negative counts from the end, -1 = last)
+   *  is emitted. Applied after the resource-tag/account-fallback COALESCE
+   *  so every downstream consumer (group-by, filters, preview) sees only
+   *  the segmented value. */
+  readonly pathSegment?: { readonly separator: string; readonly index: number } | undefined;
   /** Hidden from selectors/filter bar when false. Default true. */
   readonly enabled?: boolean | undefined;
   /** Short user-facing explanation shown on the Dimensions view. */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,6 +16,7 @@ export {
   asDateString,
   asHourString,
   tagColumnName,
+  tagDimColumn,
 } from './branded.js';
 
 export type {
@@ -33,6 +34,7 @@ export type {
   OrgNode,
   OrgTreeConfig,
 } from './config.js';
+export { OU_PATH_SOURCE_KEY } from './config.js';
 
 export type {
   Granularity,

--- a/packages/desktop/src/main/handlers/config.ts
+++ b/packages/desktop/src/main/handlers/config.ts
@@ -30,12 +30,17 @@ export function registerConfigHandlers(app: AppContext): void {
     const tags: Dimension[] = dimensions.tags
       .filter(d => d.enabled !== false)
       .map(d => ({
-        tagName: d.tagName,
+        // tagName is optional now (account-only dims like OU Path / Unit have
+        // none). Omit the key when absent so the renderer's `tagDimColumn`
+        // falls back to accountTagFallback to compute the column name.
+        ...(d.tagName === undefined || d.tagName.length === 0 ? {} : { tagName: d.tagName }),
         label: d.label,
         ...(d.concept === undefined ? {} : { concept: d.concept }),
         ...(d.normalize === undefined ? {} : { normalize: d.normalize }),
         ...(d.separator === undefined ? {} : { separator: d.separator }),
         ...(d.aliases === undefined ? {} : { aliases: d.aliases }),
+        ...(d.accountTagFallback === undefined ? {} : { accountTagFallback: d.accountTagFallback }),
+        ...(d.pathSegment === undefined ? {} : { pathSegment: d.pathSegment }),
       }));
     return [...builtIn, ...tags];
   });

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -200,7 +200,7 @@ function applyAccountNameTransforms(
   }));
 }
 
-function extractAccountTagEntry(acct: unknown): { id: string; tags: Record<string, string> } | null {
+function extractAccountTagEntry(acct: unknown): { id: string; tags: Record<string, string>; ouPath: string } | null {
   if (!isStringRecord(acct)) return null;
   const id = acct['id'];
   const tags = acct['tags'];
@@ -209,7 +209,8 @@ function extractAccountTagEntry(acct: unknown): { id: string; tags: Record<strin
   for (const [k, v] of Object.entries(tags)) {
     if (typeof v === 'string') stringTags[k] = v;
   }
-  return { id, tags: stringTags };
+  const ouPath = typeof acct['ouPath'] === 'string' ? acct['ouPath'] : '';
+  return { id, tags: stringTags, ouPath };
 }
 
 async function generateFlatOrgTags(baseDir: string, flatPath: string): Promise<string | undefined> {
@@ -330,8 +331,14 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const flatPath = path.join(baseDir, 'org-account-tags.json');
     let result: string | undefined;
     try {
-      await fs.access(flatPath);
-      result = flatPath;
+      // Probe the existing flat file's schema — older builds wrote {id, tags}
+      // only, but the OU Path fallback needs an `ouPath` field. Regenerate if
+      // missing so DuckDB can resolve `ouPath AS fallback_…`.
+      const raw = await fs.readFile(flatPath, 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      const hasOuPath = Array.isArray(parsed)
+        && (parsed.length === 0 || (isStringRecord(parsed[0]) && 'ouPath' in parsed[0]));
+      result = hasOuPath ? flatPath : await generateFlatOrgTags(baseDir, flatPath);
     } catch {
       result = await generateFlatOrgTags(baseDir, flatPath);
     }

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -545,9 +545,13 @@ export function createAppContext(ctx: IpcContext): AppContext {
 
 /** Read org-accounts.json and return an id→name map. When tagKey is set,
  *  each account's "name" is the value of that tag; accounts missing the tag
- *  fall back to the Name field. */
+ *  fall back to the Name field. The OU Path sentinel routes to the
+ *  account's `ouPath` field instead of `tags`. */
 function resolveAccountName(acct: Record<string, unknown>, tagKey: string | undefined): string | undefined {
-  if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
+  if (tagKey === '__ouPath__') {
+    const ouPath = acct['ouPath'];
+    if (typeof ouPath === 'string' && ouPath.length > 0) return ouPath;
+  } else if (tagKey !== undefined && tagKey.length > 0 && isStringRecord(acct['tags'])) {
     const tagVal = acct['tags'][tagKey];
     if (typeof tagVal === 'string' && tagVal.length > 0) return tagVal;
   }

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -12,7 +12,7 @@ import {
   computePeriodsInRange,
   logger,
   listLocalMonths,
-  tagColumnName,
+  tagDimColumn,
 } from '@costgoblin/core';
 import type {
   CostScopeCapabilities,
@@ -77,7 +77,7 @@ function logSettledError(label: string, result: PromiseSettledResult<unknown>): 
 function assertRuleDimensionsExist(config: CostScopeConfig, dimensions: DimensionsConfig): void {
   const knownIds = new Set<string>();
   for (const d of dimensions.builtIn) knownIds.add(String(d.name));
-  for (const t of dimensions.tags) knownIds.add(tagColumnName(t.tagName));
+  for (const t of dimensions.tags) knownIds.add(tagDimColumn(t));
   for (const rule of config.rules) {
     for (const cond of rule.conditions) {
       const id = String(cond.dimensionId);
@@ -170,7 +170,7 @@ export function registerCostScopeHandlers(app: AppContext): void {
       : 'FALSE';
 
     const tagColumns = dimensions.tags.map(t => ({
-      id: tagColumnName(t.tagName),
+      id: tagDimColumn(t),
       label: t.label,
     }));
 

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -254,6 +254,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(t.aliases === undefined ? {} : { aliases: Object.fromEntries(Object.entries(t.aliases).map(([k, v]) => [k, [...v]])) }),
         ...(t.accountTagFallback === undefined ? {} : { accountTagFallback: t.accountTagFallback }),
         ...(t.missingValueTemplate === undefined ? {} : { missingValueTemplate: t.missingValueTemplate }),
+        ...(t.pathSegment === undefined ? {} : { pathSegment: { separator: t.pathSegment.separator, index: t.pathSegment.index } }),
         ...(t.description === undefined ? {} : { description: t.description }),
         ...(t.enabled === false ? { enabled: false } : {}),
       })),

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -246,7 +246,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(d.enabled === false ? { enabled: false } : {}),
       })),
       tags: config.tags.map(t => ({
-        tagName: t.tagName,
+        ...(t.tagName === undefined || t.tagName.length === 0 ? {} : { tagName: t.tagName }),
         label: t.label,
         ...(t.concept === undefined ? {} : { concept: t.concept }),
         ...(t.normalize === undefined ? {} : { normalize: t.normalize }),

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -13,7 +13,7 @@ import {
   logger,
   listLocalMonths,
   parseJsonObject,
-  tagColumnName,
+  tagDimColumn,
 } from '@costgoblin/core';
 import type {
   CostMetric,
@@ -296,7 +296,7 @@ async function prepareQueryContext(app: AppContext, params: ExplorerBaseParams):
   const accountMap = await getAccountMap();
 
   const tagColumns: readonly ExplorerTagColumn[] = dimensions.tags.map(t => ({
-    id: tagColumnName(t.tagName),
+    id: tagDimColumn(t),
     label: t.label,
   }));
   const tagIdSet = new Set(tagColumns.map(t => t.id));
@@ -651,11 +651,11 @@ export function registerExplorerHandlers(app: AppContext): void {
     if (qc.empty) return [];
 
     const builtIn = qc.dimensions.builtIn.find(d => d.name === dimId);
-    const tag = qc.dimensions.tags.find(d => tagColumnName(d.tagName) === dimId);
+    const tag = qc.dimensions.tags.find(d => tagDimColumn(d) === dimId);
     const field = builtIn === undefined ? dimId : builtIn.field;
     let fieldExpr = field;
     if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
-    else if (tag !== undefined) fieldExpr = buildAliasSqlCase(tagColumnName(tag.tagName), tag);
+    else if (tag !== undefined) fieldExpr = buildAliasSqlCase(tagDimColumn(tag), tag);
 
     const sql = `
       SELECT ${fieldExpr} AS val,

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -4,7 +4,7 @@ import {
   buildAliasSqlCase,
   buildRuleMatchExpr,
   computePeriodsInRange,
-  tagColumnName,
+  tagDimColumn,
   QueryBuilder,
 } from '@costgoblin/core';
 import type { AppContext } from './context.js';
@@ -19,7 +19,7 @@ function resolveFieldExpr(
   dimensions: import('@costgoblin/core').DimensionsConfig,
 ): { field: string; fieldExpr: string } {
   const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
-  const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
+  const tag = dimensions.tags.find(d => tagDimColumn(d) === dimensionId);
   const field = builtIn === undefined ? dimensionId : builtIn.field;
   let fieldExpr = field;
   if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);

--- a/packages/desktop/src/main/handlers/query-utils.ts
+++ b/packages/desktop/src/main/handlers/query-utils.ts
@@ -6,7 +6,7 @@ import {
   getDescendantTagValues,
   listLocalMonths,
   logger,
-  tagColumnName,
+  tagDimColumn,
 } from '@costgoblin/core';
 import type {
   CostResult,
@@ -51,7 +51,7 @@ export function toStr(v: unknown): string {
 
 export function isOwnerGroupBy(groupBy: string, dimensions: DimensionsConfig): boolean {
   return dimensions.tags.some(
-    t => t.concept === 'owner' && tagColumnName(t.tagName) === groupBy,
+    t => t.concept === 'owner' && tagDimColumn(t) === groupBy,
   );
 }
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Pro
 import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
 import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
-import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagColumnName } from '@costgoblin/core/browser';
+import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
 import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
@@ -316,7 +316,7 @@ function shuffled<T>(arr: readonly T[]): T[] {
 }
 
 function dimId(dim: Dimension): string {
-  return 'tagName' in dim ? tagColumnName(dim.tagName) : dim.name;
+  return 'field' in dim ? dim.name : tagDimColumn(dim);
 }
 
 function defaultDateRange(): { start: string; end: string } {

--- a/packages/mcp/src/tools/get-filter-values.ts
+++ b/packages/mcp/src/tools/get-filter-values.ts
@@ -3,7 +3,7 @@ import {
   buildSource,
   computePeriodsInRange,
   QueryBuilder,
-  tagColumnName,
+  tagDimColumn,
   logger,
 } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
@@ -46,7 +46,7 @@ export async function getFilterValues(
   const availableColumns = await ctx.getAvailableColumns('daily');
 
   const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
-  const tag = dimensions.tags.find(d => tagColumnName(d.tagName) === dimensionId);
+  const tag = dimensions.tags.find(d => tagDimColumn(d) === dimensionId);
   const field = builtIn !== undefined ? builtIn.field : dimensionId;
   let fieldExpr = field;
   if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);

--- a/packages/mcp/src/tools/list-dimensions.ts
+++ b/packages/mcp/src/tools/list-dimensions.ts
@@ -1,4 +1,4 @@
-import { tagColumnName } from '@costgoblin/core';
+import { tagDimColumn } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
 import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
 import { toolResult } from './tool-helpers.js';
@@ -30,7 +30,7 @@ export async function listDimensions(
 
   for (const dim of dimensions.tags) {
     rows.push([
-      tagColumnName(dim.tagName),
+      tagDimColumn(dim),
       dim.label,
       dim.concept !== undefined ? `tag (${dim.concept})` : 'tag',
       dim.enabled === false ? 'no' : 'yes',

--- a/packages/mcp/src/tools/tool-helpers.ts
+++ b/packages/mcp/src/tools/tool-helpers.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_LAG_DAYS,
   listLocalMonths,
   logger,
+  tagDimColumn,
 } from '@costgoblin/core';
 import type {
   DateRange,
@@ -131,10 +132,7 @@ export function toolResult(text: string): { content: [{ type: 'text'; text: stri
 export function lookupDimension(dimensionId: string, dimensions: DimensionsConfig): { label: string; found: boolean } {
   const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
   if (builtIn !== undefined) return { label: builtIn.label, found: true };
-  const tag = dimensions.tags.find(d => {
-    const colName = `tag_${d.tagName.replaceAll(/[^a-zA-Z0-9]/g, '_')}`;
-    return colName === dimensionId;
-  });
+  const tag = dimensions.tags.find(d => tagDimColumn(d) === dimensionId);
   if (tag !== undefined) return { label: tag.label, found: true };
   return { label: dimensionId, found: false };
 }

--- a/packages/ui/src/lib/dimensions.ts
+++ b/packages/ui/src/lib/dimensions.ts
@@ -1,9 +1,13 @@
-import type { Dimension, DimensionId } from '@costgoblin/core/browser';
-import { asDimensionId, tagColumnName } from '@costgoblin/core/browser';
+import type { Dimension, DimensionId, TagDimension } from '@costgoblin/core/browser';
+import { asDimensionId, tagDimColumn } from '@costgoblin/core/browser';
+
+function isTagDim(dim: Dimension): dim is TagDimension {
+  return !('field' in dim);
+}
 
 export function getDimensionId(dim: Dimension): DimensionId {
-  if ('tagName' in dim) {
-    return asDimensionId(tagColumnName(dim.tagName));
+  if (isTagDim(dim)) {
+    return asDimensionId(tagDimColumn(dim));
   }
   return dim.name;
 }
@@ -13,17 +17,17 @@ export function getDimensionLabel(dim: Dimension): string {
 }
 
 export function isTagDimension(dim: Dimension): boolean {
-  return 'tagName' in dim;
+  return isTagDim(dim);
 }
 
 export function isEnvironmentDimension(dim: Dimension): boolean {
-  return 'tagName' in dim && dim.concept === 'environment';
+  return isTagDim(dim) && dim.concept === 'environment';
 }
 
 export function isOwnerDimension(dim: Dimension): boolean {
-  return 'tagName' in dim && dim.concept === 'owner';
+  return isTagDim(dim) && dim.concept === 'owner';
 }
 
 export function isProductDimension(dim: Dimension): boolean {
-  return 'tagName' in dim && dim.concept === 'product';
+  return isTagDim(dim) && dim.concept === 'product';
 }

--- a/packages/ui/src/lib/dimensions.ts
+++ b/packages/ui/src/lib/dimensions.ts
@@ -31,3 +31,7 @@ export function isOwnerDimension(dim: Dimension): boolean {
 export function isProductDimension(dim: Dimension): boolean {
   return isTagDim(dim) && dim.concept === 'product';
 }
+
+export function isUnitDimension(dim: Dimension): boolean {
+  return isTagDim(dim) && dim.concept === 'unit';
+}

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -25,6 +25,7 @@ import {
   isEnvironmentDimension,
   isOwnerDimension,
   isProductDimension,
+  isUnitDimension,
 } from '../lib/dimensions.js';
 import { FilterBar } from '../components/filter-bar.js';
 import { FilterActiveBanner } from '../components/filter-active-banner.js';
@@ -44,10 +45,11 @@ interface CustomViewProps {
 
 function priorityFor(d: Dimension): number {
   if (isEnvironmentDimension(d)) return 0;
-  if (isOwnerDimension(d)) return 1;
-  if (isProductDimension(d)) return 2;
-  if ('field' in d) return 3;
-  return 4;
+  if (isProductDimension(d)) return 1;
+  if (isOwnerDimension(d)) return 2;
+  if (isUnitDimension(d)) return 3;
+  if ('field' in d) return 4;
+  return 5;
 }
 
 function formatHour(d: Date): string {

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -46,7 +46,7 @@ function priorityFor(d: Dimension): number {
   if (isEnvironmentDimension(d)) return 0;
   if (isOwnerDimension(d)) return 1;
   if (isProductDimension(d)) return 2;
-  if (!('tagName' in d)) return 3;
+  if ('field' in d) return 3;
   return 4;
 }
 

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -7,6 +7,16 @@ const OU_PATH_LABEL = 'OU Path';
 function formatAccountSource(key: string): string {
   return key === OU_PATH_SOURCE_KEY ? OU_PATH_LABEL : key;
 }
+
+/** Mirror of DuckDB's split_part for the in-editor preview: 1-based,
+ *  negative indices count from the end. Returns '' when the segment
+ *  doesn't exist, matching split_part's out-of-range behaviour. */
+function takeSegment(value: string, separator: string, index: number): string {
+  const parts = value.split(separator);
+  const i = index > 0 ? index - 1 : parts.length + index;
+  if (i < 0 || i >= parts.length) return '';
+  return parts[i] ?? '';
+}
 function tagOrderKey(t: { tagName?: string | undefined; accountTagFallback?: string | undefined; label: string }): string {
   if (t.tagName !== undefined && t.tagName.length > 0) return `tag:${t.tagName}`;
   const src = t.accountTagFallback ?? '';
@@ -103,9 +113,10 @@ function reconcileOrder(config: DimensionsConfig): string[] {
 }
 
 const CONCEPTS: { value: ConceptType; label: string }[] = [
-  { value: 'owner', label: 'Owner (team)' },
-  { value: 'product', label: 'Product (system)' },
   { value: 'environment', label: 'Environment' },
+  { value: 'product', label: 'System' },
+  { value: 'owner', label: 'Owner' },
+  { value: 'unit', label: 'Unit' },
 ];
 
 const NORMALIZE_RULES: { value: NormalizationRule; label: string }[] = [
@@ -519,7 +530,13 @@ interface EditingTag {
   aliases: string;
   fallbackTag: string | undefined;
   missingValueTemplate: string;
+  pathSegIndex: string;
 }
+
+/** OU Path values are joined by ` / ` in aws-org-client.ts when the path is
+ *  built — it's an internal choice, not user data — so we hardcode the same
+ *  separator wherever we segment it. */
+const OU_PATH_SEPARATOR = ' / ';
 
 function aliasesToText(aliases: Readonly<Record<string, readonly string[]>> | undefined): string {
   if (aliases === undefined) return '';
@@ -832,12 +849,16 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
 
   const fallbackValues = (() => {
     if (state.fallbackTag === undefined || state.fallbackTag.length === 0) return [];
+    const usesOuPath = state.fallbackTag === OU_PATH_SOURCE_KEY;
+    const parsedSegIndex = parseInt(state.pathSegIndex, 10);
+    const segActive = usesOuPath && Number.isInteger(parsedSegIndex) && parsedSegIndex !== 0;
     const counts = new Map<string, number>();
     for (const acct of orgAccounts) {
-      const val = state.fallbackTag === OU_PATH_SOURCE_KEY ? acct.ouPath : acct.tags[state.fallbackTag];
-      if (val !== undefined && val.length > 0) {
-        counts.set(val, (counts.get(val) ?? 0) + 1);
-      }
+      const raw = usesOuPath ? acct.ouPath : acct.tags[state.fallbackTag];
+      if (raw === undefined || raw.length === 0) continue;
+      const val = segActive ? takeSegment(raw, OU_PATH_SEPARATOR, parsedSegIndex) : raw;
+      if (val.length === 0) continue;
+      counts.set(val, (counts.get(val) ?? 0) + 1);
     }
     return [...counts.entries()].sort((a, b) => b[1] - a[1]);
   })();
@@ -852,7 +873,19 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           <span className="text-xs text-text-muted">Concept</span>
           <select
             value={state.concept}
-            onChange={e => { setState(s => ({ ...s, concept: e.target.value })); }}
+            onChange={e => {
+              const next = e.target.value;
+              const nextLabel = CONCEPTS.find(c => c.value === next)?.label;
+              setState(s => {
+                // Auto-fill Display Label with the concept's label when the
+                // user hasn't customised it yet — empty, or still equal to the
+                // previously-selected concept's label.
+                const prevConceptLabel = CONCEPTS.find(c => c.value === s.concept)?.label;
+                const labelIsAutoFilled = s.label.length === 0 || (prevConceptLabel !== undefined && s.label === prevConceptLabel);
+                const label = labelIsAutoFilled && nextLabel !== undefined ? nextLabel : s.label;
+                return { ...s, concept: next, label };
+              });
+            }}
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
           >
             <option value="">None</option>
@@ -913,7 +946,10 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           <span className="text-xs text-text-muted">{state.tagName.length === 0 ? 'Account source' : 'Fallback (account)'}</span>
           <select
             value={state.fallbackTag ?? ''}
-            onChange={e => { setState(s => ({ ...s, fallbackTag: e.target.value.length > 0 ? e.target.value : undefined })); }}
+            onChange={e => {
+              const next = e.target.value;
+              setState(s => ({ ...s, fallbackTag: next.length > 0 ? next : undefined }));
+            }}
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
           >
             <option value="">{state.tagName.length === 0 ? 'Select a source…' : 'No fallback'}</option>
@@ -940,6 +976,27 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           </span>
         </label>
       </div>
+
+      {/* OU-Path-only: extract a single segment of the slash-joined path.
+          The OU Path is built with ` / ` in aws-org-client; users only pick
+          which segment to keep, not the separator. */}
+      {state.fallbackTag === OU_PATH_SOURCE_KEY && (
+        <div className="grid grid-cols-3 gap-4">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-text-muted">OU Path segment</span>
+            <input
+              type="number"
+              value={state.pathSegIndex}
+              onChange={e => { setState(s => ({ ...s, pathSegIndex: e.target.value })); }}
+              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
+              placeholder="full path"
+            />
+            <span className="text-[10px] text-text-muted">
+              1-based; negative counts from the end (-1 = last). Blank keeps the full path.
+            </span>
+          </label>
+        </div>
+      )}
 
       {/* Alias rules */}
       <div className="flex flex-col gap-1">
@@ -1349,7 +1406,12 @@ export function DimensionsView() {
     const aliases = textToAliases(editing.aliases);
     const accountTagFallback = editing.fallbackTag !== undefined && editing.fallbackTag.length > 0 ? editing.fallbackTag : undefined;
     const missingValueTemplate = editing.missingValueTemplate.length > 0 ? editing.missingValueTemplate : undefined;
-    return { ...base, concept, normalize, aliases, accountTagFallback, missingValueTemplate };
+    const usesOuPath = editing.fallbackTag === OU_PATH_SOURCE_KEY;
+    const parsedIndex = parseInt(editing.pathSegIndex, 10);
+    const pathSegment = usesOuPath && Number.isInteger(parsedIndex) && parsedIndex !== 0
+      ? { separator: OU_PATH_SEPARATOR, index: parsedIndex }
+      : undefined;
+    return { ...base, concept, normalize, aliases, accountTagFallback, missingValueTemplate, pathSegment };
   }
 
   async function handleSaveTag(idx: number, editing: EditingTag) {
@@ -1610,7 +1672,7 @@ export function DimensionsView() {
               user sees where the new pill will land. */}
           {addingNew && (
             <TagEditor
-              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined, missingValueTemplate: '' }}
+              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined, missingValueTemplate: '', pathSegIndex: '' }}
               onSave={(edited) => { handleAddTag(edited).catch(() => undefined); }}
               onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
               onRemove={undefined}
@@ -1714,6 +1776,7 @@ export function DimensionsView() {
                     aliases: aliasesToText(tag.aliases),
                     fallbackTag: tag.accountTagFallback,
                     missingValueTemplate: tag.missingValueTemplate ?? '',
+                    pathSegIndex: tag.pathSegment === undefined ? '' : String(tag.pathSegment.index),
                   }}
                   onSave={(edited) => { handleSaveTag(row.idx, edited).catch(() => undefined); }}
                   onCancel={() => { setEditingIdx(null); }}
@@ -1755,6 +1818,9 @@ export function DimensionsView() {
                     )}
                     {tag.missingValueTemplate !== undefined && (
                       <span className="text-[10px] text-text-muted font-mono">missing: {tag.missingValueTemplate}</span>
+                    )}
+                    {tag.pathSegment !== undefined && (
+                      <span className="text-[10px] text-text-muted font-mono">segment {String(tag.pathSegment.index)}</span>
                     )}
                   </div>
                   {tag.description !== undefined && tag.description.length > 0 && (

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { ChevronUp, ChevronDown, GripVertical, Lock } from 'lucide-react';
 import type { BuiltInDimension, DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
-import { asDimensionId } from '@costgoblin/core/browser';
+import { asDimensionId, OU_PATH_SOURCE_KEY } from '@costgoblin/core/browser';
+
+const OU_PATH_LABEL = 'OU Path';
+function formatAccountSource(key: string): string {
+  return key === OU_PATH_SOURCE_KEY ? OU_PATH_LABEL : key;
+}
+function tagOrderKey(t: { tagName?: string | undefined; accountTagFallback?: string | undefined; label: string }): string {
+  if (t.tagName !== undefined && t.tagName.length > 0) return `tag:${t.tagName}`;
+  const src = t.accountTagFallback ?? '';
+  return `tag:@${src}:${t.label}`;
+}
 
 // Core dimensions that cannot be disabled — they power the fallback chain and are always needed.
 const LOCKED_DIMENSIONS = new Set([asDimensionId('service'), asDimensionId('service_family'), asDimensionId('usage_type')]);
@@ -51,7 +61,6 @@ function useClickOutsideDismiss(
 interface DragRef { orderIdx: number }
 
 function builtInKey(name: string): string { return `builtin:${name}`; }
-function tagKey(tagName: string): string { return `tag:${tagName}`; }
 
 function defaultOrder(config: DimensionsConfig): string[] {
   const keys: string[] = [];
@@ -59,7 +68,7 @@ function defaultOrder(config: DimensionsConfig): string[] {
     if (d.enabled !== false) keys.push(builtInKey(d.name));
   }
   for (const t of config.tags) {
-    if (t.enabled !== false) keys.push(tagKey(t.tagName));
+    if (t.enabled !== false) keys.push(tagOrderKey(t));
   }
   return keys;
 }
@@ -70,7 +79,7 @@ function collectValidKeys(config: DimensionsConfig): Set<string> {
     if (d.enabled !== false) valid.add(builtInKey(d.name));
   }
   for (const t of config.tags) {
-    if (t.enabled !== false) valid.add(tagKey(t.tagName));
+    if (t.enabled !== false) valid.add(tagOrderKey(t));
   }
   return valid;
 }
@@ -87,7 +96,7 @@ function reconcileOrder(config: DimensionsConfig): string[] {
     if (d.enabled !== false && !seen.has(k)) { out.push(k); seen.add(k); }
   }
   for (const t of config.tags) {
-    const k = tagKey(t.tagName);
+    const k = tagOrderKey(t);
     if (t.enabled !== false && !seen.has(k)) { out.push(k); seen.add(k); }
   }
   return out;
@@ -236,9 +245,10 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
   // unknown (no sync data) we still let the user pre-select it from the
   // saved value, but the dropdown won't have suggestions.
   const nameSource: 'name' | 'tag' = state.accountNameFromTag.length > 0 ? 'tag' : 'name';
-  const tagKeyOptions = state.accountNameFromTag.length > 0 && !accountTagKeys.includes(state.accountNameFromTag)
+  const baseTagKeyOptions = state.accountNameFromTag.length > 0 && !accountTagKeys.includes(state.accountNameFromTag) && state.accountNameFromTag !== OU_PATH_SOURCE_KEY
     ? [state.accountNameFromTag, ...accountTagKeys]
     : [...accountTagKeys];
+  const tagKeyOptions = [OU_PATH_SOURCE_KEY, ...baseTagKeyOptions];
   const nameSourceField = (
     <div className="flex flex-col gap-2">
       <label className="flex flex-col gap-1">
@@ -248,7 +258,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
           onChange={e => {
             const v = e.target.value;
             if (v === 'name') setState(s => ({ ...s, accountNameFromTag: '' }));
-            else setState(s => ({ ...s, accountNameFromTag: s.accountNameFromTag.length > 0 ? s.accountNameFromTag : (accountTagKeys[0] ?? '') }));
+            else setState(s => ({ ...s, accountNameFromTag: s.accountNameFromTag.length > 0 ? s.accountNameFromTag : (accountTagKeys[0] ?? OU_PATH_SOURCE_KEY) }));
           }}
           className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
         >
@@ -269,7 +279,7 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
             ) : (
               <>
                 {state.accountNameFromTag.length === 0 && <option value="">Select a tag...</option>}
-                {tagKeyOptions.map(t => <option key={t} value={t}>{t}</option>)}
+                {tagKeyOptions.map(t => <option key={t} value={t}>{formatAccountSource(t)}</option>)}
               </>
             )}
           </select>
@@ -798,7 +808,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   availableTags: readonly string[];
   discoveredTags: readonly { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[];
   accountTagKeys: readonly string[];
-  orgAccounts: readonly { tags: Readonly<Record<string, string>> }[];
+  orgAccounts: readonly { tags: Readonly<Record<string, string>>; ouPath: string }[];
 }>) {
   const [state, setState] = useState(tag);
   const initialRef = useRef(tag);
@@ -824,13 +834,15 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
     if (state.fallbackTag === undefined || state.fallbackTag.length === 0) return [];
     const counts = new Map<string, number>();
     for (const acct of orgAccounts) {
-      const val = acct.tags[state.fallbackTag];
+      const val = state.fallbackTag === OU_PATH_SOURCE_KEY ? acct.ouPath : acct.tags[state.fallbackTag];
       if (val !== undefined && val.length > 0) {
         counts.set(val, (counts.get(val) ?? 0) + 1);
       }
     }
     return [...counts.entries()].sort((a, b) => b[1] - a[1]);
   })();
+  const fallbackOptions = [OU_PATH_SOURCE_KEY, ...acctTags];
+  const noSourceWarning = state.tagName.length === 0 && (state.fallbackTag === undefined || state.fallbackTag.length === 0);
 
   return (
     <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
@@ -871,7 +883,7 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
       </div>
 
       {/* Row 2: Tag Name + Fallback + Fallback format */}
-      <div className={`grid ${acctTags.length > 0 ? 'grid-cols-3' : 'grid-cols-1'} gap-4`}>
+      <div className="grid grid-cols-3 gap-4">
         <label className="flex flex-col gap-1">
           <span className="text-xs text-text-muted">Resource Tag</span>
           <select
@@ -887,44 +899,46 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
             }}
             className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
           >
-            <option value="">Select a tag...</option>
+            <option value="">No resource tag</option>
             {tagOptions.map(t => <option key={t} value={t}>{t}</option>)}
           </select>
           {tagMatch !== undefined && (
             <span className="text-[10px] text-text-muted">{String(tagMatch.coveragePct)}% coverage · {String(tagMatch.distinctCount)} distinct values</span>
           )}
+          {state.tagName.length === 0 && (
+            <span className="text-[10px] text-text-muted">Account-level only (no resource tag)</span>
+          )}
         </label>
-        {acctTags.length > 0 && (
-          <label className="flex flex-col gap-1">
-            <span className="text-xs text-text-muted">Fallback (account tag)</span>
-            <select
-              value={state.fallbackTag ?? ''}
-              onChange={e => { setState(s => ({ ...s, fallbackTag: e.target.value.length > 0 ? e.target.value : undefined })); }}
-              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
-            >
-              <option value="">No fallback</option>
-              {acctTags.map(t => <option key={t} value={t}>{t}</option>)}
-            </select>
-            {fallbackValues.length > 0 && (
-              <span className="text-[10px] text-text-muted">{String(fallbackValues.length)} distinct values</span>
-            )}
-          </label>
-        )}
-        {acctTags.length > 0 && (
-          <label className="flex flex-col gap-1">
-            <span className="text-xs text-text-muted">Fallback format</span>
-            <input
-              type="text"
-              value={state.missingValueTemplate}
-              onChange={e => { setState(s => ({ ...s, missingValueTemplate: e.target.value })); }}
-              className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
-              placeholder="{fallback}"
-            />
-            <span className="text-[10px] text-text-muted">
-              {'{fallback}'} = account tag value
-            </span>
-          </label>
-        )}
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">{state.tagName.length === 0 ? 'Account source' : 'Fallback (account)'}</span>
+          <select
+            value={state.fallbackTag ?? ''}
+            onChange={e => { setState(s => ({ ...s, fallbackTag: e.target.value.length > 0 ? e.target.value : undefined })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary outline-none focus:border-accent"
+          >
+            <option value="">{state.tagName.length === 0 ? 'Select a source…' : 'No fallback'}</option>
+            {fallbackOptions.map(t => <option key={t} value={t}>{formatAccountSource(t)}</option>)}
+          </select>
+          {fallbackValues.length > 0 && (
+            <span className="text-[10px] text-text-muted">{String(fallbackValues.length)} distinct values</span>
+          )}
+          {noSourceWarning && (
+            <span className="text-[10px] text-warning">Pick a resource tag or an account source.</span>
+          )}
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Fallback format</span>
+          <input
+            type="text"
+            value={state.missingValueTemplate}
+            onChange={e => { setState(s => ({ ...s, missingValueTemplate: e.target.value })); }}
+            className="rounded border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary font-mono outline-none focus:border-accent"
+            placeholder="{fallback}"
+          />
+          <span className="text-[10px] text-text-muted">
+            {'{fallback}'} = account value
+          </span>
+        </label>
       </div>
 
       {/* Alias rules */}
@@ -1247,8 +1261,7 @@ function resolveOrderedRow(key: string, config: DimensionsConfig): OrderedRow | 
     const dim = idx >= 0 ? config.builtIn[idx] : undefined;
     if (dim !== undefined) return { kind: 'builtIn', key, idx, dim };
   } else if (key.startsWith('tag:')) {
-    const tagName = key.slice('tag:'.length);
-    const idx = config.tags.findIndex(t => t.tagName === tagName);
+    const idx = config.tags.findIndex(t => tagOrderKey(t) === key);
     const dim = idx >= 0 ? config.tags[idx] : undefined;
     if (dim !== undefined) return { kind: 'tag', key, idx, dim };
   }
@@ -1317,7 +1330,11 @@ export function DimensionsView() {
     : [...new Set(orgData.accounts.flatMap(a => Object.keys(a.tags)))].sort((a, b) => a.localeCompare(b));
 
   // Which resource tags are already mapped as dimensions
-  const mappedTagNames = new Set(config?.tags.map(t => t.tagName) ?? []);
+  const mappedTagNames = new Set(
+    (config?.tags ?? [])
+      .map(t => t.tagName)
+      .filter((n): n is string => n !== undefined && n.length > 0),
+  );
 
   // CUR resource tags for the primary dropdown — same order as table, exclude hidden columns
   const unmappedTagKeys = discoveredTags
@@ -1325,7 +1342,8 @@ export function DimensionsView() {
     .filter(k => !mappedTagNames.has(k) && !hiddenResourceCols.has(k));
 
   function editingToTagDimension(editing: EditingTag): TagDimension {
-    const base: { tagName: string; label: string } = { tagName: editing.tagName, label: editing.label };
+    const tagName = editing.tagName.length > 0 ? editing.tagName : undefined;
+    const base: { label: string; tagName?: string } = { label: editing.label, ...(tagName === undefined ? {} : { tagName }) };
     const concept = editing.concept.length > 0 ? editing.concept as ConceptType : undefined;
     const normalize = editing.normalize.length > 0 ? editing.normalize as NormalizationRule : undefined;
     const aliases = textToAliases(editing.aliases);
@@ -1568,7 +1586,7 @@ export function DimensionsView() {
                 const isOn = tag.enabled !== false;
                 return (
                   <button
-                    key={tag.tagName}
+                    key={tagOrderKey(tag)}
                     type="button"
                     onClick={() => { toggleTagEnabled(idx); }}
                     title={isOn ? 'Click to disable' : 'Click to enable'}
@@ -1689,7 +1707,7 @@ export function DimensionsView() {
                 <TagEditor
                   key={row.key}
                   tag={{
-                    tagName: tag.tagName,
+                    tagName: tag.tagName ?? '',
                     label: tag.label,
                     concept: tag.concept ?? '',
                     normalize: tag.normalize ?? '',
@@ -1716,7 +1734,9 @@ export function DimensionsView() {
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-sm font-medium text-text-primary">{tag.label}</span>
-                    <span className="text-xs text-text-muted font-mono">tag:{tag.tagName}</span>
+                    {tag.tagName !== undefined && tag.tagName.length > 0 && (
+                      <span className="text-xs text-text-muted font-mono">tag:{tag.tagName}</span>
+                    )}
                     {tag.concept !== undefined && (
                       <span className="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
                         {tag.concept}
@@ -1729,7 +1749,9 @@ export function DimensionsView() {
                       <span className="text-[10px] text-text-muted">{String(Object.keys(tag.aliases).length)} alias rules</span>
                     )}
                     {tag.accountTagFallback !== undefined && (
-                      <span className="text-[10px] text-text-muted">fallback: {tag.accountTagFallback}</span>
+                      <span className="text-[10px] text-text-muted">
+                        {tag.tagName === undefined || tag.tagName.length === 0 ? 'source' : 'fallback'}: {formatAccountSource(tag.accountTagFallback)}
+                      </span>
                     )}
                     {tag.missingValueTemplate !== undefined && (
                       <span className="text-[10px] text-text-muted font-mono">missing: {tag.missingValueTemplate}</span>

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -167,7 +167,7 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
       if (isEnvironmentDimension(d)) return 0;
       if (isOwnerDimension(d)) return 1;
       if (isProductDimension(d)) return 2;
-      if (!('tagName' in d)) return 3;
+      if ('field' in d) return 3;
       return 4;
     };
     return priority(a) - priority(b);

--- a/packages/ui/src/views/entity-detail.tsx
+++ b/packages/ui/src/views/entity-detail.tsx
@@ -20,7 +20,7 @@ import { PieChart } from '../components/pie-chart.js';
 import type { PieSlice } from '../components/pie-chart.js';
 import { StackedBarChart, bucketBars } from '../components/stacked-bar-chart.js';
 import type { BarDay, HistogramTab } from '../components/stacked-bar-chart.js';
-import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension } from '../lib/dimensions.js';
+import { getDimensionId, getDimensionLabel, isEnvironmentDimension, isOwnerDimension, isProductDimension, isUnitDimension } from '../lib/dimensions.js';
 import { computeBucketedHourRange, computeBucketedRange, shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 
 interface EntityDetailProps {
@@ -165,10 +165,11 @@ export function EntityDetail({ entity, dimension, onBack }: Readonly<EntityDetai
   const dimensions = [...rawDimensions].sort((a, b) => {
     const priority = (d: Dimension) => {
       if (isEnvironmentDimension(d)) return 0;
-      if (isOwnerDimension(d)) return 1;
-      if (isProductDimension(d)) return 2;
-      if ('field' in d) return 3;
-      return 4;
+      if (isProductDimension(d)) return 1;
+      if (isOwnerDimension(d)) return 2;
+      if (isUnitDimension(d)) return 3;
+      if ('field' in d) return 4;
+      return 5;
     };
     return priority(a) - priority(b);
   });


### PR DESCRIPTION
## Summary

Lets users define a higher-level tag dimension (Department / BU / Unit) that lives above team, sourced from an account-level signal — an AWS Org account tag or the OU Path — with no resource tag required. Adds an OU Path segment extractor so deep paths can be rolled up to a single level. Also tidies the Concept dropdown.

## What changed

**Account-only tag dimensions + OU Path source**
- `TagDimension.tagName` is now optional. Validator requires at least one of `tagName` / `accountTagFallback`. A dim can resolve entirely from org-sync data.
- Reserved sentinel `__ouPath__` is accepted anywhere an account-tag key is — `TagDimension.accountTagFallback` and the Account built-in's `accountNameFromTag`. Query builder emits `ouPath AS fallback_<col>` instead of `tags->>'X'` in that case.
- `tagColumnName(d.tagName)` call sites across core / desktop / mcp / ui migrated to `tagDimColumn(d)` for a stable column name when `tagName` is omitted.
- `BuiltInDimension | TagDimension` discriminator switched from `'tagName' in dim` to `'field' in dim` since `tagName` can now be absent.

**OU Path segment picker**
- New optional `TagDimension.pathSegment: { separator, index }` wraps the resolved value with DuckDB `split_part`, 1-based with negative-from-end support, applied after the COALESCE so every downstream consumer sees the segmented value.
- UI exposes only a numeric index input — the separator is hardcoded ` / ` (the OU Path is built with that exact join in `aws-org-client.ts`; it's never user data). Picker renders only when the active source is OU Path.
- Preview chips recompute via a JS `takeSegment` mirror so users see segmented values live as they type.

**Concept dropdown cleanup**
- Adds `'unit'` to `ConceptType` for the new "above team" level. Validator + UI updated.
- Order is Environment / System / Owner / Unit; parenthetical hints dropped from the labels.
- Picking a concept auto-fills the Display Label with the concept's name (only when the label is empty or still matches the previously-picked concept), so users get a sensible default without losing a custom name.
- Sort priorities in `custom-view` / `entity-detail` mirror the new order.

**Runtime fixes**
- The flattened `org-account-tags.json` (`extractAccountTagEntry`) now copies `ouPath` so the JOIN's `ouPath AS fallback_…` actually resolves. `getOrgAccountsPath` probes the on-disk file and regenerates if the field is missing — one-time migration for existing installs.
- `config:dimensions` IPC handler now passes through `accountTagFallback` (and `pathSegment`) to the renderer, and omits `tagName` when absent. Without this, account-source-only dims showed up in the renderer with neither source set and `tagDimColumn` fell back to a `tag_unknown` sentinel — breaking filter-values, group-by, and any other UI that derives an ID from the dim.

## UI walkthrough

In the Dimensions view, add a tag dim with no resource tag and **Fallback = OU Path**. A new "OU Path segment" input appears. Set it to `1` to capture only the first segment of paths like `AI / production` → `AI`. Pick the **Unit** concept to label it that way (or override). The dim flows through filter-bar, group-by selectors, Explorer, and Cost views like any other dim.

## Tests

Five new query-builder tests cover OU Path as fallback, account-source-only dims, and `pathSegment` with positive/negative indices. Full `npm run check` passes — 500 tests, type-clean, lint-clean.