### PR TITLE
Per-dimension default filter values + WidgetFilterOverlay cleanup

### DIFF
--- a/packages/core/src/__tests__/views-validator.test.ts
+++ b/packages/core/src/__tests__/views-validator.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { validateViews } from '../config/views-validator.js';
 import { ConfigValidationError } from '../config/validator.js';
-import { asDimensionId } from '../types/branded.js';
 
 describe('validateViews', () => {
   it('parses a valid views config', () => {
@@ -69,22 +68,6 @@ describe('validateViews', () => {
         ] }],
       }],
     })).toThrow(ConfigValidationError);
-  });
-
-  it('parses widget filter overlay', () => {
-    const cfg = validateViews({
-      views: [{
-        id: 'v', name: 'V', rows: [{ widgets: [
-          { id: 'w', type: 'pie', size: 'medium', groupBy: 'service', filters: { account: '111111111111' } },
-        ] }],
-      }],
-    });
-    const w = cfg.views[0]?.rows[0]?.widgets[0];
-    expect(w?.filters).toBeDefined();
-    if (w?.type === 'pie') {
-      const accountDim = asDimensionId('account');
-      expect(w.filters?.[accountDim]).toBe('111111111111');
-    }
   });
 
   it('rejects duplicate widget ids within a view', () => {

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -159,6 +159,9 @@ function validateBuiltInDimension(dim: unknown, i: number) {
     : validateStringArray(dim['nameStripPatterns'], `${ctx}.nameStripPatterns`);
   const normalize = validateNormalize(dim['normalize'], ctx);
   const aliases = validateAliases(dim['aliases'], ctx);
+  const defaultFilterValues = dim['defaultFilterValues'] === undefined
+    ? undefined
+    : validateStringArray(dim['defaultFilterValues'], `${ctx}.defaultFilterValues`);
   return {
     name: asDimensionId(dim['name']),
     label: dim['label'],
@@ -171,6 +174,7 @@ function validateBuiltInDimension(dim: unknown, i: number) {
     ...(useOrgAccounts === true ? { useOrgAccounts } : {}),
     ...(accountNameFromTag === undefined ? {} : { accountNameFromTag }),
     ...(nameStripPatterns === undefined || nameStripPatterns.length === 0 ? {} : { nameStripPatterns }),
+    ...(defaultFilterValues === undefined || defaultFilterValues.length === 0 ? {} : { defaultFilterValues }),
   };
 }
 
@@ -220,6 +224,10 @@ function validateTagDimension(tag: unknown, i: number) {
     pathSegment = { separator: raw['separator'], index: raw['index'] };
   }
 
+  const defaultFilterValues = tag['defaultFilterValues'] === undefined
+    ? undefined
+    : validateStringArray(tag['defaultFilterValues'], `${ctx}.defaultFilterValues`);
+
   return {
     ...(tagName === undefined ? {} : { tagName }),
     label: tag['label'],
@@ -231,6 +239,7 @@ function validateTagDimension(tag: unknown, i: number) {
     ...(typeof tag['missingValueTemplate'] === 'string' ? { missingValueTemplate: tag['missingValueTemplate'] } : {}),
     ...(pathSegment === undefined ? {} : { pathSegment }),
     ...(enabled === false ? { enabled } : {}),
+    ...(defaultFilterValues === undefined || defaultFilterValues.length === 0 ? {} : { defaultFilterValues }),
   };
 }
 

--- a/packages/core/src/config/views-serialize.ts
+++ b/packages/core/src/config/views-serialize.ts
@@ -3,13 +3,6 @@ import type { ViewSpec, ViewsConfig, WidgetSpec } from '../types/views.js';
 function buildWidgetBase(w: WidgetSpec): Record<string, unknown> {
   const base: Record<string, unknown> = { id: w.id, type: w.type, size: w.size };
   if (w.title !== undefined) base['title'] = w.title;
-  if (w.filters !== undefined) {
-    const f: Record<string, string> = {};
-    for (const [k, v] of Object.entries(w.filters)) {
-      if (v !== undefined) f[k] = v;
-    }
-    if (Object.keys(f).length > 0) base['filters'] = f;
-  }
   return base;
 }
 

--- a/packages/core/src/config/views-validator.ts
+++ b/packages/core/src/config/views-validator.ts
@@ -1,10 +1,8 @@
-import { asDimensionId, asTagValue } from '../types/branded.js';
-import type { DimensionId, TagValue } from '../types/branded.js';
+import { asDimensionId } from '../types/branded.js';
 import type {
   SummaryMetric,
   ViewSpec,
   ViewsConfig,
-  WidgetFilterOverlay,
   WidgetSize,
   WidgetSpec,
   WidgetType,
@@ -37,22 +35,10 @@ function isSummaryMetric(s: string): s is SummaryMetric {
   return (SUMMARY_METRICS as readonly string[]).includes(s);
 }
 
-function validateFilters(raw: unknown, ctx: string): WidgetFilterOverlay | undefined {
-  if (raw === undefined) return undefined;
-  assertObject(raw, ctx);
-  const out: Partial<Record<DimensionId, TagValue>> = {};
-  for (const [k, v] of Object.entries(raw)) {
-    assertString(v, `${ctx}.${k}`);
-    out[asDimensionId(k)] = asTagValue(v);
-  }
-  return out;
-}
-
 interface WidgetBase {
   readonly id: string;
   readonly size: WidgetSize;
   readonly title?: string;
-  readonly filters?: WidgetFilterOverlay;
 }
 
 function parseWidgetBase(raw: Record<string, unknown>, ctx: string): WidgetBase {
@@ -70,12 +56,10 @@ function parseWidgetBase(raw: Record<string, unknown>, ctx: string): WidgetBase 
     );
   }
   const title = raw['title'] === undefined ? undefined : (assertString(raw['title'], `${ctx}.title`), raw['title']);
-  const filters = validateFilters(raw['filters'], `${ctx}.filters`);
   return {
     id: raw['id'],
     size: raw['size'],
     ...(title === undefined ? {} : { title }),
-    ...(filters === undefined ? {} : { filters }),
   };
 }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -68,6 +68,11 @@ export interface BuiltInDimension {
    *  friendly names (Europe (Frankfurt)) via the SSM global-infrastructure
    *  snapshot. No-op if the snapshot hasn't been synced. */
   readonly useRegionNames?: boolean | undefined;
+  /** Values pre-applied to the global filter bar when a view opens. The
+   *  user can override or clear during a session; next view-open the
+   *  default is re-applied. Stored as the post-normalize/alias-resolved
+   *  values that flow through `FilterMap`. */
+  readonly defaultFilterValues?: readonly string[] | undefined;
 }
 
 /** Sentinel value usable wherever an account-level tag key is expected
@@ -99,6 +104,10 @@ export interface TagDimension {
   readonly enabled?: boolean | undefined;
   /** Short user-facing explanation shown on the Dimensions view. */
   readonly description?: string | undefined;
+  /** Values pre-applied to the global filter bar when a view opens. The
+   *  user can override or clear during a session; next view-open the
+   *  default is re-applied. */
+  readonly defaultFilterValues?: readonly string[] | undefined;
 }
 
 export interface DimensionsConfig {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -68,7 +68,6 @@ export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingS
 
 export type {
   WidgetSize,
-  WidgetFilterOverlay,
   SummaryMetric,
   WidgetSpec,
   WidgetType,

--- a/packages/core/src/types/views.ts
+++ b/packages/core/src/types/views.ts
@@ -1,11 +1,6 @@
-import type { DimensionId, TagValue } from './branded.js';
+import type { DimensionId } from './branded.js';
 
 export type WidgetSize = 'small' | 'medium' | 'large' | 'full';
-
-/** Extra filter overlay applied on top of the view's global FilterBar. The
- *  widget's own filters compose via object spread; widget filters win on key
- *  conflict so the global bar stays the user's primary control. */
-export type WidgetFilterOverlay = Readonly<Partial<Record<DimensionId, TagValue>>>;
 
 export type SummaryMetric = 'total' | 'delta' | 'topEntity' | 'entityCount';
 
@@ -13,7 +8,6 @@ interface WidgetBase {
   readonly id: string;
   readonly title?: string | undefined;
   readonly size: WidgetSize;
-  readonly filters?: WidgetFilterOverlay | undefined;
 }
 
 export type WidgetSpec =

--- a/packages/desktop/src/main/handlers/config.ts
+++ b/packages/desktop/src/main/handlers/config.ts
@@ -26,6 +26,7 @@ export function registerConfigHandlers(app: AppContext): void {
         label: d.label,
         field: d.field,
         ...(d.displayField === undefined ? {} : { displayField: d.displayField }),
+        ...(d.defaultFilterValues === undefined || d.defaultFilterValues.length === 0 ? {} : { defaultFilterValues: d.defaultFilterValues }),
       }));
     const tags: Dimension[] = dimensions.tags
       .filter(d => d.enabled !== false)
@@ -41,6 +42,7 @@ export function registerConfigHandlers(app: AppContext): void {
         ...(d.aliases === undefined ? {} : { aliases: d.aliases }),
         ...(d.accountTagFallback === undefined ? {} : { accountTagFallback: d.accountTagFallback }),
         ...(d.pathSegment === undefined ? {} : { pathSegment: d.pathSegment }),
+        ...(d.defaultFilterValues === undefined || d.defaultFilterValues.length === 0 ? {} : { defaultFilterValues: d.defaultFilterValues }),
       }));
     return [...builtIn, ...tags];
   });

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -244,6 +244,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         // on legacy configs — we only want that for first-time migration.
         ...(d.useRegionNames === undefined ? {} : { useRegionNames: d.useRegionNames }),
         ...(d.enabled === false ? { enabled: false } : {}),
+        ...(d.defaultFilterValues !== undefined && d.defaultFilterValues.length > 0 ? { defaultFilterValues: [...d.defaultFilterValues] } : {}),
       })),
       tags: config.tags.map(t => ({
         ...(t.tagName === undefined || t.tagName.length === 0 ? {} : { tagName: t.tagName }),
@@ -257,6 +258,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
         ...(t.pathSegment === undefined ? {} : { pathSegment: { separator: t.pathSegment.separator, index: t.pathSegment.index } }),
         ...(t.description === undefined ? {} : { description: t.description }),
         ...(t.enabled === false ? { enabled: false } : {}),
+        ...(t.defaultFilterValues !== undefined && t.defaultFilterValues.length > 0 ? { defaultFilterValues: [...t.defaultFilterValues] } : {}),
       })),
       ...(config.order === undefined ? {} : { order: [...config.order] }),
     });

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -10,6 +10,24 @@ interface FilterValue {
   count: number;
 }
 
+function filterMapsEqual(a: FilterMap, b: FilterMap): boolean {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  for (const k of keysA) {
+    const va = a[k as DimensionId];
+    const vb = b[k as DimensionId];
+    if (va === undefined || vb === undefined) return false;
+    if (va.length !== vb.length) return false;
+    const sortedA = [...va].sort();
+    const sortedB = [...vb].sort();
+    for (let i = 0; i < sortedA.length; i++) {
+      if (sortedA[i] !== sortedB[i]) return false;
+    }
+  }
+  return true;
+}
+
 type DropdownState =
   | { status: 'closed' }
   | { status: 'loading' }
@@ -21,9 +39,13 @@ interface FilterBarProps {
   filters: FilterMap;
   onFilterChange: (filters: FilterMap) => void;
   getFilterValues: (dimensionId: DimensionId, currentFilters: FilterMap) => Promise<FilterValue[]>;
+  /** Per-dim default values pre-applied on view open. Exposed here so the
+   *  filter bar can show a "Reset defaults" affordance once the user's
+   *  current selection has drifted away from the defaults. */
+  defaults?: FilterMap | undefined;
 }
 
-export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues }: Readonly<FilterBarProps>) {
+export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues, defaults }: Readonly<FilterBarProps>) {
   const [openDimId, setOpenDimId] = useState<DimensionId | null>(null);
   const [dropdown, setDropdown] = useState<DropdownState>({ status: 'closed' });
   const [search, setSearch] = useState('');
@@ -33,6 +55,9 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
   const requestIdRef = useRef(0);
 
   const hasActiveFilters = Object.keys(filters).length > 0;
+  const defaultsAvailable = defaults !== undefined && Object.keys(defaults).length > 0;
+  const matchesDefaults = defaultsAvailable && filterMapsEqual(filters, defaults);
+  const canResetDefaults = defaultsAvailable && !matchesDefaults;
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -132,6 +157,11 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
 
   function handleClearAll() {
     onFilterChange({});
+  }
+
+  function handleResetDefaults() {
+    if (defaults === undefined) return;
+    onFilterChange(defaults);
   }
 
   function chipLabel(dim: Dimension, active: readonly TagValue[] | undefined): string {
@@ -310,6 +340,15 @@ export function FilterBar({ dimensions, filters, onFilterChange, getFilterValues
           className="rounded-full px-3 py-1 text-xs text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
         >
           Clear all
+        </button>
+      )}
+      {canResetDefaults && (
+        <button
+          type="button"
+          onClick={handleResetDefaults}
+          className="rounded-full px-3 py-1 text-xs text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
+        >
+          Reset defaults
         </button>
       )}
     </div>

--- a/packages/ui/src/components/widget-inspector.tsx
+++ b/packages/ui/src/components/widget-inspector.tsx
@@ -27,7 +27,6 @@ function stripTitle(w: WidgetSpec): WidgetSpec {
   const common = {
     id: w.id,
     size: w.size,
-    ...(w.filters === undefined ? {} : { filters: w.filters }),
   };
   switch (w.type) {
     case 'summary':

--- a/packages/ui/src/hooks/use-widget-query.ts
+++ b/packages/ui/src/hooks/use-widget-query.ts
@@ -10,9 +10,8 @@ import type {
   FilterMap,
   Granularity,
   QueryState,
-  WidgetFilterOverlay,
 } from '@costgoblin/core/browser';
-import { filtersKey, getDimensionFallbacks, mergeFilters } from '../widgets/widget.js';
+import { filtersKey, getDimensionFallbacks } from '../widgets/widget.js';
 
 interface DailyQueryResult {
   readonly result: DailyCostsResult;
@@ -69,7 +68,6 @@ interface WidgetQueryArgs {
   readonly dateRange: DateRange;
   readonly granularity: Granularity;
   readonly globalFilters: FilterMap;
-  readonly specFilters: WidgetFilterOverlay | undefined;
   readonly origin: string;
 }
 
@@ -85,12 +83,10 @@ export function useDailyWidgetQuery({
   dateRange,
   granularity,
   globalFilters,
-  specFilters,
   origin,
 }: WidgetQueryArgs): DailyWidgetQueryResult {
   const api = useCostApi();
-  const filters = mergeFilters(globalFilters, specFilters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
   const fallbackDims = useMemo(
     () => specGroupBy === undefined ? [] : getDimensionFallbacks(specGroupBy),
     [specGroupBy],
@@ -99,7 +95,7 @@ export function useDailyWidgetQuery({
   const query = useQuery<DailyQueryResult | null>(
     () => specGroupBy === undefined
       ? Promise.resolve(null)
-      : fetchDailyWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity, origin),
+      : fetchDailyWithFallback(api, specGroupBy, fallbackDims, dateRange, globalFilters, granularity, origin),
     [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api, origin],
   );
 
@@ -109,7 +105,7 @@ export function useDailyWidgetQuery({
     [query],
   );
 
-  return { query, activeGroupBy, dailyResult, filters };
+  return { query, activeGroupBy, dailyResult, filters: globalFilters };
 }
 
 interface CostWidgetQueryResult {
@@ -124,12 +120,10 @@ export function useCostWidgetQuery({
   dateRange,
   granularity,
   globalFilters,
-  specFilters,
   origin,
 }: WidgetQueryArgs): CostWidgetQueryResult {
   const api = useCostApi();
-  const filters = mergeFilters(globalFilters, specFilters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
   const fallbackDims = useMemo(
     () => specGroupBy === undefined ? [] : getDimensionFallbacks(specGroupBy),
     [specGroupBy],
@@ -138,7 +132,7 @@ export function useCostWidgetQuery({
   const query = useQuery<CostQueryResult | null>(
     () => specGroupBy === undefined
       ? Promise.resolve(null)
-      : fetchCostsWithFallback(api, specGroupBy, fallbackDims, dateRange, filters, granularity, origin),
+      : fetchCostsWithFallback(api, specGroupBy, fallbackDims, dateRange, globalFilters, granularity, origin),
     [specGroupBy, fallbackDims, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api, origin],
   );
 
@@ -148,5 +142,5 @@ export function useCostWidgetQuery({
     [query],
   );
 
-  return { query, activeGroupBy, costResult, filters };
+  return { query, activeGroupBy, costResult, filters: globalFilters };
 }

--- a/packages/ui/src/lib/dimensions.ts
+++ b/packages/ui/src/lib/dimensions.ts
@@ -1,5 +1,5 @@
-import type { Dimension, DimensionId, TagDimension } from '@costgoblin/core/browser';
-import { asDimensionId, tagDimColumn } from '@costgoblin/core/browser';
+import type { Dimension, DimensionId, FilterMap, TagDimension, TagValue } from '@costgoblin/core/browser';
+import { asDimensionId, asTagValue, tagDimColumn } from '@costgoblin/core/browser';
 
 function isTagDim(dim: Dimension): dim is TagDimension {
   return !('field' in dim);
@@ -34,4 +34,17 @@ export function isProductDimension(dim: Dimension): boolean {
 
 export function isUnitDimension(dim: Dimension): boolean {
   return isTagDim(dim) && dim.concept === 'unit';
+}
+
+/** Build a FilterMap seeded from each dim's `defaultFilterValues`. Used to
+ *  initialise the global filter bar on view open. Dims without defaults are
+ *  omitted, so an empty defaults set returns `{}`. */
+export function defaultsFromDimensions(dimensions: readonly Dimension[]): FilterMap {
+  const out: Partial<Record<DimensionId, readonly TagValue[]>> = {};
+  for (const d of dimensions) {
+    const values = d.defaultFilterValues;
+    if (values === undefined || values.length === 0) continue;
+    out[getDimensionId(d)] = values.map(v => asTagValue(v));
+  }
+  return out;
 }

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -22,6 +22,7 @@ import {
 } from '../hooks/use-cost-focus.js';
 import {
   getDimensionId,
+  defaultsFromDimensions,
   isEnvironmentDimension,
   isOwnerDimension,
   isProductDimension,
@@ -93,6 +94,11 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [compareEnabled, setCompareEnabled] = useState(false);
   const [filters, setFilters] = useState<FilterMap>(initialFilter ?? {});
+  // Per-mount latch: seed defaults exactly once after dims load, unless the
+  // view received an explicit `initialFilter` (drill-through, saved state).
+  // Re-mounting the view (navigation, reload) re-applies defaults — that's
+  // the "always re-apply on open" contract.
+  const defaultsAppliedRef = useRef(initialFilter !== undefined);
   const [hourlyHint, setHourlyHint] = useState(false);
   const prefsLoadedRef = useRef(false);
   const columnPrefsRef = useRef<{ hiddenColumns: readonly string[]; columnOrder: readonly string[] }>({
@@ -106,6 +112,14 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     () => [...rawDimensions].sort((a, b) => priorityFor(a) - priorityFor(b)),
     [rawDimensions],
   );
+
+  useEffect(() => {
+    if (defaultsAppliedRef.current) return;
+    if (dimensionsQuery.status !== 'success') return;
+    const defaults = defaultsFromDimensions(dimensionsQuery.data);
+    defaultsAppliedRef.current = true;
+    if (Object.keys(defaults).length > 0) setFilters(defaults);
+  }, [dimensionsQuery]);
 
   const previousDateRange = useMemo(
     () => previousRangeFor(dateRange),

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -269,6 +269,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
           filters={filters}
           onFilterChange={setFilters}
           getFilterValues={handleGetFilterValues}
+          defaults={defaultsFromDimensions(dimensions)}
         />
       )}
 

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -127,6 +127,99 @@ const NORMALIZE_RULES: { value: NormalizationRule; label: string }[] = [
   { value: 'camelCase', label: 'camelCase' },
 ];
 
+/** Per-dim "Default filter" picker. Click-to-open multi-select. Stays out of
+ *  the DB — the enclosing editor already loads & displays the dim's values
+ *  for its own preview, so we pipe that already-resolved list in via
+ *  `available` (calling `getFilterValues` here would re-run the full
+ *  alias-resolving pipeline against every row — we hit 70+s on an 86M-row
+ *  scan in a prior iteration). */
+function DefaultValuesPicker({ available, selected, onChange }: Readonly<{
+  available: readonly string[];
+  selected: readonly string[];
+  onChange: (next: readonly string[]) => void;
+}>) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectedSet = new Set(selected);
+  // Surface selected values that aren't in the discovered window — so the
+  // user always sees what they've picked, even if older.
+  const allValues = [...new Set([...selected, ...available])];
+  const filtered = search.length === 0
+    ? allValues
+    : allValues.filter(v => v.toLowerCase().includes(search.toLowerCase()));
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent): void {
+      if (!open) return;
+      if (containerRef.current === null) return;
+      if (!(e.target instanceof Node)) return;
+      if (containerRef.current.contains(e.target)) return;
+      setOpen(false);
+      setSearch('');
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => { document.removeEventListener('mousedown', onDocClick); };
+  }, [open]);
+
+  function toggle(value: string): void {
+    if (selectedSet.has(value)) onChange(selected.filter(v => v !== value));
+    else onChange([...selected, value]);
+  }
+
+  const summary = selected.length === 0
+    ? 'No defaults'
+    : selected.length <= 3 ? selected.join(', ') : `${String(selected.length)} selected`;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => { setOpen(v => !v); }}
+        className="w-full flex items-center justify-between rounded border border-border bg-bg-primary px-3 py-1.5 text-xs text-text-primary hover:bg-bg-tertiary"
+      >
+        <span className={selected.length === 0 ? 'text-text-muted' : ''}>{summary}</span>
+        <span className="text-text-muted">{open ? '▲' : '▼'}</span>
+      </button>
+      {open && (
+        <div className="absolute z-10 left-0 right-0 mt-1 rounded border border-border bg-bg-secondary shadow-lg flex flex-col">
+          {allValues.length > 6 && (
+            <input
+              type="text"
+              value={search}
+              onChange={e => { setSearch(e.target.value); }}
+              autoFocus
+              className="border-b border-border bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none"
+              placeholder="Search…"
+            />
+          )}
+          {filtered.length === 0 ? (
+            <span className="px-2 py-2 text-[10px] text-text-muted">
+              {allValues.length === 0 ? 'No discovered values yet.' : 'No matches.'}
+            </span>
+          ) : (
+            <div className="max-h-56 overflow-y-auto flex flex-col">
+              {filtered.map(v => (
+                <label key={v} className="flex items-center gap-2 px-2 py-1 text-xs text-text-primary cursor-pointer hover:bg-bg-tertiary">
+                  <input type="checkbox" checked={selectedSet.has(v)} onChange={() => { toggle(v); }} />
+                  <span className="truncate">{v}</span>
+                </label>
+              ))}
+            </div>
+          )}
+          {selected.length > 0 && (
+            <button
+              type="button"
+              onClick={() => { onChange([]); }}
+              className="border-t border-border px-2 py-1 text-[10px] text-text-muted hover:text-text-primary text-left"
+            >Clear selection</button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface EditingBuiltIn {
   label: string;
   description: string;
@@ -138,6 +231,7 @@ interface EditingBuiltIn {
   accountNameFromTag: string;
   nameStripPatterns: string;
   useRegionNames: boolean;
+  defaultFilterValues: readonly string[];
 }
 
 const TRANSFORM_FREE_FIELDS = new Set(['service', 'service_family']);
@@ -436,6 +530,17 @@ function BuiltInEditor({ dim, onSave, onCancel, accountTagKeys }: Readonly<{
           </div>
         </div>
       )}
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Default filter</span>
+        <span className="text-[10px] text-text-muted">
+          Pre-applied to the global filter bar when a view opens. Empty = no default.
+        </span>
+        <DefaultValuesPicker
+          available={preview?.values.map(v => v.value) ?? []}
+          selected={state.defaultFilterValues}
+          onChange={vals => { setState(s => ({ ...s, defaultFilterValues: vals })); }}
+        />
+      </div>
       <div className="flex items-center justify-between pt-2">
         <div className="flex gap-2">
           <button
@@ -531,6 +636,7 @@ interface EditingTag {
   fallbackTag: string | undefined;
   missingValueTemplate: string;
   pathSegIndex: string;
+  defaultFilterValues: readonly string[];
 }
 
 /** OU Path values are joined by ` / ` in aws-org-client.ts when the path is
@@ -865,6 +971,25 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
   const fallbackOptions = [OU_PATH_SOURCE_KEY, ...acctTags];
   const noSourceWarning = state.tagName.length === 0 && (state.fallbackTag === undefined || state.fallbackTag.length === 0);
 
+  // Resolved value list for the Default filter picker. Mirrors the same
+  // transformation TagValuePreview applies (normalize + alias-resolve) so the
+  // strings here match what flows through FilterMap at query time. Pulls from
+  // already-loaded sources (resource-tag sample values, account-fallback
+  // counts) — no DB call.
+  const defaultValueOptions = (() => {
+    const resourceVals = tagMatch === undefined ? [] : tagMatch.sampleValues;
+    const accountVals = fallbackValues.map(([v]) => v);
+    const allRaw = [...new Set([...resourceVals, ...accountVals])];
+    if (allRaw.length === 0) return [] as readonly string[];
+    const aliasMap = buildAliasMap(state.aliases, state.normalize);
+    const resolved = new Set<string>();
+    for (const raw of allRaw) {
+      const normalized = applyPreviewNormalize(raw, state.normalize);
+      resolved.add(aliasMap.get(normalized) ?? normalized);
+    }
+    return [...resolved].sort();
+  })();
+
   return (
     <div ref={containerRef} className="rounded-xl border border-accent/30 bg-bg-tertiary/10 px-5 py-4 flex flex-col gap-4">
       {/* Row 1: Concept + Display Label + Normalization */}
@@ -1068,6 +1193,18 @@ function TagEditor({ tag, onSave, onCancel, onRemove, availableTags, discoveredT
           });
         }}
       />
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-text-muted">Default filter</span>
+        <span className="text-[10px] text-text-muted">
+          Pre-applied to the global filter bar when a view opens. Empty = no default.
+        </span>
+        <DefaultValuesPicker
+          available={defaultValueOptions}
+          selected={state.defaultFilterValues}
+          onChange={vals => { setState(s => ({ ...s, defaultFilterValues: vals })); }}
+        />
+      </div>
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -1411,7 +1548,10 @@ export function DimensionsView() {
     const pathSegment = usesOuPath && Number.isInteger(parsedIndex) && parsedIndex !== 0
       ? { separator: OU_PATH_SEPARATOR, index: parsedIndex }
       : undefined;
-    return { ...base, concept, normalize, aliases, accountTagFallback, missingValueTemplate, pathSegment };
+    const defaultFilterValues = editing.defaultFilterValues.length > 0
+      ? [...editing.defaultFilterValues]
+      : undefined;
+    return { ...base, concept, normalize, aliases, accountTagFallback, missingValueTemplate, pathSegment, defaultFilterValues };
   }
 
   async function handleSaveTag(idx: number, editing: EditingTag) {
@@ -1473,6 +1613,7 @@ export function DimensionsView() {
         // explicitly (both true AND false) so toggling off sticks past the
         // mergeDefaultBuiltIns backfill that would otherwise re-enable it.
         ...(d.name === 'region' ? { useRegionNames: edited.useRegionNames } : {}),
+        ...(edited.defaultFilterValues.length > 0 ? { defaultFilterValues: [...edited.defaultFilterValues] } : {}),
       };
     });
     const next = { ...config, builtIn, order: reconcileOrder({ ...config, builtIn }) };
@@ -1672,7 +1813,7 @@ export function DimensionsView() {
               user sees where the new pill will land. */}
           {addingNew && (
             <TagEditor
-              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined, missingValueTemplate: '', pathSegIndex: '' }}
+              tag={quickAddState ?? { tagName: '', label: '', concept: '', normalize: '', aliases: '', fallbackTag: undefined, missingValueTemplate: '', pathSegIndex: '', defaultFilterValues: [] }}
               onSave={(edited) => { handleAddTag(edited).catch(() => undefined); }}
               onCancel={() => { setAddingNew(false); setQuickAddState(null); }}
               onRemove={undefined}
@@ -1718,6 +1859,7 @@ export function DimensionsView() {
                         accountNameFromTag: d.accountNameFromTag ?? '',
                         nameStripPatterns: d.nameStripPatterns?.join('\n') ?? '',
                         useRegionNames: d.useRegionNames === true,
+                        defaultFilterValues: d.defaultFilterValues ?? [],
                       },
                     }}
                     onSave={(edited) => { handleSaveBuiltIn(row.idx, edited).catch(() => undefined); }}
@@ -1777,6 +1919,7 @@ export function DimensionsView() {
                     fallbackTag: tag.accountTagFallback,
                     missingValueTemplate: tag.missingValueTemplate ?? '',
                     pathSegIndex: tag.pathSegment === undefined ? '' : String(tag.pathSegment.index),
+                    defaultFilterValues: tag.defaultFilterValues ?? [],
                   }}
                   onSave={(edited) => { handleSaveTag(row.idx, edited).catch(() => undefined); }}
                   onCancel={() => { setEditingIdx(null); }}

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -124,7 +124,19 @@ export function ExplorerView(): React.JSX.Element {
     // disabled dims, but it needs to fall back to the full list to render
     // chips for dims with active filters — e.g. the user clicks a Resource
     // cell and that dim is disabled-by-default high-cardinality.
-    api.getDimensions().then(dims => { setDimensions(dims); }).catch(() => { setDimensions([]); });
+    api.getDimensions().then(dims => {
+      setDimensions(dims);
+      // Seed defaults exactly once per mount. The Explorer's filter state is
+      // in-memory only, so on next mount the dim defaults re-apply — same
+      // contract as CustomView.
+      const defaults: Record<string, readonly string[]> = {};
+      for (const d of dims) {
+        const vals = d.defaultFilterValues;
+        if (vals === undefined || vals.length === 0) continue;
+        defaults[getDimensionId(d)] = [...vals];
+      }
+      if (Object.keys(defaults).length > 0) setFilters(defaults);
+    }).catch(() => { setDimensions([]); });
     api.getCostScopeCapabilities().then(setCapabilities).catch(() => { setCapabilities(null); });
     api.getExplorerPreferences().then(prefs => {
       setHiddenColumns(prefs.hiddenColumns);

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -6,7 +6,7 @@ import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { asDollars } from '@costgoblin/core/browser';
 import type { DimensionId, TrendResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters } from './widget.js';
+import { dimensionLabelFor, filtersKey } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 
@@ -32,15 +32,14 @@ export function BubbleWidget({
   const specGroupBy = spec.type === 'bubble' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
 
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
   const query = useQuery(
     () => effectiveGroupBy === undefined
       ? Promise.resolve(null)
       : api.queryTrends({
           groupBy: effectiveGroupBy,
           dateRange,
-          filters,
+          filters: globalFilters,
           deltaThreshold: DEFAULT_DELTA_THRESHOLD,
           percentThreshold: DEFAULT_PERCENT_THRESHOLD,
           origin: `widget:bubble:${String(effectiveGroupBy)}`,

--- a/packages/ui/src/widgets/heatmap-widget.tsx
+++ b/packages/ui/src/widgets/heatmap-widget.tsx
@@ -59,7 +59,6 @@ export function HeatmapWidget({
     dateRange,
     granularity,
     globalFilters,
-    specFilters: spec.filters,
     origin: `widget:heatmap:${String(effectiveGroupBy ?? '')}`,
   });
 

--- a/packages/ui/src/widgets/line-widget.tsx
+++ b/packages/ui/src/widgets/line-widget.tsx
@@ -8,7 +8,7 @@ import type { LineSeries } from '../components/line-chart.js';
 import { asTagValue } from '@costgoblin/core/browser';
 import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
+import { dimensionLabelFor, filtersKey, hasSufficientDailyCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
 
 function buildSeries(data: DailyCostsResult | null, topN: number): LineSeries[] {
@@ -66,8 +66,7 @@ export function LineWidget({
   const specGroupBy = spec.type === 'line' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const topN = spec.type === 'line' ? (spec.topN ?? 6) : 6;
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
 
   const origin = `widget:line:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
@@ -75,13 +74,12 @@ export function LineWidget({
     dateRange,
     granularity,
     globalFilters,
-    specFilters: spec.filters,
     origin,
   });
 
   const prevQuery = useQuery<DailyCostsResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
+      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters: globalFilters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
     [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );

--- a/packages/ui/src/widgets/pie-widget.tsx
+++ b/packages/ui/src/widgets/pie-widget.tsx
@@ -10,7 +10,7 @@ import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
 import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
+import { dimensionLabelFor, filtersKey, hasSufficientCoverage } from './widget.js';
 
 function rowsToSlices(data: CostResult | null): PieSlice[] {
   if (data === null) return [];
@@ -44,8 +44,7 @@ export function PieWidget({
   const specGroupBy = spec.type === 'pie' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
   const specTitle = spec.title;
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
 
   const origin = `widget:pie:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
@@ -53,13 +52,12 @@ export function PieWidget({
     dateRange,
     granularity,
     globalFilters,
-    specFilters: spec.filters,
     origin,
   });
 
   const prevQuery = useQuery<CostResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters: globalFilters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
     [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, fk, granularity, api, origin],
   );

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -7,7 +7,7 @@ import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientDailyCoverage } from './widget.js';
+import { dimensionLabelFor, filtersKey, hasSufficientDailyCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
 import { computeBucketedHourRange, computeBucketedRange } from '../lib/drag-select.js';
 
@@ -60,8 +60,7 @@ export function StackedBarWidget({
   const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'stackedBar' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
 
   const origin = `widget:stackedBar:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, dailyResult } = useDailyWidgetQuery({
@@ -69,13 +68,12 @@ export function StackedBarWidget({
     dateRange,
     granularity,
     globalFilters,
-    specFilters: spec.filters,
     origin,
   });
 
   const prevQuery = useQuery<DailyCostsResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
+      ? api.queryDailyCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters: globalFilters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
     [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );

--- a/packages/ui/src/widgets/summary-widget.tsx
+++ b/packages/ui/src/widgets/summary-widget.tsx
@@ -6,7 +6,7 @@ import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { asDimensionId } from '@costgoblin/core/browser';
 import type { CostResult } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
+import { filtersKey, hasSufficientCoverage } from './widget.js';
 
 export function SummaryWidget({
   dateRange,
@@ -20,15 +20,14 @@ export function SummaryWidget({
   const isSummary = spec.type === 'summary';
 
   const groupBy = asDimensionId('account');
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
 
   const cur = useQuery<CostResult | null>(
-    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters, granularity, origin: 'widget:summary:total' }) : Promise.resolve(null),
+    () => isSummary ? api.queryCosts({ groupBy, dateRange, filters: globalFilters, granularity, origin: 'widget:summary:total' }) : Promise.resolve(null),
     [isSummary, groupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, granularity, api],
   );
   const prev = useQuery<CostResult | null>(
-    () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters, granularity, origin: 'widget:summary:total/prev' }) : Promise.resolve(null),
+    () => isSummary && compareEnabled ? api.queryCosts({ groupBy, dateRange: previousDateRange, filters: globalFilters, granularity, origin: 'widget:summary:total/prev' }) : Promise.resolve(null),
     [isSummary, compareEnabled, groupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api],
   );
 

--- a/packages/ui/src/widgets/table-widget.tsx
+++ b/packages/ui/src/widgets/table-widget.tsx
@@ -9,7 +9,7 @@ import { asDimensionId, asTagValue, OVERVIEW_SEED_VIEW } from '@costgoblin/core/
 import type { AggregatedTableRow, ExplorerFilterMap, ExplorerSort } from '@costgoblin/core/browser';
 import type { SortingState } from '@tanstack/react-table';
 import type { WidgetCommonProps } from './widget.js';
-import { filtersKey, mergeFilters } from './widget.js';
+import { filtersKey } from './widget.js';
 import { getDimensionId } from '../lib/dimensions.js';
 import type { TableColumn } from '../lib/table-types.js';
 
@@ -84,16 +84,15 @@ export function TableWidget({
 
   const specEnabled = spec.type === 'table' ? (spec.enabledColumns ?? DEFAULT_ENABLED) : DEFAULT_ENABLED;
 
-  const widgetFilters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(widgetFilters);
+  const fk = filtersKey(globalFilters);
 
   const explorerFilters = useMemo<ExplorerFilterMap>(() => {
     const map: Record<string, readonly string[]> = {};
-    for (const [k, v] of Object.entries(widgetFilters)) {
+    for (const [k, v] of Object.entries(globalFilters)) {
       if (v !== undefined) map[k] = v;
     }
     return map;
-  }, [widgetFilters]);
+  }, [globalFilters]);
 
   const [sort, setSort] = useState<ExplorerSort | undefined>(undefined);
   const [enabledColumns, setEnabledColumns] = useState(specEnabled);

--- a/packages/ui/src/widgets/top-n-bar-widget.tsx
+++ b/packages/ui/src/widgets/top-n-bar-widget.tsx
@@ -9,7 +9,7 @@ import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
 import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
+import { dimensionLabelFor, filtersKey, hasSufficientCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
 
 function rowsToBars(data: CostResult | null): TopNBar[] {
@@ -43,8 +43,7 @@ export function TopNBarWidget({
   const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'topNBar' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
 
   const origin = `widget:topNBar:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
@@ -52,13 +51,12 @@ export function TopNBarWidget({
     dateRange,
     granularity,
     globalFilters,
-    specFilters: spec.filters,
     origin,
   });
 
   const prevQuery = useQuery<CostResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters: globalFilters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
     [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );

--- a/packages/ui/src/widgets/treemap-widget.tsx
+++ b/packages/ui/src/widgets/treemap-widget.tsx
@@ -9,7 +9,7 @@ import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 import { asTagValue } from '@costgoblin/core/browser';
 import type { CostResult, DimensionId } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
-import { dimensionLabelFor, filtersKey, mergeFilters, hasSufficientCoverage } from './widget.js';
+import { dimensionLabelFor, filtersKey, hasSufficientCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
 
 function rowsToCells(data: CostResult | null): TreemapCell[] {
@@ -38,8 +38,7 @@ export function TreemapWidget({
   const [groupByOverride, setGroupByOverride] = useState<DimensionId | undefined>(undefined);
   const specGroupBy = spec.type === 'treemap' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
-  const filters = mergeFilters(globalFilters, spec.filters);
-  const fk = filtersKey(filters);
+  const fk = filtersKey(globalFilters);
 
   const origin = `widget:treemap:${String(effectiveGroupBy ?? '')}`;
   const { query, activeGroupBy, costResult } = useCostWidgetQuery({
@@ -47,13 +46,12 @@ export function TreemapWidget({
     dateRange,
     granularity,
     globalFilters,
-    specFilters: spec.filters,
     origin,
   });
 
   const prevQuery = useQuery<CostResult | null>(
     () => compareEnabled && effectiveGroupBy !== undefined
-      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters, granularity, origin: `${origin}/prev` })
+      ? api.queryCosts({ groupBy: effectiveGroupBy, dateRange: previousDateRange, filters: globalFilters, granularity, origin: `${origin}/prev` })
       : Promise.resolve(null),
     [compareEnabled, effectiveGroupBy, previousDateRange.start, previousDateRange.end, previousDateRange.startHour, previousDateRange.endHour, fk, granularity, api, origin],
   );

--- a/packages/ui/src/widgets/widget.ts
+++ b/packages/ui/src/widgets/widget.ts
@@ -9,7 +9,6 @@ import type {
   FilterMap,
   Granularity,
   TagValue,
-  WidgetFilterOverlay,
   WidgetSize,
   WidgetSpec,
 } from '@costgoblin/core/browser';
@@ -65,18 +64,6 @@ const SIZE_TO_FRACTION: Readonly<Record<WidgetSize, number>> = {
 export function widgetFlexBasis(size: WidgetSize): string {
   const frac = SIZE_TO_FRACTION[size];
   return `${((frac / 4) * 100).toFixed(2)}%`;
-}
-
-/** Compose global filters with a widget's optional overlay. Overlay wins on
- *  conflict so a widget can pin a specific dimension while the FilterBar
- *  remains the user's primary control. */
-export function mergeFilters(global: FilterMap, overlay?: WidgetFilterOverlay): FilterMap {
-  if (overlay === undefined) return global;
-  const merged = { ...global };
-  for (const [k, v] of Object.entries(overlay)) {
-    if (v !== undefined) (merged as Record<string, readonly TagValue[]>)[k] = [v];
-  }
-  return merged;
 }
 
 /** Stable key for a FilterMap. Used as a useQuery dep so widgets refetch on


### PR DESCRIPTION
## Summary

Each dimension can now declare a set of default filter values that pre-apply to the global filter bar whenever a view opens. Users can override or clear during a session; the next view-open re-seeds. A new "Reset defaults" affordance restores them on demand. Also drops the unused `WidgetFilterOverlay` plumbing.

## Per-dim default filter values

**Schema**: `BuiltInDimension` and `TagDimension` each gain an optional `defaultFilterValues: readonly string[]`. Validator parses it, YAML save persists it, and the `config:dimensions` IPC projection passes it through (so the renderer actually sees it — the same gap that bit us with `accountTagFallback`).

**Authoring**: a new "Default filter" multi-select dropdown at the bottom of every dim editor (Dimensions view). Closed-pill UI showing the selected summary (`No defaults` / first 1–3 values / `N selected`); click to open a checkbox list with a search box once the value count passes ~6. Stays out of the DB — the dropdown reuses values the editor's existing preview already loads:
- Built-in dims: `discoverColumnValues` (latest period only).
- Tag dims: `tagMatch.sampleValues` + account-fallback values, normalized & alias-resolved client-side using the same helpers `TagValuePreview` uses.

This avoids the 70+ second full-table scan an earlier iteration triggered when calling `getFilterValues` directly.

**Runtime**: per-mount seeding in `CustomViewInner` and `ExplorerView`. A ref-latch ensures defaults apply exactly once per mount unless an explicit `initialFilter` is provided (drill-through). Re-mounting (navigation, reload) re-applies defaults, matching the in-memory-only filter state the app already had.

**Reset defaults**: a button next to "Clear all" in the filter bar. Visible whenever any dim defines defaults AND the current selection diverges. Clicking restores the per-dim defaults in one shot.

## WidgetFilterOverlay cleanup

`WidgetSpec.filters` was a per-widget overlay carried through schema / validator / serializer / hook, but no UI ever authored it (the widget inspector only round-tripped it; only seed views in code ever set it). Dropping the type, validator/YAML branches, the `mergeFilters` helper, the hook's `specFilters` arg, and every widget's call site. `globalFilters` flows straight through now.

## Tests

`npm run check` clean — 499 tests pass (the removed `WidgetFilterOverlay` validator test went with it).