### PR TITLE
Bubble trend: scale picker, empty/error states, tunable thresholds

### DIFF
--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -139,6 +139,63 @@ describe('buildSource narrowed paths', () => {
   });
 });
 
+describe('buildTrendQuery with fallback-bearing tag dim', () => {
+  // Mirrors the user's real-world `user_sb_system` setup: resource-tag + account
+  // fallback + missingValueTemplate + normalize + aliases. The trend query needs
+  // to compile cleanly and reference the materialized column in the alias CASE.
+  const dims: DimensionsConfig = {
+    builtIn: [{ name: asDimensionId('service'), label: 'Service', field: 'service' }],
+    tags: [{
+      tagName: 'user_sb_system',
+      label: 'System',
+      concept: 'product',
+      normalize: 'lowercase',
+      aliases: {
+        'core-banking': ['core_banking', 'corebanking'],
+        'platform': ['cpe'],
+      },
+      accountTagFallback: 'sb:account-owner',
+      missingValueTemplate: 'unknown-{fallback}',
+    }],
+  };
+
+  it('produces SQL referencing the materialized column in the alias CASE', () => {
+    const { sql } = buildTrendQuery(
+      {
+        groupBy: asDimensionId('tag_user_sb_system'),
+        dateRange: { start: asDateString('2026-04-01'), end: asDateString('2026-04-30') },
+        filters: {},
+        deltaThreshold: asDollars(0),
+        percentThreshold: 0,
+      },
+      { dataDir: '/data', dimensions: dims, orgAccountsPath: '/org.json' },
+    );
+    // The COALESCE / missingValueTemplate expression lives in the source subquery.
+    expect(sql).toContain("COALESCE(NULLIF(element_at(cur.resource_tags, 'user_sb_system')[1], '')");
+    expect(sql).toContain("'unknown-' || acct_tags.fallback_tag_user_sb_system || ''");
+    // The OUTER group-by references the bare column name (not the COALESCE), so
+    // the alias CASE doesn't repeat the full expression for every WHEN.
+    expect(sql).toContain('LOWER(tag_user_sb_system)');
+    expect(sql).toContain("WHEN LOWER(tag_user_sb_system) IN ('core_banking', 'corebanking') THEN 'core-banking'");
+    expect(sql).not.toContain("WHEN LOWER(COALESCE");
+  });
+
+  it('runs cleanly with the user-style materializedSource path too', () => {
+    const { sql } = buildTrendQuery(
+      {
+        groupBy: asDimensionId('tag_user_sb_system'),
+        dateRange: { start: asDateString('2026-04-01'), end: asDateString('2026-04-30') },
+        filters: {},
+        deltaThreshold: asDollars(0),
+        percentThreshold: 0,
+      },
+      { dataDir: '/data', dimensions: dims, orgAccountsPath: '/org.json', materializedSource: 'mat_table' },
+    );
+    expect(sql).toContain('FROM mat_table');
+    expect(sql).toContain('LOWER(tag_user_sb_system)');
+  });
+});
+
 describe('buildTrendQuery', () => {
   it('includes periods from both current and previous spans', () => {
     // 30-day window ending 2026-04-18 → current is 2026-03/2026-04, previous

--- a/packages/core/src/config/views-serialize.ts
+++ b/packages/core/src/config/views-serialize.ts
@@ -25,6 +25,8 @@ export function widgetToYaml(w: WidgetSpec): Record<string, unknown> {
     case 'bubble':
       addGroupByFields(base, w);
       if (w.logScale !== undefined) base['logScale'] = w.logScale;
+      if (w.deltaThreshold !== undefined) base['deltaThreshold'] = w.deltaThreshold;
+      if (w.percentThreshold !== undefined) base['percentThreshold'] = w.percentThreshold;
       return base;
     case 'treemap':
       addGroupByFields(base, w);

--- a/packages/core/src/config/views-validator.ts
+++ b/packages/core/src/config/views-validator.ts
@@ -88,12 +88,31 @@ function validateGroupByWidget(raw: Record<string, unknown>, ctx: string, base: 
   }
   if (type === 'pie') return { type, ...base, groupBy };
   if (type === 'bubble') {
-    let logScale: number | undefined;
-    if (raw['logScale'] !== undefined) {
-      assertNumber(raw['logScale'], `${ctx}.logScale`);
-      logScale = raw['logScale'];
+    let logScale: number | 'linear' | undefined;
+    const rawLog: unknown = raw['logScale'];
+    if (rawLog === 'linear') {
+      logScale = 'linear';
+    } else if (typeof rawLog === 'number') {
+      logScale = rawLog;
+    } else if (rawLog !== undefined) {
+      throw new ConfigValidationError(`${ctx}.logScale must be a number or 'linear'`);
     }
-    return { type, ...base, groupBy, ...(logScale === undefined ? {} : { logScale }) };
+    let deltaThreshold: number | undefined;
+    if (raw['deltaThreshold'] !== undefined) {
+      assertNumber(raw['deltaThreshold'], `${ctx}.deltaThreshold`);
+      deltaThreshold = raw['deltaThreshold'];
+    }
+    let percentThreshold: number | undefined;
+    if (raw['percentThreshold'] !== undefined) {
+      assertNumber(raw['percentThreshold'], `${ctx}.percentThreshold`);
+      percentThreshold = raw['percentThreshold'];
+    }
+    return {
+      type, ...base, groupBy,
+      ...(logScale === undefined ? {} : { logScale }),
+      ...(deltaThreshold === undefined ? {} : { deltaThreshold }),
+      ...(percentThreshold === undefined ? {} : { percentThreshold }),
+    };
   }
   return { type, ...base, groupBy };
 }

--- a/packages/core/src/types/views.ts
+++ b/packages/core/src/types/views.ts
@@ -47,7 +47,13 @@ export type WidgetSpec =
   | (WidgetBase & {
       readonly type: 'bubble';
       readonly groupBy: DimensionId;
-      readonly logScale?: number | undefined;
+      /** `'linear'` selects `scaleLinear`. A number is the symlog
+       *  "linearization constant" — defaults to 10 when unset. */
+      readonly logScale?: number | 'linear' | undefined;
+      /** Minimum absolute $ delta for a group to appear. Defaults to 0. */
+      readonly deltaThreshold?: number | undefined;
+      /** Minimum absolute % change for a group to appear. Defaults to 0. */
+      readonly percentThreshold?: number | undefined;
     })
   | (WidgetBase & {
       readonly type: 'table';

--- a/packages/ui/src/components/bubble-chart.tsx
+++ b/packages/ui/src/components/bubble-chart.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { Group } from '@visx/group';
-import { scaleSymlog, scaleSqrt } from '@visx/scale';
+import { scaleLinear, scaleSymlog, scaleSqrt } from '@visx/scale';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { GridRows, GridColumns } from '@visx/grid';
 import { useTooltip, TooltipWithBounds } from '@visx/tooltip';
@@ -18,7 +18,8 @@ const DEFAULT_LOG_SCALE = 10;
 
 interface BubbleChartProps {
   readonly data: readonly TrendRow[];
-  readonly logScale?: number | undefined;
+  /** `'linear'` selects `scaleLinear`. A number is the symlog constant. */
+  readonly logScale?: number | 'linear' | undefined;
   readonly onEntityClick: (entity: EntityRef) => void;
   readonly externalHoveredName?: string | null | undefined;
   readonly onEntityHover?: ((name: string | null) => void) | undefined;
@@ -94,21 +95,35 @@ function BubbleChartInner({
   const deltaMax = Math.max(...absDeltas);
   const costMax = Math.max(...costs);
 
-  const symlogConstant = logScale ?? DEFAULT_LOG_SCALE;
+  const scaleKind: 'linear' | number = logScale === 'linear'
+    ? 'linear'
+    : (typeof logScale === 'number' ? logScale : DEFAULT_LOG_SCALE);
 
-  const xScale = scaleSymlog<number>({
-    domain: [percentMin - percentPad, percentMax + percentPad],
-    range: [0, innerWidth],
-    nice: true,
-    constant: symlogConstant,
-  });
+  const xScale = scaleKind === 'linear'
+    ? scaleLinear<number>({
+        domain: [percentMin - percentPad, percentMax + percentPad],
+        range: [0, innerWidth],
+        nice: true,
+      })
+    : scaleSymlog<number>({
+        domain: [percentMin - percentPad, percentMax + percentPad],
+        range: [0, innerWidth],
+        nice: true,
+        constant: scaleKind,
+      });
 
-  const yScale = scaleSymlog<number>({
-    domain: [0, deltaMax * 1.15],
-    range: [innerHeight, 0],
-    nice: true,
-    constant: symlogConstant,
-  });
+  const yScale = scaleKind === 'linear'
+    ? scaleLinear<number>({
+        domain: [0, deltaMax * 1.15],
+        range: [innerHeight, 0],
+        nice: true,
+      })
+    : scaleSymlog<number>({
+        domain: [0, deltaMax * 1.15],
+        range: [innerHeight, 0],
+        nice: true,
+        constant: scaleKind,
+      });
 
   const rScale = scaleSqrt<number>({
     domain: [0, costMax],

--- a/packages/ui/src/components/widget-inspector.tsx
+++ b/packages/ui/src/components/widget-inspector.tsx
@@ -36,7 +36,12 @@ function stripTitle(w: WidgetSpec): WidgetSpec {
     case 'stackedBar':
       return { ...common, type: w.type, groupBy: w.groupBy };
     case 'bubble':
-      return { ...common, type: w.type, groupBy: w.groupBy, ...(w.logScale === undefined ? {} : { logScale: w.logScale }) };
+      return {
+        ...common, type: w.type, groupBy: w.groupBy,
+        ...(w.logScale === undefined ? {} : { logScale: w.logScale }),
+        ...(w.deltaThreshold === undefined ? {} : { deltaThreshold: w.deltaThreshold }),
+        ...(w.percentThreshold === undefined ? {} : { percentThreshold: w.percentThreshold }),
+      };
     case 'treemap':
       return { ...common, type: w.type, groupBy: w.groupBy, ...(w.drillTo === undefined ? {} : { drillTo: w.drillTo }) };
     case 'line':
@@ -233,22 +238,63 @@ export function WidgetInspector({
         </div>
       )}
 
-      {widget.type === 'bubble' && (
-        <label className="flex items-center gap-2">
-          <span className="text-text-muted shrink-0 w-14">Log scale</span>
-          <input
-            type="number"
-            min={1}
-            max={1000}
-            value={widget.logScale ?? 10}
-            onChange={(e) => {
-              const v = Number.parseInt(e.target.value, 10);
-              if (Number.isFinite(v) && v >= 1) onChange({ ...widget, logScale: v });
-            }}
-            className="w-20 bg-transparent border border-border rounded px-2 py-1 text-text-primary"
-          />
-        </label>
-      )}
+      {widget.type === 'bubble' && (() => {
+        type ScaleOpt = { value: number | 'linear'; label: string };
+        const SCALE_OPTIONS: readonly ScaleOpt[] = [
+          { value: 'linear', label: 'Linear' },
+          { value: 2, label: 'Log 2' },
+          { value: 10, label: 'Log 10' },
+        ];
+        const current: number | 'linear' = widget.logScale ?? 10;
+        return (
+          <>
+            <label className="flex items-center gap-2">
+              <span className="text-text-muted shrink-0 w-14">Scale</span>
+              <div className="flex items-center gap-0.5 rounded border border-border p-0.5">
+                {SCALE_OPTIONS.map(o => (
+                  <button
+                    key={String(o.value)}
+                    type="button"
+                    onClick={() => { onChange({ ...widget, logScale: o.value }); }}
+                    className={[
+                      'px-2 py-0.5 rounded text-[11px]',
+                      current === o.value ? 'bg-bg-tertiary text-text-primary' : 'text-text-secondary hover:text-text-primary',
+                    ].join(' ')}
+                  >
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="text-text-muted shrink-0 w-14">Min $</span>
+              <input
+                type="number"
+                min={0}
+                value={widget.deltaThreshold ?? 0}
+                onChange={(e) => {
+                  const v = Number.parseFloat(e.target.value);
+                  if (Number.isFinite(v) && v >= 0) onChange({ ...widget, deltaThreshold: v });
+                }}
+                className="w-20 bg-transparent border border-border rounded px-2 py-1 text-text-primary"
+              />
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="text-text-muted shrink-0 w-14">Min %</span>
+              <input
+                type="number"
+                min={0}
+                value={widget.percentThreshold ?? 0}
+                onChange={(e) => {
+                  const v = Number.parseFloat(e.target.value);
+                  if (Number.isFinite(v) && v >= 0) onChange({ ...widget, percentThreshold: v });
+                }}
+                className="w-20 bg-transparent border border-border rounded px-2 py-1 text-text-primary"
+              />
+            </label>
+          </>
+        );
+      })()}
 
       {(widget.type === 'line' || widget.type === 'topNBar' || widget.type === 'heatmap') && (
         <label className="flex items-center gap-2">

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -33,7 +33,14 @@ interface TrendsState {
   granularity: Granularity;
   deltaThreshold: number;
   percentThreshold: number;
+  logScale: number | 'linear';
 }
+
+const SCALE_OPTIONS: readonly { value: number | 'linear'; label: string }[] = [
+  { value: 'linear', label: 'Linear' },
+  { value: 2, label: 'Log 2' },
+  { value: 10, label: 'Log 10' },
+];
 
 function TrendRowItem({ row, onClick }: Readonly<{ row: TrendRow; onClick: (e: EntityRef) => void }>) {
   const isIncrease = row.delta > 0;
@@ -80,6 +87,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
     granularity: 'daily' satisfies Granularity,
     deltaThreshold: 0,
     percentThreshold: 0,
+    logScale: 10,
   }));
 
   const dimensions: Dimension[] =
@@ -234,6 +242,24 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
                 className="w-16 rounded border border-border bg-bg-primary px-2 py-1 text-xs text-text-primary"
               />
             </label>
+            <div className="flex items-center gap-1.5">
+              <span>Scale</span>
+              <div className="flex items-center gap-0.5 rounded border border-border p-0.5">
+                {SCALE_OPTIONS.map(o => (
+                  <button
+                    key={String(o.value)}
+                    type="button"
+                    onClick={() => { setState(p => ({ ...p, logScale: o.value })); }}
+                    className={[
+                      'rounded px-2 py-0.5 text-[11px]',
+                      state.logScale === o.value ? 'bg-bg-tertiary text-text-primary' : 'text-text-secondary hover:text-text-primary',
+                    ].join(' ')}
+                  >
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       )}
@@ -256,7 +282,7 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
       )}
 
       {rows.length > 0 && (
-        <BubbleChart data={rows} onEntityClick={handleEntityClick} />
+        <BubbleChart data={rows} logScale={state.logScale} onEntityClick={handleEntityClick} />
       )}
 
       {rows.length > 0 && (

--- a/packages/ui/src/widgets/bubble-widget.tsx
+++ b/packages/ui/src/widgets/bubble-widget.tsx
@@ -10,8 +10,11 @@ import { dimensionLabelFor, filtersKey } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
 
-const DEFAULT_DELTA_THRESHOLD = asDollars(50);
-const DEFAULT_PERCENT_THRESHOLD = 5;
+// Defaults match the dedicated Trends view (0 / 0) so a freshly-added bubble
+// shows every group, not "no movement above $50/5%" which silently looked
+// like a stuck loading state on high-cardinality dims.
+const DEFAULT_DELTA_THRESHOLD = asDollars(0);
+const DEFAULT_PERCENT_THRESHOLD = 0;
 
 function combinedRows(data: TrendResult | null): TrendResult['increases'] {
   if (data === null) return [];
@@ -32,6 +35,13 @@ export function BubbleWidget({
   const specGroupBy = spec.type === 'bubble' ? spec.groupBy : undefined;
   const effectiveGroupBy = groupByOverride ?? specGroupBy;
 
+  const deltaThreshold = spec.type === 'bubble' && spec.deltaThreshold !== undefined
+    ? asDollars(spec.deltaThreshold)
+    : DEFAULT_DELTA_THRESHOLD;
+  const percentThreshold = spec.type === 'bubble' && spec.percentThreshold !== undefined
+    ? spec.percentThreshold
+    : DEFAULT_PERCENT_THRESHOLD;
+
   const fk = filtersKey(globalFilters);
   const query = useQuery(
     () => effectiveGroupBy === undefined
@@ -40,11 +50,11 @@ export function BubbleWidget({
           groupBy: effectiveGroupBy,
           dateRange,
           filters: globalFilters,
-          deltaThreshold: DEFAULT_DELTA_THRESHOLD,
-          percentThreshold: DEFAULT_PERCENT_THRESHOLD,
+          deltaThreshold,
+          percentThreshold,
           origin: `widget:bubble:${String(effectiveGroupBy)}`,
         }),
-    [effectiveGroupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, api],
+    [effectiveGroupBy, dateRange.start, dateRange.end, dateRange.startHour, dateRange.endHour, fk, api, deltaThreshold, percentThreshold],
   );
 
   const data = useMemo(
@@ -53,17 +63,43 @@ export function BubbleWidget({
   );
 
   if (spec.type !== 'bubble' || effectiveGroupBy === undefined) return null;
+
+  const header = (
+    <div className="mb-2">
+      {spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={effectiveGroupBy} onGroupByChange={setGroupByOverride} label={dimensionLabelFor(dimensions, effectiveGroupBy)} />}
+    </div>
+  );
+
   if (query.status === 'loading') return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
       <CoinRainLoader height={260} count={5} />
     </div>
   );
 
+  if (query.status === 'error') return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      {header}
+      <div className="flex items-center justify-center h-[260px] text-xs text-warning">
+        Query failed: {query.error.message}
+      </div>
+    </div>
+  );
+
+  if (data.length === 0) return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
+      {header}
+      <div className="flex flex-col items-center justify-center h-[260px] text-xs text-text-muted gap-1">
+        <span>No groups passed the trend thresholds.</span>
+        {(deltaThreshold > 0 || percentThreshold > 0) && (
+          <span>Lower &ldquo;Min $&rdquo; / &ldquo;Min %&rdquo; in the widget settings to widen.</span>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/50 px-4 py-4">
-      <div className="mb-2">
-        {spec.title ?? <GroupByTitle dimensions={dimensions} currentGroupBy={effectiveGroupBy} onGroupByChange={setGroupByOverride} label={dimensionLabelFor(dimensions, effectiveGroupBy)} />}
-      </div>
+      {header}
       <BubbleChart
         data={data}
         logScale={spec.logScale}


### PR DESCRIPTION
## Summary

Three independent reasons a bubble-trend widget could appear "stuck loading" with certain dimensions — all fixed.

## What changed

**Scale picker (Linear / Log 2 / Log 10)**
- Replaced the free-form numeric `Log scale` input in the widget inspector with a three-button picker styled like the Size picker.
- Same picker added to the dedicated Trends view next to Min $ / Min %.
- `scaleLinear` now backs the Linear option; `scaleSymlog` keeps the numeric branch.
- Schema accepts `number | 'linear'`; validator, YAML serializer, and chart all updated.

**Empty + error states in `BubbleWidget`**
- Loading-only rendering was the root cause of "stuck loading" — query errors and empty results both produced a blank box that looked identical to a spinner.
- Added explicit error state (shows the error message) and empty state ("No groups passed the trend thresholds" with a hint to lower thresholds when they're non-zero).

**Tunable thresholds**
- The widget hardcoded `deltaThreshold: $50 / percentThreshold: 5%` with no UI to tune them. On high-cardinality tag dims (e.g. `team`, `system`) where individual groups move less than that, every row was filtered out and the chart silently rendered nothing.
- Defaults dropped to **0 / 0** to match the dedicated Trends view's defaults — a freshly added bubble shows every group out of the box.
- Inspector now exposes `Min $` and `Min %` inputs, persisted through schema / validator / YAML serializer.

## Tests

New `buildTrendQuery` test covering a fallback-bearing tag dim (`accountTagFallback + missingValueTemplate + aliases`) — confirms the outer alias CASE references the materialized column name, not the full COALESCE expression that lives inside the source subquery. `npm run check` clean — 501 tests, type-clean, lint-clean.