### PR TITLE
Auto-updater: surface failures in the modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -221,13 +221,26 @@ export interface UpdateInfo {
   readonly releaseNotes: string | null;
 }
 
+export type UpdateStage = 'check' | 'download' | 'install';
+
+export interface UpdateLogEntry {
+  readonly timestamp: number;
+  readonly level: 'info' | 'warn' | 'error';
+  readonly message: string;
+}
+
 export type UpdateStatus =
   | { readonly state: 'idle' }
   | { readonly state: 'checking' }
   | { readonly state: 'available'; readonly info: UpdateInfo }
   | { readonly state: 'downloading'; readonly percent: number; readonly info: UpdateInfo }
   | { readonly state: 'downloaded'; readonly info: UpdateInfo }
-  | { readonly state: 'error'; readonly error: string };
+  | {
+      readonly state: 'error';
+      readonly error: string;
+      readonly stage: UpdateStage;
+      readonly logs: readonly UpdateLogEntry[];
+    };
 
 export interface UpdateApi {
   checkForUpdates(): Promise<void>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -64,7 +64,7 @@ export type {
   QueryState,
 } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateStatus, UpdateApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/update-manager.ts
+++ b/packages/desktop/src/main/update-manager.ts
@@ -79,9 +79,7 @@ let hasTriedFullDownload = false;
 
 export function initAutoUpdater(): void {
   const updater = autoUpdater;
-  // Start downloading immediately on update-available; the user is only
-  // prompted to confirm the install/restart at the end.
-  updater.autoDownload = true;
+  updater.autoDownload = false;
   updater.autoInstallOnAppQuit = false;
 
   updater.on('checking-for-update', () => {

--- a/packages/desktop/src/main/update-manager.ts
+++ b/packages/desktop/src/main/update-manager.ts
@@ -1,12 +1,26 @@
 import pkg from 'electron-updater';
 const { autoUpdater } = pkg;
 import { logger, isStringRecord } from '@costgoblin/core';
-import type { UpdateInfo, UpdateStatus } from '@costgoblin/core';
+import type { UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus } from '@costgoblin/core';
 
 type StatusListener = (status: UpdateStatus) => void;
 
+const LOG_BUFFER_LIMIT = 50;
+
 let currentStatus: UpdateStatus = { state: 'idle' };
 const listeners = new Set<StatusListener>();
+const logBuffer: UpdateLogEntry[] = [];
+
+function pushLog(level: UpdateLogEntry['level'], message: string): void {
+  logBuffer.push({ timestamp: Date.now(), level, message });
+  if (logBuffer.length > LOG_BUFFER_LIMIT) {
+    logBuffer.splice(0, logBuffer.length - LOG_BUFFER_LIMIT);
+  }
+}
+
+function snapshotLogs(): readonly UpdateLogEntry[] {
+  return logBuffer.slice();
+}
 
 function setStatus(status: UpdateStatus): void {
   currentStatus = status;
@@ -41,15 +55,37 @@ function toUpdateInfo(info: { version: string; releaseDate: string; releaseNotes
   };
 }
 
+function stageForCurrentStatus(): UpdateStage {
+  switch (currentStatus.state) {
+    case 'downloading':
+    case 'available':
+      return 'download';
+    case 'downloaded':
+      return 'install';
+    default:
+      return 'check';
+  }
+}
+
+function formatError(err: unknown): { message: string; details: string | null } {
+  if (err instanceof Error) {
+    return { message: err.message, details: err.stack ?? null };
+  }
+  return { message: String(err), details: null };
+}
+
 let currentInfo: UpdateInfo | null = null;
 let hasTriedFullDownload = false;
 
 export function initAutoUpdater(): void {
   const updater = autoUpdater;
-  updater.autoDownload = false;
+  // Start downloading immediately on update-available; the user is only
+  // prompted to confirm the install/restart at the end.
+  updater.autoDownload = true;
   updater.autoInstallOnAppQuit = false;
 
   updater.on('checking-for-update', () => {
+    pushLog('info', 'Checking for updates');
     setStatus({ state: 'checking' });
   });
 
@@ -57,25 +93,34 @@ export function initAutoUpdater(): void {
     currentInfo = toUpdateInfo(info);
     hasTriedFullDownload = false;
     updater.disableDifferentialDownload = false;
+    pushLog('info', `Update available: v${currentInfo.version} (${currentInfo.releaseDate})`);
     setStatus({ state: 'available', info: currentInfo });
   });
 
   updater.on('update-not-available', () => {
+    pushLog('info', 'No update available');
     setStatus({ state: 'idle' });
   });
 
   updater.on('download-progress', (progress) => {
     if (currentInfo === null) return;
-    setStatus({ state: 'downloading', percent: Math.round(progress.percent), info: currentInfo });
+    const percent = Math.round(progress.percent);
+    // Log at 25% increments to avoid flooding the buffer.
+    if (percent % 25 === 0) {
+      pushLog('info', `Download progress: ${String(percent)}%`);
+    }
+    setStatus({ state: 'downloading', percent, info: currentInfo });
   });
 
   updater.on('update-downloaded', (info) => {
     const downloadedInfo = toUpdateInfo(info);
     currentInfo = downloadedInfo;
+    pushLog('info', `Download complete: v${downloadedInfo.version}`);
     setStatus({ state: 'downloaded', info: downloadedInfo });
   });
 
   updater.on('error', (err) => {
+    const { message, details } = formatError(err);
     // Differential download can hang or fail mid-stream when the cached
     // blockmap from the previously installed version doesn't reconstruct
     // cleanly against the new zip. Fall back to a full download once
@@ -87,19 +132,30 @@ export function initAutoUpdater(): void {
     // "already in progress" guard and return the same rejected promise.
     // Defer with setImmediate so the .finally runs first.
     if (currentStatus.state === 'downloading' && !hasTriedFullDownload && currentInfo !== null) {
-      logger.warn('Differential download failed, retrying with full download', { error: err.message });
+      logger.warn('Differential download failed, retrying with full download', { error: message });
+      pushLog('warn', `Differential download failed, retrying with full download: ${message}`);
       hasTriedFullDownload = true;
       updater.disableDifferentialDownload = true;
       setStatus({ state: 'downloading', percent: 0, info: currentInfo });
       setImmediate(() => {
         autoUpdater.downloadUpdate().catch((retryErr: unknown) => {
-          const message = retryErr instanceof Error ? retryErr.message : String(retryErr);
-          setStatus({ state: 'error', error: message });
+          const retryFormatted = formatError(retryErr);
+          pushLog('error', `Full-download retry failed: ${retryFormatted.message}`);
+          if (retryFormatted.details !== null) pushLog('error', retryFormatted.details);
+          setStatus({
+            state: 'error',
+            error: retryFormatted.message,
+            stage: 'download',
+            logs: snapshotLogs(),
+          });
         });
       });
       return;
     }
-    setStatus({ state: 'error', error: err.message });
+    const stage = stageForCurrentStatus();
+    pushLog('error', `${stage} failed: ${message}`);
+    if (details !== null) pushLog('error', details);
+    setStatus({ state: 'error', error: message, stage, logs: snapshotLogs() });
   });
 
   logger.info('Auto-updater initialized');
@@ -114,6 +170,7 @@ export function downloadUpdate(): Promise<void> {
 }
 
 export function quitAndInstall(): void {
+  pushLog('info', 'User requested install + restart');
   autoUpdater.quitAndInstall();
 }
 

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostS
 import type { NavItem } from '@costgoblin/ui';
 import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
-import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
+import { RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
 import { OptionsMenu } from './top-menu/options-menu.js';
@@ -131,6 +131,18 @@ function SyncAnnouncer({
   );
 }
 
+function formatLogTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function stageLabel(stage: 'check' | 'download' | 'install'): string {
+  if (stage === 'check') return 'Checking for updates';
+  if (stage === 'download') return 'Downloading update';
+  return 'Installing update';
+}
+
 function ReleaseNotesModal({
   open,
   onOpenChange,
@@ -140,6 +152,46 @@ function ReleaseNotesModal({
   onOpenChange: (open: boolean) => void;
   status: UpdateStatus;
 }>): React.JSX.Element | null {
+  if (status.state === 'error') {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogTitle>Update failed</DialogTitle>
+          <DialogDescription>
+            {stageLabel(status.stage)} did not complete. You can try again or copy the log below.
+          </DialogDescription>
+          <div className="mt-3 rounded-md border border-negative/40 bg-negative-muted p-3 text-sm text-text-primary">
+            {status.error}
+          </div>
+          {status.logs.length > 0 && (
+            <div className="mt-3">
+              <div className="text-xs text-text-secondary mb-1">Recent events</div>
+              <pre className="max-h-60 overflow-y-auto rounded-md bg-bg-primary p-3 text-xs text-text-secondary whitespace-pre-wrap break-words">
+                {status.logs.map((entry, i) => (
+                  <div key={i} className={entry.level === 'error' ? 'text-negative' : entry.level === 'warn' ? 'text-warning' : undefined}>
+                    [{formatLogTimestamp(entry.timestamp)}] {entry.level.toUpperCase()}: {entry.message}
+                  </div>
+                ))}
+              </pre>
+            </div>
+          )}
+          <div className="mt-4 flex justify-end gap-2">
+            <DialogClose>
+              <Button variant="ghost" size="sm">Close</Button>
+            </DialogClose>
+            <Button
+              size="sm"
+              onClick={() => { globalThis.costgoblinUpdate.checkForUpdates().catch(() => undefined); }}
+            >
+              <RotateCw size={14} className="mr-1.5" />
+              Retry
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   if (status.state !== 'available' && status.state !== 'downloading' && status.state !== 'downloaded') return null;
   const { info } = status;
 
@@ -158,6 +210,12 @@ function ReleaseNotesModal({
         <DialogDescription>
           Released {info.releaseDate}
         </DialogDescription>
+        {status.state === 'available' && (
+          <div className="mt-3 flex items-center gap-1.5 text-xs text-text-secondary">
+            <RefreshCw size={12} className="animate-spin" />
+            Preparing download...
+          </div>
+        )}
         {status.state === 'downloading' && (
           <div className="mt-3">
             <div className="flex items-center justify-between text-xs text-text-secondary mb-1.5">
@@ -185,17 +243,6 @@ function ReleaseNotesModal({
           <DialogClose>
             <Button variant="ghost" size="sm">Dismiss</Button>
           </DialogClose>
-          {status.state === 'available' && (
-            <Button
-              size="sm"
-              onClick={() => {
-                globalThis.costgoblinUpdate.downloadUpdate().catch(() => undefined);
-              }}
-            >
-              <Download size={14} className="mr-1.5" />
-              Download
-            </Button>
-          )}
           {status.state === 'downloaded' && (
             <Button
               size="sm"
@@ -424,8 +471,14 @@ function AppShell(): React.JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (autoOpenRef.current) return;
     if (setupCheck.status !== 'ready') return;
+    // Always surface errors so the user can see what went wrong; for other
+    // user-visible states open only once per session.
+    if (updateStatus.state === 'error') {
+      setReleaseNotesOpen(true);
+      return;
+    }
+    if (autoOpenRef.current) return;
     if (updateStatus.state === 'available' || updateStatus.state === 'downloaded') {
       autoOpenRef.current = true;
       setReleaseNotesOpen(true);

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostS
 import type { NavItem } from '@costgoblin/ui';
 import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
-import { RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
+import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
 import { OptionsMenu } from './top-menu/options-menu.js';
@@ -210,12 +210,6 @@ function ReleaseNotesModal({
         <DialogDescription>
           Released {info.releaseDate}
         </DialogDescription>
-        {status.state === 'available' && (
-          <div className="mt-3 flex items-center gap-1.5 text-xs text-text-secondary">
-            <RefreshCw size={12} className="animate-spin" />
-            Preparing download...
-          </div>
-        )}
         {status.state === 'downloading' && (
           <div className="mt-3">
             <div className="flex items-center justify-between text-xs text-text-secondary mb-1.5">
@@ -243,6 +237,17 @@ function ReleaseNotesModal({
           <DialogClose>
             <Button variant="ghost" size="sm">Dismiss</Button>
           </DialogClose>
+          {status.state === 'available' && (
+            <Button
+              size="sm"
+              onClick={() => {
+                globalThis.costgoblinUpdate.downloadUpdate().catch(() => undefined);
+              }}
+            >
+              <Download size={14} className="mr-1.5" />
+              Download
+            </Button>
+          )}
           {status.state === 'downloaded' && (
             <Button
               size="sm"


### PR DESCRIPTION
## Summary

Two changes so the user can see why an auto-update fails:

1. **In-memory log buffer** in the update manager (last 50 entries) capturing each lifecycle event: checking, available, download progress (25% increments to avoid flooding), differential-download fallback, errors with stack traces, install + restart request.
2. **Error rendering in the modal**. Previously the modal returned `null` on error, so the user never learned why an update failed. Now the error state renders:
   - A clear "Update failed" title with the stage label (Checking / Downloading / Installing).
   - The error message in a callout.
   - A scrollable, colour-coded log of the recent update events.
   - A Retry button that re-runs `checkForUpdates`.
   
   Error state auto-opens every time (not gated by the once-per-session ref) so the user always sees failures.

The existing user-driven flow is preserved: user clicks Download to start the download, then Install and Restart to install.

## Type changes

`UpdateStatus.error` gained `stage: 'check' | 'download' | 'install'` and `logs: readonly UpdateLogEntry[]`. New types exported from `@costgoblin/core`: `UpdateLogEntry`, `UpdateStage`.

## Verification

- `npm run check` clean (typecheck + lint + 501 tests passing).
- Existing `update-manager.test.ts` differential-fallback coverage still passes against the new error shape.
- Auto-updater UI cannot easily be exercised in dev (electron-updater needs a packaged build talking to a real release feed); the manager logic is covered by the integration tests, and the modal change is a declarative React render off `UpdateStatus`.