### PR TITLE
Cost metrics overhaul: fix amortized, add list price, retire blended

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,74 +62,86 @@ On first launch, the setup wizard guides you through connecting to your AWS CUR 
 
 ### Setting Up a CUR Report
 
-If you don't have a CUR report yet, create one in the [AWS Console](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html).
+CostGoblin reads **CUR 2.0 via AWS Data Exports** (not legacy CUR). Create one in the [AWS Billing Console → Data Exports](https://docs.aws.amazon.com/cur/latest/userguide/what-is-data-exports.html).
 
-**Report settings:**
+**Export settings:**
 
 | Setting | Value |
 |---------|-------|
-| Report type | CUR 2.0 (Data Exports) |
+| Export type | **Standard data export** (table: `COST_AND_USAGE_REPORT`) |
 | Time granularity | Daily |
 | Format | Parquet |
-| Compression | Parquet (Snappy) |
-| Additional content | **Include resource IDs** + **Include net columns** (both) |
+| Compression | Snappy |
+| Overwrite | Overwrite existing data export file |
 
-**Why both "additional content" boxes.** Each ticks on a family of columns that the app uses for a specific metric / perspective. Tick only one and you get half the matrix — the app still runs, but Amortized and/or Net silently fall back to Unblended.
+> CUR 2.0 Data Exports does **not** have "Include resource IDs" / "Include net columns" checkboxes — those are legacy CUR. In Data Exports you pick the columns explicitly in the SQL editor (see below).
 
-| Setting | Unlocks | Without it |
-|---------|---------|------------|
-| *Include resource IDs* | Amortized metric (accurate RI/SP smoothing) + the resource_id column Missing-Tags analysis needs | Amortized degrades to Unblended; Missing Tags view can't isolate resources |
-| *Include net columns* | Net perspective (credits / refunds / promotional discounts applied) | Net falls back to Gross on every metric |
+#### Columns to select
 
-**Required columns** — the base set the app needs to function:
+Paste this into the **SQL query** field when creating the export. It's the full set of columns CostGoblin can read — extras you don't paste become inline "Degraded" warnings in Cost Scope but never break queries.
 
-| Column | Purpose |
-|--------|---------|
-| `line_item_usage_start_date` | Date partitioning |
-| `line_item_usage_account_id` | Account dimension |
-| `line_item_usage_account_name` | Account display name |
-| `line_item_line_item_type` | Charge type (Usage / Fee / Credit / Tax / RIFee / ...). Drives Cost Scope exclusion rules |
-| `line_item_line_item_description` | Line item description |
-| `line_item_operation` | AWS operation |
-| `line_item_usage_type` | Usage details |
-| `line_item_usage_amount` | Usage quantity |
-| `line_item_resource_id` | Resource ARN (Missing-Tags analysis) |
-| `line_item_unblended_cost` | Primary cost metric. **Always required** — the universal fallback for every metric / perspective combination |
-| `pricing_public_on_demand_cost` | On-demand list price (shown alongside cost in Line Items table) |
-| `product_servicecode` | AWS service code (e.g. `AmazonEC2`) |
-| `product_product_family` | Service family (e.g. `Compute Instance`) |
-| `product_region_code` | AWS region |
-| `resource_tags` | Tag key-value pairs |
+```sql
+SELECT
+  -- Required: app won't function without these
+  line_item_usage_start_date,
+  line_item_usage_account_id,
+  line_item_usage_account_name,
+  line_item_line_item_type,
+  line_item_line_item_description,
+  line_item_operation,
+  line_item_usage_type,
+  line_item_usage_amount,
+  line_item_resource_id,
+  line_item_unblended_cost,
+  product_servicecode,
+  product_product_family,
+  product_region_code,
+  resource_tags,
+  -- Recommended: each unlocks one metric option in Cost Scope
+  pricing_public_on_demand_cost,            -- "On-demand list price" metric
+  reservation_effective_cost,               -- "Amortized" metric (RI portion)
+  savings_plan_savings_plan_effective_cost, -- "Amortized" metric (SP portion)
+  -- Optional: enables the "Net" perspective (credits/refunds applied)
+  line_item_net_unblended_cost,
+  reservation_net_effective_cost,
+  savings_plan_net_savings_plan_effective_cost
+FROM COST_AND_USAGE_REPORT
+```
 
-**Cost-metric columns** — pick both variants of each pair so Gross *and* Net views stay accurate:
+> The doubled prefix on `savings_plan_savings_plan_effective_cost` is AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost` — not a typo. Same for the `_net_` variant.
 
-| Column | Unlocks |
-|--------|---------|
-| `line_item_blended_cost` | **Blended** metric (consolidated-billing weighted average) |
-| `line_item_net_unblended_cost` | **Net** perspective for every metric |
-| `reservation_effective_cost` | **Amortized** metric, Gross — RI-covered usage |
-| `reservation_net_effective_cost` | **Amortized** metric, Net — RI-covered usage |
-| `savings_plan_savings_plan_effective_cost` | **Amortized** metric, Gross — SP-covered usage |
-| `savings_plan_net_savings_plan_effective_cost` | **Amortized** metric, Net — SP-covered usage |
+> **Why no `line_item_blended_cost`?** CostGoblin intentionally doesn't ship AWS's "Blended" metric. It was designed to distribute classic RI discounts fairly across linked accounts when commitments sat in a central payer account — but AWS never extended the math to Savings Plans, and SPs are how virtually all modern fleets buy commitment-based discounts. On an SP-based fleet, Blended is nearly indistinguishable from Unblended and provides none of the chargeback fairness it was originally invented for. We use **Amortized** for chargeback (it spreads SP/RI fees correctly across covered usage) and **On-demand list price** for fair per-team cost views when commitment allocation is uneven. If your config still has `costMetric: "blended"` it's silently migrated to `amortized` at load time. Skipping this column also keeps your CUR export lighter.
 
-> The doubled prefix on the SP columns is AWS's snake_case conversion of `savingsPlan/SavingsPlanEffectiveCost` — not a typo.
+#### What each tier unlocks
 
-**Metric × Perspective matrix** — the column the app actually reads for each UI selection (first available, in priority order):
+| Tier | If you skip these |
+|------|-------------------|
+| **Required** | App won't ingest the export at all |
+| **Recommended** | The matching metric in Cost Scope shows "Degraded — falls back to Unblended"; numbers are still correct under the Unblended metric |
+| **Optional (Net)** | The Net perspective toggle silently falls back to Gross |
 
-| Selection | Reads from (first available wins) |
-|-----------|-----------------------------------|
+The app probes your parquet schema once at startup and shows the warning inline next to each affected metric. Queries never error on a missing column — they fall through to the next available one.
+
+#### Already have an export running with fewer columns?
+
+CUR 2.0 exports are immutable, so you can't add columns to an existing export. Create a new one with the full SQL above, point it at a fresh S3 prefix, wait one billing cycle for the first partition to land, then update CostGoblin's S3 prefix in the setup wizard.
+
+<details>
+<summary><strong>Reference: which column wires up which metric × perspective</strong></summary>
+
+For each metric / perspective combo, the app reads the **first available** column in priority order, falling back down the chain when a column isn't in the export:
+
+| Selection | Reads from |
+|-----------|------------|
 | Unblended · Gross | `line_item_unblended_cost` |
 | Unblended · Net | `line_item_net_unblended_cost` → `line_item_unblended_cost` |
-| Blended · Gross | `line_item_blended_cost` → `line_item_unblended_cost` |
-| Blended · Net | `line_item_net_unblended_cost` → `line_item_blended_cost` → `line_item_unblended_cost` [^1] |
-| Amortized · Gross | `reservation_effective_cost` → `savings_plan_savings_plan_effective_cost` → `line_item_unblended_cost` |
-| Amortized · Net | `reservation_net_effective_cost` → `savings_plan_net_savings_plan_effective_cost` → `line_item_net_unblended_cost` → `line_item_unblended_cost` |
+| Amortized · Gross | `CASE` on `line_item_line_item_type`: `DiscountedUsage` → `reservation_effective_cost`; `SavingsPlanCoveredUsage` → `savings_plan_savings_plan_effective_cost`; RI/SP fee rows → `0`; everything else → `line_item_unblended_cost` |
+| Amortized · Net | Same `CASE`, but using the `_net_` variants of each column and `line_item_net_unblended_cost` as the fallback |
+| On-demand list price | `pricing_public_on_demand_cost` → `line_item_unblended_cost` |
 
-[^1]: AWS doesn't publish a standalone `line_item_net_blended_cost` — Blended × Net uses the next-closest net accounting column.
+The Amortized expression uses a `CASE` on `line_item_type` rather than a plain `COALESCE` because AWS populates `reservation_effective_cost` and `savings_plan_savings_plan_effective_cost` with `0` (not `NULL`) for non-applicable rows — a `COALESCE` chain would silently zero out every Usage / Tax / Credit row.
 
-**What the app does on first launch.** It probes your parquet schema once (cached per session) and shows an inline warning next to any degraded metric / perspective combination in the Cost Scope view. Queries never fail with a missing-column error; they fall back down the chain.
-
-**Changing the settings.** CUR reports are immutable, so enabling *Include resource IDs* / *Include net columns* on an existing report requires creating a new report. Point it at the same (or a fresh) S3 prefix, wait one billing cycle for the new columns to land, then point CostGoblin at the updated prefix.
+</details>
 
 The S3 export should look like:
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Then use the Data tab to repartition the downloaded files.
 - **Custom dimensions** — map any AWS tag to a first-class cost allocation dimension
 - **Tag normalization** — aliases applied at query time, fix messy tags without re-processing
 - **Composable views** — drag-and-drop widget builder with 9 widget types (pie, bar, stacked bar, line, treemap, heatmap, bubble, table, summary)
-- **Cost Scope** — configure cost metrics (unblended, blended, amortized) and exclusion rules
+- **Cost Scope** — configure cost metrics (amortized, on-demand list price, unblended) and exclusion rules
 - **Vault encryption** — optional AES-256-GCM at-rest encryption for local billing data, with system keychain integration
 - **MCP server** — Model Context Protocol integration for querying cost data from AI assistants
 - **Dark/light mode** — theme toggle with two chart color palettes (standard + Okabe-Ito colorblind-safe)

--- a/docs/index.html
+++ b/docs/index.html
@@ -2167,7 +2167,6 @@ S3 path prefix:  <span class="code-dir">cur_daily</span>  <span class="code-comm
 
 <span class="code-comment"># Cost columns</span>
  &bull; <span class="code-file">line_item_unblended_cost</span>                      <span class="code-comment">raw cost</span>
- &bull; <span class="code-file">line_item_blended_cost</span>                        <span class="code-comment">blended across accounts</span>
  &bull; <span class="code-file">line_item_net_unblended_cost</span>                  <span class="code-comment">cost after discounts</span>
  &bull; <span class="code-file">pricing_public_on_demand_cost</span>                 <span class="code-comment">on-demand list price</span>
 

--- a/e2e/views-config.test.ts
+++ b/e2e/views-config.test.ts
@@ -350,14 +350,17 @@ test.describe('Cost Scope', () => {
     await expect(page.getByText(/Define what counts as cost/)).toBeVisible();
   });
 
-  test('cost metric picker lists Unblended, Blended, Amortized (no List)', async () => {
+  test('cost metric picker lists Amortized, List, Unblended (Blended retired)', async () => {
     await expect(page.getByRole('heading', { name: 'Cost metric' })).toBeVisible();
     // Check the actual radio values, which are unique — the labels repeat
     // in adjacent description copy so role/name queries are ambiguous.
-    await expect(page.locator('input[type="radio"][value="unblended"]')).toBeVisible();
-    await expect(page.locator('input[type="radio"][value="blended"]')).toBeVisible();
     await expect(page.locator('input[type="radio"][value="amortized"]')).toBeVisible();
-    await expect(page.locator('input[type="radio"][value="list"]')).toHaveCount(0);
+    await expect(page.locator('input[type="radio"][value="list"]')).toBeVisible();
+    await expect(page.locator('input[type="radio"][value="unblended"]')).toBeVisible();
+    // Blended was removed; AWS never extended it to Savings Plans and on an
+    // SP-based fleet it barely differs from Unblended. Legacy configs with
+    // costMetric: 'blended' are migrated to 'amortized' at load time.
+    await expect(page.locator('input[type="radio"][value="blended"]')).toHaveCount(0);
 
     // Exactly one metric radio is selected — the specific one depends on
     // what the user has saved to cost-scope.yaml, so we don't assume a
@@ -366,11 +369,14 @@ test.describe('Cost Scope', () => {
     await screenshot(page, 'cost-scope-metric');
   });
 
-  test('exclusion rules section lists both built-in rules', async () => {
+  test('exclusion rules section lists shipped built-in rules', async () => {
     await expect(page.getByRole('heading', { name: 'Exclusion rules' })).toBeVisible();
     // Rule names are rendered in inputs (they're editable).
     await expect(page.locator('input[value="AWS Premium Support"]')).toBeVisible();
-    await expect(page.locator('input[value="RI & Savings Plan purchases"]')).toBeVisible();
+    await expect(page.locator('input[value="Tax"]')).toBeVisible();
+    // RI & Savings Plan purchases rule was retired — subsumed by the
+    // On-demand list price metric. Stripped silently on load.
+    await expect(page.locator('input[value="RI & Savings Plan purchases"]')).toHaveCount(0);
     // Built-in pill appears next to each
     const builtInPills = page.getByText('built-in', { exact: true });
     expect(await builtInPills.count()).toBeGreaterThanOrEqual(2);

--- a/e2e/views-config.test.ts
+++ b/e2e/views-config.test.ts
@@ -373,7 +373,9 @@ test.describe('Cost Scope', () => {
     await expect(page.getByRole('heading', { name: 'Exclusion rules' })).toBeVisible();
     // Rule names are rendered in inputs (they're editable).
     await expect(page.locator('input[value="AWS Premium Support"]')).toBeVisible();
-    await expect(page.locator('input[value="Tax"]')).toBeVisible();
+    // Tax rule has values=["Tax"] so two inputs match (name + value field).
+    // Just assert the name input exists.
+    await expect(page.locator('input[value="Tax"]').first()).toBeVisible();
     // RI & Savings Plan purchases rule was retired — subsumed by the
     // On-demand list price metric. Stripped silently on load.
     await expect(page.locator('input[value="RI & Savings Plan purchases"]')).toHaveCount(0);

--- a/packages/core/src/__fixtures__/setup.ts
+++ b/packages/core/src/__fixtures__/setup.ts
@@ -77,7 +77,7 @@ function generateFixtureRow(date: string, cfg: FixtureConfig, rand: () => number
   if (env !== null) tagEntries.push(`'user_environment': '${env}'`);
 
   const netCost = Math.round(cost * 0.97 * 100) / 100;
-  return `(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', '${meta.family}', '${operation}', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(cost)}, ${String(netCost)}, ${String(listCost)}, NULL, NULL, NULL, NULL, 'Usage', '${operation}', 'Usage', MAP {${tagEntries.join(', ')}})`;
+  return `(TIMESTAMP '${date}', '${account.id}', '${account.name}', '${region}', '${service.name}', '${meta.family}', '${operation}', '${resourceId}', ${String(usageAmount)}, ${String(cost)}, ${String(netCost)}, ${String(listCost)}, NULL, NULL, NULL, NULL, 'Usage', '${operation}', 'Usage', MAP {${tagEntries.join(', ')}})`;
 }
 
 interface ActionType {
@@ -213,7 +213,6 @@ export async function setup(): Promise<void> {
       line_item_resource_id VARCHAR,
       line_item_usage_amount DOUBLE,
       line_item_unblended_cost DOUBLE,
-      line_item_blended_cost DOUBLE,
       line_item_net_unblended_cost DOUBLE,
       pricing_public_on_demand_cost DOUBLE,
       reservation_effective_cost DOUBLE,

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -4,8 +4,9 @@ import {
   buildDailyCostsQuery,
 } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
-import type { CostScopeConfig } from '../types/cost-scope.js';
-import { DEFAULT_COST_SCOPE } from '../config/cost-scope-seed.js';
+import type { CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
+import { DEFAULT_COST_SCOPE, BUILTIN_EXCLUSION_RULES, mergeBuiltInExclusionRules } from '../config/cost-scope-seed.js';
+import { validateCostScope } from '../config/cost-scope-validator.js';
 import { asDimensionId, asDateString } from '../types/branded.js';
 
 const dimensions: DimensionsConfig = {
@@ -45,15 +46,22 @@ describe('cost metric column selection', () => {
     expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
   });
 
-  it('uses blended when metric is blended', () => {
-    const sql = buildQuery({ costMetric: 'blended', rules: [] });
-    expect(sql).toMatch(/COALESCE\(line_item_blended_cost, 0\) AS cost/);
+  it('amortized uses CASE on line_item_type per AWS amortized definition', () => {
+    const sql = buildQuery({ costMetric: 'amortized', rules: [] });
+    // DiscountedUsage → reservation_effective_cost; SP-covered → SP effective;
+    // RI/SP fee rows → 0 (already amortized into covered-usage); else unblended.
+    expect(sql).toContain("WHEN line_item_line_item_type = 'DiscountedUsage' THEN COALESCE(reservation_effective_cost, line_item_unblended_cost, 0)");
+    expect(sql).toContain("WHEN line_item_line_item_type = 'SavingsPlanCoveredUsage' THEN COALESCE(savings_plan_savings_plan_effective_cost, line_item_unblended_cost, 0)");
+    expect(sql).toContain("WHEN line_item_line_item_type IN ('RIFee', 'SavingsPlanRecurringFee', 'SavingsPlanUpfrontFee', 'SavingsPlanNegation') THEN 0");
+    expect(sql).toContain('ELSE COALESCE(line_item_unblended_cost, 0)');
   });
 
-  it('falls back through effective cost → unblended when metric is amortized', () => {
+  it('amortized does NOT use a flat COALESCE on effective-cost columns', () => {
+    // Regression: AWS populates reservation_effective_cost / savings_plan_*_effective_cost
+    // with 0 (not NULL) for non-applicable rows. A flat COALESCE returned 0 for every
+    // Usage / Tax / Credit row and silently zeroed out ~90% of cost.
     const sql = buildQuery({ costMetric: 'amortized', rules: [] });
-    // Amortized layers effective-cost columns over unblended via COALESCE.
-    expect(sql).toMatch(/COALESCE\(reservation_effective_cost, savings_plan_savings_plan_effective_cost, line_item_unblended_cost, 0\) AS cost/);
+    expect(sql).not.toMatch(/COALESCE\(reservation_effective_cost, savings_plan_savings_plan_effective_cost, line_item_unblended_cost, 0\)/);
   });
 
   it('net perspective uses line_item_net_unblended_cost when available', () => {
@@ -92,7 +100,9 @@ describe('cost metric column selection', () => {
       ]) },
       5,
     );
-    expect(sql).toMatch(/COALESCE\(reservation_net_effective_cost, savings_plan_net_savings_plan_effective_cost, line_item_net_unblended_cost, line_item_unblended_cost, 0\) AS cost/);
+    expect(sql).toContain("WHEN line_item_line_item_type = 'DiscountedUsage' THEN COALESCE(reservation_net_effective_cost, line_item_net_unblended_cost, 0)");
+    expect(sql).toContain("WHEN line_item_line_item_type = 'SavingsPlanCoveredUsage' THEN COALESCE(savings_plan_net_savings_plan_effective_cost, line_item_net_unblended_cost, 0)");
+    expect(sql).toContain('ELSE COALESCE(line_item_net_unblended_cost, 0)');
   });
 
   it('amortized + net degrades to unblended when no net/effective columns present', () => {
@@ -106,6 +116,33 @@ describe('cost metric column selection', () => {
     expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
     expect(sql).not.toContain('net_effective_cost');
     expect(sql).not.toContain('net_unblended_cost');
+  });
+
+  it('list metric uses pricing_public_on_demand_cost', () => {
+    const sql = buildQuery({ costMetric: 'list', rules: [] });
+    expect(sql).toMatch(/COALESCE\(pricing_public_on_demand_cost, 0\) AS cost/);
+  });
+
+  it('list metric restricts source to usage-bearing line item types', () => {
+    const sql = buildQuery({ costMetric: 'list', rules: [] });
+    // Filter is inlined in the source subquery so every downstream query
+    // (Explorer, custom views, MCP, materialized base) sees the same slice.
+    expect(sql).toContain("line_item_line_item_type, '') IN ('Usage', 'SavingsPlanCoveredUsage', 'DiscountedUsage')");
+  });
+
+  it('list metric degrades to unblended when on-demand column missing', () => {
+    const { sql } = buildCostQuery(
+      baseParams,
+      { dataDir: '/data', dimensions, costScope: { costMetric: 'list', rules: [] }, availableColumns: new Set(['line_item_unblended_cost']) },
+      5,
+    );
+    expect(sql).toMatch(/COALESCE\(line_item_unblended_cost, 0\) AS cost/);
+    expect(sql).not.toContain('pricing_public_on_demand_cost, 0) AS cost');
+  });
+
+  it('non-list metrics do not inject the line-item-type filter', () => {
+    const sql = buildQuery({ costMetric: 'unblended', rules: [] });
+    expect(sql).not.toContain("'Usage', 'SavingsPlanCoveredUsage', 'DiscountedUsage'");
   });
 });
 
@@ -276,18 +313,119 @@ describe('exclusion clauses', () => {
   });
 });
 
+describe('mergeBuiltInExclusionRules', () => {
+  function retiredRiSpRule(enabled: boolean): ExclusionRule {
+    return {
+      id: 'builtin:ri-sp-purchases',
+      name: 'RI & Savings Plan purchases',
+      enabled,
+      builtIn: true,
+      conditions: [{ dimensionId: asDimensionId('line_item_type'), values: ['RIFee'] }],
+    };
+  }
+
+  function retiredCoveredUsageRule(enabled: boolean): ExclusionRule {
+    return {
+      id: 'builtin:commitment-covered-usage',
+      name: 'RI & SP covered usage',
+      enabled,
+      builtIn: true,
+      conditions: [{ dimensionId: asDimensionId('line_item_type'), values: ['DiscountedUsage'] }],
+    };
+  }
+
+  it('does not ship the retired RI/SP rules in the default seed', () => {
+    const ids = BUILTIN_EXCLUSION_RULES.map(r => r.id);
+    expect(ids).not.toContain('builtin:ri-sp-purchases');
+    expect(ids).not.toContain('builtin:commitment-covered-usage');
+  });
+
+  it('drops retired rules from loaded configs silently', () => {
+    const loaded: CostScopeConfig = {
+      costMetric: 'unblended',
+      rules: [retiredRiSpRule(false), retiredCoveredUsageRule(false)],
+    };
+    const merged = mergeBuiltInExclusionRules(loaded);
+    const ids = merged.rules.map(r => r.id);
+    expect(ids).not.toContain('builtin:ri-sp-purchases');
+    expect(ids).not.toContain('builtin:commitment-covered-usage');
+  });
+
+  it('migrates costMetric to `list` when the retired ri-sp-purchases rule was enabled', () => {
+    const loaded: CostScopeConfig = {
+      costMetric: 'unblended',
+      rules: [retiredRiSpRule(true)],
+    };
+    const merged = mergeBuiltInExclusionRules(loaded);
+    expect(merged.costMetric).toBe('list');
+  });
+
+  it('does not change costMetric when ri-sp-purchases rule was disabled', () => {
+    const loaded: CostScopeConfig = {
+      costMetric: 'amortized',
+      rules: [retiredRiSpRule(false)],
+    };
+    const merged = mergeBuiltInExclusionRules(loaded);
+    expect(merged.costMetric).toBe('amortized');
+  });
+
+  it('preserves user-authored custom rules', () => {
+    const customRule: ExclusionRule = {
+      id: 'user-uuid',
+      name: 'Custom',
+      enabled: true,
+      builtIn: false,
+      conditions: [{ dimensionId: asDimensionId('service'), values: ['AmazonS3'] }],
+    };
+    const loaded: CostScopeConfig = {
+      costMetric: 'unblended',
+      rules: [retiredRiSpRule(false), customRule],
+    };
+    const merged = mergeBuiltInExclusionRules(loaded);
+    expect(merged.rules.find(r => r.id === 'user-uuid')).toEqual(customRule);
+  });
+
+  it('backfills surviving built-ins missing from the loaded config', () => {
+    const loaded: CostScopeConfig = { costMetric: 'unblended', rules: [] };
+    const merged = mergeBuiltInExclusionRules(loaded);
+    const ids = merged.rules.map(r => r.id);
+    expect(ids).toContain('builtin:tax');
+    expect(ids).toContain('builtin:aws-premium-support');
+  });
+
+  it('returns input unchanged when config is already coherent', () => {
+    const loaded: CostScopeConfig = {
+      costMetric: 'unblended',
+      rules: [...BUILTIN_EXCLUSION_RULES],
+    };
+    const merged = mergeBuiltInExclusionRules(loaded);
+    expect(merged).toBe(loaded);
+  });
+});
+
+describe('validateCostScope: blended migration', () => {
+  it('migrates costMetric "blended" to "amortized" silently', () => {
+    const result = validateCostScope({ costMetric: 'blended', rules: [] });
+    expect(result.costMetric).toBe('amortized');
+  });
+
+  it('rejects truly unknown costMetric values', () => {
+    expect(() => validateCostScope({ costMetric: 'nonsense', rules: [] })).toThrow(/costScope.costMetric must be one of/);
+  });
+});
+
 describe('buildDailyCostsQuery with costScope', () => {
   it('injects exclusion clause in daily costs query', () => {
     const { sql, params } = buildDailyCostsQuery(
       { ...baseParams, granularity: 'daily' },
       { dataDir: '/data', dimensions, costScope: {
-        costMetric: 'blended',
+        costMetric: 'unblended',
         rules: [{ id: 'support', name: 'Support', enabled: true, builtIn: true, conditions: [{ dimensionId: asDimensionId('service_family'), values: ['Support'] }] }],
       } },
     );
     // Single-condition rules use merged NOT IN form
     expect(sql).toContain('service_family NOT IN ($');
     expect(params).toContain('Support');
-    expect(sql).toContain('line_item_blended_cost');
+    expect(sql).toContain('line_item_unblended_cost');
   });
 });

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -23,20 +23,6 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
     ],
   },
   {
-    id: 'builtin:ri-sp-purchases',
-    name: 'RI & Savings Plan purchases',
-    description:
-      'Upfront/recurring fees for Reserved Instances and Savings Plans, plus SP negation adjustments. RI/SP-covered usage still appears under DiscountedUsage / SavingsPlanCoveredUsage and is not affected by this rule.',
-    enabled: false,
-    builtIn: true,
-    conditions: [
-      {
-        dimensionId: asDimensionId('line_item_type'),
-        values: ['RIFee', 'SavingsPlanRecurringFee', 'SavingsPlanUpfrontFee', 'SavingsPlanNegation'],
-      },
-    ],
-  },
-  {
     id: 'builtin:tax',
     name: 'Tax',
     description:
@@ -69,21 +55,20 @@ export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
       { dimensionId: asDimensionId('line_item_type'), values: ['BundledDiscount'] },
     ],
   },
-  {
-    id: 'builtin:commitment-covered-usage',
-    name: 'RI & SP covered usage',
-    description:
-      'Usage already covered by a Reserved Instance (DiscountedUsage) or Savings Plan (SavingsPlanCoveredUsage paired with SavingsPlanNegation). Toggle on to isolate on-demand spend — the workloads NOT yet covered by a commitment. SP negation is bundled so its discount does not leak when the usage it offsets is removed.',
-    enabled: false,
-    builtIn: true,
-    conditions: [
-      {
-        dimensionId: asDimensionId('line_item_type'),
-        values: ['DiscountedUsage', 'SavingsPlanCoveredUsage', 'SavingsPlanNegation'],
-      },
-    ],
-  },
 ];
+
+/** Built-in rule IDs that have been removed since older configs were written.
+ *  Loaded configs may still carry them; the merge step drops them silently and
+ *  may migrate other fields (see mergeBuiltInExclusionRules) to preserve the
+ *  spirit of the user's prior choice. */
+const RETIRED_BUILTIN_RULE_IDS: ReadonlySet<string> = new Set([
+  // Subsumed by the `list` cost metric — when that metric is selected, the
+  // query layer auto-filters the same line item types this rule used to.
+  'builtin:ri-sp-purchases',
+  // Removed entirely: this was a savings-sizing tool, not a coherent
+  // cost-scope toggle. Belongs in a dedicated commitment-coverage view.
+  'builtin:commitment-covered-usage',
+]);
 
 export const DEFAULT_COST_SCOPE: CostScopeConfig = {
   costMetric: 'unblended',
@@ -92,10 +77,28 @@ export const DEFAULT_COST_SCOPE: CostScopeConfig = {
 
 /** Merge shipped built-in rules into a loaded config. Mirrors
  *  mergeDefaultBuiltIns for dimensions: preserve user edits on existing
- *  built-ins, add any that are missing. User rules are untouched. */
+ *  built-ins, add any that are missing. User rules are untouched.
+ *
+ *  Also drops retired built-in rules (RETIRED_BUILTIN_RULE_IDS) silently —
+ *  these were superseded by the `list` cost metric. If the user had the
+ *  retired `builtin:ri-sp-purchases` rule enabled, the metric is rewritten
+ *  to `list` so the spirit of their choice (exclude RI/SP fee rows) is
+ *  preserved with the new coherent model. */
 export function mergeBuiltInExclusionRules(loaded: CostScopeConfig): CostScopeConfig {
-  const loadedById = new Map(loaded.rules.map(r => [r.id, r]));
-  const missingBuiltins = BUILTIN_EXCLUSION_RULES.filter(b => !loadedById.has(b.id));
-  if (missingBuiltins.length === 0) return loaded;
-  return { ...loaded, rules: [...loaded.rules, ...missingBuiltins] };
+  const retiredRiSpPurchasesEnabled = loaded.rules.some(
+    r => r.id === 'builtin:ri-sp-purchases' && r.enabled,
+  );
+
+  const survivingRules = loaded.rules.filter(r => !RETIRED_BUILTIN_RULE_IDS.has(r.id));
+  const survivingIds = new Set(survivingRules.map(r => r.id));
+  const missingBuiltins = BUILTIN_EXCLUSION_RULES.filter(b => !survivingIds.has(b.id));
+
+  const droppedAny = survivingRules.length !== loaded.rules.length;
+  if (!droppedAny && missingBuiltins.length === 0 && !retiredRiSpPurchasesEnabled) {
+    return loaded;
+  }
+
+  const rules = [...survivingRules, ...missingBuiltins];
+  const costMetric = retiredRiSpPurchasesEnabled ? 'list' : loaded.costMetric;
+  return { ...loaded, costMetric, rules };
 }

--- a/packages/core/src/config/cost-scope-validator.ts
+++ b/packages/core/src/config/cost-scope-validator.ts
@@ -1,5 +1,6 @@
 import { assertArray, assertNumber, assertObject, assertString, ConfigValidationError } from './validator.js';
 import { asDimensionId } from '../types/branded.js';
+import { logger } from '../logger/logger.js';
 import type {
   CostMetric,
   CostPerspective,
@@ -61,7 +62,16 @@ function validateRule(raw: unknown, ctx: string): ExclusionRule {
 export function validateCostScope(raw: unknown): CostScopeConfig {
   assertObject(raw, 'costScope');
   assertString(raw['costMetric'], 'costScope.costMetric');
-  if (!isCostMetric(raw['costMetric'])) {
+  // 'blended' was removed: AWS never extended blended math to Savings Plans,
+  // so on SP-based fleets it barely differs from unblended and provides none
+  // of the chargeback fairness it was originally designed for. Silently
+  // migrate legacy configs to 'amortized' (the recommended chargeback metric).
+  let costMetricRaw: string = raw['costMetric'];
+  if (costMetricRaw === 'blended') {
+    logger.warn('costScope.costMetric was "blended" (removed); migrating to "amortized"');
+    costMetricRaw = 'amortized';
+  }
+  if (!isCostMetric(costMetricRaw)) {
     throw new ConfigValidationError(
       `costScope.costMetric must be one of: ${COST_METRICS.join(', ')}`,
     );
@@ -90,7 +100,7 @@ export function validateCostScope(raw: unknown): CostScopeConfig {
   assertArray(raw['rules'], 'costScope.rules');
   const rules = raw['rules'].map((r, i) => validateRule(r, `costScope.rules[${String(i)}]`));
   return {
-    costMetric: raw['costMetric'],
+    costMetric: costMetricRaw,
     ...(costPerspective === undefined ? {} : { costPerspective }),
     ...(lagDays === undefined ? {} : { lagDays }),
     rules,

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -5,7 +5,7 @@ import { tagDimColumn } from '../types/branded.js';
 import { OU_PATH_SOURCE_KEY } from '../types/config.js';
 import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
-import { costExprFor } from './cost-metric.js';
+import { costExprFor, LIST_METRIC_LINE_ITEM_TYPES } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
 import { assertDateString, assertHourString, SecurityError } from './identifier-validator.js';
 
@@ -409,6 +409,15 @@ export function buildSource(opts: BuildSourceOptions): string {
       COALESCE(${tablePrefix}line_item_usage_amount, 0) AS usage_amount,
       COALESCE(${tablePrefix}pricing_public_on_demand_cost, 0) AS list_cost,`;
 
+  // The `list` metric reports on-demand list price for usage that actually
+  // happened. RI/SP fee rows (RIFee, SavingsPlanRecurringFee, etc.) have no
+  // retail equivalent, and including them just adds zero-cost rows that bloat
+  // group-by buckets. Restrict at the source level so every downstream query
+  // (Explorer, custom views, MCP, materialized base) sees a consistent slice.
+  const metricWhere = costMetric === 'list'
+    ? `\n    WHERE COALESCE(${tablePrefix}line_item_line_item_type, '') IN (${LIST_METRIC_LINE_ITEM_TYPES.map(t => `'${t}'`).join(', ')})`
+    : '';
+
   return `(
     SELECT
       ${dateExpr},
@@ -422,7 +431,7 @@ export function buildSource(opts: BuildSourceOptions): string {
       COALESCE(${tablePrefix}line_item_line_item_type, '') AS line_item_type,
       COALESCE(${tablePrefix}line_item_operation, '') AS operation,
       COALESCE(${tablePrefix}line_item_usage_type, '') AS usage_type${tagClause}
-    FROM ${fromClause}
+    FROM ${fromClause}${metricWhere}
   )`;
 }
 

--- a/packages/core/src/query/cost-metric.ts
+++ b/packages/core/src/query/cost-metric.ts
@@ -33,28 +33,63 @@ function unblendedExpr(prefix: string, net: boolean, has: (col: string) => boole
   return coalesceCol(prefix, 'line_item_unblended_cost');
 }
 
-function blendedExpr(prefix: string, net: boolean, has: (col: string) => boolean): string {
-  if (net && has('line_item_net_unblended_cost')) {
-    return coalesceCol(prefix, 'line_item_net_unblended_cost');
-  }
-  if (has('line_item_blended_cost')) {
-    return coalesceCol(prefix, 'line_item_blended_cost');
+function listExpr(prefix: string, has: (col: string) => boolean): string {
+  // On-demand list price. Net perspective is meaningless here (credits/refunds
+  // don't apply to a hypothetical retail rate), so perspective is ignored.
+  // When the column isn't present we fall back to unblended so the query still
+  // returns numbers rather than zeros — the UI gates this case with a warning.
+  if (has('pricing_public_on_demand_cost')) {
+    return coalesceCol(prefix, 'pricing_public_on_demand_cost');
   }
   return coalesceCol(prefix, 'line_item_unblended_cost');
 }
 
 function amortizedExpr(prefix: string, net: boolean, has: (col: string) => boolean): string {
-  const parts: string[] = [];
-  if (net) {
-    if (has('reservation_net_effective_cost')) parts.push(`${prefix}reservation_net_effective_cost`);
-    if (has('savings_plan_net_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_net_savings_plan_effective_cost`);
-    if (has('line_item_net_unblended_cost')) parts.push(`${prefix}line_item_net_unblended_cost`);
-  } else {
-    if (has('reservation_effective_cost')) parts.push(`${prefix}reservation_effective_cost`);
-    if (has('savings_plan_savings_plan_effective_cost')) parts.push(`${prefix}savings_plan_savings_plan_effective_cost`);
+  // True amortized cost per AWS Cost Explorer's definition, keyed on
+  // line_item_type rather than a flat COALESCE:
+  //
+  //   DiscountedUsage         → reservation_effective_cost
+  //                             (per-hour amortized RI value)
+  //   SavingsPlanCoveredUsage → savings_plan_savings_plan_effective_cost
+  //                             (per-hour amortized SP value)
+  //   RIFee / SP*Fee / SP-Negation → 0
+  //                             (these are already amortized into the
+  //                              covered-usage rows above; counting both
+  //                              double-counts the commitment cost)
+  //   everything else         → line_item_unblended_cost
+  //                             (Usage, Tax, Credit, EdpDiscount,
+  //                              BundledDiscount, Refund, …)
+  //
+  // A plain COALESCE on the effective-cost columns does NOT work here:
+  // AWS populates `reservation_effective_cost` and the SP equivalent with
+  // 0 (not NULL) for non-applicable rows, so COALESCE returns 0 for every
+  // Usage row and silently zeroes out ~90% of cost.
+  const litCol = `${prefix}line_item_line_item_type`;
+  const unblended = net && has('line_item_net_unblended_cost')
+    ? `${prefix}line_item_net_unblended_cost`
+    : `${prefix}line_item_unblended_cost`;
+  const riCol = net && has('reservation_net_effective_cost')
+    ? `${prefix}reservation_net_effective_cost`
+    : has('reservation_effective_cost') ? `${prefix}reservation_effective_cost` : null;
+  const spCol = net && has('savings_plan_net_savings_plan_effective_cost')
+    ? `${prefix}savings_plan_net_savings_plan_effective_cost`
+    : has('savings_plan_savings_plan_effective_cost') ? `${prefix}savings_plan_savings_plan_effective_cost` : null;
+
+  // Without either effective-cost family, amortized has nothing to amortize
+  // against — degrade to unblended, same as the old code.
+  if (riCol === null && spCol === null) {
+    return `COALESCE(${unblended}, 0)`;
   }
-  parts.push(`${prefix}line_item_unblended_cost`);
-  return `COALESCE(${parts.join(', ')}, 0)`;
+
+  const branches: string[] = [];
+  if (riCol !== null) {
+    branches.push(`WHEN ${litCol} = 'DiscountedUsage' THEN COALESCE(${riCol}, ${unblended}, 0)`);
+  }
+  if (spCol !== null) {
+    branches.push(`WHEN ${litCol} = 'SavingsPlanCoveredUsage' THEN COALESCE(${spCol}, ${unblended}, 0)`);
+  }
+  branches.push(`WHEN ${litCol} IN ('RIFee', 'SavingsPlanRecurringFee', 'SavingsPlanUpfrontFee', 'SavingsPlanNegation') THEN 0`);
+  return `CASE ${branches.join(' ')} ELSE COALESCE(${unblended}, 0) END`;
 }
 
 export function costExprFor(
@@ -67,7 +102,19 @@ export function costExprFor(
   const net = perspective === 'net';
   switch (metric) {
     case 'unblended': return unblendedExpr(prefix, net, has);
-    case 'blended': return blendedExpr(prefix, net, has);
     case 'amortized': return amortizedExpr(prefix, net, has);
+    case 'list': return listExpr(prefix, has);
   }
 }
+
+/** Line-item types that carry a list price. RI/SP fee rows have
+ *  `pricing_public_on_demand_cost = 0` (no retail equivalent) so the
+ *  `list` metric restricts to these types to avoid muddying the picture
+ *  with zero-cost rows that still inflate row counts and group-by buckets.
+ *
+ *  Mirrors what the Backstage AWS Cost plugin filters on. */
+export const LIST_METRIC_LINE_ITEM_TYPES: readonly string[] = [
+  'Usage',
+  'SavingsPlanCoveredUsage',
+  'DiscountedUsage',
+] as const;

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -50,7 +50,6 @@ const ALLOWED_CUR_COLUMNS = new Set([
   'line_item_resource_id',
   'line_item_usage_amount',
   'line_item_unblended_cost',
-  'line_item_blended_cost',
   'pricing_public_on_demand_cost',
   'line_item_line_item_type',
   'line_item_operation',

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -3,18 +3,29 @@ import type { DimensionId } from './branded.js';
 /** Which cost perspective backs the `cost` alias in every query.
  *  - `unblended`  — what you were actually billed; upfront RI/SP fees land
  *                   as a lump in their month.
- *  - `blended`    — consolidated-billing blended rate (weighted average of
- *                   usage rates across the accounts in the org). Reporting
- *                   construct; makes linked-account costs comparable.
  *  - `amortized`  — spreads RI/SP upfront payments over their term and uses
  *                   effective cost for covered usage. Best for run-rate and
  *                   forecasting.
+ *  - `list`       — hypothetical on-demand list price (`pricing_public_on_demand_cost`),
+ *                   ignoring all RI/SP discounts. Not money actually spent;
+ *                   shows what usage would have cost without commitments.
+ *                   When selected, queries are automatically restricted to
+ *                   usage-bearing line items (`Usage`, `SavingsPlanCoveredUsage`,
+ *                   `DiscountedUsage`) because RI/SP fee rows have no list price.
+ *
+ *  AWS's `blended` (consolidated-billing weighted-average) metric was
+ *  intentionally NOT shipped: AWS never extended blended math to Savings
+ *  Plans, so on any modern SP-based fleet it's nearly indistinguishable
+ *  from unblended and ships none of the chargeback fairness it was
+ *  originally designed for. Users on legacy configs with
+ *  `costMetric: 'blended'` are silently migrated to `'amortized'` at load
+ *  time (see cost-scope-validator.ts).
+ *
  *  The SQL expression that each value resolves to lives in
- *  packages/core/src/query/cost-metric.ts. Net-of-credits is a separate
- *  axis we haven't shipped yet; see `costPerspective` below when it lands. */
-export type CostMetric = 'unblended' | 'blended' | 'amortized';
+ *  packages/core/src/query/cost-metric.ts. */
+export type CostMetric = 'unblended' | 'amortized' | 'list';
 
-export const COST_METRICS: readonly CostMetric[] = ['unblended', 'blended', 'amortized'] as const;
+export const COST_METRICS: readonly CostMetric[] = ['unblended', 'amortized', 'list'] as const;
 
 /** Whether the cost column should be the as-billed ("gross") value or the
  *  post-credit/refund ("net") value. Orthogonal to the metric axis —
@@ -119,14 +130,14 @@ export interface CostScopeCapabilities {
    *  degrade to Unblended. Both columns ship only when the CUR has
    *  "Include Resource IDs" enabled. */
   readonly hasEffectiveCostColumns: boolean;
-  /** `line_item_blended_cost` is present. Usually true, but some CUR
-   *  configurations omit it — when missing we degrade Blended to
-   *  Unblended. */
-  readonly hasBlendedColumn: boolean;
   /** `line_item_net_unblended_cost` is present. Ships only when the
    *  CUR has "Include Net Columns" enabled. Without it, the Net
    *  perspective toggle falls back to Gross. */
   readonly hasNetColumns: boolean;
+  /** `pricing_public_on_demand_cost` is present. Almost always true
+   *  for CUR v2 exports but technically optional. Required for the
+   *  `list` metric — without it, list-price queries return zeros. */
+  readonly hasListPriceColumn: boolean;
 }
 
 export interface CostScopePreviewResult {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -394,10 +394,18 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const fetch = (async (): Promise<ReadonlySet<string>> => {
       try {
         const months = await listLocalMonths(ctx.dataDir, tier);
-        if (months.length === 0) return new Set<string>();
-        // First-month sample is enough — CUR schema is stable across
-        // months within a billing report (AWS bumps schema on CUR
-        // version changes, which is rare and user-initiated).
+        if (months.length === 0) {
+          // No data on disk for this tier — log loudly because the silent
+          // fallback used to surface as misleading "Degraded" warnings in
+          // Cost Scope when capability checks interpreted the empty set as
+          // "all columns missing."
+          logger.warn('column-probe: no months on disk', { tier, dataDir: ctx.dataDir });
+          return new Set<string>();
+        }
+        // Latest month sample is enough — CUR schema is stable across months
+        // within a billing report (AWS bumps schema on version changes, rare
+        // and user-initiated). Recent months also reflect any newly enabled
+        // optional columns whereas older months won't.
         const month = months.at(-1);
         const glob = `${ctx.dataDir}/aws/raw/${tier}-${String(month)}/*.parquet`;
         const rows = await ctx.db.runQuery(`DESCRIBE SELECT * FROM read_parquet('${glob}') LIMIT 0`);
@@ -407,10 +415,8 @@ export function createAppContext(ctx: IpcContext): AppContext {
           if (typeof name === 'string') cols.add(name);
         }
         return cols;
-      } catch {
-        // If the probe fails, return an empty set. Downstream code treats
-        // "unknown columns" as "assume present" to preserve previous
-        // behaviour — we only gate columns when we KNOW they're missing.
+      } catch (err: unknown) {
+        logger.warn(`column-probe: failed — ${err instanceof Error ? err.message : String(err)}`, { tier });
         return new Set<string>();
       }
     })();

--- a/packages/desktop/src/main/handlers/cost-scope.ts
+++ b/packages/desktop/src/main/handlers/cost-scope.ts
@@ -324,8 +324,8 @@ export function registerCostScopeHandlers(app: AppContext): void {
     return {
       hasEffectiveCostColumns:
         cols.has('reservation_effective_cost') && cols.has('savings_plan_savings_plan_effective_cost'),
-      hasBlendedColumn: cols.has('line_item_blended_cost'),
       hasNetColumns: cols.has('line_item_net_unblended_cost'),
+      hasListPriceColumn: cols.has('pricing_public_on_demand_cost'),
     };
   });
 

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -118,7 +118,7 @@ function clampRowLimit(n: number): number {
 
 function pickMetric(metric: CostMetric | undefined, cols: ReadonlySet<string>): CostMetric {
   if (metric === 'amortized' && cols.has('reservation_effective_cost') && cols.has('savings_plan_savings_plan_effective_cost')) return 'amortized';
-  if (metric === 'blended' && cols.has('line_item_blended_cost')) return 'blended';
+  if (metric === 'list' && cols.has('pricing_public_on_demand_cost')) return 'list';
   return 'unblended';
 }
 

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -290,7 +290,7 @@ export class MockCostApi implements CostApi {
     });
   }
   getCostScopeCapabilities(): Promise<CostScopeCapabilities> {
-    return Promise.resolve({ hasEffectiveCostColumns: true, hasBlendedColumn: true, hasNetColumns: true });
+    return Promise.resolve({ hasEffectiveCostColumns: true, hasNetColumns: true, hasListPriceColumn: true });
   }
   revealCostScopeFolder(): Promise<void> { return Promise.resolve(); }
   queryExplorerOverview(): Promise<ExplorerOverviewResult> {

--- a/packages/ui/src/components/list-metric-banner.tsx
+++ b/packages/ui/src/components/list-metric-banner.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import type { CostMetric } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+
+export function ListMetricBanner(): React.JSX.Element | null {
+  const api = useCostApi();
+  const [metric, setMetric] = useState<CostMetric | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getCostScope().then(scope => {
+      if (!cancelled) setMetric(scope.costMetric);
+    }).catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [api]);
+
+  if (metric !== 'list') return null;
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/10 px-4 py-3 text-sm">
+      <span aria-hidden="true" className="mt-0.5 text-warning">⚠</span>
+      <div className="flex flex-col gap-0.5">
+        <span className="font-medium text-text-primary">Showing on-demand list price &mdash; not money spent</span>
+        <span className="text-text-secondary">
+          The active cost metric is <strong className="text-text-primary">On-demand list price</strong>.
+          Numbers reflect what usage would have cost at AWS retail rates with no RI/SP discounts.
+          Change in Cost Scope &rarr; Cost metric to see actual billed cost.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -12,7 +12,7 @@ import type {
   ExclusionRule,
   Dimension,
 } from '@costgoblin/core/browser';
-import { BUILTIN_EXCLUSION_RULES, COST_METRICS, DEFAULT_COST_SCOPE, DEFAULT_LAG_DAYS, asDimensionId } from '@costgoblin/core/browser';
+import { BUILTIN_EXCLUSION_RULES, DEFAULT_COST_SCOPE, DEFAULT_LAG_DAYS, asDimensionId } from '@costgoblin/core/browser';
 import { getDimensionId } from '../lib/dimensions.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
@@ -20,19 +20,43 @@ import { formatDollars } from '../components/format.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js';
 import { Button } from '../components/ui/button.js';
 
-const METRIC_LABELS: Record<CostMetric, { label: string; description: string }> = {
-  unblended: {
-    label: 'Unblended',
-    description: 'Cost as billed each day. Upfront RI/SP fees land as a lump on their purchase day; RI/SP-covered usage shows the discounted rate. Default.',
-  },
-  blended: {
-    label: 'Blended',
-    description: 'Consolidated-billing rate — each linked account is charged the org-wide weighted average for the same usage type. Accounting construct for per-account comparisons; not what you actually pay.',
-  },
+type MetricTone = 'recommended' | 'specific' | 'rarely';
+
+interface MetricMeta {
+  readonly label: string;
+  readonly description: string;
+  readonly tag: { readonly text: string; readonly tone: MetricTone };
+}
+
+const METRIC_LABELS: Record<CostMetric, MetricMeta> = {
   amortized: {
     label: 'Amortized',
-    description: 'Spreads RI/SP purchases over the commitment term and uses effective cost for covered usage. Smooths the bursts in Unblended; best for run-rate and forecasting.',
+    tag: { text: 'Recommended', tone: 'recommended' },
+    description:
+      'Spreads RI/SP purchases evenly across the commitment term and charges each covered hour at its effective amortized rate. What AWS Cost Explorer shows by default. Use this for run-rate, forecasting, team chargeback, and almost any "what did this cost?" question.',
   },
+  list: {
+    label: 'On-demand list price',
+    tag: { text: 'Fair chargeback & sizing', tone: 'specific' },
+    description:
+      'What your usage would have cost at AWS retail rates with no commitments — hypothetical, NOT money spent. The fair view for per-team chargeback when RIs/SPs are bought at the org level: AWS allocates commitment discounts unevenly across teams, so two teams running identical workloads can have very different Amortized/Unblended bills. List price values every hour at the same retail rate. Also useful for sizing future RI/SP purchases and comparing to vendor list rates. RI/SP fee rows are filtered out automatically.',
+  },
+  unblended: {
+    label: 'Unblended',
+    tag: { text: 'Recommended for reconciliation', tone: 'recommended' },
+    description:
+      'Matches your AWS invoice line by line. Upfront RI/SP fees appear as one-day spikes in the month bought; covered usage shows the discounted rate. Use this when reconciling with finance, auditing a specific charge, or trying to answer "what did AWS actually bill on day X?".',
+  },
+};
+
+/** Display order, top to bottom. Independent from COST_METRICS (the type
+ *  enum's order) so the picker can lead with the recommended choice. */
+const METRIC_DISPLAY_ORDER: readonly CostMetric[] = ['amortized', 'list', 'unblended'];
+
+const TAG_TONE_CLASSES: Record<MetricTone, string> = {
+  recommended: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30',
+  specific: 'bg-amber-500/15 text-amber-300 border border-amber-500/30',
+  rarely: 'bg-text-muted/10 text-text-muted border border-text-muted/20',
 };
 
 function formatExcluded(cost: number, rows: number): string {
@@ -626,7 +650,7 @@ export function CostScopeView(): React.JSX.Element {
     api.getCostScopeCapabilities().then(setCapabilities).catch(() => {
       // capabilities are advisory — if the probe fails, assume
       // everything is present (matches legacy behaviour).
-      setCapabilities({ hasEffectiveCostColumns: true, hasBlendedColumn: true, hasNetColumns: true });
+      setCapabilities({ hasEffectiveCostColumns: true, hasNetColumns: true, hasListPriceColumn: true });
     });
   }, [api]);
 
@@ -826,7 +850,7 @@ export function CostScopeView(): React.JSX.Element {
               <CardTitle className="text-base">Cost metric</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              {COST_METRICS.map(metric => (
+              {METRIC_DISPLAY_ORDER.map(metric => (
                 <label key={metric} className="flex items-start gap-3 cursor-pointer group">
                   <input
                     type="radio"
@@ -837,8 +861,13 @@ export function CostScopeView(): React.JSX.Element {
                     className="mt-0.5 accent-accent"
                   />
                   <div>
-                    <span className="text-sm font-medium text-text-primary">{METRIC_LABELS[metric].label}</span>
-                    <span className="ml-2 text-xs text-text-muted">{METRIC_LABELS[metric].description}</span>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-text-primary">{METRIC_LABELS[metric].label}</span>
+                      <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wider ${TAG_TONE_CLASSES[METRIC_LABELS[metric].tag.tone]}`}>
+                        {METRIC_LABELS[metric].tag.text}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-text-muted leading-relaxed">{METRIC_LABELS[metric].description}</p>
                     {metric === 'amortized' && capabilities !== null && !capabilities.hasEffectiveCostColumns && (
                       <div className="mt-1 text-xs text-warning">
                         Degraded &mdash; falls back to Unblended because your CUR export doesn&apos;t include{' '}
@@ -849,10 +878,16 @@ export function CostScopeView(): React.JSX.Element {
                         an accurate amortized view (takes one billing cycle to land).
                       </div>
                     )}
-                    {metric === 'blended' && capabilities !== null && !capabilities.hasBlendedColumn && (
+                    {metric === 'list' && capabilities !== null && !capabilities.hasListPriceColumn && (
                       <div className="mt-1 text-xs text-warning">
                         Degraded &mdash; falls back to Unblended because your CUR export doesn&apos;t include{' '}
-                        <code className="mx-1 text-[11px]">line_item_blended_cost</code>.
+                        <code className="mx-1 text-[11px]">pricing_public_on_demand_cost</code>.
+                      </div>
+                    )}
+                    {metric === 'list' && (capabilities === null || capabilities.hasListPriceColumn) && (
+                      <div className="mt-1 text-xs text-warning">
+                        Hypothetical &mdash; this is not money you actually paid. Queries are restricted to usage rows ({' '}
+                        <code className="text-[11px]">Usage</code>, <code className="text-[11px]">SavingsPlanCoveredUsage</code>, <code className="text-[11px]">DiscountedUsage</code>) because RI/SP fee rows have no list price.
                       </div>
                     )}
                   </div>

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -30,6 +30,7 @@ import {
 } from '../lib/dimensions.js';
 import { FilterBar } from '../components/filter-bar.js';
 import { FilterActiveBanner } from '../components/filter-active-banner.js';
+import { ListMetricBanner } from '../components/list-metric-banner.js';
 import {
   DateRangePicker,
   getDefaultDateRange,
@@ -272,6 +273,8 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
           defaults={defaultsFromDimensions(dimensions)}
         />
       )}
+
+      <ListMetricBanner />
 
       <FilterActiveBanner />
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -209,7 +209,7 @@ export function ExplorerView(): React.JSX.Element {
   useEffect(() => {
     if (capabilities === null) return;
     if (costMetric === 'amortized' && !capabilities.hasEffectiveCostColumns) setCostMetric('unblended');
-    if (costMetric === 'blended' && !capabilities.hasBlendedColumn) setCostMetric('unblended');
+    if (costMetric === 'list' && !capabilities.hasListPriceColumn) setCostMetric('unblended');
     if (costPerspective === 'net' && !capabilities.hasNetColumns) setCostPerspective('gross');
   }, [capabilities, costMetric, costPerspective]);
 
@@ -563,9 +563,9 @@ function ExplorerOptions({
   onCostPerspectiveChange,
 }: ExplorerOptionsProps): React.JSX.Element {
   const metricOptions: { value: CostMetric; label: string; available: boolean }[] = [
-    { value: 'unblended', label: 'Unblended', available: true },
-    { value: 'blended', label: 'Blended', available: capabilities?.hasBlendedColumn !== false },
     { value: 'amortized', label: 'Amortized', available: capabilities?.hasEffectiveCostColumns !== false },
+    { value: 'list', label: 'List price', available: capabilities?.hasListPriceColumn !== false },
+    { value: 'unblended', label: 'Unblended', available: true },
   ];
   const netAvailable = capabilities?.hasNetColumns !== false;
 


### PR DESCRIPTION
## Summary

Several issues compounded into "the cost numbers in Cost Scope are not trustworthy" — this PR addresses them as one coherent pass.

### Fixes

- **Amortized cost was returning ~2% of unblended.** The old SQL was a flat `COALESCE(reservation_effective_cost, savings_plan_savings_plan_effective_cost, line_item_unblended_cost, 0)`. AWS populates the effective-cost columns with `0` (not `NULL`) for non-applicable rows, so COALESCE returned `0` for every Usage/Tax/Credit row and silently zeroed out ~90% of cost. Replaced with a `CASE` on `line_item_type` matching AWS Cost Explorer's amortized definition: `DiscountedUsage` and `SavingsPlanCoveredUsage` swap in their effective cost; RI/SP fee rows are zeroed (already amortized into covered-usage above); everything else uses `line_item_unblended_cost`. Verified against a real CUR sample: the OLD formula returned $1,842 for a month where unblended was $89,170 (2%). The NEW formula returns $58,383 (65%).

- **Column-probe failures were silent.** Probe used to swallow exceptions and a downstream check then interpreted the empty column set as "all optional columns missing", surfacing as confusing "Degraded" warnings in Cost Scope. Now logs a `warn` on both the no-data and failure paths so the root cause is visible.

### New metric

- **On-demand list price** — backed by `pricing_public_on_demand_cost` with the source auto-restricted to `Usage` / `SavingsPlanCoveredUsage` / `DiscountedUsage` (RI/SP fee rows have no list price). Reconciles with the Backstage AWS Cost plugin's metric and provides a fair per-team chargeback view when commitments are bought centrally and AWS allocates them unevenly across teams. A persistent warning banner appears on every dashboard while this metric is active.

### Removals

- **Blended metric retired.** AWS never extended blended math to Savings Plans, so on an SP-based fleet it's nearly indistinguishable from Unblended and provides none of the chargeback fairness it was originally designed for. Existing configs with \`costMetric: "blended"\` are silently migrated to \`"amortized"\` at load time. Skipping \`line_item_blended_cost\` also keeps the CUR export lighter — one fewer column to enable.

- **Two confusing built-in exclusion rules retired.** \`builtin:ri-sp-purchases\` and \`builtin:commitment-covered-usage\` let users assemble incoherent fee-vs-coverage combinations. Both are now either subsumed by the metric choice (purchases) or deferred to a future dedicated commitment-coverage view (covered usage). They're dropped from the seed and stripped silently from loaded configs; if \`ri-sp-purchases\` was enabled, the metric migrates to \`list\` so the spirit of the user's prior choice is preserved.

### UX

- **Cost Scope picker reordered by usefulness** with explicit recommendation tags (Amortized: *Recommended*; On-demand list price: *Fair chargeback & sizing*; Unblended: *Recommended for reconciliation*). Descriptions rewritten to tell users when to actually pick each metric.

- **README CUR setup clarified.** CUR 2.0 Data Exports uses column-by-column SQL selection — the "Include resource IDs" / "Include net columns" checkboxes from legacy CUR no longer apply. The old dual-table layout plus priority matrix has been replaced with a single copy-pasteable `SELECT` grouped by **Required / Recommended / Optional** tier, with inline comments mapping each recommended column to its UI feature. The metric × perspective priority table is preserved in a collapsed `<details>` reference block. Added a clear "why no `line_item_blended_cost`" note explaining the SP-coverage gap.

## Migration impact

- Configs with `costMetric: "blended"` load successfully and are auto-migrated to `"amortized"` (with a warn log).
- Configs containing the retired exclusion rules load successfully — the rules are silently dropped, and if `ri-sp-purchases` was enabled, the metric becomes `list`.
- No CUR re-export required. Users not needing Amortized/Net/List can ignore the recommended-column note; the app continues to work on an Unblended-only export.