### PR TITLE
ci: pin Node.js to 22 LTS (fix e2e via electron/electron#51619)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Generate fixtures


### PR DESCRIPTION
## Why

Every PR's `test-e2e` shards have been red since main was bumped past Node 24.16. Root cause is an upstream bug, not anything in our code:

- `extract-zip@2.0.1` (used by electron's `install.js`) depends on `yauzl@^2`
- `yauzl@2` silently breaks under Node.js **24.16.0+** / 26.1.0+
- electron's postinstall calls extract-zip, the extraction silently no-ops, `node_modules/electron/dist/` ends up with only `locales/`, no `path.txt` is written, npm postinstall exits 0
- Every e2e shard then dies at `_electron.launch()` with *"Electron failed to install correctly"*

Tracking: [electron/electron#51619](https://github.com/electron/electron/issues/51619)

## What this PR does

Pin every CI job's `node-version` from `24` to `22`. Node 22 LTS predates the regression and is comfortably inside the project's `engines.node: ">=20"` range.

## Why not the upstream "fix"

The issue thread suggests `"overrides": { "yauzl": "^3.3.1" }`, but per AviVahl's comment that doesn't actually work — `extract-zip@2.0.1` pins `yauzl@^2` in its own `package.json` and the override doesn't propagate. The only reliable workarounds (link2xt's `execSync('unzip ...')` patch, AviVahl's `@zip.js/zip.js` rewrite) require vendoring/patching `node_modules/electron/install.js`, which is intrusive. Pinning Node is a one-line workaround that doesn't touch any deps or runtime behavior.

## Why not pin Ubuntu

The runner image (`ubuntu-latest` vs `ubuntu-22.04`) doesn't matter — `setup-node` downloads the same Node.js binary regardless of the underlying Ubuntu version. I confirmed this empirically on #325 (commit `02c0b8f`), where pinning `runs-on: ubuntu-22.04` left e2e red.

## Follow-up

When extract-zip ships a yauzl@3-based release, or when electron migrates off extract-zip, we can lift the Node 22 pin and move back to whatever the project's current target is.