### PR TITLE
ci(release): auto-generate release notes from PRs/commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,26 @@ jobs:
           APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
+
+  # electron-builder creates the GitHub release but leaves the body empty.
+  # Populate it with GitHub's auto-generated changelog (PR titles + commit
+  # subjects since the previous tag) after all matrix builds have finished
+  # uploading their assets. Single job to avoid the matrix-vs-release-body
+  # race that would happen if we patched the body from inside the build job.
+  notes:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          NOTES=$(gh api -X POST "repos/${GITHUB_REPO}/releases/generate-notes" \
+            -f tag_name="${TAG}" \
+            --jq .body)
+          gh release edit "${TAG}" --notes "${NOTES}"


### PR DESCRIPTION
## Why

Current releases land with an empty body (see [v0.2.4](https://github.com/etiennechabert/cost-goblin/releases/tag/v0.2.4)): \`electron-builder --publish always\` creates the GitHub release and uploads installers, but doesn't fill the changelog.

## Change

Adds a single \`notes\` job to the existing \`Release\` workflow. It runs **after** the build matrix and calls GitHub's [\`POST /repos/{owner}/{repo}/releases/generate-notes\`](https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release) API to build a changelog from PR titles + commit subjects since the previous tag, then patches the release body via \`gh release edit\`.

\`\`\`yaml
notes:
  needs: build
  runs-on: ubuntu-latest
  permissions:
    contents: write
  steps:
    - name: Set release notes
      env:
        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        GITHUB_REPO: ${{ github.repository }}
        TAG: ${{ github.ref_name }}
      run: |
        set -euo pipefail
        NOTES=$(gh api -X POST "repos/${GITHUB_REPO}/releases/generate-notes" \
          -f tag_name="${TAG}" \
          --jq .body)
        gh release edit "${TAG}" --notes "${NOTES}"
\`\`\`

## Design notes

- **Separate job, runs after build.** Inside the matrix we'd race four parallel runners patching the same release body. The \`needs: build\` makes it sequential.
- **`gh` + raw API, not `softprops/action-gh-release`.** Same effect as the [ez-wishlist-overlay workflow](https://github.com/etiennechabert/ez-wishlist-overlay/blob/main/.github/workflows/release.yml)'s \`generate_release_notes: true\` flag, but without adding a new third-party action dependency to the supply chain. Uses what GitHub-hosted runners already have (\`gh\` CLI).
- **No change to the existing build matrix or signing config.** Pure addition.

## Verification

Can't dry-run a tag push, but the API call is documented and \`gh release edit --notes\` is a standard operation. Worst case for a tag push: the notes job fails, the release still has all the binaries (same as today's empty release), and we re-run the job manually.

## Next release

Once merged, the next \`git tag v0.2.5 && git push --tags\` should produce a release with the standard "## What's Changed" section.