### PR TITLE
ci: require version bump on PR, verify tag matches package.json on re…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,47 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+  version-bump:
+    name: version bumped past latest release
+    runs-on: ubuntu-latest
+    # PR-only: pushes to main shouldn't fail (main IS where the version
+    # eventually equals a fresh tag, between bump and tagging).
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Full tag history needed to find the latest `v*` tag.
+          fetch-depth: 0
+      - name: Verify package.json version is ahead of latest released tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkg_v=$(node -p "require('./package.json').version")
+          desktop_v=$(node -p "require('./packages/desktop/package.json').version")
+          if [ "$pkg_v" != "$desktop_v" ]; then
+            echo "::error::root package.json ($pkg_v) and packages/desktop/package.json ($desktop_v) disagree — bump both together."
+            exit 1
+          fi
+          latest=$(git tag -l 'v*' | sed 's/^v//' | sort -V | tail -n1)
+          echo "package.json version: $pkg_v"
+          echo "Latest released tag : ${latest:-<none>}"
+          if [ -z "$latest" ]; then
+            echo "No v* tag exists yet — nothing to compare against; skipping."
+            exit 0
+          fi
+          if [ "$pkg_v" = "$latest" ]; then
+            echo "::error file=package.json::version $pkg_v matches the latest released tag v$latest — bump it before merging so the next release has a fresh version to tag."
+            exit 1
+          fi
+          # Defence-in-depth: also reject regressions, since release.yml's
+          # tag-vs-package.json guard only catches them at tag-push time.
+          highest=$(printf '%s\n%s\n' "$pkg_v" "$latest" | sort -V | tail -n1)
+          if [ "$highest" != "$pkg_v" ]; then
+            echo "::error file=package.json::version $pkg_v is older than the latest released tag v$latest."
+            exit 1
+          fi
+          echo "OK: $pkg_v > $latest"
+
   sonarcloud:
     runs-on: ubuntu-latest
     needs: [lint, test-unit, test-e2e]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,24 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Fail fast if someone tags `v0.2.5` without first bumping
+      # package.json to 0.2.5. Without this guard, electron-builder
+      # publishes artifacts named for the old version and (worse) silently
+      # skips uploads when the matching release is >2h old, leaving a
+      # tag with no binaries attached — exactly what happened to v0.2.5.
+      - name: Verify package.json version matches tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/v}"
+          pkg_v=$(node -p "require('./package.json').version")
+          desktop_v=$(node -p "require('./packages/desktop/package.json').version")
+          if [ "$pkg_v" != "$tag" ] || [ "$desktop_v" != "$tag" ]; then
+            echo "::error::Tag v$tag does not match package.json ($pkg_v) / packages/desktop/package.json ($desktop_v). Bump both, push, then re-tag."
+            exit 1
+          fi
+          echo "OK: tag v$tag == package.json $pkg_v"
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -12492,7 +12492,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1041.0",
         "@aws-sdk/client-s3": "^3.1041.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
…lease

Two-layer guard adapted from ez-wishlist-overlay to prevent a repeat of v0.2.5, where a tag was pushed without bumping package.json. electron-builder read 0.2.4 from package.json, tried to publish to the pre-existing v0.2.4 release, and silently skipped every asset because the release was >2h old — leaving v0.2.5 with no binaries.

- ci.yml: new PR-only `version-bump` job. Fails if root and desktop package.json disagree, or if the version equals/trails the latest v* tag. Forces every merged PR to ship with a version already past the last release.

- release.yml: pre-flight step on tag push. Fails fast if the tag does not match package.json (and packages/desktop/package.json) before electron-builder ever runs, so a mismatch produces a red workflow instead of a ghost tag.

- Bump 0.2.4 -> 0.2.5 so the new check goes green on this PR.