### PR TITLE
ci(release): pass --repo to gh release edit in notes job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,4 +90,4 @@ jobs:
           NOTES=$(gh api -X POST "repos/${GITHUB_REPO}/releases/generate-notes" \
             -f tag_name="${TAG}" \
             --jq .body)
-          gh release edit "${TAG}" --notes "${NOTES}"
+          gh release edit "${TAG}" --repo "${GITHUB_REPO}" --notes "${NOTES}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -12492,7 +12492,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1041.0",
         "@aws-sdk/client-s3": "^3.1041.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

The `notes` job in `release.yml` has no `actions/checkout` step (it doesn't need source code — it only patches the release body via the GitHub API). `gh release edit` infers the target repo from the surrounding git checkout, so without one it bails with:

> `failed to run git: fatal: not a git repository (or any of the parent directories): .git`

That's what failed in [v0.2.5's run](https://github.com/etiennechabert/cost-goblin/actions/runs/27057816723/job/79865836166). The binaries all published cleanly (v0.2.5 has 18 assets) — only the body patch failed, leaving the release with an empty description.

Fix: pass `--repo "${GITHUB_REPO}"` explicitly so the job stays checkout-free. `gh api` already gets the repo from its URL path, so it was unaffected.

Also bumps `0.2.5` → `0.2.6` to satisfy the version-bump check from #328 (the latest released tag is now `v0.2.5`).

### Follow-up

The empty v0.2.5 release body can be backfilled manually with the same `gh api releases/generate-notes` + `gh release edit` combo if you want it populated.