### PR TITLE
mcp: add format parameter (markdown|json|csv) to every tool

### DIFF
--- a/packages/mcp/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp/src/__tests__/mcp-server.test.ts
@@ -428,6 +428,64 @@ describe('MCP server E2E', () => {
     expect(text).toMatch(/error|select|not allowed/i);
   });
 
+  // ---------- format parameter ----------
+
+  it('format=json returns a JSON-parseable response with meta and tables', async () => {
+    const { text } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      format: 'json',
+    });
+    const parsed = JSON.parse(text) as { title: string; meta: { label: string; value: unknown; type: string }[]; tables: { columns: { key: string; type: string }[]; rows: unknown[][] }[] };
+    expect(parsed.title).toMatch(/Costs by/);
+    expect(parsed.meta.find(m => m.label === 'Total')?.type).toBe('currency');
+    expect(typeof parsed.meta.find(m => m.label === 'Total')?.value).toBe('number');
+    expect(parsed.tables[0]?.columns.find(c => c.key === 'cost')?.type).toBe('currency');
+    expect(parsed.tables[0]?.rows.length).toBeGreaterThan(0);
+    const firstRow = parsed.tables[0]?.rows[0];
+    expect(Array.isArray(firstRow)).toBe(true);
+    expect(typeof firstRow?.[1]).toBe('number');
+  });
+
+  it('format=csv returns CSV with header and data rows', async () => {
+    const { text } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      format: 'csv',
+    });
+    const lines = text.split('\n');
+    const dataLines = lines.filter(l => !l.startsWith('#') && l.length > 0);
+    expect(dataLines[0]).toContain('Service');
+    expect(dataLines[0]).toContain('Cost');
+    expect(dataLines.length).toBeGreaterThan(1);
+    expect(dataLines[1]).toMatch(/^[^,]+,[\d.]+,/);
+  });
+
+  it('format=markdown is the default and matches no-format behavior', async () => {
+    const { text: defaultText } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+    });
+    const { text: mdText } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      format: 'markdown',
+    });
+    expect(defaultText).toBe(mdText);
+    expect(defaultText).toContain('|');
+    expect(defaultText).toMatch(/## Costs by/);
+  });
+
+  it('format=json on get_cost_overview includes multiple tables', async () => {
+    const { text } = await client.callTool('get_cost_overview', {
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      format: 'json',
+    });
+    const parsed = JSON.parse(text) as { tables: { title?: string }[] };
+    expect(parsed.tables.length).toBeGreaterThanOrEqual(1);
+    expect(parsed.tables.some(t => t.title === 'Top Services')).toBe(true);
+  });
+
   // ---------- Error handling ----------
 
   it('returns error for invalid dimension', async () => {

--- a/packages/mcp/src/formatters/result.ts
+++ b/packages/mcp/src/formatters/result.ts
@@ -1,0 +1,194 @@
+import { markdownTable, type ColumnDef, type Alignment } from './markdown-table.js';
+import { formatDollars, formatPercent, formatDelta, formatNumber } from './cost.js';
+
+export type ResponseFormat = 'markdown' | 'json' | 'csv';
+
+export type CellType = 'string' | 'currency' | 'percent' | 'change' | 'number' | 'delta';
+
+export type Cell = string | number | null;
+
+export interface Column {
+  readonly key: string;
+  readonly header: string;
+  readonly type?: CellType;
+  readonly align?: Alignment;
+}
+
+export interface Table {
+  readonly title?: string;
+  readonly columns: readonly Column[];
+  readonly rows: readonly (readonly Cell[])[];
+  readonly footer?: string;
+}
+
+export interface MetaField {
+  readonly label: string;
+  readonly value: string | number;
+  readonly type?: CellType;
+}
+
+export interface StructuredResult {
+  readonly title: string;
+  readonly meta?: readonly MetaField[];
+  readonly notes?: readonly string[];
+  readonly tables?: readonly Table[];
+}
+
+function formatCell(value: Cell, type: CellType | undefined): string {
+  if (value === null) return '';
+  if (type === undefined || type === 'string') {
+    return typeof value === 'string' ? value : String(value);
+  }
+  if (typeof value !== 'number') return value;
+  switch (type) {
+    case 'currency': return formatDollars(value);
+    case 'percent': return Number.isFinite(value) ? `${value.toFixed(1)}%` : 'N/A';
+    case 'change': return formatPercent(value);
+    case 'delta': return formatDelta(value);
+    case 'number': return formatNumber(value);
+  }
+}
+
+function defaultAlign(type: CellType | undefined, explicit: Alignment | undefined): Alignment {
+  if (explicit !== undefined) return explicit;
+  if (type === 'currency' || type === 'percent' || type === 'change' || type === 'delta' || type === 'number') return 'right';
+  return 'left';
+}
+
+function formatTableMarkdown(table: Table): string {
+  const colDefs: ColumnDef[] = table.columns.map(c => ({
+    header: c.header,
+    align: defaultAlign(c.type, c.align),
+  }));
+  const rows = table.rows.map(row => row.map((cell, i) => formatCell(cell, table.columns[i]?.type)));
+  const sections: string[] = [];
+  if (table.title !== undefined && table.title.length > 0) {
+    sections.push(`### ${table.title}`);
+    sections.push('');
+  }
+  sections.push(markdownTable(colDefs, rows));
+  if (table.footer !== undefined && table.footer.length > 0) {
+    sections.push(table.footer);
+  }
+  return sections.join('\n');
+}
+
+export function formatAsMarkdown(result: StructuredResult): string {
+  const parts: string[] = [];
+  parts.push(`## ${result.title}`);
+  parts.push('');
+  if (result.meta !== undefined) {
+    for (const field of result.meta) {
+      parts.push(`**${field.label}**: ${formatCell(field.value, field.type)}`);
+    }
+    parts.push('');
+  }
+  if (result.notes !== undefined) {
+    for (const note of result.notes) {
+      parts.push(note);
+      parts.push('');
+    }
+  }
+  if (result.tables !== undefined) {
+    for (let i = 0; i < result.tables.length; i++) {
+      const table = result.tables[i];
+      if (table === undefined) continue;
+      parts.push(formatTableMarkdown(table));
+      if (i < result.tables.length - 1) parts.push('');
+    }
+  }
+  return parts.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+}
+
+interface JsonTable {
+  readonly title?: string;
+  readonly columns: readonly { key: string; header: string; type: CellType }[];
+  readonly rows: readonly (readonly Cell[])[];
+  readonly footer?: string;
+}
+
+interface JsonMetaField {
+  readonly label: string;
+  readonly value: string | number;
+  readonly type: CellType;
+}
+
+interface JsonResult {
+  readonly title: string;
+  readonly meta?: readonly JsonMetaField[];
+  readonly notes?: readonly string[];
+  readonly tables?: readonly JsonTable[];
+}
+
+export function formatAsJson(result: StructuredResult): string {
+  const out: JsonResult = {
+    title: result.title,
+    ...(result.meta !== undefined ? {
+      meta: result.meta.map(f => ({ label: f.label, value: f.value, type: f.type ?? 'string' })),
+    } : {}),
+    ...(result.notes !== undefined && result.notes.length > 0 ? { notes: result.notes } : {}),
+    ...(result.tables !== undefined ? {
+      tables: result.tables.map(t => ({
+        ...(t.title !== undefined ? { title: t.title } : {}),
+        columns: t.columns.map(c => ({ key: c.key, header: c.header, type: c.type ?? 'string' })),
+        rows: t.rows,
+        ...(t.footer !== undefined && t.footer.length > 0 ? { footer: t.footer.trim() } : {}),
+      })),
+    } : {}),
+  };
+  return JSON.stringify(out, null, 2);
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+  return value;
+}
+
+function cellToCsv(value: Cell, type: CellType | undefined): string {
+  if (value === null) return '';
+  if (typeof value === 'number') {
+    if (type === 'currency' || type === 'delta') return value.toFixed(2);
+    if (type === 'percent' || type === 'change') return value.toFixed(2);
+    return String(value);
+  }
+  return value;
+}
+
+export function formatAsCsv(result: StructuredResult): string {
+  const lines: string[] = [];
+  lines.push(`# ${result.title}`);
+  if (result.meta !== undefined) {
+    for (const field of result.meta) {
+      lines.push(`# ${field.label}: ${formatCell(field.value, field.type)}`);
+    }
+  }
+  if (result.notes !== undefined) {
+    for (const note of result.notes) lines.push(`# ${note.replaceAll('\n', ' ')}`);
+  }
+  if (result.tables !== undefined) {
+    for (let ti = 0; ti < result.tables.length; ti++) {
+      const table = result.tables[ti];
+      if (table === undefined) continue;
+      if (ti > 0) lines.push('');
+      if (table.title !== undefined && table.title.length > 0) lines.push(`# ${table.title}`);
+      lines.push(table.columns.map(c => csvEscape(c.header)).join(','));
+      for (const row of table.rows) {
+        lines.push(row.map((cell, i) => csvEscape(cellToCsv(cell, table.columns[i]?.type))).join(','));
+      }
+      if (table.footer !== undefined && table.footer.length > 0) {
+        lines.push(`# ${table.footer.trim().replace(/^\*|\*$/g, '')}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+export function formatResult(result: StructuredResult, format: ResponseFormat): string {
+  switch (format) {
+    case 'markdown': return formatAsMarkdown(result);
+    case 'json': return formatAsJson(result);
+    case 'csv': return formatAsCsv(result);
+  }
+}

--- a/packages/mcp/src/tools/explore-data.ts
+++ b/packages/mcp/src/tools/explore-data.ts
@@ -6,15 +6,15 @@ import {
 } from '@costgoblin/core';
 import type { DateRange } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars, formatNumber } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
   defaultDateRange,
+  resolveFormat,
+  structuredToolResult,
   toDateRange,
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 
 const VALID_COLUMNS: ReadonlySet<string> = new Set([
@@ -35,8 +35,10 @@ export async function exploreData(
     groupByColumns?: readonly string[] | undefined;
     sort?: { column: string; direction: 'asc' | 'desc' } | undefined;
     limit?: number | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const dateRange: DateRange = params.dateRange !== undefined
     ? toDateRange(params.dateRange)
     : defaultDateRange();
@@ -98,24 +100,24 @@ export async function exploreData(
 
     const rows = await ctx.runQuery(sql);
 
-    const columns: ColumnDef[] = [
-      ...groupByColumns.map(c => ({ header: c })),
-      { header: 'Cost', align: 'right' as const },
-      { header: 'Rows', align: 'right' as const },
+    const columns: Column[] = [
+      ...groupByColumns.map((c): Column => ({ key: c, header: c })),
+      { key: 'cost', header: 'Cost', type: 'currency' },
+      { key: 'row_count', header: 'Rows', type: 'number' },
     ];
 
-    const tableRows = rows.map(r => [
-      ...groupByColumns.map(c => toStr(r[c])),
-      formatDollars(toNum(r['cost'])),
-      formatNumber(toNum(r['row_count'])),
+    const tableRows: Cell[][] = rows.map(r => [
+      ...groupByColumns.map((c): Cell => toStr(r[c])),
+      toNum(r['cost']),
+      toNum(r['row_count']),
     ]);
 
-    const sections: string[] = [];
-    sections.push(`## Aggregated Data (${dateRange.start} to ${dateRange.end})`);
-    sections.push(`**Group By**: ${groupByColumns.join(', ')}`);
-    sections.push('');
-    sections.push(markdownTable(columns, tableRows));
-    return toolResult(sections.join('\n'));
+    const result: StructuredResult = {
+      title: `Aggregated Data (${dateRange.start} to ${dateRange.end})`,
+      meta: [{ label: 'Group By', value: groupByColumns.join(', ') }],
+      tables: [{ columns, rows: tableRows }],
+    };
+    return structuredToolResult(result, format);
   }
 
   const sortExpr = params.sort !== undefined && isValidColumn(params.sort.column)
@@ -141,30 +143,29 @@ export async function exploreData(
 
   const rows = await ctx.runQuery(sql);
 
-  const columns: ColumnDef[] = [
-    { header: 'Date' },
-    { header: 'Account' },
-    { header: 'Service' },
-    { header: 'Resource' },
-    { header: 'Cost', align: 'right' },
+  const columns: Column[] = [
+    { key: 'date', header: 'Date' },
+    { key: 'account', header: 'Account' },
+    { key: 'service', header: 'Service' },
+    { key: 'resource', header: 'Resource' },
+    { key: 'cost', header: 'Cost', type: 'currency' },
   ];
 
-  const tableRows = rows.map(r => {
+  const tableRows: Cell[][] = rows.map(r => {
     const resourceId = toStr(r['resource_id']);
     return [
       toStr(r['usage_date']),
       toStr(r['account_name']) || toStr(r['account_id']),
       toStr(r['service']),
       resourceId.length > 30 ? `${resourceId.slice(0, 27)}...` : resourceId,
-      formatDollars(toNum(r['cost'])),
+      toNum(r['cost']),
     ];
   });
 
-  const sections: string[] = [];
-  sections.push(`## Raw Data (${dateRange.start} to ${dateRange.end})`);
-  sections.push(`**Showing**: ${String(rows.length)} rows (sorted by |cost|)`);
-  sections.push('');
-  sections.push(markdownTable(columns, tableRows));
-
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `Raw Data (${dateRange.start} to ${dateRange.end})`,
+    meta: [{ label: 'Showing', value: `${String(rows.length)} rows (sorted by |cost|)` }],
+    tables: [{ columns, rows: tableRows }],
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/get-cost-overview.ts
+++ b/packages/mcp/src/tools/get-cost-overview.ts
@@ -5,23 +5,24 @@ import {
   logger,
 } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
   defaultDateRange,
+  resolveFormat,
+  structuredToolResult,
   toDateRange,
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 import type { DateRange, FilterMap } from '@costgoblin/core';
 
 export async function getCostOverview(
   ctx: McpContext,
-  params: { dateRange?: { start: string; end: string } | undefined },
+  params: { dateRange?: { start: string; end: string } | undefined; format?: string | undefined },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const dateRange: DateRange = params.dateRange !== undefined
     ? toDateRange(params.dateRange)
     : defaultDateRange();
@@ -85,37 +86,40 @@ export async function getCostOverview(
     ...dimensions.tags.filter(d => d.enabled !== false).map(d => d.label),
   ];
 
-  const sections: string[] = [];
-  sections.push(`## Cost Overview (${dateRange.start} to ${dateRange.end})`);
-  sections.push('');
-  sections.push(`**Total Cost**: ${formatDollars(serviceTotalCost)}`);
-  sections.push(`**Data Range**: ${months[0] ?? '?'} to ${months[months.length - 1] ?? '?'}`);
-  sections.push(`**Available Dimensions**: ${enabledDims.join(', ')}`);
-
-  sections.push('');
-  sections.push('### Top Services');
-  const svcCols: ColumnDef[] = [
-    { header: 'Service' },
-    { header: 'Cost', align: 'right' },
-    { header: '% of Total', align: 'right' },
+  const svcColumns: Column[] = [
+    { key: 'service', header: 'Service' },
+    { key: 'cost', header: 'Cost', type: 'currency' },
+    { key: 'pct', header: '% of Total', type: 'percent' },
   ];
-  const svcRows = topServices.map(([name, cost]) => [
+  const svcRows: Cell[][] = topServices.map(([name, cost]) => [
     name,
-    formatDollars(cost),
-    serviceTotalCost > 0 ? `${((cost / serviceTotalCost) * 100).toFixed(1)}%` : '0%',
+    cost,
+    serviceTotalCost > 0 ? (cost / serviceTotalCost) * 100 : 0,
   ]);
-  sections.push(markdownTable(svcCols, svcRows));
+
+  const tables: Table[] = [
+    { title: 'Top Services', columns: svcColumns, rows: svcRows },
+  ];
 
   if (topAccounts.length > 0) {
-    sections.push('');
-    sections.push('### Top Accounts');
-    const acctCols: ColumnDef[] = [
-      { header: 'Account' },
-      { header: 'Cost', align: 'right' },
-    ];
-    const acctRows = topAccounts.map(([name, cost]) => [name, formatDollars(cost)]);
-    sections.push(markdownTable(acctCols, acctRows));
+    tables.push({
+      title: 'Top Accounts',
+      columns: [
+        { key: 'account', header: 'Account' },
+        { key: 'cost', header: 'Cost', type: 'currency' },
+      ],
+      rows: topAccounts.map(([name, cost]): Cell[] => [name, cost]),
+    });
   }
 
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `Cost Overview (${dateRange.start} to ${dateRange.end})`,
+    meta: [
+      { label: 'Total Cost', value: serviceTotalCost, type: 'currency' },
+      { label: 'Data Range', value: `${months[0] ?? '?'} to ${months[months.length - 1] ?? '?'}` },
+      { label: 'Available Dimensions', value: enabledDims.join(', ') },
+    ],
+    tables,
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/get-filter-values.ts
+++ b/packages/mcp/src/tools/get-filter-values.ts
@@ -7,18 +7,18 @@ import {
   logger,
 } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars } from '../formatters/cost.js';
 import { truncateFooter, truncateRows } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
   defaultDateRange,
   lookupDimension,
   resolveEntityName,
+  resolveFormat,
+  structuredToolResult,
   toDateRange,
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 import type { DateRange } from '@costgoblin/core';
 
@@ -29,8 +29,10 @@ export async function getFilterValues(
     filters?: Record<string, readonly string[]> | undefined;
     dateRange?: { start: string; end: string } | undefined;
     limit?: number | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const dimensionId = params.dimensionId;
   const dateRange: DateRange = params.dateRange !== undefined
     ? toDateRange(params.dateRange)
@@ -103,26 +105,26 @@ export async function getFilterValues(
 
   const totalCost = items.reduce((sum, i) => sum + i.cost, 0);
 
-  const columns: ColumnDef[] = [
-    { header: dimLabel },
-    { header: 'Cost', align: 'right' },
-    { header: '% Total', align: 'right' },
+  const columns: Column[] = [
+    { key: 'value', header: dimLabel },
+    { key: 'cost', header: 'Cost', type: 'currency' },
+    { key: 'pct', header: '% Total', type: 'percent' },
   ];
 
   const { visible, hiddenCount, hiddenCost } = truncateRows(items, limit, i => i.cost);
-  const tableRows = visible.map(i => [
+  const tableRows: Cell[][] = visible.map(i => [
     i.value,
-    formatDollars(i.cost),
-    totalCost > 0 ? `${((i.cost / totalCost) * 100).toFixed(1)}%` : '0%',
+    i.cost,
+    totalCost > 0 ? (i.cost / totalCost) * 100 : 0,
   ]);
 
-  const sections: string[] = [];
-  sections.push(`## ${dimLabel} Values (${dateRange.start} to ${dateRange.end})`);
-  sections.push('');
-  sections.push(`**Total**: ${formatDollars(totalCost)} across ${String(items.length)} values`);
-  sections.push('');
-  sections.push(markdownTable(columns, tableRows));
-  sections.push(truncateFooter(hiddenCount, hiddenCost));
-
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `${dimLabel} Values (${dateRange.start} to ${dateRange.end})`,
+    meta: [
+      { label: 'Total', value: totalCost, type: 'currency' },
+      { label: 'Distinct Values', value: items.length, type: 'number' },
+    ],
+    tables: [{ columns, rows: tableRows, footer: truncateFooter(hiddenCount, hiddenCost) }],
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -21,6 +21,12 @@ const dateRangeSchema = z.object({
 const filtersSchema = z.record(z.string(), z.array(z.string())).optional()
   .describe('Filter map: dimension ID -> array of values to include');
 
+const formatSchema = z.enum(['markdown', 'json', 'csv']).optional().describe(
+  'Response format. "markdown" (default) for human-readable tables. ' +
+  '"json" for machine-readable rows the LLM can ingest directly without re-parsing markdown — use this when reasoning over many rows or chaining queries. ' +
+  '"csv" for downstream tooling.',
+);
+
 export function registerTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
     'get_cost_overview',
@@ -28,6 +34,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
       description: 'Get a high-level overview of cloud costs: total spend, top services, top accounts, available dimensions. Start here.',
       inputSchema: {
         dateRange: dateRangeSchema,
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -43,10 +50,13 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
     'list_dimensions',
     {
       description: 'List all available dimensions (groupBy/filter fields) with their IDs, labels, types, and descriptions.',
+      inputSchema: {
+        format: formatSchema,
+      },
     },
-    async () => {
+    async (params) => {
       try {
-        return await listDimensions(ctx);
+        return await listDimensions(ctx, params);
       } catch (err: unknown) {
         return toolError(err instanceof Error ? err.message : String(err));
       }
@@ -62,6 +72,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         dateRange: dateRangeSchema,
         filters: filtersSchema,
         limit: z.number().optional().describe('Max values to return (default 50)'),
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -82,6 +93,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         dateRange: dateRangeSchema,
         filters: filtersSchema,
         limit: z.number().optional().describe('Max rows to return (default 15)'),
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -101,6 +113,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         groupBy: z.string().optional().describe('Dimension ID to group by (default: "service")'),
         dateRange: dateRangeSchema,
         filters: filtersSchema,
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -123,6 +136,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         deltaThreshold: z.number().optional().describe('Min absolute delta to include (default $1)'),
         percentThreshold: z.number().optional().describe('Min % change to include (default 5%)'),
         limit: z.number().optional().describe('Max rows per section (default 15)'),
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -143,6 +157,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         dimension: z.string().describe('Dimension ID the entity belongs to'),
         dateRange: dateRangeSchema,
         filters: filtersSchema,
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -164,6 +179,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         filters: filtersSchema,
         minCost: z.number().optional().describe('Min cost per resource to include (default $10)'),
         limit: z.number().optional().describe('Max resources to show (default 20)'),
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -189,6 +205,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
           direction: z.enum(['asc', 'desc']),
         }).optional().describe('Sort order'),
         limit: z.number().optional().describe('Max rows (default 50, max 200)'),
+        format: formatSchema,
       },
     },
     async (params) => {
@@ -208,6 +225,7 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         sql: z.string().describe('SQL query (SELECT/WITH only). A "costs" CTE with columns: usage_date, account_id, account_name, region, service, service_family, line_item_type, operation, usage_type, description, resource_id, usage_amount, cost, list_cost, plus tag columns.'),
         dateRange: dateRangeSchema,
         limit: z.number().optional().describe('Max rows (default 100, max 500)'),
+        format: formatSchema,
       },
     },
     async (params) => {

--- a/packages/mcp/src/tools/list-dimensions.ts
+++ b/packages/mcp/src/tools/list-dimensions.ts
@@ -1,23 +1,24 @@
 import { tagDimColumn } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
-import { toolResult } from './tool-helpers.js';
+import type { Cell, Column, StructuredResult } from '../formatters/result.js';
+import { resolveFormat, structuredToolResult } from './tool-helpers.js';
 
 export async function listDimensions(
   ctx: McpContext,
+  params: { format?: string | undefined } = {},
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const dimensions = await ctx.getDimensions();
 
-  const columns: ColumnDef[] = [
-    { header: 'ID' },
-    { header: 'Label' },
-    { header: 'Type' },
-    { header: 'Enabled' },
-    { header: 'Description' },
+  const columns: Column[] = [
+    { key: 'id', header: 'ID' },
+    { key: 'label', header: 'Label' },
+    { key: 'type', header: 'Type' },
+    { key: 'enabled', header: 'Enabled' },
+    { key: 'description', header: 'Description' },
   ];
 
-  const rows: string[][] = [];
-
+  const rows: Cell[][] = [];
   for (const dim of dimensions.builtIn) {
     rows.push([
       dim.name,
@@ -27,7 +28,6 @@ export async function listDimensions(
       dim.description ?? '',
     ]);
   }
-
   for (const dim of dimensions.tags) {
     rows.push([
       tagDimColumn(dim),
@@ -38,6 +38,10 @@ export async function listDimensions(
     ]);
   }
 
-  const table = markdownTable(columns, rows);
-  return toolResult(`## Available Dimensions\n\n${table}\n\nUse the \`id\` column value as the \`groupBy\`, \`dimensionId\`, or filter key in other tools.`);
+  const result: StructuredResult = {
+    title: 'Available Dimensions',
+    tables: [{ columns, rows }],
+    notes: ['Use the `id` column value as the `groupBy`, `dimensionId`, or filter key in other tools.'],
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/query-costs.ts
+++ b/packages/mcp/src/tools/query-costs.ts
@@ -4,21 +4,21 @@ import {
 } from '@costgoblin/core';
 import type { DateRange, DimensionId } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars } from '../formatters/cost.js';
 import { truncateRows, truncateFooter } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
   defaultDateRange,
   lookupDimension,
   resolveEntityName,
+  resolveFormat,
+  structuredToolResult,
   toDimensionId,
   toDateRange,
   toFilterMap,
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 
 export async function queryCosts(
@@ -28,8 +28,10 @@ export async function queryCosts(
     dateRange?: { start: string; end: string } | undefined;
     filters?: Record<string, readonly string[]> | undefined;
     limit?: number | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const groupBy: DimensionId = toDimensionId(params.groupBy);
   const dateRange: DateRange = params.dateRange !== undefined
     ? toDateRange(params.dateRange)
@@ -86,29 +88,26 @@ export async function queryCosts(
 
   const { label: dimLabel } = lookupDimension(groupBy, opts.dimensions);
 
-  const columns: ColumnDef[] = [
-    { header: dimLabel },
-    { header: 'Cost', align: 'right' },
-    { header: '% Total', align: 'right' },
-    ...topServices.map(s => ({ header: s, align: 'right' as const })),
+  const columns: Column[] = [
+    { key: 'entity', header: dimLabel },
+    { key: 'cost', header: 'Cost', type: 'currency' },
+    { key: 'pct', header: '% Total', type: 'percent' },
+    ...topServices.map((s): Column => ({ key: `svc_${s}`, header: s, type: 'currency' })),
   ];
 
   const { visible, hiddenCount, hiddenCost } = truncateRows(costRows, limit, r => r.totalCost);
 
-  const tableRows = visible.map(r => [
+  const tableRows: Cell[][] = visible.map(r => [
     r.entity,
-    formatDollars(r.totalCost),
-    grandTotal > 0 ? `${((r.totalCost / grandTotal) * 100).toFixed(1)}%` : '0%',
-    ...topServices.map(s => formatDollars(r.serviceCosts[s] ?? 0)),
+    r.totalCost,
+    grandTotal > 0 ? (r.totalCost / grandTotal) * 100 : 0,
+    ...topServices.map((s): Cell => r.serviceCosts[s] ?? 0),
   ]);
 
-  const sections: string[] = [];
-  sections.push(`## Costs by ${dimLabel} (${dateRange.start} to ${dateRange.end})`);
-  sections.push('');
-  sections.push(`**Total**: ${formatDollars(grandTotal)}`);
-  sections.push('');
-  sections.push(markdownTable(columns, tableRows));
-  sections.push(truncateFooter(hiddenCount, hiddenCost));
-
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `Costs by ${dimLabel} (${dateRange.start} to ${dateRange.end})`,
+    meta: [{ label: 'Total', value: grandTotal, type: 'currency' }],
+    tables: [{ columns, rows: tableRows, footer: truncateFooter(hiddenCount, hiddenCost) }],
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/query-daily-costs.ts
+++ b/packages/mcp/src/tools/query-daily-costs.ts
@@ -5,18 +5,18 @@ import {
 } from '@costgoblin/core';
 import type { DateRange, DimensionId } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
   defaultDateRange,
   lookupDimension,
+  resolveFormat,
+  structuredToolResult,
   toDimensionId,
   toDateRange,
   toFilterMap,
   toNum,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 
 export async function queryDailyCosts(
@@ -25,8 +25,10 @@ export async function queryDailyCosts(
     groupBy?: string | undefined;
     dateRange?: { start: string; end: string } | undefined;
     filters?: Record<string, readonly string[]> | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const groupBy: DimensionId = params.groupBy !== undefined
     ? toDimensionId(params.groupBy)
     : asDimensionId('service');
@@ -88,19 +90,18 @@ export async function queryDailyCosts(
 
   const { label: dimLabel } = lookupDimension(groupBy, opts.dimensions);
 
-  const columns: ColumnDef[] = [
-    { header: 'Date' },
-    { header: 'Total', align: 'right' },
-    ...topGroups.map(g => ({ header: g, align: 'right' as const })),
-  ];
-
   const startMs = new Date(`${dateRange.start}T00:00:00Z`).getTime();
   const endMs = new Date(`${dateRange.end}T00:00:00Z`).getTime();
   const windowDays = Math.round((endMs - startMs) / 86_400_000) + 1;
   const useWeekly = windowDays > 14;
 
-  let tableRows: string[][];
+  const columns: Column[] = [
+    { key: 'date', header: useWeekly ? 'Week' : 'Date' },
+    { key: 'total', header: 'Total', type: 'currency' },
+    ...topGroups.map((g): Column => ({ key: `grp_${g}`, header: g, type: 'currency' })),
+  ];
 
+  let tableRows: Cell[][];
   if (useWeekly) {
     const weekMap = new Map<string, Record<string, number>>();
     for (const [date, breakdown] of sortedDays) {
@@ -118,31 +119,29 @@ export async function queryDailyCosts(
       }
     }
     const sortedWeeks = [...weekMap.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-    tableRows = sortedWeeks.map(([week, breakdown]) => {
+    tableRows = sortedWeeks.map(([week, breakdown]): Cell[] => {
       const dayTotal = Object.values(breakdown).reduce((s, v) => s + v, 0);
       return [
         `w/${week}`,
-        formatDollars(dayTotal),
-        ...topGroups.map(g => formatDollars(breakdown[g] ?? 0)),
+        dayTotal,
+        ...topGroups.map((g): Cell => breakdown[g] ?? 0),
       ];
     });
   } else {
-    tableRows = sortedDays.map(([date, breakdown]) => {
+    tableRows = sortedDays.map(([date, breakdown]): Cell[] => {
       const dayTotal = Object.values(breakdown).reduce((s, v) => s + v, 0);
       return [
         date,
-        formatDollars(dayTotal),
-        ...topGroups.map(g => formatDollars(breakdown[g] ?? 0)),
+        dayTotal,
+        ...topGroups.map((g): Cell => breakdown[g] ?? 0),
       ];
     });
   }
 
-  const sections: string[] = [];
-  sections.push(`## ${useWeekly ? 'Weekly' : 'Daily'} Costs by ${dimLabel} (${dateRange.start} to ${dateRange.end})`);
-  sections.push('');
-  sections.push(`**Total**: ${formatDollars(totalCost)}`);
-  sections.push('');
-  sections.push(markdownTable(columns, tableRows));
-
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `${useWeekly ? 'Weekly' : 'Daily'} Costs by ${dimLabel} (${dateRange.start} to ${dateRange.end})`,
+    meta: [{ label: 'Total', value: totalCost, type: 'currency' }],
+    tables: [{ columns, rows: tableRows }],
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/query-entity-detail.ts
+++ b/packages/mcp/src/tools/query-entity-detail.ts
@@ -5,20 +5,20 @@ import {
 } from '@costgoblin/core';
 import type { DateRange, DimensionId, EntityRef } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
   defaultDateRange,
   lookupDimension,
   resolveEntityName,
+  resolveFormat,
+  structuredToolResult,
   toDimensionId,
   toDateRange,
   toFilterMap,
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 
 export async function queryEntityDetail(
@@ -28,8 +28,10 @@ export async function queryEntityDetail(
     dimension: string;
     dateRange?: { start: string; end: string } | undefined;
     filters?: Record<string, readonly string[]> | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const entity: EntityRef = asEntityRef(params.entity);
   const dimension: DimensionId = toDimensionId(params.dimension);
   const dateRange: DateRange = params.dateRange !== undefined
@@ -76,55 +78,46 @@ export async function queryEntityDetail(
 
   const { label: dimLabel } = lookupDimension(dimension, opts.dimensions);
 
-  const sections: string[] = [];
-  sections.push(`## ${params.entity} (${dimLabel})`);
-  sections.push(`**Period**: ${dateRange.start} to ${dateRange.end}`);
-  sections.push(`**Total Cost**: ${formatDollars(totalCost)}`);
-  sections.push('');
+  const tables: Table[] = [];
 
   const svcSlices = [...serviceMap.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
   if (svcSlices.length > 0) {
-    sections.push('### Service Breakdown');
-    const svcCols: ColumnDef[] = [
-      { header: 'Service' },
-      { header: 'Cost', align: 'right' },
-      { header: '% Total', align: 'right' },
+    const svcCols: Column[] = [
+      { key: 'service', header: 'Service' },
+      { key: 'cost', header: 'Cost', type: 'currency' },
+      { key: 'pct', header: '% Total', type: 'percent' },
     ];
-    const svcRows = svcSlices.map(([name, cost]) => [
+    const svcRows: Cell[][] = svcSlices.map(([name, cost]) => [
       name,
-      formatDollars(cost),
-      totalCost > 0 ? `${((cost / totalCost) * 100).toFixed(1)}%` : '0%',
+      cost,
+      totalCost > 0 ? (cost / totalCost) * 100 : 0,
     ]);
-    sections.push(markdownTable(svcCols, svcRows));
-    sections.push('');
+    tables.push({ title: 'Service Breakdown', columns: svcCols, rows: svcRows });
   }
 
   const acctSlices = [...accountCostMap.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
   if (acctSlices.length > 1) {
-    sections.push('### Account Breakdown');
-    const acctCols: ColumnDef[] = [
-      { header: 'Account' },
-      { header: 'Cost', align: 'right' },
-      { header: '% Total', align: 'right' },
+    const acctCols: Column[] = [
+      { key: 'account', header: 'Account' },
+      { key: 'cost', header: 'Cost', type: 'currency' },
+      { key: 'pct', header: '% Total', type: 'percent' },
     ];
-    const acctRows = acctSlices.map(([id, cost]) => [
+    const acctRows: Cell[][] = acctSlices.map(([id, cost]) => [
       resolveEntityName(id, accountMap),
-      formatDollars(cost),
-      totalCost > 0 ? `${((cost / totalCost) * 100).toFixed(1)}%` : '0%',
+      cost,
+      totalCost > 0 ? (cost / totalCost) * 100 : 0,
     ]);
-    sections.push(markdownTable(acctCols, acctRows));
-    sections.push('');
+    tables.push({ title: 'Account Breakdown', columns: acctCols, rows: acctRows });
   }
 
   const sortedDays = [...dailyMap.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   if (sortedDays.length > 0 && sortedDays.length <= 31) {
-    sections.push('### Daily Trend');
-    const dailyCols: ColumnDef[] = [
-      { header: 'Date' },
-      { header: 'Cost', align: 'right' },
+    const dailyCols: Column[] = [
+      { key: 'date', header: 'Date' },
+      { key: 'cost', header: 'Cost', type: 'currency' },
     ];
-    const dailyRows = sortedDays.map(([date, data]) => [date, formatDollars(data.cost)]);
-    sections.push(markdownTable(dailyCols, dailyRows));
+    const dailyRows: Cell[][] = sortedDays.map(([date, data]) => [date, data.cost]);
+    tables.push({ title: 'Daily Trend', columns: dailyCols, rows: dailyRows });
   } else if (sortedDays.length > 31) {
     const weekMap = new Map<string, number>();
     for (const [date, data] of sortedDays) {
@@ -134,16 +127,23 @@ export async function queryEntityDetail(
       const weekKey = monday.toISOString().slice(0, 10);
       weekMap.set(weekKey, (weekMap.get(weekKey) ?? 0) + data.cost);
     }
-    sections.push('### Weekly Trend');
-    const weeklyCols: ColumnDef[] = [
-      { header: 'Week' },
-      { header: 'Cost', align: 'right' },
+    const weeklyCols: Column[] = [
+      { key: 'week', header: 'Week' },
+      { key: 'cost', header: 'Cost', type: 'currency' },
     ];
-    const weeklyRows = [...weekMap.entries()]
+    const weeklyRows: Cell[][] = [...weekMap.entries()]
       .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([week, cost]) => [`w/${week}`, formatDollars(cost)]);
-    sections.push(markdownTable(weeklyCols, weeklyRows));
+      .map(([week, cost]) => [`w/${week}`, cost]);
+    tables.push({ title: 'Weekly Trend', columns: weeklyCols, rows: weeklyRows });
   }
 
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `${params.entity} (${dimLabel})`,
+    meta: [
+      { label: 'Period', value: `${dateRange.start} to ${dateRange.end}` },
+      { label: 'Total Cost', value: totalCost, type: 'currency' },
+    ],
+    tables,
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/query-missing-tags.ts
+++ b/packages/mcp/src/tools/query-missing-tags.ts
@@ -5,13 +5,14 @@ import {
 } from '@costgoblin/core';
 import type { DateRange, DimensionId } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars } from '../formatters/cost.js';
 import { truncateRows, truncateFooter } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
   defaultDateRange,
   resolveEntityName,
+  resolveFormat,
+  structuredToolResult,
   toDimensionId,
   toDollars,
   toDateRange,
@@ -19,7 +20,6 @@ import {
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 
 export async function queryMissingTags(
@@ -30,8 +30,10 @@ export async function queryMissingTags(
     filters?: Record<string, readonly string[]> | undefined;
     minCost?: number | undefined;
     limit?: number | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const tagDimension: DimensionId = toDimensionId(params.tagDimension);
   const dateRange: DateRange = params.dateRange !== undefined
     ? toDateRange(params.dateRange)
@@ -98,37 +100,46 @@ export async function queryMissingTags(
     nonResourceCost += toNum(row['cost']);
   }
 
-  const sections: string[] = [];
-  sections.push(`## Missing Tags: ${params.tagDimension} (${dateRange.start} to ${dateRange.end})`);
-  sections.push('');
-  sections.push(`**Actionable**: ${String(actionableCount)} resources, ${formatDollars(actionableCost)}`);
-  sections.push(`**Likely Untaggable**: ${String(untaggableCount)} resources, ${formatDollars(untaggableCost)}`);
-  sections.push(`**Non-Resource Cost**: ${formatDollars(nonResourceCost)} (tax, support, credits, etc.)`);
-  sections.push('');
-
   const actionableItems = items.filter(i => i.bucket === 'actionable').sort((a, b) => b.cost - a.cost);
 
+  const notes: string[] = [];
+  const tables: Table[] = [];
+
   if (actionableItems.length > 0) {
-    sections.push('### Top Actionable Untagged Resources');
-    sections.push('');
-    const columns: ColumnDef[] = [
-      { header: 'Account' },
-      { header: 'Service' },
-      { header: 'Resource' },
-      { header: 'Cost', align: 'right' },
+    const columns: Column[] = [
+      { key: 'account', header: 'Account' },
+      { key: 'service', header: 'Service' },
+      { key: 'resource', header: 'Resource' },
+      { key: 'cost', header: 'Cost', type: 'currency' },
     ];
     const { visible, hiddenCount, hiddenCost } = truncateRows(actionableItems, limit, i => i.cost);
-    const tableRows = visible.map(i => [
+    const rows: Cell[][] = visible.map(i => [
       i.accountName,
       i.service,
       i.resourceId.length > 40 ? `${i.resourceId.slice(0, 37)}...` : i.resourceId,
-      formatDollars(i.cost),
+      i.cost,
     ]);
-    sections.push(markdownTable(columns, tableRows));
-    sections.push(truncateFooter(hiddenCount, hiddenCost));
+    tables.push({
+      title: 'Top Actionable Untagged Resources',
+      columns,
+      rows,
+      footer: truncateFooter(hiddenCount, hiddenCost),
+    });
   } else {
-    sections.push('*No actionable untagged resources above the cost threshold.*');
+    notes.push('*No actionable untagged resources above the cost threshold.*');
   }
 
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `Missing Tags: ${params.tagDimension} (${dateRange.start} to ${dateRange.end})`,
+    meta: [
+      { label: 'Actionable Resources', value: actionableCount, type: 'number' },
+      { label: 'Actionable Cost', value: actionableCost, type: 'currency' },
+      { label: 'Likely Untaggable Resources', value: untaggableCount, type: 'number' },
+      { label: 'Likely Untaggable Cost', value: untaggableCost, type: 'currency' },
+      { label: 'Non-Resource Cost', value: nonResourceCost, type: 'currency' },
+    ],
+    notes,
+    tables,
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/query-trends.ts
+++ b/packages/mcp/src/tools/query-trends.ts
@@ -6,13 +6,15 @@ import {
 } from '@costgoblin/core';
 import type { DateRange, DimensionId, TrendRow } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { formatDollars, formatPercent, formatDelta, truncateRows, truncateFooter } from '../formatters/cost.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
+import { formatDollars, truncateRows, truncateFooter } from '../formatters/cost.js';
+import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
   defaultDateRange,
   lookupDimension,
   resolveEntityName,
+  resolveFormat,
+  structuredToolResult,
   toDimensionId,
   toDollars,
   toDateRange,
@@ -20,7 +22,6 @@ import {
   toNum,
   toStr,
   toolError,
-  toolResult,
 } from './tool-helpers.js';
 
 export async function queryTrends(
@@ -32,8 +33,10 @@ export async function queryTrends(
     deltaThreshold?: number | undefined;
     percentThreshold?: number | undefined;
     limit?: number | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const groupBy: DimensionId = toDimensionId(params.groupBy);
   const dateRange: DateRange = params.dateRange !== undefined
     ? toDateRange(params.dateRange)
@@ -95,53 +98,47 @@ export async function queryTrends(
 
   const { label: dimLabel } = lookupDimension(groupBy, opts.dimensions);
 
-  const sections: string[] = [];
-  sections.push(`## Cost Trends by ${dimLabel} (${dateRange.start} to ${dateRange.end})`);
-  sections.push('');
-
-  const trendColumns: ColumnDef[] = [
-    { header: dimLabel },
-    { header: 'Current', align: 'right' },
-    { header: 'Previous', align: 'right' },
-    { header: 'Delta', align: 'right' },
-    { header: 'Change', align: 'right' },
+  const trendColumns: Column[] = [
+    { key: 'entity', header: dimLabel },
+    { key: 'current', header: 'Current', type: 'currency' },
+    { key: 'previous', header: 'Previous', type: 'currency' },
+    { key: 'delta', header: 'Delta', type: 'delta' },
+    { key: 'change', header: 'Change', type: 'change' },
   ];
 
-  if (increases.length > 0) {
-    sections.push(`### Top Increases (${formatDollars(totalIncrease)} total)`);
-    sections.push('');
-    const { visible, hiddenCount, hiddenCost } = truncateRows(increases, limit, r => r.delta);
-    const tableRows = visible.map(r => [
-      r.entity,
-      formatDollars(r.currentCost),
-      formatDollars(r.previousCost),
-      formatDelta(r.delta),
-      formatPercent(r.percentChange),
-    ]);
-    sections.push(markdownTable(trendColumns, tableRows));
-    sections.push(truncateFooter(hiddenCount, hiddenCost));
-  } else {
-    sections.push('*No significant increases found.*');
-  }
+  const tables: Table[] = [];
+  const notes: string[] = [];
 
-  sections.push('');
+  if (increases.length > 0) {
+    const { visible, hiddenCount, hiddenCost } = truncateRows(increases, limit, r => r.delta);
+    const rows: Cell[][] = visible.map(r => [r.entity, r.currentCost, r.previousCost, r.delta, r.percentChange]);
+    tables.push({
+      title: `Top Increases (${formatDollars(totalIncrease)} total)`,
+      columns: trendColumns,
+      rows,
+      footer: truncateFooter(hiddenCount, hiddenCost),
+    });
+  } else {
+    notes.push('*No significant increases found.*');
+  }
 
   if (savings.length > 0) {
-    sections.push(`### Top Savings (${formatDollars(totalSavings)} total)`);
-    sections.push('');
     const { visible, hiddenCount, hiddenCost } = truncateRows(savings, limit, r => Math.abs(r.delta));
-    const tableRows = visible.map(r => [
-      r.entity,
-      formatDollars(r.currentCost),
-      formatDollars(r.previousCost),
-      formatDelta(r.delta),
-      formatPercent(r.percentChange),
-    ]);
-    sections.push(markdownTable(trendColumns, tableRows));
-    sections.push(truncateFooter(hiddenCount, hiddenCost));
+    const rows: Cell[][] = visible.map(r => [r.entity, r.currentCost, r.previousCost, r.delta, r.percentChange]);
+    tables.push({
+      title: `Top Savings (${formatDollars(totalSavings)} total)`,
+      columns: trendColumns,
+      rows,
+      footer: truncateFooter(hiddenCount, hiddenCost),
+    });
   } else {
-    sections.push('*No significant savings found.*');
+    notes.push('*No significant savings found.*');
   }
 
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `Cost Trends by ${dimLabel} (${dateRange.start} to ${dateRange.end})`,
+    notes,
+    tables,
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/run-sql.ts
+++ b/packages/mcp/src/tools/run-sql.ts
@@ -7,8 +7,14 @@ import {
   logger,
 } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
-import { markdownTable, type ColumnDef } from '../formatters/markdown-table.js';
-import { toStr, toolError, toolResult } from './tool-helpers.js';
+import type { Cell, Column, StructuredResult } from '../formatters/result.js';
+import {
+  resolveFormat,
+  structuredToolResult,
+  toStr,
+  toolError,
+  toolResult,
+} from './tool-helpers.js';
 
 const MAX_LIMIT = 500;
 
@@ -24,8 +30,10 @@ export async function runSql(
     sql: string;
     limit?: number | undefined;
     dateRange?: { start: string; end: string } | undefined;
+    format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const format = resolveFormat(params.format);
   const userSql = params.sql.trim();
   const limit = Math.min(params.limit ?? 100, MAX_LIMIT);
 
@@ -101,24 +109,37 @@ export async function runSql(
   }
   const columnNames = Object.keys(firstRow);
 
-  const columns: ColumnDef[] = columnNames.map(name => ({ header: name }));
-  const tableRows = rows.map(r =>
-    columnNames.map(name => {
+  const columns: Column[] = columnNames.map(name => {
+    const sample = firstRow[name];
+    return {
+      key: name,
+      header: name,
+      type: typeof sample === 'number' ? 'number' : 'string',
+    };
+  });
+
+  const tableRows: Cell[][] = rows.map(r =>
+    columnNames.map((name): Cell => {
       const val = r[name];
-      if (typeof val === 'number') {
-        return Number.isInteger(val) ? String(val) : val.toFixed(4);
-      }
+      if (typeof val === 'number') return val;
+      if (typeof val === 'bigint') return Number(val);
       return toStr(val);
     }),
   );
 
-  const sections: string[] = [];
-  sections.push(`## Query Result (${String(rows.length)} rows)`);
-  sections.push('');
-  sections.push(markdownTable(columns, tableRows));
+  const meta: { label: string; value: string | number; type?: 'number' }[] = [
+    { label: 'Rows', value: rows.length, type: 'number' },
+  ];
+  const notes: string[] = [];
   if (rows.length >= limit) {
-    sections.push(`\n*Results limited to ${String(limit)} rows.*`);
+    notes.push(`*Results limited to ${String(limit)} rows.*`);
   }
 
-  return toolResult(sections.join('\n'));
+  const result: StructuredResult = {
+    title: `Query Result`,
+    meta,
+    notes,
+    tables: [{ columns, rows: tableRows }],
+  };
+  return structuredToolResult(result, format);
 }

--- a/packages/mcp/src/tools/tool-helpers.ts
+++ b/packages/mcp/src/tools/tool-helpers.ts
@@ -19,6 +19,7 @@ import type {
   TagValue,
 } from '@costgoblin/core';
 import type { McpContext, RawRow } from '../context.js';
+import { formatResult, type ResponseFormat, type StructuredResult } from '../formatters/result.js';
 
 export function toNum(v: unknown): number {
   if (typeof v === 'number') return v;
@@ -127,6 +128,18 @@ export function toolError(message: string): { content: [{ type: 'text'; text: st
 
 export function toolResult(text: string): { content: [{ type: 'text'; text: string }] } {
   return { content: [{ type: 'text' as const, text }] };
+}
+
+export function structuredToolResult(
+  result: StructuredResult,
+  format: ResponseFormat,
+): { content: [{ type: 'text'; text: string }] } {
+  return toolResult(formatResult(result, format));
+}
+
+export function resolveFormat(raw: string | undefined): ResponseFormat {
+  if (raw === 'json' || raw === 'csv' || raw === 'markdown') return raw;
+  return 'markdown';
 }
 
 export function lookupDimension(dimensionId: string, dimensions: DimensionsConfig): { label: string; found: boolean } {


### PR DESCRIPTION
Closes #338.

## Summary

Every MCP cost-returning tool now accepts a `format` parameter:

- `markdown` (default) — preserves the current human-readable output verbatim.
- `json` — emits a JSON object with `title`, `meta` (typed fields), and `tables` (typed columns + raw row values). Lets the LLM ingest many rows without re-parsing a markdown table.
- `csv` — header line + quoted values, with comments for the title and metadata.

## Implementation

- New `packages/mcp/src/formatters/result.ts` defines `StructuredResult` (title, meta, notes, tables) with typed cells. Three formatters (`formatAsMarkdown`, `formatAsJson`, `formatAsCsv`) dispatch from `formatResult(result, format)`.
- Every tool was refactored to compute a `StructuredResult` first, then format. Cell values stay as raw numbers; format-time helpers (`formatDollars`, `formatPercent`, etc.) only run for markdown/csv. JSON receives raw numbers and column-level type hints (`currency`, `percent`, `change`, `delta`, `number`, `string`).
- A new `change` cell type is used by `query_trends` for signed period-over-period deltas; `percent` is now an unsigned ratio (used by `% of Total` columns in `query_costs`, `get_cost_overview`, etc.). Previously the trends-style `formatPercent` was leaking a `+` sign into ratio columns when I first wired the refactor; the new split keeps each tool's display semantics intact.
- New tests cover the json shape (parseable object, raw numeric values, typed columns), csv shape (header + quoted data rows), and that `format: 'markdown'` is identical to the default.

Validated against the running dev MCP server (port 19532) — markdown, json, and csv round-trip for `query_costs`, `query_trends`, and `get_cost_overview`.