### PR TITLE
mcp: prepend data-coverage banner to every tool response

### DIFF
--- a/packages/mcp/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp/src/__tests__/mcp-server.test.ts
@@ -428,6 +428,49 @@ describe('MCP server E2E', () => {
     expect(text).toMatch(/error|select|not allowed/i);
   });
 
+  // ---------- data-coverage banner ----------
+
+  it('every response includes a data-coverage banner', async () => {
+    const { text } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+    });
+    expect(text).toMatch(/\*Data coverage:/);
+    expect(text).toMatch(/Latest day: \d{4}-\d{2}-\d{2}/);
+  });
+
+  it('coverage banner makes missing requested periods explicit on partial overlap', async () => {
+    // 2025-12 is missing, 2026-01 is present in fixtures — banner should call this out
+    const { text } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2025-12-01', end: '2026-01-31' },
+    });
+    expect(text).toMatch(/Missing periods in your requested range: 2025-12/);
+  });
+
+  it('coverage is included as a structured field when format=json', async () => {
+    const { text } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      format: 'json',
+    });
+    const parsed = JSON.parse(text) as { coverage: { latestDay: string; lagDays: number; availableMonths: string[]; missingPeriods: string[]; missingInRange: string[] } };
+    expect(parsed.coverage).toBeDefined();
+    expect(parsed.coverage.latestDay).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(Array.isArray(parsed.coverage.availableMonths)).toBe(true);
+    expect(parsed.coverage.availableMonths.length).toBeGreaterThan(0);
+    expect(typeof parsed.coverage.lagDays).toBe('number');
+  });
+
+  it('coverage is included as a CSV comment when format=csv', async () => {
+    const { text } = await client.callTool('query_costs', {
+      groupBy: 'service',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      format: 'csv',
+    });
+    expect(text).toMatch(/^# Data coverage:/m);
+  });
+
   // ---------- format parameter ----------
 
   it('format=json returns a JSON-parseable response with meta and tables', async () => {

--- a/packages/mcp/src/formatters/result.ts
+++ b/packages/mcp/src/formatters/result.ts
@@ -3,6 +3,40 @@ import { formatDollars, formatPercent, formatDelta, formatNumber } from './cost.
 
 export type ResponseFormat = 'markdown' | 'json' | 'csv';
 
+export interface DataCoverage {
+  readonly availableMonths: readonly string[];
+  readonly latestDay: string | null;
+  readonly earliestDay: string | null;
+  readonly lagDays: number | null;
+  readonly totalDays: number | null;
+  /** Months between earliest and latest available with NO data (global gaps). */
+  readonly missingPeriods: readonly string[];
+  /** Months from the requested range with no data. */
+  readonly missingInRange: readonly string[];
+}
+
+export function dataCoverageBanner(coverage: DataCoverage): string {
+  if (coverage.availableMonths.length === 0) {
+    return '*Data coverage: no synced data found.*';
+  }
+  const parts: string[] = [];
+  if (coverage.earliestDay !== null && coverage.latestDay !== null && coverage.totalDays !== null) {
+    parts.push(`${coverage.earliestDay} to ${coverage.latestDay} (${String(coverage.totalDays)} days)`);
+  }
+  if (coverage.latestDay !== null && coverage.lagDays !== null) {
+    const lagWord = coverage.lagDays === 0 ? 'today'
+      : coverage.lagDays === 1 ? '1 day ago'
+      : `${String(coverage.lagDays)} days ago`;
+    parts.push(`Latest day: ${coverage.latestDay} (${lagWord})`);
+  }
+  if (coverage.missingInRange.length > 0) {
+    parts.push(`Missing periods in your requested range: ${coverage.missingInRange.join(', ')}`);
+  } else if (coverage.missingPeriods.length > 0) {
+    parts.push(`Missing periods: ${coverage.missingPeriods.join(', ')}`);
+  }
+  return `*Data coverage: ${parts.join('. ')}.*`;
+}
+
 export type CellType = 'string' | 'currency' | 'percent' | 'change' | 'number' | 'delta';
 
 export type Cell = string | number | null;
@@ -32,6 +66,7 @@ export interface StructuredResult {
   readonly meta?: readonly MetaField[];
   readonly notes?: readonly string[];
   readonly tables?: readonly Table[];
+  readonly coverage?: DataCoverage;
 }
 
 function formatCell(value: Cell, type: CellType | undefined): string {
@@ -75,6 +110,10 @@ function formatTableMarkdown(table: Table): string {
 
 export function formatAsMarkdown(result: StructuredResult): string {
   const parts: string[] = [];
+  if (result.coverage !== undefined) {
+    parts.push(dataCoverageBanner(result.coverage));
+    parts.push('');
+  }
   parts.push(`## ${result.title}`);
   parts.push('');
   if (result.meta !== undefined) {
@@ -115,6 +154,7 @@ interface JsonMetaField {
 
 interface JsonResult {
   readonly title: string;
+  readonly coverage?: DataCoverage;
   readonly meta?: readonly JsonMetaField[];
   readonly notes?: readonly string[];
   readonly tables?: readonly JsonTable[];
@@ -123,6 +163,7 @@ interface JsonResult {
 export function formatAsJson(result: StructuredResult): string {
   const out: JsonResult = {
     title: result.title,
+    ...(result.coverage !== undefined ? { coverage: result.coverage } : {}),
     ...(result.meta !== undefined ? {
       meta: result.meta.map(f => ({ label: f.label, value: f.value, type: f.type ?? 'string' })),
     } : {}),
@@ -158,6 +199,9 @@ function cellToCsv(value: Cell, type: CellType | undefined): string {
 
 export function formatAsCsv(result: StructuredResult): string {
   const lines: string[] = [];
+  if (result.coverage !== undefined) {
+    lines.push(`# ${dataCoverageBanner(result.coverage).replace(/^\*|\*$/g, '')}`);
+  }
   lines.push(`# ${result.title}`);
   if (result.meta !== undefined) {
     for (const field of result.meta) {

--- a/packages/mcp/src/tools/explore-data.ts
+++ b/packages/mcp/src/tools/explore-data.ts
@@ -8,13 +8,14 @@ import type { DateRange } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
 import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   resolveFormat,
   structuredToolResult,
   toDateRange,
   toNum,
   toStr,
-  toolError,
 } from './tool-helpers.js';
 
 const VALID_COLUMNS: ReadonlySet<string> = new Set([
@@ -50,7 +51,7 @@ export async function exploreData(
   const available = await listLocalMonths(ctx.dataDir, 'daily');
   const required = computePeriodsInRange(dateRange);
   const periods = required.filter(p => available.includes(p));
-  if (periods.length === 0) return toolError(`No data for ${dateRange.start} to ${dateRange.end}.`);
+  if (periods.length === 0) return emptyRangeResult(ctx, dateRange, format, `Explore Data (${dateRange.start} to ${dateRange.end})`);
 
   const matSource = ctx.materializedBase.getSource(dateRange, 'daily');
   const source = matSource ?? buildSource({
@@ -112,8 +113,10 @@ export async function exploreData(
       toNum(r['row_count']),
     ]);
 
+    const coverage = await computeDataCoverage(ctx, dateRange);
     const result: StructuredResult = {
       title: `Aggregated Data (${dateRange.start} to ${dateRange.end})`,
+      coverage,
       meta: [{ label: 'Group By', value: groupByColumns.join(', ') }],
       tables: [{ columns, rows: tableRows }],
     };
@@ -162,8 +165,10 @@ export async function exploreData(
     ];
   });
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `Raw Data (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     meta: [{ label: 'Showing', value: `${String(rows.length)} rows (sorted by |cost|)` }],
     tables: [{ columns, rows: tableRows }],
   };

--- a/packages/mcp/src/tools/get-cost-overview.ts
+++ b/packages/mcp/src/tools/get-cost-overview.ts
@@ -8,7 +8,9 @@ import type { McpContext } from '../context.js';
 import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   resolveFormat,
   structuredToolResult,
   toDateRange,
@@ -34,7 +36,7 @@ export async function getCostOverview(
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
   if (empty) {
-    return toolError(`No data available for the period ${dateRange.start} to ${dateRange.end}. Available months: ${months.join(', ')}`);
+    return emptyRangeResult(ctx, dateRange, format, `Cost Overview (${dateRange.start} to ${dateRange.end})`);
   }
 
   const emptyFilters: FilterMap = {};
@@ -112,11 +114,12 @@ export async function getCostOverview(
     });
   }
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `Cost Overview (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     meta: [
       { label: 'Total Cost', value: serviceTotalCost, type: 'currency' },
-      { label: 'Data Range', value: `${months[0] ?? '?'} to ${months[months.length - 1] ?? '?'}` },
       { label: 'Available Dimensions', value: enabledDims.join(', ') },
     ],
     tables,

--- a/packages/mcp/src/tools/get-filter-values.ts
+++ b/packages/mcp/src/tools/get-filter-values.ts
@@ -10,6 +10,7 @@ import type { McpContext } from '../context.js';
 import { truncateFooter, truncateRows } from '../formatters/cost.js';
 import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
+  computeDataCoverage,
   defaultDateRange,
   lookupDimension,
   resolveEntityName,
@@ -118,8 +119,10 @@ export async function getFilterValues(
     totalCost > 0 ? (i.cost / totalCost) * 100 : 0,
   ]);
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `${dimLabel} Values (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     meta: [
       { label: 'Total', value: totalCost, type: 'currency' },
       { label: 'Distinct Values', value: items.length, type: 'number' },

--- a/packages/mcp/src/tools/list-dimensions.ts
+++ b/packages/mcp/src/tools/list-dimensions.ts
@@ -1,7 +1,7 @@
 import { tagDimColumn } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
 import type { Cell, Column, StructuredResult } from '../formatters/result.js';
-import { resolveFormat, structuredToolResult } from './tool-helpers.js';
+import { computeDataCoverage, resolveFormat, structuredToolResult } from './tool-helpers.js';
 
 export async function listDimensions(
   ctx: McpContext,
@@ -38,8 +38,10 @@ export async function listDimensions(
     ]);
   }
 
+  const coverage = await computeDataCoverage(ctx);
   const result: StructuredResult = {
     title: 'Available Dimensions',
+    coverage,
     tables: [{ columns, rows }],
     notes: ['Use the `id` column value as the `groupBy`, `dimensionId`, or filter key in other tools.'],
   };

--- a/packages/mcp/src/tools/query-costs.ts
+++ b/packages/mcp/src/tools/query-costs.ts
@@ -8,7 +8,9 @@ import { truncateRows, truncateFooter } from '../formatters/cost.js';
 import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   lookupDimension,
   resolveEntityName,
   resolveFormat,
@@ -18,7 +20,6 @@ import {
   toFilterMap,
   toNum,
   toStr,
-  toolError,
 } from './tool-helpers.js';
 
 export async function queryCosts(
@@ -40,7 +41,7 @@ export async function queryCosts(
   const limit = params.limit ?? 15;
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
-  if (empty) return toolError(`No data for ${dateRange.start} to ${dateRange.end}.`);
+  if (empty) return emptyRangeResult(ctx, dateRange, format, `Costs by ${params.groupBy} (${dateRange.start} to ${dateRange.end})`);
 
   const { sql, params: queryParams } = buildCostQuery(
     { groupBy, dateRange, filters },
@@ -104,8 +105,10 @@ export async function queryCosts(
     ...topServices.map((s): Cell => r.serviceCosts[s] ?? 0),
   ]);
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `Costs by ${dimLabel} (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     meta: [{ label: 'Total', value: grandTotal, type: 'currency' }],
     tables: [{ columns, rows: tableRows, footer: truncateFooter(hiddenCount, hiddenCost) }],
   };

--- a/packages/mcp/src/tools/query-daily-costs.ts
+++ b/packages/mcp/src/tools/query-daily-costs.ts
@@ -8,7 +8,9 @@ import type { McpContext } from '../context.js';
 import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   lookupDimension,
   resolveFormat,
   structuredToolResult,
@@ -16,7 +18,6 @@ import {
   toDateRange,
   toFilterMap,
   toNum,
-  toolError,
 } from './tool-helpers.js';
 
 export async function queryDailyCosts(
@@ -38,7 +39,7 @@ export async function queryDailyCosts(
   const filters = toFilterMap(params.filters);
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
-  if (empty) return toolError(`No data for ${dateRange.start} to ${dateRange.end}.`);
+  if (empty) return emptyRangeResult(ctx, dateRange, format, `Daily Costs (${dateRange.start} to ${dateRange.end})`);
 
   const { sql, params: queryParams } = buildDailyCostsQuery(
     { groupBy, dateRange, filters },
@@ -138,8 +139,10 @@ export async function queryDailyCosts(
     });
   }
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `${useWeekly ? 'Weekly' : 'Daily'} Costs by ${dimLabel} (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     meta: [{ label: 'Total', value: totalCost, type: 'currency' }],
     tables: [{ columns, rows: tableRows }],
   };

--- a/packages/mcp/src/tools/query-entity-detail.ts
+++ b/packages/mcp/src/tools/query-entity-detail.ts
@@ -8,7 +8,9 @@ import type { McpContext } from '../context.js';
 import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   lookupDimension,
   resolveEntityName,
   resolveFormat,
@@ -18,7 +20,6 @@ import {
   toFilterMap,
   toNum,
   toStr,
-  toolError,
 } from './tool-helpers.js';
 
 export async function queryEntityDetail(
@@ -40,7 +41,7 @@ export async function queryEntityDetail(
   const filters = toFilterMap(params.filters);
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
-  if (empty) return toolError(`No data for ${dateRange.start} to ${dateRange.end}.`);
+  if (empty) return emptyRangeResult(ctx, dateRange, format, `${params.entity} (${dateRange.start} to ${dateRange.end})`);
 
   const { sql, params: queryParams } = buildEntityDetailQuery(
     { entity, dimension, dateRange, filters },
@@ -137,8 +138,10 @@ export async function queryEntityDetail(
     tables.push({ title: 'Weekly Trend', columns: weeklyCols, rows: weeklyRows });
   }
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `${params.entity} (${dimLabel})`,
+    coverage,
     meta: [
       { label: 'Period', value: `${dateRange.start} to ${dateRange.end}` },
       { label: 'Total Cost', value: totalCost, type: 'currency' },

--- a/packages/mcp/src/tools/query-missing-tags.ts
+++ b/packages/mcp/src/tools/query-missing-tags.ts
@@ -9,7 +9,9 @@ import { truncateRows, truncateFooter } from '../formatters/cost.js';
 import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   resolveEntityName,
   resolveFormat,
   structuredToolResult,
@@ -19,7 +21,6 @@ import {
   toFilterMap,
   toNum,
   toStr,
-  toolError,
 } from './tool-helpers.js';
 
 export async function queryMissingTags(
@@ -43,7 +44,7 @@ export async function queryMissingTags(
   const limit = params.limit ?? 20;
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
-  if (empty) return toolError(`No data for ${dateRange.start} to ${dateRange.end}.`);
+  if (empty) return emptyRangeResult(ctx, dateRange, format, `Missing Tags: ${params.tagDimension} (${dateRange.start} to ${dateRange.end})`);
 
   const resourceQuery = buildMissingTagsQuery(
     { tagDimension, dateRange, filters, minCost },
@@ -129,8 +130,10 @@ export async function queryMissingTags(
     notes.push('*No actionable untagged resources above the cost threshold.*');
   }
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `Missing Tags: ${params.tagDimension} (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     meta: [
       { label: 'Actionable Resources', value: actionableCount, type: 'number' },
       { label: 'Actionable Cost', value: actionableCost, type: 'currency' },

--- a/packages/mcp/src/tools/query-trends.ts
+++ b/packages/mcp/src/tools/query-trends.ts
@@ -10,7 +10,9 @@ import { formatDollars, truncateRows, truncateFooter } from '../formatters/cost.
 import type { Cell, Column, StructuredResult, Table } from '../formatters/result.js';
 import {
   buildQueryContextOpts,
+  computeDataCoverage,
   defaultDateRange,
+  emptyRangeResult,
   lookupDimension,
   resolveEntityName,
   resolveFormat,
@@ -21,7 +23,6 @@ import {
   toFilterMap,
   toNum,
   toStr,
-  toolError,
 } from './tool-helpers.js';
 
 export async function queryTrends(
@@ -47,7 +48,7 @@ export async function queryTrends(
   const limit = params.limit ?? 15;
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
-  if (empty) return toolError(`No data for ${dateRange.start} to ${dateRange.end}.`);
+  if (empty) return emptyRangeResult(ctx, dateRange, format, `Cost Trends (${dateRange.start} to ${dateRange.end})`);
 
   const { sql, params: queryParams } = buildTrendQuery(
     { groupBy, dateRange, filters, deltaThreshold, percentThreshold },
@@ -135,8 +136,10 @@ export async function queryTrends(
     notes.push('*No significant savings found.*');
   }
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `Cost Trends by ${dimLabel} (${dateRange.start} to ${dateRange.end})`,
+    coverage,
     notes,
     tables,
   };

--- a/packages/mcp/src/tools/run-sql.ts
+++ b/packages/mcp/src/tools/run-sql.ts
@@ -9,6 +9,8 @@ import {
 import type { McpContext } from '../context.js';
 import type { Cell, Column, StructuredResult } from '../formatters/result.js';
 import {
+  computeDataCoverage,
+  emptyRangeResult,
   resolveFormat,
   structuredToolResult,
   toStr,
@@ -70,7 +72,7 @@ export async function runSql(
     const required = computePeriodsInRange(dateRange);
     const periods = required.filter(p => available.includes(p));
     if (periods.length === 0) {
-      return toolError(`No data available for ${dateRange.start} to ${dateRange.end}.`);
+      return emptyRangeResult(ctx, dateRange, format, `Query Result`);
     }
     const source = buildSource({
       dataDir: ctx.dataDir,
@@ -135,8 +137,10 @@ export async function runSql(
     notes.push(`*Results limited to ${String(limit)} rows.*`);
   }
 
+  const coverage = await computeDataCoverage(ctx, dateRange);
   const result: StructuredResult = {
     title: `Query Result`,
+    coverage,
     meta,
     notes,
     tables: [{ columns, rows: tableRows }],

--- a/packages/mcp/src/tools/tool-helpers.ts
+++ b/packages/mcp/src/tools/tool-helpers.ts
@@ -19,7 +19,7 @@ import type {
   TagValue,
 } from '@costgoblin/core';
 import type { McpContext, RawRow } from '../context.js';
-import { formatResult, type ResponseFormat, type StructuredResult } from '../formatters/result.js';
+import { formatResult, type DataCoverage, type ResponseFormat, type StructuredResult } from '../formatters/result.js';
 
 export function toNum(v: unknown): number {
   if (typeof v === 'number') return v;
@@ -137,9 +137,107 @@ export function structuredToolResult(
   return toolResult(formatResult(result, format));
 }
 
+export async function emptyRangeResult(
+  ctx: McpContext,
+  dateRange: { readonly start: string; readonly end: string },
+  format: ResponseFormat,
+  title: string,
+): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  const coverage = await computeDataCoverage(ctx, dateRange);
+  const result: StructuredResult = {
+    title,
+    coverage,
+    notes: [`*No data available for the requested range ${dateRange.start} to ${dateRange.end}. See coverage banner above for what is available.*`],
+  };
+  return structuredToolResult(result, format);
+}
+
 export function resolveFormat(raw: string | undefined): ResponseFormat {
   if (raw === 'json' || raw === 'csv' || raw === 'markdown') return raw;
   return 'markdown';
+}
+
+function computeMissingMonthsBetween(available: readonly string[]): string[] {
+  if (available.length === 0) return [];
+  const set = new Set(available);
+  const first = available[0];
+  const last = available[available.length - 1];
+  if (first === undefined || last === undefined) return [];
+  const [fy, fm] = first.split('-').map(n => Number(n));
+  const [ly, lm] = last.split('-').map(n => Number(n));
+  if (fy === undefined || fm === undefined || ly === undefined || lm === undefined) return [];
+  const missing: string[] = [];
+  let y = fy;
+  let m = fm;
+  while (y < ly || (y === ly && m <= lm)) {
+    const key = `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}`;
+    if (!set.has(key)) missing.push(key);
+    m += 1;
+    if (m > 12) { m = 1; y += 1; }
+  }
+  return missing;
+}
+
+export async function computeDataCoverage(
+  ctx: McpContext,
+  dateRange?: { readonly start: string; readonly end: string },
+): Promise<DataCoverage> {
+  const { listLocalMonths, computePeriodsInRange } = await import('@costgoblin/core');
+  const available = await listLocalMonths(ctx.dataDir, 'daily');
+  if (available.length === 0) {
+    return {
+      availableMonths: [],
+      latestDay: null,
+      lagDays: null,
+      earliestDay: null,
+      missingPeriods: [],
+      missingInRange: dateRange !== undefined ? computePeriodsInRange(dateRange) : [],
+      totalDays: null,
+    };
+  }
+  const earliestMonth = available[0];
+  const latestMonth = available[available.length - 1];
+  let latestDay: string | null = null;
+  if (latestMonth !== undefined) {
+    const glob = `${ctx.dataDir}/aws/raw/daily-${latestMonth}/*.parquet`;
+    try {
+      const rows = await ctx.runQuery(
+        `SELECT MAX(line_item_usage_start_date::DATE)::VARCHAR AS d FROM read_parquet('${glob}')`,
+      );
+      const v = rows[0]?.['d'];
+      if (typeof v === 'string' && v.length >= 10) latestDay = v.slice(0, 10);
+    } catch { /* fall through */ }
+  }
+  const earliestDay = earliestMonth !== undefined ? `${earliestMonth}-01` : null;
+
+  let lagDays: number | null = null;
+  if (latestDay !== null) {
+    const latestMs = new Date(`${latestDay}T00:00:00Z`).getTime();
+    const todayMs = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z').getTime();
+    lagDays = Math.max(0, Math.round((todayMs - latestMs) / 86_400_000));
+  }
+
+  let totalDays: number | null = null;
+  if (earliestDay !== null && latestDay !== null) {
+    const startMs = new Date(`${earliestDay}T00:00:00Z`).getTime();
+    const endMs = new Date(`${latestDay}T00:00:00Z`).getTime();
+    totalDays = Math.round((endMs - startMs) / 86_400_000) + 1;
+  }
+
+  const missingPeriods = computeMissingMonthsBetween(available);
+  const requestedPeriods = dateRange !== undefined ? computePeriodsInRange(dateRange) : [];
+  const availableSet = new Set(available);
+  const missingInRange = requestedPeriods.filter(p => !availableSet.has(p));
+
+  return {
+    availableMonths: available,
+    latestDay,
+    lagDays,
+    earliestDay,
+    missingPeriods,
+    missingInRange,
+    totalDays,
+  };
 }
 
 export function lookupDimension(dimensionId: string, dimensions: DimensionsConfig): { label: string; found: boolean } {


### PR DESCRIPTION
Closes #336.

## Summary

Every MCP tool response now starts with a `*Data coverage: ...*` banner that exposes the synced data range, latest day, lag, and any missing months in the requested range. The banner solves the failure mode in the issue: a tool that succeeds against the data it has, while silently dropping months the caller asked for, gives an LLM no way to detect the gap. Now the gap is right at the top of the response in every format.

Examples (from the running dev MCP):

Full overlap:
```
*Data coverage: 2025-05-01 to 2026-06-30 (426 days). Latest day: 2026-06-30 (today).*
```

Partial overlap (2025-04 missing, 2025-05 present):
```
*Data coverage: 2025-05-01 to 2026-06-30 (426 days). Latest day: 2026-06-30 (today). Missing periods in your requested range: 2025-04.*
```

## Implementation

- `DataCoverage` type added to `formatters/result.ts`. Each `StructuredResult` now carries an optional `coverage` field; `formatAsMarkdown` prepends the banner line, `formatAsJson` includes a structured `coverage` object alongside `meta`/`tables`, `formatAsCsv` emits it as a `# Data coverage: ...` comment row.
- `computeDataCoverage(ctx, dateRange?)` derives coverage from `listLocalMonths` plus a single-row `MAX(line_item_usage_start_date)` probe against the latest available month. Adds no per-call DuckDB cost beyond that one tiny query.
- New `emptyRangeResult(ctx, dateRange, format, title)` helper: when the requested range falls fully outside synced data, tools return a structured result with the coverage banner + a "no data" note instead of a bare error string. The LLM can now see what range it should retry against in the same response.
- Tests: added four MCP E2E cases covering the markdown banner, partial-overlap explicit listing, JSON `coverage` field, and CSV `# Data coverage` comment.

No version bump (main was already at 0.2.6, latest released tag is v0.2.5 — CI requires `>`, not `>=` per the lesson I just saved).