### PR TITLE
mcp: query_missing_tags treats placeholder values as missing

### DIFF
--- a/packages/core/src/__tests__/query-builder.test.ts
+++ b/packages/core/src/__tests__/query-builder.test.ts
@@ -255,6 +255,39 @@ describe('buildMissingTagsQuery', () => {
     const result = buildMissingTagsQuery(baseParams, { dataDir: '/data', dimensions });
     expect(result.sql).not.toContain('r.cost >= $');
   });
+
+  it('treats default placeholder patterns as missing tags', () => {
+    const result = buildMissingTagsQuery(baseParams, { dataDir: '/data', dimensions });
+    // Each default placeholder pattern becomes a parameterized NOT ILIKE clause.
+    expect(result.sql).toMatch(/NOT ILIKE \$\d+/);
+    expect(result.params).toContain('unknown-%');
+    expect(result.params).toContain('unknown_%');
+    expect(result.params).toContain('unassigned-%');
+    expect(result.params).toContain('none');
+    expect(result.params).toContain('n/a');
+    expect(result.params).toContain('tbd');
+  });
+
+  it('uses custom placeholder patterns when provided', () => {
+    const result = buildMissingTagsQuery(
+      { ...baseParams, placeholderPatterns: ['placeholder-%', 'TODO'] },
+      { dataDir: '/data', dimensions },
+    );
+    expect(result.params).toContain('placeholder-%');
+    expect(result.params).toContain('TODO');
+    expect(result.params).not.toContain('unknown-%');
+    expect(result.params).not.toContain('none');
+  });
+
+  it('treats empty placeholderPatterns as no placeholder filtering', () => {
+    const result = buildMissingTagsQuery(
+      { ...baseParams, placeholderPatterns: [] },
+      { dataDir: '/data', dimensions },
+    );
+    expect(result.sql).not.toContain('NOT ILIKE');
+    expect(result.params).not.toContain('unknown-%');
+    expect(result.params).not.toContain('none');
+  });
 });
 
 describe('buildNonResourceCostQuery', () => {

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1,5 +1,6 @@
 import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
 import type { CostQueryParams, DailyCostsParams, FilterMap, TrendQueryParams, MissingTagsParams, EntityDetailParams } from '../types/query.js';
+import { DEFAULT_PLACEHOLDER_PATTERNS } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
 import { tagDimColumn } from '../types/branded.js';
 import { OU_PATH_SOURCE_KEY } from '../types/config.js';
@@ -727,6 +728,21 @@ export function buildMissingTagsQuery(
     ...exclusionClauses,
   ];
 
+  // Treat placeholder values (e.g. `unknown-cyber-security`, `none`, `n/a`)
+  // as missing in addition to NULL and empty string. Without this, tagging
+  // pipelines that backfill a placeholder to satisfy "non-empty" downstream
+  // constraints would be counted as tagged and the gap would be understated.
+  const placeholderPatterns = params.placeholderPatterns ?? DEFAULT_PLACEHOLDER_PATTERNS;
+  const placeholderClauses = placeholderPatterns.map(pattern => {
+    const placeholder = qb.addParam(pattern);
+    return `${tagCheckField} NOT ILIKE ${placeholder}`;
+  });
+  const isTaggedExpr = [
+    `${tagCheckField} IS NOT NULL`,
+    `${tagCheckField} != ''`,
+    ...placeholderClauses,
+  ].join(' AND ');
+
   const sql = `
     WITH resources AS (
       SELECT
@@ -736,7 +752,7 @@ export function buildMissingTagsQuery(
         service_family,
         resource_id,
         SUM(cost) AS cost,
-        MAX(CASE WHEN ${tagCheckField} IS NOT NULL AND ${tagCheckField} != '' THEN 1 ELSE 0 END) AS has_tag,
+        MAX(CASE WHEN ${isTaggedExpr} THEN 1 ELSE 0 END) AS has_tag,
         MAX(${tagResolved.rawField}) AS closest_owner
       FROM ${source}
       WHERE ${whereConditions.join(' AND ')}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -63,6 +63,7 @@ export type {
   SyncStatus,
   QueryState,
 } from './query.js';
+export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';
 
 export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateStatus, UpdateApi } from './api.js';
 

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -74,7 +74,30 @@ export interface MissingTagsParams {
   readonly minCost: Dollars;
   readonly tagDimension: DimensionId;
   readonly origin?: string | undefined;
+  /**
+   * SQL LIKE patterns whose matching tag values are treated as missing in
+   * addition to NULL and empty string. Common backfill placeholders like
+   * `unknown-{team}` or `none` are not real tags — counting them as tagged
+   * understates the true tagging gap. Pass an empty array to treat all
+   * non-null non-empty values as tagged.
+   */
+  readonly placeholderPatterns?: readonly string[] | undefined;
 }
+
+/**
+ * Default placeholder patterns used by query_missing_tags when the caller
+ * does not specify any. Matches common backfill conventions seen in real
+ * tagging pipelines.
+ */
+export const DEFAULT_PLACEHOLDER_PATTERNS: readonly string[] = [
+  'unknown-%',
+  'unknown_%',
+  'unassigned-%',
+  'unassigned_%',
+  'none',
+  'n/a',
+  'tbd',
+];
 
 /**
  * Classification of an untagged resource line:

--- a/packages/mcp/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp/src/__tests__/mcp-server.test.ts
@@ -388,6 +388,40 @@ describe('MCP server E2E', () => {
     expect(text).toMatch(/missing|untagged|tag/i);
   });
 
+  it('query_missing_tags shows default placeholder patterns in response', async () => {
+    const { text } = await client.callTool('query_missing_tags', {
+      tagDimension: 'tag_team',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      minCost: 0,
+    });
+    expect(text).toContain('Placeholder Patterns Treated As Missing');
+    expect(text).toContain('unknown-%');
+    expect(text).toContain('none');
+  });
+
+  it('query_missing_tags accepts custom placeholderPatterns', async () => {
+    const { text } = await client.callTool('query_missing_tags', {
+      tagDimension: 'tag_team',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      minCost: 0,
+      placeholderPatterns: ['todo-%', 'placeholder'],
+    });
+    expect(text).toContain('todo-%');
+    expect(text).toContain('placeholder');
+    expect(text).not.toContain('unknown-%');
+  });
+
+  it('query_missing_tags accepts empty placeholderPatterns array', async () => {
+    const { text } = await client.callTool('query_missing_tags', {
+      tagDimension: 'tag_team',
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+      minCost: 0,
+      placeholderPatterns: [],
+    });
+    expect(text).toContain('Placeholder Patterns Treated As Missing');
+    expect(text).toContain('(none)');
+  });
+
   // ---------- explore_data ----------
 
   it('explore_data returns raw rows', async () => {

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -179,6 +179,11 @@ export function registerTools(server: McpServer, ctx: McpContext): void {
         filters: filtersSchema,
         minCost: z.number().optional().describe('Min cost per resource to include (default $10)'),
         limit: z.number().optional().describe('Max resources to show (default 20)'),
+        placeholderPatterns: z.array(z.string()).optional().describe(
+          'SQL LIKE patterns (case-insensitive) whose matching tag values are treated as missing in addition to NULL and empty string. ' +
+          'Defaults to ["unknown-%", "unknown_%", "unassigned-%", "unassigned_%", "none", "n/a", "tbd"] — common backfill placeholders that are not real tags. ' +
+          'Pass an empty array to count any non-null non-empty value as tagged.',
+        ),
         format: formatSchema,
       },
     },

--- a/packages/mcp/src/tools/query-missing-tags.ts
+++ b/packages/mcp/src/tools/query-missing-tags.ts
@@ -1,6 +1,7 @@
 import {
   buildMissingTagsQuery,
   buildNonResourceCostQuery,
+  DEFAULT_PLACEHOLDER_PATTERNS,
   logger,
 } from '@costgoblin/core';
 import type { DateRange, DimensionId } from '@costgoblin/core';
@@ -31,6 +32,7 @@ export async function queryMissingTags(
     filters?: Record<string, readonly string[]> | undefined;
     minCost?: number | undefined;
     limit?: number | undefined;
+    placeholderPatterns?: readonly string[] | undefined;
     format?: string | undefined;
   },
 ): Promise<{ content: [{ type: 'text'; text: string }] }> {
@@ -42,12 +44,13 @@ export async function queryMissingTags(
   const filters = toFilterMap(params.filters);
   const minCost = toDollars(params.minCost ?? 10);
   const limit = params.limit ?? 20;
+  const placeholderPatterns = params.placeholderPatterns ?? DEFAULT_PLACEHOLDER_PATTERNS;
 
   const { opts, empty } = await buildQueryContextOpts(ctx, dateRange);
   if (empty) return emptyRangeResult(ctx, dateRange, format, `Missing Tags: ${params.tagDimension} (${dateRange.start} to ${dateRange.end})`);
 
   const resourceQuery = buildMissingTagsQuery(
-    { tagDimension, dateRange, filters, minCost },
+    { tagDimension, dateRange, filters, minCost, placeholderPatterns },
     opts,
   );
   const nonResourceQuery = buildNonResourceCostQuery(
@@ -140,6 +143,10 @@ export async function queryMissingTags(
       { label: 'Likely Untaggable Resources', value: untaggableCount, type: 'number' },
       { label: 'Likely Untaggable Cost', value: untaggableCost, type: 'currency' },
       { label: 'Non-Resource Cost', value: nonResourceCost, type: 'currency' },
+      {
+        label: 'Placeholder Patterns Treated As Missing',
+        value: placeholderPatterns.length === 0 ? '(none)' : placeholderPatterns.join(', '),
+      },
     ],
     notes,
     tables,


### PR DESCRIPTION
Closes #337.

## Summary

Tagging pipelines often backfill placeholder values (e.g. `unknown-cyber-security`, `unassigned-team-x`, `none`, `n/a`, `tbd`) so downstream tooling that requires a non-empty value doesn't break. These placeholders are not real tags. The old `query_missing_tags` only treated NULL/empty as missing, so categories full of placeholder-tagged resources were counted as fully tagged — the issue's real example had a category jump from 27% missing to 90% missing once placeholders were excluded.

## Implementation

- `MissingTagsParams` (core) gains `placeholderPatterns?: readonly string[]`.
- New `DEFAULT_PLACEHOLDER_PATTERNS` constant: `['unknown-%', 'unknown_%', 'unassigned-%', 'unassigned_%', 'none', 'n/a', 'tbd']`. Defaults are SQL LIKE patterns, applied case-insensitively via `NOT ILIKE`.
- `buildMissingTagsQuery` adds one parameterized `NOT ILIKE` clause per pattern to the `has_tag` CASE expression. All patterns go through `QueryBuilder.addParam` — no string interpolation, no injection surface.
- `query_missing_tags` MCP tool exposes the parameter and reflects the active set in the response meta as `Placeholder Patterns Treated As Missing`. The LLM and the human transcript reader can both see what was counted as missing.
- Passing `placeholderPatterns: []` restores the pre-#337 behaviour.

## Tests

**core unit (`query-builder.test.ts`):**
- Default patterns are parameterized and present in `result.params`.
- Custom array overrides defaults cleanly (custom values present, defaults absent).
- Empty array emits no `NOT ILIKE` clauses at all.

**mcp e2e (`mcp-server.test.ts`):**
- Default placeholders appear in the response meta.
- Custom `placeholderPatterns` override defaults in the response.
- Empty array shows `(none)` in the meta.

## Validation

Validated against the running dev MCP. The dev dataset's `unknown-*` values come from account-level fallback (raw resource tag is NULL → already classified as missing by the original query). The new filter additionally catches resources whose *literal* resource tag is a placeholder value — exactly the issue's described scenario. The unit + e2e tests prove the SQL transformation and the user-visible behaviour; the runtime numbers on this particular dataset don't change because there are no resources with literal placeholder tag values to flip.