### PR TITLE
fix(ui): guard CSV exports against spreadsheet formula injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/ui/src/__tests__/csv-export.test.ts
+++ b/packages/ui/src/__tests__/csv-export.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { asEntityRef, asDollars } from '@costgoblin/core/browser';
+import type { CostRow } from '@costgoblin/core/browser';
+import { buildCsv, escapeCell } from '../components/csv-export.js';
+import { escapeCsv } from '../components/table-csv-export.js';
+
+describe('escapeCell (cost CSV export)', () => {
+  it('neutralises spreadsheet formula triggers by prefixing a quote', () => {
+    for (const trigger of ['=', '+', '-', '@', '\t', '\r']) {
+      const result = escapeCell(`${trigger}cmd`);
+      // The neutralised value must no longer start with the trigger character.
+      const unquoted = result.startsWith('"') ? result.slice(1, -1) : result;
+      expect(unquoted.startsWith("'")).toBe(true);
+      expect(unquoted[1]).toBe(trigger);
+    }
+  });
+
+  it('leaves benign values untouched', () => {
+    expect(escapeCell('AmazonEC2')).toBe('AmazonEC2');
+    expect(escapeCell('team-a')).toBe('team-a'); // internal hyphen is fine
+  });
+
+  it('still quotes commas, quotes and newlines', () => {
+    expect(escapeCell('a,b')).toBe('"a,b"');
+    expect(escapeCell('a"b')).toBe('"a""b"');
+    expect(escapeCell('a\nb')).toBe('"a\nb"');
+  });
+
+  it('quotes and neutralises a value that is both a formula and contains a comma', () => {
+    expect(escapeCell('=1,2')).toBe('"\'=1,2"');
+  });
+});
+
+describe('buildCsv', () => {
+  function row(entity: string, total: number, services: Record<string, number>): CostRow {
+    const serviceCosts: Record<string, ReturnType<typeof asDollars>> = {};
+    for (const [k, v] of Object.entries(services)) serviceCosts[k] = asDollars(v);
+    return { entity: asEntityRef(entity), totalCost: asDollars(total), serviceCosts };
+  }
+
+  it('neutralises a malicious entity value in the output', () => {
+    const csv = buildCsv(
+      [row('=HYPERLINK("http://evil","x")', 10, { AmazonEC2: 10 })],
+      ['AmazonEC2'],
+    );
+    // The dangerous cell is present but defused: no data line starts a formula.
+    const lines = csv.split('\n');
+    for (const line of lines) {
+      expect(line.startsWith('=')).toBe(false);
+    }
+    expect(csv).toContain("'=HYPERLINK");
+  });
+});
+
+describe('escapeCsv (table CSV export)', () => {
+  it('neutralises formula triggers on string cells', () => {
+    expect(escapeCsv('=1+1')).toBe("'=1+1");
+    expect(escapeCsv('@SUM(A1)')).toBe("'@SUM(A1)");
+  });
+
+  it('does not prefix numeric cells (a negative number is not a formula)', () => {
+    expect(escapeCsv(-12.5)).toBe('-12.5');
+    expect(escapeCsv(42)).toBe('42');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(escapeCsv(null)).toBe('');
+    expect(escapeCsv(undefined)).toBe('');
+  });
+});

--- a/packages/ui/src/components/csv-export.tsx
+++ b/packages/ui/src/components/csv-export.tsx
@@ -6,14 +6,21 @@ interface CsvExportProps {
   filename?: string;
 }
 
-function escapeCell(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replaceAll('"', '""')}"`;
+// A leading =, +, -, @, tab, or CR makes Excel/Sheets evaluate the cell as a
+// formula. Entity/header values are derived from billing data (service names,
+// account names, resource tag values an AWS user controls), so neutralise the
+// trigger by prefixing the cell with a single quote before quoting.
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
+export function escapeCell(value: string): string {
+  const guarded = FORMULA_TRIGGER.test(value) ? `'${value}` : value;
+  if (guarded.includes(',') || guarded.includes('"') || guarded.includes('\n')) {
+    return `"${guarded.replaceAll('"', '""')}"`;
   }
-  return value;
+  return guarded;
 }
 
-function buildCsv(rows: readonly CostRow[], topServices: readonly string[]): string {
+export function buildCsv(rows: readonly CostRow[], topServices: readonly string[]): string {
   const headers = ['Entity', 'Total Cost', ...topServices];
   const lines = [headers.map(escapeCell).join(',')];
 

--- a/packages/ui/src/components/table-csv-export.tsx
+++ b/packages/ui/src/components/table-csv-export.tsx
@@ -1,11 +1,21 @@
 import type { Table } from '@tanstack/react-table';
 import { Download } from 'lucide-react';
 
-function escapeCsv(value: unknown): string {
+// A leading =, +, -, @, tab, or CR makes Excel/Sheets evaluate the cell as a
+// formula. Cell values can come from billing-derived text (resource tag values
+// an AWS user controls), so neutralise the trigger on string cells by prefixing
+// a single quote. Numeric cells are left as-is — a negative number is not an
+// injection vector.
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
+export function escapeCsv(value: unknown): string {
   if (value === null || value === undefined) return '';
   let str = '';
-  if (typeof value === 'string') str = value;
-  else if (typeof value === 'number') str = value.toString();
+  if (typeof value === 'string') {
+    str = FORMULA_TRIGGER.test(value) ? `'${value}` : value;
+  } else if (typeof value === 'number') {
+    str = value.toString();
+  }
   if (str.includes(',') || str.includes('"') || str.includes('\n')) {
     return `"${str.replaceAll('"', '""')}"`;
   }


### PR DESCRIPTION
Fixes #345.

## Problem
`csv-export.tsx` and `table-csv-export.tsx` quoted cells for `,`, `"`, and `\n`, but passed through values beginning with `=`, `+`, `-`, `@`, tab, or CR. Those make Excel/Google Sheets evaluate the cell as a formula. The `entity` column and table cells are derived from billing data — including resource tag values an AWS user controls — so an exported file could carry attacker-supplied formulas (`=HYPERLINK(...)`, `=WEBSERVICE(...)`, legacy DDE) that run when the file is opened.

## Fix
- Neutralise **string** cells whose first character is a formula trigger by prefixing a single quote (OWASP-recommended), in addition to the existing quoting.
- Numeric cells are left untouched — a negative number is not an injection vector, and prefixing would corrupt legitimate values.
- Exported the previously-private `buildCsv`/`escapeCell`/`escapeCsv` helpers for unit testing.

## Test
`packages/ui/src/__tests__/csv-export.test.ts`: each trigger char is neutralised; benign values and internal hyphens are untouched; comma/quote/newline quoting still works; a combined formula+comma value is both quoted and defused; a malicious entity in `buildCsv` yields no line starting with a formula; numeric cells are not prefixed.

## Verification
- `packages/ui`: `npm run check` → tsc + eslint + 133 tests pass.
- Root `npm run check` (pre-commit) → 536 passed.

Also bumps version to `0.2.7` for the version-bump CI check. No `any`/`as`/non-null assertions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJDaY6hzPq6SNEkWkWquZc)_