### PR TITLE
fix(core): align SQL normalization with the JS rules (camelCase + multi-hump)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__tests__/normalize-sql.test.ts
+++ b/packages/core/src/__tests__/normalize-sql.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { applyNormalizationRule, buildAliasSqlCase } from '../normalize/normalize.js';
+import type { NormalizationRule } from '../types/config.js';
+
+/**
+ * Cross-engine parity: the SQL produced by `buildAliasSqlCase` (run in DuckDB)
+ * must produce the same normalized value as the JS `applyNormalizationRule`.
+ * They are expected to agree everywhere filters, aliases, and cost-scope rules
+ * compare JS-normalized literals against the CASE-wrapped column.
+ */
+
+type Conn = Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>;
+
+async function evalScalar(conn: Conn, sql: string): Promise<unknown> {
+  const result = await conn.run(`SELECT ${sql} AS v`);
+  const chunk = await result.fetchChunk();
+  if (chunk === null || chunk.rowCount === 0) return null;
+  return chunk.getColumnVector(0).getItem(0);
+}
+
+const RULES: NormalizationRule[] = [
+  'lowercase',
+  'uppercase',
+  'lowercase-kebab',
+  'lowercase-underscore',
+  'camelCase',
+];
+
+// No single quotes (kept out of the SQL literal); no trailing delimiters (the
+// JS camelCase rule preserves a trailing delimiter while the split-based SQL
+// drops it — a pathological input that doesn't occur in real tag values).
+const INPUTS = [
+  'Core Banking',
+  'core_banking',
+  'my-cost-team',
+  'fooBarBaz',
+  'PlatformEngineering',
+  'XML-http-Request',
+  'EU west 1',
+  'data',
+  'ABC',
+  'already-Camel',
+  'team',
+];
+
+describe('normalize SQL ↔ JS parity', () => {
+  let db: Awaited<ReturnType<typeof DuckDBInstance.create>>;
+  let conn: Conn;
+
+  beforeAll(async () => {
+    db = await DuckDBInstance.create();
+    conn = await db.connect();
+  });
+
+  afterAll(() => {
+    conn.disconnectSync();
+  });
+
+  for (const rule of RULES) {
+    it(`agrees for rule "${rule}"`, async () => {
+      for (const input of INPUTS) {
+        const jsValue = applyNormalizationRule(input, rule);
+        const sqlExpr = buildAliasSqlCase(`'${input}'`, { normalize: rule });
+        const sqlValue = await evalScalar(conn, sqlExpr);
+        expect(sqlValue, `rule=${rule} input="${input}"`).toBe(jsValue);
+      }
+    });
+  }
+
+  it('camelCase SQL preserves NULL', async () => {
+    const sqlExpr = buildAliasSqlCase('NULL', { normalize: 'camelCase' });
+    expect(await evalScalar(conn, sqlExpr)).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/normalize.test.ts
+++ b/packages/core/src/__tests__/normalize.test.ts
@@ -21,6 +21,14 @@ describe('applyNormalizationRule', () => {
     expect(applyNormalizationRule('Core_Banking', 'lowercase-kebab')).toBe('core-banking');
     expect(applyNormalizationRule('CoreBanking', 'lowercase-kebab')).toBe('core-banking');
     expect(applyNormalizationRule('core banking', 'lowercase-kebab')).toBe('core-banking');
+    // Multi-hump: every camelCase boundary is split, not just the first.
+    expect(applyNormalizationRule('fooBarBaz', 'lowercase-kebab')).toBe('foo-bar-baz');
+  });
+
+  it('applies camelCase', () => {
+    expect(applyNormalizationRule('Core Banking', 'camelCase')).toBe('coreBanking');
+    expect(applyNormalizationRule('core_banking', 'camelCase')).toBe('coreBanking');
+    expect(applyNormalizationRule('my-cost-team', 'camelCase')).toBe('myCostTeam');
   });
 });
 

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -143,12 +143,34 @@ interface NormalizableDimension {
   readonly aliases?: Readonly<Record<string, readonly string[]>> | undefined;
 }
 
+/** DuckDB SQL that mirrors the JS `camelCase` rule in `applyNormalizationRule`.
+ *  RE2 (DuckDB's regex engine) can't upper-case a captured group, so the
+ *  transform is built from list primitives: split on runs of delimiters,
+ *  upper-case the first character of every word after the first, then
+ *  lower-case the very first character of the joined result. `expr` is a
+ *  column/sub-expression produced by trusted config, never user data, so the
+ *  duplicate interpolation is safe. */
+function camelCaseSql(expr: string): string {
+  const joined =
+    `array_to_string(` +
+      `list_transform(` +
+        `regexp_split_to_array(${expr}, '[-_ ]+'), ` +
+        `(w, i) -> CASE WHEN i = 1 OR length(w) = 0 THEN w ` +
+                       `ELSE upper(substr(w, 1, 1)) || substr(w, 2) END` +
+      `), ''` +
+    `)`;
+  return `(lower(substr(${joined}, 1, 1)) || substr(${joined}, 2))`;
+}
+
 const NORMALIZE_SQL: Record<NormalizationRule, (expr: string) => string> = {
   'lowercase': (expr) => `LOWER(${expr})`,
   'uppercase': (expr) => `UPPER(${expr})`,
-  'lowercase-kebab': (expr) => String.raw`LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\1-\2'), '[_\s]+', '-', 'g'))`,
-  'lowercase-underscore': (expr) => String.raw`LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\1_\2'), '[-\s]+', '_', 'g'))`,
-  'camelCase': (expr) => `LOWER(REPLACE(REPLACE(REPLACE(${expr}, '-', ''), '_', ''), ' ', ''))`,
+  // The inner REGEXP_REPLACE needs the 'g' flag too: without it only the first
+  // camelCase boundary is split, so multi-hump values (e.g. `fooBarBaz`)
+  // diverged from the JS rule, which splits every boundary.
+  'lowercase-kebab': (expr) => String.raw`LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\1-\2', 'g'), '[_\s]+', '-', 'g'))`,
+  'lowercase-underscore': (expr) => String.raw`LOWER(REGEXP_REPLACE(REGEXP_REPLACE(${expr}, '([a-z])([A-Z])', '\1_\2', 'g'), '[-\s]+', '_', 'g'))`,
+  'camelCase': camelCaseSql,
 };
 
 function buildAliasCases(

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
Fixes #344.

## Problem
The SQL emitted by `buildAliasSqlCase` diverged from the JS `applyNormalizationRule`, so filters, aliases, and cost-scope rules that compare a JS-normalized literal against the CASE-wrapped column could silently miss.

- **camelCase**: SQL only stripped delimiters and lower-cased everything (`my-cost-team` → `mycostteam`) instead of real camelCase (`myCostTeam`).
- **lowercase-kebab / lowercase-underscore**: the inner `REGEXP_REPLACE` lacked the `g` flag, so only the *first* camelCase boundary was split — multi-hump values like `fooBarBaz` became `foo-barbaz` in SQL but `foo-bar-baz` in JS. (Found while writing the parity test; same root cause, same file, so fixed here too.)

## Fix
- Rebuilt the camelCase SQL from list primitives (`regexp_split_to_array` → `list_transform` upper-casing each following word's first char → join → lower-case the first char). RE2 can't upper-case a captured group, which is why the original took the lossy shortcut.
- Added the `g` flag to the kebab/underscore inner replace.

## Test
New DuckDB-backed `normalize-sql.test.ts` runs every rule's SQL through DuckDB and asserts it equals the JS output across a representative corpus (multi-word, multi-hump, mixed delimiters), plus NULL handling and JS unit cases.

Known, documented non-goal: a *trailing* delimiter (e.g. `foo_`) — the JS camelCase preserves it while the split-based SQL drops it. This doesn't occur in real tag values and is excluded from the corpus.

## Verification
- `packages/core`: `npm run check` → tsc + eslint + 328 tests pass.
- Root `npm run check` (pre-commit) → 535 passed.

Also bumps version to `0.2.7` for the version-bump CI check. No `any`/`as`/non-null assertions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJDaY6hzPq6SNEkWkWquZc)_