### PR TITLE
fix(ui): keep the UI responsive while views load (apply query results as transitions)

### DIFF
--- a/packages/ui/src/hooks/use-query.ts
+++ b/packages/ui/src/hooks/use-query.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { startTransition, useEffect, useState } from 'react';
 import type { QueryState } from '@costgoblin/core/browser';
 
 const MAX_CANCEL_RETRIES = 2;
@@ -45,7 +45,18 @@ export function useQuery<T>(
     const delay = retryCount > 0 ? 150 : 0;
     const timer = setTimeout(() => {
       fetcher()
-        .then((data) => { handleFetchSuccess(data, cancelled, setState); })
+        .then((data) => {
+          // Apply the result inside a transition so the (potentially heavy)
+          // render it triggers — visx charts, large tables — stays
+          // interruptible. When a view mounts many widgets, their results
+          // arrive in a burst; without this, React renders each one as an
+          // urgent, blocking commit and the renderer's main thread can't
+          // service input, so the top menu appears frozen until the burst
+          // drains. As a transition, React time-slices the work and lets a
+          // click (e.g. opening the menu) preempt it. The `loading` state
+          // above stays urgent so spinners still appear instantly.
+          startTransition(() => { handleFetchSuccess(data, cancelled, setState); });
+        })
         .catch((err: unknown) => { handleFetchError(err, cancelled, retryCount, setState, setRetryCount); });
     }, delay);
 

--- a/packages/ui/src/views/explorer.tsx
+++ b/packages/ui/src/views/explorer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   CostMetric,
   CostPerspective,
@@ -234,7 +234,9 @@ export function ExplorerView(): React.JSX.Element {
     })
       .then(data => {
         if (reqId !== overviewReqIdRef.current) return;
-        setOverview({ data, loading: false, error: null });
+        // Transition: keep the histogram render interruptible so input isn't
+        // starved while it commits (see use-query.ts for the rationale).
+        startTransition(() => { setOverview({ data, loading: false, error: null }); });
       })
       .catch((err: unknown) => {
         if (reqId !== overviewReqIdRef.current) return;
@@ -267,7 +269,9 @@ export function ExplorerView(): React.JSX.Element {
     })
       .then(data => {
         if (reqId !== rowsReqIdRef.current) return;
-        setRows({ data, loading: false, error: null });
+        // Transition: the rows table can be large; keep its render interruptible
+        // so the UI stays responsive while it commits.
+        startTransition(() => { setRows({ data, loading: false, error: null }); });
       })
       .catch((err: unknown) => {
         if (reqId !== rowsReqIdRef.current) return;


### PR DESCRIPTION
## Problem
You reported the top menu becoming unclickable while a view loads — "something freezing the app," recovering on its own after a moment.

It's **renderer main-thread contention**, not a crash. A dashboard view mounts many widgets; each fires its own async query (via `useQuery` → `use-widget-query`), and their results arrive in a burst. Each result triggered an **urgent** React commit that synchronously builds a visx chart or a large table. The renderer is single-threaded and the top menu is a React component on that same thread, so while the burst of chart renders ran, the thread couldn't service input and the menu appeared frozen — until the burst drained and control "came back."

## Fix
Apply query results inside `startTransition`. React then treats those (potentially heavy) renders as **interruptible**: it time-slices the chart/table work and lets user input — opening the menu, navigating — preempt it. The render work still happens, but it no longer starves input.

- **`use-query.ts`** — the shared hook behind every widget and analytics view (cost overview/trends, entity detail, savings, missing-tags, custom dashboards). Single chokepoint, so one change covers the common multi-widget case.
- **`explorer.tsx`** — the two manual fetch paths (histogram + the large rows table), wrapped for consistency since they don't go through `useQuery`.

The `loading` state stays **urgent**, so spinners still appear instantly, and the existing cancellation guards (`cancelled` ref / `reqId`) are unchanged.

## Why this is the right lever
- visx charts compute their layout/scales **in render** (declarative SVG), so React can time-slice them during a transition — even a single large chart yields between its child fibers.
- The codebase already uses concurrent-React primitives (`useDeferredValue` in `views-editor.tsx`), so this fits the existing approach.
- No behavior contract changes — results still resolve to success/error — so the existing component tests that drive `useQuery` continue to pass.

## Verification
- Root `npm run check` (pre-commit) → **560 passed**, 5 skipped; tsc + eslint clean across all packages.
- `packages/ui` check → 133 tests pass.

Note: this is a UI-thread responsiveness fix, not a unit-testable branch (a transition is a scheduling hint with the same observable outcome), so verification is the existing suite passing rather than a new assertion.

## No version bump
This PR deliberately does **not** touch the version. `main` is already at `0.2.7`, which is one patch above the latest released tag (`v0.2.6`), so it already satisfies the version-bump gate — no bump needed. (The earlier `0.2.8` bump was over-cautious and has been reverted.) A companion PR tightens that CI check so over-increments like that are rejected rather than silently allowed.

## Possible follow-up (not in this PR)
`custom-view.tsx` also prefetches filter values for **every** dimension on mount, which competes with the visible widget queries for the worker pool and can prolong load. Deferring that prefetch until after the widgets resolve (it already falls back to a live query on cache miss) would shorten the load window further. Happy to do it separately if you want.

No `any` / `as` / non-null assertions.