### PR TITLE
ci: require package.json to be exactly one release ahead of the latest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           # Full tag history needed to find the latest `v*` tag.
           fetch-depth: 0
-      - name: Verify package.json version is ahead of latest released tag
+      - name: Verify package.json is exactly one release ahead of the latest tag
         shell: bash
         run: |
           set -euo pipefail
@@ -143,18 +143,33 @@ jobs:
             echo "No v* tag exists yet — nothing to compare against; skipping."
             exit 0
           fi
+          if ! printf '%s' "$latest" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Latest tag v$latest is not a plain X.Y.Z version — skipping the strict check."
+            exit 0
+          fi
+          # package.json must sit EXACTLY one release ahead of the latest tag —
+          # the next patch (X.Y.Z+1), minor (X.Y+1.0), or major (X+1.0.0). Once
+          # main is already one ahead, later PRs inherit that version and need no
+          # bump; only the first PR after a release bumps. This also rejects
+          # over-incrementing (e.g. 0.2.8 while 0.2.7 was never released) and
+          # regressions. `10#` forces base-10 so a value like `08` isn't read as
+          # octal.
+          IFS=. read -r maj min pat <<< "$latest"
+          next_patch="${maj}.${min}.$((10#$pat + 1))"
+          next_minor="${maj}.$((10#$min + 1)).0"
+          next_major="$((10#$maj + 1)).0.0"
+          case "$pkg_v" in
+            "$next_patch"|"$next_minor"|"$next_major")
+              echo "OK: $pkg_v is exactly one release ahead of v$latest"
+              exit 0
+              ;;
+          esac
           if [ "$pkg_v" = "$latest" ]; then
-            echo "::error file=package.json::version $pkg_v matches the latest released tag v$latest — bump it before merging so the next release has a fresh version to tag."
-            exit 1
+            echo "::error file=package.json::version $pkg_v matches the latest released tag v$latest — bump it to $next_patch (or $next_minor / $next_major) before merging."
+          else
+            echo "::error file=package.json::version $pkg_v must be exactly one release ahead of the latest tag v$latest. Expected one of: $next_patch (patch), $next_minor (minor), $next_major (major). Don't skip or over-increment versions."
           fi
-          # Defence-in-depth: also reject regressions, since release.yml's
-          # tag-vs-package.json guard only catches them at tag-push time.
-          highest=$(printf '%s\n%s\n' "$pkg_v" "$latest" | sort -V | tail -n1)
-          if [ "$highest" != "$pkg_v" ]; then
-            echo "::error file=package.json::version $pkg_v is older than the latest released tag v$latest."
-            exit 1
-          fi
-          echo "OK: $pkg_v > $latest"
+          exit 1
 
   sonarcloud:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,19 @@ fi
 npm run check
 ```
 
+## Versioning & releases
+
+The project version lives in `package.json` and `packages/desktop/package.json` — **keep the two in sync** (CI rejects a mismatch). Releases are cut by pushing a `v<version>` tag, which triggers `release.yml` (it verifies the tag matches `package.json`, then builds and publishes).
+
+**Rule: `package.json` must be exactly one release ahead of the latest `v*` tag** — the next patch (`X.Y.Z+1`), or a deliberate minor (`X.Y+1.0`) / major (`X+1.0.0`). The `version bumped past latest release` CI job enforces this on every PR.
+
+What this means in practice:
+- **Don't bump on every PR.** Once `main` is one release ahead of the latest tag, that version is correct — further PRs inherit it and change nothing. Only the **first** PR of a new release cycle bumps the version.
+- **Don't over-increment.** If the latest tag is `v0.2.6`, the target is `0.2.7`. Setting `0.2.8` (skipping `0.2.7`) is rejected — pick `0.2.7`, or, for an intentional minor/major release, `0.3.0` / `1.0.0`.
+- A bump (when needed) updates **both** `package.json` files together.
+
+So the lifecycle is: tag `v0.2.6` released → first PR bumps both to `0.2.7` → subsequent PRs stay at `0.2.7` → maintainer tags `v0.2.7` to release → next PR bumps to `0.2.8`.
+
 ## Key Architecture Decisions
 
 - **Tag normalization at query time** — aliases applied via SQL, not during sync. Changing aliases takes effect immediately.


### PR DESCRIPTION
Addresses your feedback on #355: stop the version-bump check from effectively requiring (and allowing over-) bumps on every PR.

## Problem
The `version bumped past latest release` job only required `package.json > latest tag`. That meant:
- Nothing caught **over-incrementing** — a PR could set `0.2.8` while `0.2.7` was never released (exactly what I did on #355, since reverted).
- It read as "every PR must bump," creating churn.

## Change
The version must now be **exactly one release ahead of the latest `v*` tag** — the next patch (`X.Y.Z+1`), or a deliberate minor (`X.Y+1.0`) / major (`X+1.0.0`).

Behavioral consequences:
- **No bump on most PRs.** Once `main` is one release ahead of the latest tag, that version is already correct, so subsequent PRs inherit it and change nothing. Only the **first** PR of a new release cycle bumps.
- **Over-increments and regressions are rejected**, with an error that names the expected version(s). e.g. with latest tag `v0.2.6`: `0.2.7` ✓, `0.3.0`/`1.0.0` ✓ (deliberate minor/major), `0.2.8` ✗, `0.2.6` ✗, `0.2.5` ✗.

Implementation notes:
- The job `name:` ("version bumped past latest release") is **kept unchanged** so any branch-protection required-check reference stays valid; only the step logic and step name changed.
- `10#` forces base-10 arithmetic so a component like `08` isn't misread as octal.
- Non-`X.Y.Z` latest tags (e.g. a pre-release) are skipped rather than erroring.

## Docs
Adds a **"Versioning & releases"** section to `CLAUDE.md` describing the rule and the lifecycle: `v0.2.6` released → first PR bumps both `package.json`s to `0.2.7` → later PRs stay at `0.2.7` → maintainer tags `v0.2.7` → next PR bumps to `0.2.8`.

## Verification
I unit-tested the bash logic locally against the full matrix:

| package.json | latest tag | result |
|---|---|---|
| 0.2.7 | v0.2.6 | ✅ OK (patch+1) |
| 0.2.6 | v0.2.6 | ❌ matches tag |
| 0.2.8 | v0.2.6 | ❌ over-increment |
| 0.3.0 | v0.2.6 | ✅ OK (minor+1) |
| 1.0.0 | v0.2.6 | ✅ OK (major+1) |
| 0.2.5 | v0.2.6 | ❌ regression |
| 0.2.11 | v0.2.10 | ✅ OK (double-digit) |

This PR itself stays at `0.2.7` (no bump — `main` is already one ahead of `v0.2.6`), which is exactly the new "no churn" behavior in action. Because the workflow change runs from the PR head, this PR is validated by the new check. `npm run check` → 560 passed.

## Edge case to be aware of
The rule allows a single minor/major bump (`0.3.0`, `1.0.0`) but rejects jumps like `0.4.0` or `0.2.9` from `v0.2.6`. If you'd ever want looser/stricter semantics (e.g. patch-only), it's a one-line change — say the word.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJDaY6hzPq6SNEkWkWquZc)_