### PR TITLE
test(ui): stabilize flaky async UI tests that timed out on CI

### DIFF
--- a/packages/ui/src/__tests__/error-states.test.tsx
+++ b/packages/ui/src/__tests__/error-states.test.tsx
@@ -32,11 +32,13 @@ describe('DataManagement error states', () => {
       new Error('To authenticate, run: aws sso login --profile prod'),
     );
     renderDataManagement(api);
-    await waitFor(() => {
-      expect(screen.getByText('To authenticate, run: aws sso login --profile prod')).toBeDefined();
-    });
-    expect(screen.getByText('Open SSO Login')).toBeDefined();
-    expect(screen.getByText('A browser window will open. Refresh this page after logging in.')).toBeDefined();
+    // The error message renders as soon as the inventory query rejects, but the
+    // SSO button is gated on a second query (awsProfile) also resolving. Assert
+    // each with findByText so the button/hint wait for that later commit rather
+    // than racing it — the synchronous getByText was flaky on slow CI runners.
+    expect(await screen.findByText('To authenticate, run: aws sso login --profile prod')).toBeDefined();
+    expect(await screen.findByText('Open SSO Login')).toBeDefined();
+    expect(await screen.findByText('A browser window will open. Refresh this page after logging in.')).toBeDefined();
   });
 
   it('shows permission denied error without refresh hint', async () => {

--- a/packages/ui/src/__tests__/setup.ts
+++ b/packages/ui/src/__tests__/setup.ts
@@ -1,5 +1,13 @@
-import { cleanup } from '@testing-library/react';
+import { cleanup, configure } from '@testing-library/react';
 import { afterEach } from 'vitest';
+
+// CI runners are slower than dev machines, and the default 1000ms async timeout
+// for waitFor/findBy is borderline for data-heavy views (charts, large tables)
+// that only render after a mock query resolves — causing flaky timeouts that
+// don't reproduce locally. Give async utilities more headroom. A passing
+// assertion still resolves as soon as its condition is met, so this only
+// affects genuinely slow or failing waits, not overall suite speed.
+configure({ asyncUtilTimeout: 5000 });
 
 globalThis.ResizeObserver = class ResizeObserver {
   observe() { /* noop */ }


### PR DESCRIPTION
## Problem
Two UI tests pass locally but intermittently fail on CI (they failed `test-unit` twice in a row on an unrelated docs/CI PR, #356). Both are async-render races that only surface on slower CI runners:

1. **`cost-overview.test.tsx` → "renders summary and chart sections after data loads"** — `waitFor(() => getByText('Total Cost'))` exceeds the default **1000ms** async timeout while the chart-heavy view finishes rendering.
2. **`error-states.test.tsx` → "shows SSO login error with refresh hint"** — the test waits for the error message, then asserts the **"Open SSO Login"** button *synchronously*. But that button is gated on a **second** query resolving:
   ```tsx
   {inventoryQuery.status === 'error' && (
     <p>{inventoryQuery.error.message}</p>
     {inventoryQuery.error.message.includes('aws sso login') && awsProfile !== null && (
       <SsoLoginButton .../>   // ← needs awsProfile (a separate query) too
     )}
   )}
   ```
   The message renders as soon as the inventory query rejects, but the button only renders once `awsProfile` loads — a commit later. On CI the synchronous `getByText` raced that commit and failed.

Neither is a product bug — the content does render; the tests just didn't wait for it.

## Fix
- **Raise the global `asyncUtilTimeout` to 5000ms** in `packages/ui/src/__tests__/setup.ts`. A passing assertion still resolves the instant its condition is met, so this only adds headroom for slow/failing waits — it doesn't slow the suite down.
- **Assert the SSO button/hint with `findByText`** so they wait for the `awsProfile` commit instead of racing it.

## Verification
- The two previously-flaky files: pass.
- `packages/ui` check → tsc + eslint + 133 tests pass.
- Root `npm run check` (pre-commit) → 560 passed.

## Context
This unblocks #356 (the versioning-check PR), whose `test-unit` was tripping on exactly these two flakes — but the fix is repo-wide: it stabilizes CI for **every** PR. No version bump (`main` is already one patch ahead of `v0.2.6`). No `any` / `as` / non-null assertions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJDaY6hzPq6SNEkWkWquZc)_