### PR TITLE
release: single mac build job (fixes broken macOS auto-update) + bump to 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,21 @@ jobs:
   build:
     environment: release
     strategy:
+      # Exactly ONE job per platform. electron-builder.yml pins the arch list
+      # per target, so a single invocation builds every arch for the platform
+      # (CLI --x64/--arm64 flags do NOT narrow it). Splitting mac into per-arch
+      # jobs made both jobs build BOTH archs and race on publishing: each
+      # "overwrite published file" replaced the other's binaries, leaving a
+      # latest-mac.yml whose sha512/size didn't match the surviving zips —
+      # which made every macOS auto-update fail checksum validation (v0.2.6).
       matrix:
         include:
           - os: macos-latest
             platform: mac
-            arch: arm64
-          - os: macos-latest
-            platform: mac
-            arch: x64
           - os: windows-latest
             platform: win
-            arch: x64
           - os: ubuntu-latest
             platform: linux
-            arch: x64
 
     runs-on: ${{ matrix.os }}
 
@@ -60,7 +61,7 @@ jobs:
       - run: npm run build --workspaces --if-present
 
       - name: Build installers
-        run: npx --no-install electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish always
+        run: npx --no-install electron-builder --${{ matrix.platform }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MAC_CERTIFICATE_P12 || '' }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## Why macOS auto-update has been failing

The v0.2.6 release's `latest-mac.yml` advertises an arm64 zip with `size: 165723344` and sha512 `ZmhLOc1/…`, but the actual `CostGoblin-0.2.6-arm64-mac.zip` asset is **165723353 bytes** and hashes to `zAbRHaAF…` (verified by downloading and hashing). electron-updater validates the sha512 after download, so on Apple Silicon every update **downloads fine, then fails checksum validation and never installs**. The x64 entries happen to match, so Intel Macs were unaffected.

### Root cause (from the v0.2.6 release job logs)

`electron-builder.yml` pins `arch: [x64, arm64]` on each mac target, and those config lists **override the CLI `--x64` / `--arm64` flags**. So both mac matrix jobs built BOTH archs and published all four mac artifacts to the same release, overwriting each other:

- the `--arm64` job's log: `packaging arch=arm64` → `packaging arch=x64` → `overwrite published file file=CostGoblin-0.2.6-mac.zip` → `overwrite published file file=latest-mac.yml` (16:29:19)
- the `--x64` job's log: also built both archs → `overwrite published file file=CostGoblin-0.2.6-arm64-mac.zip` (16:28:19)

Net result: the arm64 binaries that survived came from one job, `latest-mac.yml` from the other — and two separately signed/notarized builds are never byte-identical, hence the hash mismatch.

### Fix

One build job per platform; drop the no-op arch flags. A single `electron-builder --mac` invocation already builds + notarizes both archs (each duplicate job was doing exactly that in ~9 min anyway) and publishes one internally consistent `latest-mac.yml`. Windows and Linux already worked this way (single job each).

## Version bump

`v0.3.0` is the next intended release: both `package.json` files go `0.2.7 → 0.3.0` (deliberate minor, satisfies the "exactly one release ahead of v0.2.6" CI check).

## Verification

- `npm run check` green (typecheck + lint + 607 tests).
- `release.yml` parses; `matrix.arch` had no other references.
- Note: #315 (better update-error surfacing) is complementary — once merged, a failure like this would show the actual `sha512 checksum mismatch` error in the modal instead of failing silently.

https://claude.ai/code/session_01VbYUnGMqbLyV4md4r5KKEo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbYUnGMqbLyV4md4r5KKEo)_