### PR TITLE
feat: peer data sharing — pull a teammate's billing data + config over the LAN (TLS-PSK)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.2.6",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.2.6",
+      "version": "0.3.2",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -682,7 +682,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -690,19 +692,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -718,6 +722,58 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "dev": true,
@@ -727,12 +783,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -741,13 +799,45 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
+    "node_modules/@babel/generator/node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -758,6 +848,8 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -765,7 +857,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -773,25 +867,43 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -809,7 +921,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -817,7 +931,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -825,7 +941,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -833,12 +951,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -881,34 +1015,142 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
@@ -5973,7 +6215,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6047,7 +6291,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6058,7 +6304,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.3.tgz",
+      "integrity": "sha512-fJuAi3QO096TeMRa/1Z/Z4xVxx2NVXFQc8aOX5huX0gA1V7NkIw+Qv1/Y16MatpJUeYs4mLXAsRs6RUp4sylIQ==",
       "dev": true,
       "funding": [
         {
@@ -6076,10 +6324,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -6257,7 +6505,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001786",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -7175,7 +7425,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -8458,17 +8710,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8773,7 +9025,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8783,9 +9037,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9123,7 +9377,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9183,6 +9449,8 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9582,6 +9850,8 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9896,9 +10166,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9929,9 +10199,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "9.0.0",
@@ -10490,7 +10765,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11672,9 +11949,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -11689,9 +11966,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -11706,9 +11983,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -11723,9 +12000,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -11740,9 +12017,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -11757,9 +12034,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -11774,9 +12051,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -11791,9 +12068,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -11808,9 +12085,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -11825,9 +12102,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -11842,9 +12119,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -11859,9 +12136,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -11876,9 +12153,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -11893,9 +12170,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -11910,9 +12187,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -11927,9 +12204,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -11944,9 +12221,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -11961,9 +12238,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -11978,9 +12255,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -11995,9 +12272,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -12012,9 +12289,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -12029,9 +12306,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -12046,9 +12323,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -12063,9 +12340,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -12080,9 +12357,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -12097,9 +12374,9 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -12114,9 +12391,9 @@
       }
     },
     "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -12127,32 +12404,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/type-check": {
@@ -12226,7 +12503,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12309,6 +12588,8 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -12416,7 +12697,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12795,6 +13078,8 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
@@ -12889,7 +13174,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.2.6",
+      "version": "0.3.2",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1063.0",
         "@aws-sdk/client-s3": "^3.1063.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,
@@ -59,6 +59,9 @@
     "node": ">=20"
   },
   "overrides": {
-    "tmp": "^0.2.7"
+    "tmp": "^0.2.7",
+    "electron-vite": { "vite": "7.3.5" },
+    "@tailwindcss/vite": { "vite": "7.3.5" },
+    "vitest": { "vite": "7.3.5" }
   }
 }

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -73,6 +73,27 @@ describe('validateDimensions', () => {
       tags: [{ tagName: 'x', label: 'X', normalize: 'invalid' }],
     })).toThrow(ConfigValidationError);
   });
+
+  it('accepts a legitimately-named built-in column', () => {
+    expect(() => validateDimensions({
+      builtIn: [{ name: 'svc', label: 'Service', field: 'product_service_name', displayField: 'account_name' }],
+      tags: [],
+    })).not.toThrow();
+  });
+
+  it('rejects a built-in field that smuggles SQL injection', () => {
+    expect(() => validateDimensions({
+      builtIn: [{ name: 'x', label: 'X', field: 'account_id) OR 1=1 --' }],
+      tags: [],
+    })).toThrow(ConfigValidationError);
+  });
+
+  it('rejects a built-in displayField that smuggles SQL injection', () => {
+    expect(() => validateDimensions({
+      builtIn: [{ name: 'x', label: 'X', field: 'account_id', displayField: 'name; DROP TABLE cost_base' }],
+      tags: [],
+    })).toThrow(ConfigValidationError);
+  });
 });
 
 describe('validateOrgTree', () => {

--- a/packages/core/src/__tests__/identifier-validator.test.ts
+++ b/packages/core/src/__tests__/identifier-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assertDateString, assertHourString, validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
+import { assertDateString, assertHourString, isSafeColumnIdentifier, validateColumnName, validateTablePath, SecurityError } from '../query/identifier-validator.js';
 import type { DimensionsConfig } from '../types/config.js';
 import { asDimensionId } from '../types/branded.js';
 
@@ -82,6 +82,31 @@ describe('validateColumnName', () => {
   it('throws SecurityError with descriptive message', () => {
     expect(() => { validateColumnName('bad_column', testDimensions); })
       .toThrow('Invalid column name "bad_column" - not in dimensions config allow-list');
+  });
+});
+
+describe('isSafeColumnIdentifier', () => {
+  it('accepts bare snake_case column identifiers', () => {
+    for (const col of ['account_id', 'region', 'service_family', 'line_item_type', 'product_service_name', '_internal', 'col123']) {
+      expect(isSafeColumnIdentifier(col)).toBe(true);
+    }
+  });
+
+  it('rejects identifiers that could break out of an interpolated SQL position', () => {
+    for (const bad of [
+      'account_id; DROP TABLE cost_base',
+      "account_id') OR 1=1 --",
+      'account_id IN (SELECT 1)',
+      'MAX(cost)',
+      'a b',
+      '1cost',
+      'résumé',
+      '',
+      'tag-name',
+      'a.b',
+    ]) {
+      expect(isSafeColumnIdentifier(bad)).toBe(false);
+    }
   });
 });
 

--- a/packages/core/src/__tests__/pack-manifest.test.ts
+++ b/packages/core/src/__tests__/pack-manifest.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { generateIdentityKeyPair } from '../peer/identity.js';
+import {
+  isSafePackPath,
+  parseSignedManifest,
+  serializeSignedManifest,
+  sha256Hex,
+  signManifest,
+  verifyManifestSignature,
+  PackManifestError,
+  PACK_MANIFEST_VERSION,
+  type PackManifest,
+} from '../peer/pack-manifest.js';
+
+function fixtureManifest(publisher: string): PackManifest {
+  return {
+    v: PACK_MANIFEST_VERSION,
+    createdAt: '2026-06-21T00:00:00.000Z',
+    publisher,
+    label: "Etienne's CostGoblin",
+    configBundle: 'kind: costgoblin-config-bundle\n',
+    enrichment: { orgAccounts: '{"accounts":[]}', regionNames: null, orgAccountTags: null },
+    files: [
+      { path: 'aws/raw/daily-2026-06/part-0.parquet', size: 1024, sha256: sha256Hex(Buffer.from('a')) },
+      { path: 'aws/raw/daily-2026-06/part-1.parquet', size: 2048, sha256: sha256Hex(Buffer.from('b')) },
+    ],
+  };
+}
+
+describe('sha256Hex', () => {
+  it('hashes deterministically', () => {
+    expect(sha256Hex(Buffer.from('x'))).toBe(sha256Hex(Buffer.from('x')));
+    expect(sha256Hex(Buffer.from('x'))).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('isSafePackPath', () => {
+  it('accepts data-tree parquet paths', () => {
+    expect(isSafePackPath('aws/raw/daily-2026-06/part-0.parquet')).toBe(true);
+    expect(isSafePackPath('aws/raw/cost-opt-2026-06-08/part.parquet')).toBe(true);
+  });
+  it('rejects traversal and out-of-tree paths', () => {
+    for (const p of [
+      '../../etc/passwd',
+      '/etc/passwd',
+      'aws/raw/daily-2026-06/../../x.parquet',
+      'aws/raw/daily-2026-06/file.txt',
+      'config/dimensions.yaml',
+      'aws/raw/daily-2026-06/sub/dir/x.parquet',
+    ]) {
+      expect(isSafePackPath(p)).toBe(false);
+    }
+  });
+});
+
+describe('signed pack manifest', () => {
+  it('signs, serializes, parses, and verifies a round trip', () => {
+    const id = generateIdentityKeyPair();
+    const signed = signManifest(fixtureManifest(id.publicKey), id.privateKey);
+    const parsed = parseSignedManifest(serializeSignedManifest(signed));
+    expect(parsed.manifest).toEqual(signed.manifest);
+    expect(verifyManifestSignature(parsed)).toBe(true);
+  });
+
+  it('fails verification when the manifest is tampered after signing', () => {
+    const id = generateIdentityKeyPair();
+    const signed = signManifest(fixtureManifest(id.publicKey), id.privateKey);
+    const tampered = { ...signed, manifest: { ...signed.manifest, label: 'Evil' } };
+    expect(verifyManifestSignature(tampered)).toBe(false);
+  });
+
+  it('fails verification when signed by a different identity', () => {
+    const publisher = generateIdentityKeyPair();
+    const attacker = generateIdentityKeyPair();
+    // Attacker signs a manifest that claims the publisher's key.
+    const forged = signManifest(fixtureManifest(publisher.publicKey), attacker.privateKey);
+    expect(verifyManifestSignature(forged)).toBe(false);
+  });
+
+  it('rejects a manifest whose file path escapes the data tree', () => {
+    const id = generateIdentityKeyPair();
+    const m = fixtureManifest(id.publicKey);
+    const evil: PackManifest = {
+      ...m,
+      files: [{ path: '../../../etc/cron.d/x.parquet', size: 1, sha256: sha256Hex(Buffer.from('c')) }],
+    };
+    const signed = signManifest(evil, id.privateKey);
+    expect(() => parseSignedManifest(serializeSignedManifest(signed))).toThrow(PackManifestError);
+  });
+
+  it('rejects malformed JSON and missing signature', () => {
+    expect(() => parseSignedManifest('not json')).toThrow(PackManifestError);
+    expect(() => parseSignedManifest(JSON.stringify({ manifest: {} }))).toThrow(PackManifestError);
+  });
+});

--- a/packages/core/src/__tests__/pack-manifest.test.ts
+++ b/packages/core/src/__tests__/pack-manifest.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateIdentityKeyPair } from '../peer/identity.js';
 import {
+  classifyPackPath,
   isSafePackPath,
   parseSignedManifest,
   serializeSignedManifest,
@@ -50,6 +51,24 @@ describe('isSafePackPath', () => {
     ]) {
       expect(isSafePackPath(p)).toBe(false);
     }
+  });
+});
+
+describe('classifyPackPath', () => {
+  it('classifies daily and hourly paths by their tier prefix', () => {
+    expect(classifyPackPath('aws/raw/daily-2026-06/part-0.parquet')).toEqual({ tier: 'daily', period: '2026-06' });
+    expect(classifyPackPath('aws/raw/hourly-2026-05/part-1.parquet')).toEqual({ tier: 'hourly', period: '2026-05' });
+  });
+
+  it('maps the cost-opt directory prefix to the cost-optimization tier and a YYYY-MM period', () => {
+    // cost-opt directories carry a -DD day suffix; the period is still the month.
+    expect(classifyPackPath('aws/raw/cost-opt-2026-04-08/r.parquet')).toEqual({ tier: 'cost-optimization', period: '2026-04' });
+  });
+
+  it('returns null for unknown prefixes and non-pack paths', () => {
+    expect(classifyPackPath('aws/raw/weekly-2026-06/x.parquet')).toBeNull();
+    expect(classifyPackPath('config/dimensions.yaml')).toBeNull();
+    expect(classifyPackPath('../../etc/passwd')).toBeNull();
   });
 });
 

--- a/packages/core/src/__tests__/peer-transport.test.ts
+++ b/packages/core/src/__tests__/peer-transport.test.ts
@@ -67,6 +67,52 @@ describe('encrypted peer transport (TLS-PSK)', () => {
     expect(accesses.filter(a => a.kind === 'file')).toHaveLength(files.size);
   });
 
+  it('reports served byte counts and observes peer connections', async () => {
+    const id = generateIdentityKeyPair();
+    const psk = Buffer.from('shared-access-secret-0123456789ab');
+    const signed = signManifest(buildManifest(id.publicKey), id.privateKey);
+    const body = serializeSignedManifest(signed);
+    const accesses: SharingAccessEvent[] = [];
+    const connectionCounts: number[] = [];
+
+    const server = await startSharingServer(
+      {
+        psk,
+        host: '127.0.0.1',
+        onAccess: (e) => accesses.push(e),
+        onConnectionsChanged: (n) => connectionCounts.push(n),
+      },
+      {
+        getManifest: () => body,
+        readFile: (p) => {
+          const buf = files.get(p);
+          if (buf === undefined) throw new Error(`unknown file ${p}`);
+          return Promise.resolve(buf);
+        },
+      },
+    );
+
+    try {
+      const endpoint = { host: '127.0.0.1', port: server.port, psk };
+      await fetchManifest(endpoint);
+      for (const entry of signed.manifest.files) {
+        await fetchFile(endpoint, entry.path);
+      }
+    } finally {
+      await server.close();
+    }
+
+    // Manifest byte count matches the serialized body.
+    const manifestAccess = accesses.find(a => a.kind === 'manifest');
+    expect(manifestAccess?.bytes).toBe(Buffer.byteLength(body));
+    // Each file's reported byte count matches its actual size.
+    const fileBytes = accesses.filter(a => a.kind === 'file').map(a => a.bytes).sort((x, y) => x - y);
+    const expected = [...files.values()].map(b => b.length).sort((x, y) => x - y);
+    expect(fileBytes).toEqual(expected);
+    // At least one authenticated peer connection was observed.
+    expect(Math.max(0, ...connectionCounts)).toBeGreaterThanOrEqual(1);
+  });
+
   it('rejects a client presenting the wrong psk', async () => {
     const id = generateIdentityKeyPair();
     const server = await startSharingServer(

--- a/packages/core/src/__tests__/peer-transport.test.ts
+++ b/packages/core/src/__tests__/peer-transport.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { generateIdentityKeyPair } from '../peer/identity.js';
+import {
+  parseSignedManifest,
+  serializeSignedManifest,
+  sha256Hex,
+  signManifest,
+  verifyManifestSignature,
+  type PackManifest,
+} from '../peer/pack-manifest.js';
+import { startSharingServer } from '../peer/secure-server.js';
+import { fetchFile, fetchManifest } from '../peer/secure-client.js';
+
+const files = new Map<string, Buffer>([
+  ['aws/raw/daily-2026-06/part-0.parquet', Buffer.from('parquet-A-bytes')],
+  ['aws/raw/daily-2026-06/part-1.parquet', Buffer.from('parquet-B-bytes')],
+]);
+
+function buildManifest(publisher: string): PackManifest {
+  return {
+    v: 1,
+    createdAt: '2026-06-21T00:00:00.000Z',
+    publisher,
+    label: 'Test Publisher',
+    configBundle: 'kind: costgoblin-config-bundle\n',
+    enrichment: { orgAccounts: '{"accounts":[]}', regionNames: null, orgAccountTags: null },
+    files: [...files].map(([path, buf]) => ({ path, size: buf.length, sha256: sha256Hex(buf) })),
+  };
+}
+
+describe('encrypted peer transport (TLS-PSK)', () => {
+  it('pulls and verifies a signed snapshot over an encrypted channel', async () => {
+    const id = generateIdentityKeyPair();
+    const psk = Buffer.from('shared-access-secret-0123456789ab');
+    const signed = signManifest(buildManifest(id.publicKey), id.privateKey);
+
+    const server = await startSharingServer(
+      { psk, host: '127.0.0.1' },
+      {
+        getManifest: () => serializeSignedManifest(signed),
+        readFile: (p) => {
+          const buf = files.get(p);
+          if (buf === undefined) throw new Error(`unknown file ${p}`);
+          return Promise.resolve(buf);
+        },
+      },
+    );
+
+    try {
+      const endpoint = { host: '127.0.0.1', port: server.port, psk };
+      const parsed = parseSignedManifest(await fetchManifest(endpoint));
+
+      expect(verifyManifestSignature(parsed)).toBe(true);
+      expect(parsed.manifest.publisher).toBe(id.publicKey);
+
+      for (const entry of parsed.manifest.files) {
+        const buf = await fetchFile(endpoint, entry.path);
+        expect(sha256Hex(buf)).toBe(entry.sha256);
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects a client presenting the wrong psk', async () => {
+    const id = generateIdentityKeyPair();
+    const server = await startSharingServer(
+      { psk: Buffer.from('correct-secret-aaaaaaaaaaaaaaaaaa'), host: '127.0.0.1' },
+      {
+        getManifest: () => serializeSignedManifest(signManifest(buildManifest(id.publicKey), id.privateKey)),
+        readFile: () => Promise.resolve(Buffer.alloc(0)),
+      },
+    );
+
+    try {
+      await expect(
+        fetchManifest({ host: '127.0.0.1', port: server.port, psk: Buffer.from('WRONG-secret-bbbbbbbbbbbbbbbbbbbb') }),
+      ).rejects.toThrow();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects a request for a path outside the data tree', async () => {
+    const id = generateIdentityKeyPair();
+    const psk = Buffer.from('shared-access-secret-0123456789ab');
+    const server = await startSharingServer(
+      { psk, host: '127.0.0.1' },
+      {
+        getManifest: () => serializeSignedManifest(signManifest(buildManifest(id.publicKey), id.privateKey)),
+        readFile: () => Promise.resolve(Buffer.from('should-not-reach')),
+      },
+    );
+
+    try {
+      await expect(
+        fetchFile({ host: '127.0.0.1', port: server.port, psk }, '../../etc/passwd'),
+      ).rejects.toThrow();
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/core/src/__tests__/peer-transport.test.ts
+++ b/packages/core/src/__tests__/peer-transport.test.ts
@@ -8,7 +8,7 @@ import {
   verifyManifestSignature,
   type PackManifest,
 } from '../peer/pack-manifest.js';
-import { startSharingServer } from '../peer/secure-server.js';
+import { startSharingServer, type SharingAccessEvent } from '../peer/secure-server.js';
 import { fetchFile, fetchManifest } from '../peer/secure-client.js';
 
 const files = new Map<string, Buffer>([
@@ -33,9 +33,10 @@ describe('encrypted peer transport (TLS-PSK)', () => {
     const id = generateIdentityKeyPair();
     const psk = Buffer.from('shared-access-secret-0123456789ab');
     const signed = signManifest(buildManifest(id.publicKey), id.privateKey);
+    const accesses: SharingAccessEvent[] = [];
 
     const server = await startSharingServer(
-      { psk, host: '127.0.0.1' },
+      { psk, host: '127.0.0.1', onAccess: (e) => accesses.push(e) },
       {
         getManifest: () => serializeSignedManifest(signed),
         readFile: (p) => {
@@ -60,6 +61,10 @@ describe('encrypted peer transport (TLS-PSK)', () => {
     } finally {
       await server.close();
     }
+
+    // Publisher-side feedback fired for the manifest and each file.
+    expect(accesses.some(a => a.kind === 'manifest')).toBe(true);
+    expect(accesses.filter(a => a.kind === 'file')).toHaveLength(files.size);
   });
 
   it('rejects a client presenting the wrong psk', async () => {

--- a/packages/core/src/__tests__/peer.test.ts
+++ b/packages/core/src/__tests__/peer.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateIdentityKeyPair,
+  isValidPublicKey,
+  publicKeyFingerprint,
+  signBytes,
+  verifyBytes,
+} from '../peer/identity.js';
+import {
+  encodeSharingKey,
+  parseSharingKey,
+  SharingKeyError,
+  SHARING_KEY_VERSION,
+  type SharingKeyPayload,
+} from '../peer/sharing-key.js';
+
+describe('identity keypair', () => {
+  it('generates a 32-byte raw public key and a PEM private key', () => {
+    const id = generateIdentityKeyPair();
+    expect(isValidPublicKey(id.publicKey)).toBe(true);
+    expect(Buffer.from(id.publicKey, 'base64url')).toHaveLength(32);
+    expect(id.privateKey).toContain('BEGIN PRIVATE KEY');
+  });
+
+  it('signs and verifies a round trip', () => {
+    const id = generateIdentityKeyPair();
+    const data = Buffer.from('manifest-bytes');
+    const sig = signBytes(id.privateKey, data);
+    expect(verifyBytes(id.publicKey, data, sig)).toBe(true);
+  });
+
+  it('rejects a signature from a different identity', () => {
+    const a = generateIdentityKeyPair();
+    const b = generateIdentityKeyPair();
+    const data = Buffer.from('payload');
+    const sig = signBytes(a.privateKey, data);
+    expect(verifyBytes(b.publicKey, data, sig)).toBe(false);
+  });
+
+  it('rejects tampered data', () => {
+    const id = generateIdentityKeyPair();
+    const sig = signBytes(id.privateKey, Buffer.from('original'));
+    expect(verifyBytes(id.publicKey, Buffer.from('tampered'), sig)).toBe(false);
+  });
+
+  it('produces a deterministic, formatted fingerprint', () => {
+    const id = generateIdentityKeyPair();
+    const fp = publicKeyFingerprint(id.publicKey);
+    expect(fp).toBe(publicKeyFingerprint(id.publicKey));
+    expect(fp).toMatch(/^[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$/);
+  });
+});
+
+function validPayload(): SharingKeyPayload {
+  const id = generateIdentityKeyPair();
+  return {
+    v: SHARING_KEY_VERSION,
+    hosts: ['192.168.1.42', 'etienne-mbp.local'],
+    port: 53170,
+    pub: id.publicKey,
+    psk: Buffer.alloc(24, 7).toString('base64url'),
+    label: "Etienne's CostGoblin",
+  };
+}
+
+describe('sharing key', () => {
+  it('round-trips a valid payload', () => {
+    const payload = validPayload();
+    const parsed = parseSharingKey(encodeSharingKey(payload));
+    expect(parsed).toEqual(payload);
+  });
+
+  it('tolerates surrounding whitespace on paste', () => {
+    const key = encodeSharingKey(validPayload());
+    expect(() => parseSharingKey(`\n  ${key}  \n`)).not.toThrow();
+  });
+
+  it('rejects a key without the CostGoblin prefix', () => {
+    expect(() => parseSharingKey('not-a-key')).toThrow(SharingKeyError);
+  });
+
+  it('rejects a corrupt / truncated key', () => {
+    const key = encodeSharingKey(validPayload());
+    expect(() => parseSharingKey(key.slice(0, key.length - 10))).toThrow(SharingKeyError);
+  });
+
+  it('rejects an unsupported version', () => {
+    const payload = { ...validPayload(), v: 99 };
+    const encoded = 'CGSHARE1-' + Buffer.from(JSON.stringify(payload)).toString('base64url');
+    expect(() => parseSharingKey(encoded)).toThrow(/Unsupported sharing key version/);
+  });
+
+  it('rejects invalid hosts, ports, keys, secrets, and labels', () => {
+    const base = validPayload();
+    const variants: SharingKeyPayload[] = [
+      { ...base, hosts: [] },
+      { ...base, hosts: ['999.1.1.1'] },
+      { ...base, hosts: ['evil host;rm -rf'] },
+      { ...base, port: 0 },
+      { ...base, port: 70000 },
+      { ...base, pub: 'too-short' },
+      { ...base, psk: Buffer.alloc(4).toString('base64url') },
+      { ...base, label: '' },
+    ];
+    for (const v of variants) {
+      expect(() => parseSharingKey(encodeSharingKey(v))).toThrow(SharingKeyError);
+    }
+  });
+});

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -1,4 +1,5 @@
 import { asBucketPath, asDimensionId } from '../types/branded.js';
+import { isSafeColumnIdentifier } from '../query/identifier-validator.js';
 import type {
   CostGoblinConfig,
   DefaultsConfig,
@@ -141,13 +142,26 @@ function validateStringArray(value: unknown, ctx: string): string[] {
   });
 }
 
+/** Like `assertString`, but also rejects anything that is not a bare SQL
+ *  column identifier — `field`/`displayField` are interpolated into SQL, so a
+ *  shared/imported config must not be able to smuggle injection through them. */
+function assertSafeColumn(value: unknown, context: string): asserts value is string {
+  assertString(value, context);
+  if (!isSafeColumnIdentifier(value)) {
+    throw new ConfigValidationError(
+      `${context} "${value}" is not a valid column identifier — only letters, digits, and underscores are allowed. ` +
+      `This prevents SQL injection via shared or imported configs.`,
+    );
+  }
+}
+
 function validateBuiltInDimension(dim: unknown, i: number) {
   const ctx = `builtIn[${String(i)}]`;
   assertObject(dim, ctx);
   assertString(dim['name'], `${ctx}.name`);
   assertString(dim['label'], `${ctx}.label`);
-  assertString(dim['field'], `${ctx}.field`);
-  const displayField = dim['displayField'] === undefined ? undefined : (assertString(dim['displayField'], `${ctx}.displayField`), dim['displayField']);
+  assertSafeColumn(dim['field'], `${ctx}.field`);
+  const displayField = dim['displayField'] === undefined ? undefined : (assertSafeColumn(dim['displayField'], `${ctx}.displayField`), dim['displayField']);
   const enabled = dim['enabled'] === false ? false : undefined;
   const description = dim['description'] === undefined ? undefined : (assertString(dim['description'], `${ctx}.description`), dim['description']);
   const useOrgAccounts = dim['useOrgAccounts'] === true ? true : undefined;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './config/index.js';
 export * from './normalize/index.js';
 export * from './models/index.js';
 export * from './query/index.js';
+export * from './peer/index.js';
 export * from './sync/index.js';
 export * from './logger/index.js';
 export * from './utils/index.js';

--- a/packages/core/src/peer/identity.ts
+++ b/packages/core/src/peer/identity.ts
@@ -1,0 +1,77 @@
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+  type KeyObject,
+} from 'node:crypto';
+
+/** Thrown when a peer identity key cannot be parsed or used. */
+export class PeerIdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PeerIdentityError';
+  }
+}
+
+/** A persistent Ed25519 identity for one CostGoblin instance. The private key
+ *  never leaves the machine; the public key is what a peer pins — it travels
+ *  inside a sharing key, so the consumer authenticates the channel against it
+ *  with no separate confirmation step (handing over the key is the exchange). */
+export interface IdentityKeyPair {
+  /** Raw Ed25519 public key (32 bytes), base64url. */
+  readonly publicKey: string;
+  /** PKCS#8 private key, PEM. Stays on disk, owner-only. */
+  readonly privateKey: string;
+}
+
+/** Export an Ed25519 public KeyObject as its raw 32-byte value, base64url. */
+function publicKeyToB64url(pub: KeyObject): string {
+  const jwk = pub.export({ format: 'jwk' });
+  if (typeof jwk.x !== 'string') {
+    throw new PeerIdentityError('Failed to export Ed25519 public key');
+  }
+  return jwk.x;
+}
+
+/** Reconstruct an Ed25519 public KeyObject from its raw base64url value. */
+function publicKeyFromB64url(publicKey: string): KeyObject {
+  try {
+    return createPublicKey({ key: { kty: 'OKP', crv: 'Ed25519', x: publicKey }, format: 'jwk' });
+  } catch {
+    throw new PeerIdentityError('Invalid Ed25519 public key');
+  }
+}
+
+/** Generate a fresh Ed25519 identity. Call once per instance, then persist. */
+export function generateIdentityKeyPair(): IdentityKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    publicKey: publicKeyToB64url(publicKey),
+    privateKey: privateKey.export({ type: 'pkcs8', format: 'pem' }),
+  };
+}
+
+/** True when `publicKey` is a well-formed raw Ed25519 public key (base64url). */
+export function isValidPublicKey(publicKey: string): boolean {
+  return Buffer.from(publicKey, 'base64url').length === 32;
+}
+
+/** A short, human-comparable fingerprint of a public key, e.g. for showing in
+ *  the UI so two colleagues can eyeball that they pinned the same identity. */
+export function publicKeyFingerprint(publicKey: string): string {
+  const hex = createHash('sha256').update(Buffer.from(publicKey, 'base64url')).digest('hex');
+  return hex.slice(0, 16).replace(/(.{4})(?=.)/g, '$1-').toUpperCase();
+}
+
+/** Sign bytes with a PKCS#8 PEM private key. Returns a base64url signature. */
+export function signBytes(privateKeyPem: string, data: Buffer): string {
+  return cryptoSign(null, data, createPrivateKey(privateKeyPem)).toString('base64url');
+}
+
+/** Verify a base64url Ed25519 signature against a raw base64url public key. */
+export function verifyBytes(publicKey: string, data: Buffer, signature: string): boolean {
+  return cryptoVerify(null, data, publicKeyFromB64url(publicKey), Buffer.from(signature, 'base64url'));
+}

--- a/packages/core/src/peer/index.ts
+++ b/packages/core/src/peer/index.ts
@@ -31,7 +31,7 @@ export type {
   SignedPackManifest,
 } from './pack-manifest.js';
 export { startSharingServer } from './secure-server.js';
-export type { SharingServer, SharingServerConfig, SharingServerHandlers } from './secure-server.js';
+export type { SharingAccessEvent, SharingServer, SharingServerConfig, SharingServerHandlers } from './secure-server.js';
 export { fetchManifest, fetchFile } from './secure-client.js';
 export type { PeerEndpoint } from './secure-client.js';
 export {

--- a/packages/core/src/peer/index.ts
+++ b/packages/core/src/peer/index.ts
@@ -15,6 +15,7 @@ export {
 } from './sharing-key.js';
 export type { SharingKeyPayload } from './sharing-key.js';
 export {
+  classifyPackPath,
   isSafePackPath,
   parseSignedManifest,
   serializeSignedManifest,
@@ -28,6 +29,7 @@ export type {
   PackEnrichment,
   PackFileEntry,
   PackManifest,
+  PackTier,
   SignedPackManifest,
 } from './pack-manifest.js';
 export { startSharingServer } from './secure-server.js';

--- a/packages/core/src/peer/index.ts
+++ b/packages/core/src/peer/index.ts
@@ -1,0 +1,42 @@
+export {
+  generateIdentityKeyPair,
+  isValidPublicKey,
+  publicKeyFingerprint,
+  signBytes,
+  verifyBytes,
+  PeerIdentityError,
+} from './identity.js';
+export type { IdentityKeyPair } from './identity.js';
+export {
+  encodeSharingKey,
+  parseSharingKey,
+  SharingKeyError,
+  SHARING_KEY_VERSION,
+} from './sharing-key.js';
+export type { SharingKeyPayload } from './sharing-key.js';
+export {
+  isSafePackPath,
+  parseSignedManifest,
+  serializeSignedManifest,
+  sha256Hex,
+  signManifest,
+  verifyManifestSignature,
+  PackManifestError,
+  PACK_MANIFEST_VERSION,
+} from './pack-manifest.js';
+export type {
+  PackEnrichment,
+  PackFileEntry,
+  PackManifest,
+  SignedPackManifest,
+} from './pack-manifest.js';
+export { startSharingServer } from './secure-server.js';
+export type { SharingServer, SharingServerConfig, SharingServerHandlers } from './secure-server.js';
+export { fetchManifest, fetchFile } from './secure-client.js';
+export type { PeerEndpoint } from './secure-client.js';
+export {
+  SHARING_PSK_IDENTITY,
+  SHARING_TLS_CIPHERS,
+  SHARING_TLS_MAX_VERSION,
+  SHARING_TLS_MIN_VERSION,
+} from './tls-psk.js';

--- a/packages/core/src/peer/pack-manifest.ts
+++ b/packages/core/src/peer/pack-manifest.ts
@@ -1,0 +1,160 @@
+import { createHash } from 'node:crypto';
+import { isStringRecord } from '../utils/json.js';
+import { isValidPublicKey, signBytes, verifyBytes } from './identity.js';
+
+/** Thrown when a pack manifest is malformed or fails validation. */
+export class PackManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PackManifestError';
+  }
+}
+
+export const PACK_MANIFEST_VERSION = 1;
+
+/** One Parquet data file in a snapshot. The consumer drops it byte-identical
+ *  into its local data tree and queries it in place — no ETL. */
+export interface PackFileEntry {
+  /** Relative path under the data root, e.g. "aws/raw/daily-2026-06/x.parquet". */
+  readonly path: string;
+  readonly size: number;
+  /** SHA-256 of the file contents, lowercase hex. */
+  readonly sha256: string;
+}
+
+/** Per-machine enrichment (AWS-Org/SSM-gated) carried inline so an S3-less
+ *  consumer sees real account/region names instead of raw IDs. Small JSON. */
+export interface PackEnrichment {
+  readonly orgAccounts: string | null;
+  readonly regionNames: string | null;
+  readonly orgAccountTags: string | null;
+}
+
+/** Describes a data+config snapshot. Signed as a whole by the publisher, so
+ *  the inline config/enrichment and the per-file hashes are all tamper-evident. */
+export interface PackManifest {
+  readonly v: typeof PACK_MANIFEST_VERSION;
+  readonly createdAt: string;
+  /** Publisher Ed25519 public key (raw, base64url) — pins the source. */
+  readonly publisher: string;
+  readonly label: string;
+  /** Serialized config bundle (#354 YAML) shared with the data, or null. */
+  readonly configBundle: string | null;
+  readonly enrichment: PackEnrichment;
+  readonly files: readonly PackFileEntry[];
+}
+
+export interface SignedPackManifest {
+  readonly manifest: PackManifest;
+  /** Ed25519 signature (base64url) over the canonical manifest bytes. */
+  readonly signature: string;
+}
+
+/** SHA-256 of a byte buffer, lowercase hex — used to hash each data file. */
+export function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/** Deterministic, key-sorted serialization so signing and verifying produce
+ *  identical bytes regardless of JSON key order on either machine. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const entries = Object.entries(value).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
+}
+
+function canonicalManifestBytes(manifest: PackManifest): Buffer {
+  return Buffer.from(stableStringify(manifest), 'utf-8');
+}
+
+export function signManifest(manifest: PackManifest, privateKeyPem: string): SignedPackManifest {
+  return { manifest, signature: signBytes(privateKeyPem, canonicalManifestBytes(manifest)) };
+}
+
+/** Verify the signature was produced by the manifest's stated publisher key.
+ *  The caller must still check that `publisher` is a key it has pinned. */
+export function verifyManifestSignature(signed: SignedPackManifest): boolean {
+  return verifyBytes(signed.manifest.publisher, canonicalManifestBytes(signed.manifest), signed.signature);
+}
+
+export function serializeSignedManifest(signed: SignedPackManifest): string {
+  return JSON.stringify(signed);
+}
+
+/** Pack file paths are written to disk by the consumer, so they are confined
+ *  to the data tree: `aws/raw/{tier}-{period}/<file>.parquet`, no traversal. */
+const PACK_FILE_PATH = /^aws\/raw\/[a-z][a-z-]*-\d{4}-\d{2}(?:-\d{2})?\/[A-Za-z0-9._-]+\.parquet$/;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+export function isSafePackPath(path: string): boolean {
+  return !path.includes('..') && PACK_FILE_PATH.test(path);
+}
+
+function validateEnrichment(raw: unknown): PackEnrichment {
+  if (!isStringRecord(raw)) throw new PackManifestError('manifest.enrichment is malformed');
+  const field = (key: string): string | null => {
+    const v = raw[key];
+    if (v === null || v === undefined) return null;
+    if (typeof v !== 'string') throw new PackManifestError(`manifest.enrichment.${key} must be a string or null`);
+    return v;
+  };
+  return { orgAccounts: field('orgAccounts'), regionNames: field('regionNames'), orgAccountTags: field('orgAccountTags') };
+}
+
+function validateFile(raw: unknown, i: number): PackFileEntry {
+  if (!isStringRecord(raw)) throw new PackManifestError(`manifest.files[${String(i)}] is malformed`);
+  const { path, size, sha256 } = raw;
+  if (typeof path !== 'string' || !isSafePackPath(path)) {
+    throw new PackManifestError(`manifest.files[${String(i)}].path is unsafe or invalid`);
+  }
+  if (typeof size !== 'number' || !Number.isInteger(size) || size < 0) {
+    throw new PackManifestError(`manifest.files[${String(i)}].size is invalid`);
+  }
+  if (typeof sha256 !== 'string' || !SHA256_HEX.test(sha256)) {
+    throw new PackManifestError(`manifest.files[${String(i)}].sha256 is invalid`);
+  }
+  return { path, size, sha256 };
+}
+
+function validateManifest(raw: unknown): PackManifest {
+  if (!isStringRecord(raw)) throw new PackManifestError('manifest is malformed');
+  if (raw['v'] !== PACK_MANIFEST_VERSION) {
+    throw new PackManifestError(`Unsupported pack manifest version (${String(raw['v'])})`);
+  }
+  const createdAt = raw['createdAt'];
+  if (typeof createdAt !== 'string' || createdAt.length === 0) throw new PackManifestError('manifest.createdAt is invalid');
+  const publisher = raw['publisher'];
+  if (typeof publisher !== 'string' || !isValidPublicKey(publisher)) throw new PackManifestError('manifest.publisher is invalid');
+  const label = raw['label'];
+  if (typeof label !== 'string' || label.length === 0 || label.length > 200) throw new PackManifestError('manifest.label is invalid');
+  const configBundle = raw['configBundle'];
+  if (configBundle !== null && typeof configBundle !== 'string') throw new PackManifestError('manifest.configBundle must be a string or null');
+  const files = raw['files'];
+  if (!Array.isArray(files)) throw new PackManifestError('manifest.files must be an array');
+  return {
+    v: PACK_MANIFEST_VERSION,
+    createdAt,
+    publisher,
+    label,
+    configBundle,
+    enrichment: validateEnrichment(raw['enrichment']),
+    files: files.map(validateFile),
+  };
+}
+
+/** Parse and structurally validate a transported manifest. Does NOT verify the
+ *  signature or trust the publisher — call `verifyManifestSignature` and check
+ *  the publisher key against your pinned set afterwards. */
+export function parseSignedManifest(json: string): SignedPackManifest {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new PackManifestError('Pack manifest is not valid JSON');
+  }
+  if (!isStringRecord(raw)) throw new PackManifestError('Pack manifest is malformed');
+  const signature = raw['signature'];
+  if (typeof signature !== 'string' || signature.length === 0) throw new PackManifestError('Pack manifest signature is missing');
+  return { manifest: validateManifest(raw['manifest']), signature };
+}

--- a/packages/core/src/peer/pack-manifest.ts
+++ b/packages/core/src/peer/pack-manifest.ts
@@ -91,6 +91,33 @@ export function isSafePackPath(path: string): boolean {
   return !path.includes('..') && PACK_FILE_PATH.test(path);
 }
 
+/** A data tier as named in selections/availability. The on-disk directory
+ *  prefix differs for cost-optimization (`cost-opt`), so callers must not
+ *  assume tier === prefix. */
+export type PackTier = 'daily' | 'hourly' | 'cost-optimization';
+
+/** Maps an on-disk `aws/raw/` directory prefix to its tier. Mirrors
+ *  sync-utils' TIER_RAW_PREFIXES; kept here so the peer module stays
+ *  self-contained. */
+const TIER_BY_PREFIX: ReadonlyMap<string, PackTier> = new Map([
+  ['daily', 'daily'],
+  ['hourly', 'hourly'],
+  ['cost-opt', 'cost-optimization'],
+]);
+
+/** Classify a pack file path — `aws/raw/{prefix}-{YYYY-MM}[-DD]/<file>.parquet`
+ *  — into its tier and YYYY-MM period. Returns null for paths that don't match
+ *  a known tier prefix. NOTE: do not reuse a `[a-z-]+` period regex for this —
+ *  it swallows the prefix and can't distinguish daily/hourly/cost-opt. */
+export function classifyPackPath(path: string): { readonly tier: PackTier; readonly period: string } | null {
+  const m = /^aws\/raw\/([a-z][a-z-]*)-(\d{4}-\d{2})(?:-\d{2})?\//.exec(path);
+  const prefix = m?.[1];
+  const period = m?.[2];
+  if (prefix === undefined || period === undefined) return null;
+  const tier = TIER_BY_PREFIX.get(prefix);
+  return tier === undefined ? null : { tier, period };
+}
+
 function validateEnrichment(raw: unknown): PackEnrichment {
   if (!isStringRecord(raw)) throw new PackManifestError('manifest.enrichment is malformed');
   const field = (key: string): string | null => {

--- a/packages/core/src/peer/secure-client.ts
+++ b/packages/core/src/peer/secure-client.ts
@@ -1,0 +1,76 @@
+import { request, type RequestOptions } from 'node:https';
+import type { ConnectionOptions } from 'node:tls';
+import {
+  SHARING_PSK_IDENTITY,
+  SHARING_TLS_CIPHERS,
+  SHARING_TLS_MAX_VERSION,
+  SHARING_TLS_MIN_VERSION,
+} from './tls-psk.js';
+
+export interface PeerEndpoint {
+  readonly host: string;
+  readonly port: number;
+  readonly psk: Buffer;
+  readonly pskIdentity?: string;
+}
+
+/** Manifests carry config + enrichment inline but are still small. */
+const MAX_MANIFEST_BYTES = 16 * 1024 * 1024;
+/** A single Parquet partition. Buffered in memory for now; streaming straight
+ *  to disk is the eventual optimization for very large monthly files. */
+const MAX_FILE_BYTES = 1024 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function requestOptions(endpoint: PeerEndpoint, path: string): RequestOptions & ConnectionOptions {
+  return {
+    host: endpoint.host,
+    port: endpoint.port,
+    path,
+    method: 'GET',
+    ciphers: SHARING_TLS_CIPHERS,
+    minVersion: SHARING_TLS_MIN_VERSION,
+    maxVersion: SHARING_TLS_MAX_VERSION,
+    // No certificate is in play — PSK provides mutual authentication, and the
+    // manifest signature pins the publisher independently.
+    rejectUnauthorized: false,
+    pskCallback: () => ({ psk: endpoint.psk, identity: endpoint.pskIdentity ?? SHARING_PSK_IDENTITY }),
+  };
+}
+
+function get(endpoint: PeerEndpoint, path: string, maxBytes: number): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const req = request(requestOptions(endpoint, path), (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`Peer responded ${String(res.statusCode)} for ${path}`));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      let total = 0;
+      res.on('data', (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > maxBytes) {
+          req.destroy(new Error('Peer response exceeded the size limit'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      res.on('end', () => { resolve(Buffer.concat(chunks)); });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => { req.destroy(new Error('Peer request timed out')); });
+    req.end();
+  });
+}
+
+/** Fetch the publisher's serialized SignedPackManifest. The caller must parse
+ *  it, verify the signature, and check the publisher key is the pinned one. */
+export function fetchManifest(endpoint: PeerEndpoint): Promise<string> {
+  return get(endpoint, '/manifest', MAX_MANIFEST_BYTES).then((buf) => buf.toString('utf-8'));
+}
+
+/** Fetch one data file by its safe pack path. Verify its SHA-256 before use. */
+export function fetchFile(endpoint: PeerEndpoint, path: string): Promise<Buffer> {
+  return get(endpoint, `/file?path=${encodeURIComponent(path)}`, MAX_FILE_BYTES);
+}

--- a/packages/core/src/peer/secure-server.ts
+++ b/packages/core/src/peer/secure-server.ts
@@ -1,0 +1,96 @@
+import { createServer, type Server } from 'node:https';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { isSafePackPath } from './pack-manifest.js';
+import {
+  SHARING_PSK_IDENTITY,
+  SHARING_TLS_CIPHERS,
+  SHARING_TLS_MAX_VERSION,
+  SHARING_TLS_MIN_VERSION,
+} from './tls-psk.js';
+
+export interface SharingServerHandlers {
+  /** Returns the serialized SignedPackManifest JSON to advertise. */
+  readonly getManifest: () => Promise<string> | string;
+  /** Reads a pack file. `path` is already validated as a safe pack path. */
+  readonly readFile: (path: string) => Promise<Buffer>;
+}
+
+export interface SharingServerConfig {
+  /** Pre-shared access secret. Only a peer holding it can complete the handshake. */
+  readonly psk: Buffer;
+  /** Interface to bind. Default 0.0.0.0 so LAN peers can reach it. */
+  readonly host?: string;
+  /** Port to bind. Default 0 (ephemeral) — the chosen port is reported back. */
+  readonly port?: number;
+  readonly pskIdentity?: string;
+}
+
+export interface SharingServer {
+  readonly port: number;
+  readonly close: () => Promise<void>;
+}
+
+/** Start a TLS-PSK HTTP server exposing GET /manifest and GET /file?path=…
+ *  The TLS handshake is the access gate (no psk → no connection); content is
+ *  additionally Ed25519-signed in the manifest, so the channel encrypts and
+ *  the payload is independently tamper-evident. */
+export async function startSharingServer(
+  config: SharingServerConfig,
+  handlers: SharingServerHandlers,
+): Promise<SharingServer> {
+  const identity = config.pskIdentity ?? SHARING_PSK_IDENTITY;
+  const server: Server = createServer(
+    {
+      ciphers: SHARING_TLS_CIPHERS,
+      minVersion: SHARING_TLS_MIN_VERSION,
+      maxVersion: SHARING_TLS_MAX_VERSION,
+      pskCallback: (_socket, id) => (id === identity ? config.psk : null),
+    },
+    (req, res) => { void handleRequest(req, res, handlers); },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => { reject(err); };
+    server.once('error', onError);
+    server.listen(config.port ?? 0, config.host ?? '0.0.0.0', () => {
+      server.removeListener('error', onError);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  const port = typeof address === 'object' && address !== null ? address.port : 0;
+  return {
+    port,
+    close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
+  };
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse, handlers: SharingServerHandlers): Promise<void> {
+  try {
+    if (req.method !== 'GET') { res.writeHead(405); res.end(); return; }
+    const url = new URL(req.url ?? '/', 'https://peer.local');
+
+    if (url.pathname === '/manifest') {
+      const body = await handlers.getManifest();
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    if (url.pathname === '/file') {
+      const path = url.searchParams.get('path');
+      if (path === null || !isSafePackPath(path)) { res.writeHead(400); res.end(); return; }
+      const file = await handlers.readFile(path);
+      res.writeHead(200, { 'content-type': 'application/octet-stream', 'content-length': String(file.length) });
+      res.end(file);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  } catch {
+    if (!res.headersSent) res.writeHead(500);
+    res.end();
+  }
+}

--- a/packages/core/src/peer/secure-server.ts
+++ b/packages/core/src/peer/secure-server.ts
@@ -15,6 +15,14 @@ export interface SharingServerHandlers {
   readonly readFile: (path: string) => Promise<Buffer>;
 }
 
+/** Emitted after a request is successfully served, so the publisher can show
+ *  who is pulling. Fired only for authenticated (handshake-passed) requests. */
+export interface SharingAccessEvent {
+  readonly kind: 'manifest' | 'file';
+  readonly path: string | null;
+  readonly remoteAddress: string | null;
+}
+
 export interface SharingServerConfig {
   /** Pre-shared access secret. Only a peer holding it can complete the handshake. */
   readonly psk: Buffer;
@@ -23,6 +31,8 @@ export interface SharingServerConfig {
   /** Port to bind. Default 0 (ephemeral) — the chosen port is reported back. */
   readonly port?: number;
   readonly pskIdentity?: string;
+  /** Called after each served request, for activity feedback. */
+  readonly onAccess?: (event: SharingAccessEvent) => void;
 }
 
 export interface SharingServer {
@@ -46,7 +56,13 @@ export async function startSharingServer(
       maxVersion: SHARING_TLS_MAX_VERSION,
       pskCallback: (_socket, id) => (id === identity ? config.psk : null),
     },
-    (req, res) => { void handleRequest(req, res, handlers); },
+    (req, res) => {
+      const remoteAddress = req.socket.remoteAddress ?? null;
+      const report = (kind: 'manifest' | 'file', path: string | null): void => {
+        config.onAccess?.({ kind, path, remoteAddress });
+      };
+      void handleRequest(req, res, handlers, report);
+    },
   );
 
   await new Promise<void>((resolve, reject) => {
@@ -66,7 +82,12 @@ export async function startSharingServer(
   };
 }
 
-async function handleRequest(req: IncomingMessage, res: ServerResponse, handlers: SharingServerHandlers): Promise<void> {
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  handlers: SharingServerHandlers,
+  report: (kind: 'manifest' | 'file', path: string | null) => void,
+): Promise<void> {
   try {
     if (req.method !== 'GET') { res.writeHead(405); res.end(); return; }
     const url = new URL(req.url ?? '/', 'https://peer.local');
@@ -75,6 +96,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, handlers
       const body = await handlers.getManifest();
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(body);
+      report('manifest', null);
       return;
     }
 
@@ -84,6 +106,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, handlers
       const file = await handlers.readFile(path);
       res.writeHead(200, { 'content-type': 'application/octet-stream', 'content-length': String(file.length) });
       res.end(file);
+      report('file', path);
       return;
     }
 

--- a/packages/core/src/peer/secure-server.ts
+++ b/packages/core/src/peer/secure-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:https';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { TLSSocket } from 'node:tls';
 import { isSafePackPath } from './pack-manifest.js';
 import {
   SHARING_PSK_IDENTITY,
@@ -21,6 +22,8 @@ export interface SharingAccessEvent {
   readonly kind: 'manifest' | 'file';
   readonly path: string | null;
   readonly remoteAddress: string | null;
+  /** Bytes written for this response — drives served-byte totals + throughput. */
+  readonly bytes: number;
 }
 
 export interface SharingServerConfig {
@@ -33,6 +36,8 @@ export interface SharingServerConfig {
   readonly pskIdentity?: string;
   /** Called after each served request, for activity feedback. */
   readonly onAccess?: (event: SharingAccessEvent) => void;
+  /** Called whenever the count of authenticated, connected peers changes. */
+  readonly onConnectionsChanged?: (count: number) => void;
 }
 
 export interface SharingServer {
@@ -58,12 +63,25 @@ export async function startSharingServer(
     },
     (req, res) => {
       const remoteAddress = req.socket.remoteAddress ?? null;
-      const report = (kind: 'manifest' | 'file', path: string | null): void => {
-        config.onAccess?.({ kind, path, remoteAddress });
+      const report = (kind: 'manifest' | 'file', path: string | null, bytes: number): void => {
+        config.onAccess?.({ kind, path, remoteAddress, bytes });
       };
       void handleRequest(req, res, handlers, report);
     },
   );
+
+  // Track authenticated peer sockets so we can report a live connected count
+  // and force-close them on stop (server.close() alone waits for keep-alive
+  // sockets to idle out, which would make "Stop sharing" appear to hang).
+  const sockets = new Set<TLSSocket>();
+  server.on('secureConnection', (socket: TLSSocket) => {
+    sockets.add(socket);
+    config.onConnectionsChanged?.(sockets.size);
+    socket.on('close', () => {
+      sockets.delete(socket);
+      config.onConnectionsChanged?.(sockets.size);
+    });
+  });
 
   await new Promise<void>((resolve, reject) => {
     const onError = (err: Error): void => { reject(err); };
@@ -78,7 +96,10 @@ export async function startSharingServer(
   const port = typeof address === 'object' && address !== null ? address.port : 0;
   return {
     port,
-    close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
+    close: () => new Promise<void>((resolve) => {
+      for (const socket of sockets) socket.destroy();
+      server.close(() => { resolve(); });
+    }),
   };
 }
 
@@ -86,7 +107,7 @@ async function handleRequest(
   req: IncomingMessage,
   res: ServerResponse,
   handlers: SharingServerHandlers,
-  report: (kind: 'manifest' | 'file', path: string | null) => void,
+  report: (kind: 'manifest' | 'file', path: string | null, bytes: number) => void,
 ): Promise<void> {
   try {
     if (req.method !== 'GET') { res.writeHead(405); res.end(); return; }
@@ -96,7 +117,7 @@ async function handleRequest(
       const body = await handlers.getManifest();
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(body);
-      report('manifest', null);
+      report('manifest', null, Buffer.byteLength(body));
       return;
     }
 
@@ -106,7 +127,7 @@ async function handleRequest(
       const file = await handlers.readFile(path);
       res.writeHead(200, { 'content-type': 'application/octet-stream', 'content-length': String(file.length) });
       res.end(file);
-      report('file', path);
+      report('file', path, file.length);
       return;
     }
 

--- a/packages/core/src/peer/sharing-key.ts
+++ b/packages/core/src/peer/sharing-key.ts
@@ -1,0 +1,99 @@
+import { isStringRecord } from '../utils/json.js';
+import { isValidPublicKey } from './identity.js';
+
+/** Thrown when a sharing key is malformed, corrupt, or unsupported. */
+export class SharingKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SharingKeyError';
+  }
+}
+
+export const SHARING_KEY_VERSION = 1;
+const SHARING_KEY_PREFIX = 'CGSHARE1-';
+
+/** Everything a consumer needs to connect to a publisher, packed into one
+ *  copy-paste token — so no network broadcast/discovery is required. The
+ *  publisher generates it on "enable sharing"; the consumer pastes it.
+ *
+ *  `pub` (the publisher's Ed25519 public key) is the trust anchor: the channel
+ *  is authenticated against it, so a rogue peer cannot impersonate the source.
+ *  `psk` is the access secret: only a holder of the key can connect, and it
+ *  seeds the session encryption. */
+export interface SharingKeyPayload {
+  readonly v: typeof SHARING_KEY_VERSION;
+  /** Candidate LAN addresses of the publisher (one per network interface). */
+  readonly hosts: readonly string[];
+  readonly port: number;
+  /** Publisher Ed25519 public key, raw 32 bytes, base64url. */
+  readonly pub: string;
+  /** Access secret, base64url (>= 16 bytes of entropy). */
+  readonly psk: string;
+  /** Friendly label, e.g. "Etienne's CostGoblin". */
+  readonly label: string;
+}
+
+export function encodeSharingKey(payload: SharingKeyPayload): string {
+  return SHARING_KEY_PREFIX + Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+}
+
+export function parseSharingKey(key: string): SharingKeyPayload {
+  const trimmed = key.trim();
+  if (!trimmed.startsWith(SHARING_KEY_PREFIX)) {
+    throw new SharingKeyError('This does not look like a CostGoblin sharing key.');
+  }
+  const json = Buffer.from(trimmed.slice(SHARING_KEY_PREFIX.length), 'base64url').toString('utf-8');
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new SharingKeyError('Sharing key is corrupt or incomplete.');
+  }
+  return validateSharingKeyPayload(raw);
+}
+
+const IPV4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+const HOSTNAME = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,62})(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,62}))*$/;
+
+function isValidHost(host: string): boolean {
+  const m = IPV4.exec(host);
+  if (m !== null) return m.slice(1).every(octet => Number(octet) <= 255);
+  return host.length <= 253 && HOSTNAME.test(host);
+}
+
+function decodedLength(b64url: string): number {
+  return Buffer.from(b64url, 'base64url').length;
+}
+
+function validateSharingKeyPayload(raw: unknown): SharingKeyPayload {
+  if (!isStringRecord(raw)) {
+    throw new SharingKeyError('Sharing key payload is malformed.');
+  }
+  if (raw['v'] !== SHARING_KEY_VERSION) {
+    throw new SharingKeyError(`Unsupported sharing key version (${String(raw['v'])}). Update CostGoblin and retry.`);
+  }
+  const hosts = raw['hosts'];
+  if (!Array.isArray(hosts) || hosts.length === 0) {
+    throw new SharingKeyError('Sharing key has no host addresses.');
+  }
+  if (!hosts.every((h: unknown): h is string => typeof h === 'string' && isValidHost(h))) {
+    throw new SharingKeyError('Sharing key has an invalid host address.');
+  }
+  const port = raw['port'];
+  if (typeof port !== 'number' || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new SharingKeyError('Sharing key has an invalid port.');
+  }
+  const pub = raw['pub'];
+  if (typeof pub !== 'string' || !isValidPublicKey(pub)) {
+    throw new SharingKeyError('Sharing key has an invalid public key.');
+  }
+  const psk = raw['psk'];
+  if (typeof psk !== 'string' || decodedLength(psk) < 16) {
+    throw new SharingKeyError('Sharing key has an invalid access secret.');
+  }
+  const label = raw['label'];
+  if (typeof label !== 'string' || label.length === 0 || label.length > 200) {
+    throw new SharingKeyError('Sharing key has an invalid label.');
+  }
+  return { v: SHARING_KEY_VERSION, hosts, port, pub, psk, label };
+}

--- a/packages/core/src/peer/tls-psk.ts
+++ b/packages/core/src/peer/tls-psk.ts
@@ -1,0 +1,15 @@
+import type { SecureVersion } from 'node:tls';
+
+/** TLS-PSK parameters shared by the sharing server and client.
+ *
+ *  Pinned to TLS 1.2 with an ECDHE-PSK AEAD suite: this gives encryption,
+ *  mutual authentication (a peer without the psk fails the handshake), and
+ *  forward secrecy (the ECDHE keys are ephemeral). TLS 1.3 external PSK is
+ *  intentionally avoided — Node's server-side support for it is unreliable. */
+export const SHARING_TLS_MIN_VERSION: SecureVersion = 'TLSv1.2';
+export const SHARING_TLS_MAX_VERSION: SecureVersion = 'TLSv1.2';
+export const SHARING_TLS_CIPHERS = 'ECDHE-PSK-CHACHA20-POLY1305';
+
+/** PSK identity advertised by the client. Routing only — the psk itself is
+ *  what the TLS handshake actually verifies. */
+export const SHARING_PSK_IDENTITY = 'costgoblin';

--- a/packages/core/src/query/identifier-validator.ts
+++ b/packages/core/src/query/identifier-validator.ts
@@ -121,6 +121,25 @@ export function validateColumnName(columnName: string, dimensions: DimensionsCon
 }
 
 /**
+ * A bare, injection-safe SQL column identifier: a leading letter or underscore
+ * followed by letters, digits, or underscores.
+ *
+ * A built-in dimension's `field`/`displayField` is interpolated into SQL as a
+ * bare identifier — `${field} IN (...)`, `MAX(${field})`, `LOWER(${field})` —
+ * so quotes, parentheses, whitespace, or semicolons could break out of the
+ * identifier position. A config can arrive from another user (shared bundle /
+ * imported snapshot), so these strings are untrusted: anything not matching
+ * this shape is rejected. A character-shape check (rather than a fixed column
+ * allow-list) stays airtight without rejecting legitimately-named CUR columns.
+ */
+const SAFE_COLUMN_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** True when `name` is a bare SQL column identifier safe to interpolate. */
+export function isSafeColumnIdentifier(name: string): boolean {
+  return SAFE_COLUMN_IDENTIFIER.test(name);
+}
+
+/**
  * Valid table path tiers (CUR data organization levels).
  */
 const ALLOWED_TIERS = new Set(['daily', 'hourly', 'cost-optimization']);

--- a/packages/core/src/sync/data-inventory.ts
+++ b/packages/core/src/sync/data-inventory.ts
@@ -73,6 +73,34 @@ async function getRawTierSize(rawDir: string, tierPrefix: string): Promise<numbe
   }
 }
 
+/** Build an inventory purely from what's on disk — no S3 listing. Used by a
+ *  consumer that pulled a shared snapshot and has no AWS credentials at all:
+ *  every local period is reported as present so the Sync view renders, and
+ *  there is no remote to compare against (auto-sync treats it as "imported").  */
+export async function getLocalDataInventory(dataDir: string, tier: DataTier = 'daily'): Promise<DataInventory> {
+  const rawDir = join(dataDir, 'aws', 'raw');
+  const tierPrefix = getRawDirPrefix(tier);
+  const localPeriodList = await listRawPeriods(rawDir, tierPrefix);
+  const diskBytes = await getRawTierSize(rawDir, tierPrefix);
+
+  const periods: BillingPeriod[] = [...localPeriodList]
+    .sort((a, b) => b.localeCompare(a))
+    .map(period => ({ period, files: [], totalSize: 0, localStatus: 'repartitioned' }));
+
+  return {
+    periods,
+    totalRemoteSize: 0,
+    totalLocalPeriods: localPeriodList.length,
+    totalRemotePeriods: 0,
+    local: {
+      periods: localPeriodList,
+      diskBytes,
+      oldestPeriod: localPeriodList[0] ?? null,
+      newestPeriod: localPeriodList.at(-1) ?? null,
+    },
+  };
+}
+
 export async function getDataInventory(
   bucketPath: string,
   profile: string,

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -20,6 +20,7 @@ export {
   type BillingPeriod,
   type DataInventory,
   getDataInventory,
+  getLocalDataInventory,
 } from './data-inventory.js';
 
 export {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -11,9 +11,11 @@ import type {
   DataSharingStatus,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
+  PreviewSharedSourceResult,
   PublishConfigBundleResult,
   PullSharedSourceResult,
   SharedPullProgress,
+  SharedPullSelection,
   SharedSourceInfo,
 } from './sharing.js';
 import type {
@@ -244,15 +246,23 @@ export interface CostApi {
   /** Publisher: rotate the access secret (revokes outstanding keys) and
    *  return a fresh sharing key. */
   rotateDataSharingKey(): Promise<DataSharingResult>;
+  /** Consumer: fetch + verify a teammate's manifest WITHOUT downloading data,
+   *  so the UI can show which tiers/months are on offer before committing. */
+  previewSharedSource(key: string): Promise<PreviewSharedSourceResult>;
+  /** Consumer: same preview, but for the already-saved source (the key stays
+   *  in the main process — used by the "reconnect" affordance). */
+  previewStoredSource(): Promise<PreviewSharedSourceResult>;
   /** Consumer: connect with a pasted sharing key, pull the snapshot over the
-   *  encrypted channel, verify it, and import data + config locally. */
-  addSharedSource(key: string): Promise<PullSharedSourceResult>;
+   *  encrypted channel, verify it, and import data + config locally. `selection`
+   *  limits which tiers/periods are pulled; omit to pull everything. */
+  addSharedSource(key: string, selection?: SharedPullSelection): Promise<PullSharedSourceResult>;
   /** Consumer: the configured shared source, or null if none. */
   getSharedSource(): Promise<SharedSourceInfo | null>;
   /** Consumer: live progress of an in-flight pull (polled by the UI). */
   getSharedPullProgress(): Promise<SharedPullProgress>;
-  /** Consumer: re-pull the latest snapshot from the configured source. */
-  refreshSharedSource(): Promise<PullSharedSourceResult>;
+  /** Consumer: re-pull from the configured source. `selection` overrides the
+   *  stored choice; omit to reuse what was last pulled. */
+  refreshSharedSource(selection?: SharedPullSelection): Promise<PullSharedSourceResult>;
   /** Consumer: forget the configured source (local data is left in place). */
   removeSharedSource(): Promise<void>;
   cancelPendingQueries(): Promise<void>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -13,6 +13,7 @@ import type {
   PreviewConfigBundleResult,
   PublishConfigBundleResult,
   PullSharedSourceResult,
+  SharedPullProgress,
   SharedSourceInfo,
 } from './sharing.js';
 import type {
@@ -248,6 +249,8 @@ export interface CostApi {
   addSharedSource(key: string): Promise<PullSharedSourceResult>;
   /** Consumer: the configured shared source, or null if none. */
   getSharedSource(): Promise<SharedSourceInfo | null>;
+  /** Consumer: live progress of an in-flight pull (polled by the UI). */
+  getSharedPullProgress(): Promise<SharedPullProgress>;
   /** Consumer: re-pull the latest snapshot from the configured source. */
   refreshSharedSource(): Promise<PullSharedSourceResult>;
   /** Consumer: forget the configured source (local data is left in place). */

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -7,9 +7,13 @@ import type {
   ApplyConfigBundleResult,
   CheckConfigBeaconParams,
   CheckConfigBeaconResult,
+  DataSharingResult,
+  DataSharingStatus,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
   PublishConfigBundleResult,
+  PullSharedSourceResult,
+  SharedSourceInfo,
 } from './sharing.js';
 import type {
   ExplorerFilterValue,
@@ -229,6 +233,25 @@ export interface CostApi {
   /** Probe a bucket for a published team configuration. Used by the setup
    *  wizard right after bucket selection. */
   checkConfigBeacon(params: CheckConfigBeaconParams): Promise<CheckConfigBeaconResult>;
+  // --- Peer data sharing (LAN, TLS-PSK) ---
+  /** Publisher: current sharing state, including the sharing key while on. */
+  getDataSharingStatus(): Promise<DataSharingStatus>;
+  /** Publisher: start sharing this machine's data on the local network. */
+  enableDataSharing(): Promise<DataSharingResult>;
+  /** Publisher: stop sharing. */
+  disableDataSharing(): Promise<DataSharingResult>;
+  /** Publisher: rotate the access secret (revokes outstanding keys) and
+   *  return a fresh sharing key. */
+  rotateDataSharingKey(): Promise<DataSharingResult>;
+  /** Consumer: connect with a pasted sharing key, pull the snapshot over the
+   *  encrypted channel, verify it, and import data + config locally. */
+  addSharedSource(key: string): Promise<PullSharedSourceResult>;
+  /** Consumer: the configured shared source, or null if none. */
+  getSharedSource(): Promise<SharedSourceInfo | null>;
+  /** Consumer: re-pull the latest snapshot from the configured source. */
+  refreshSharedSource(): Promise<PullSharedSourceResult>;
+  /** Consumer: forget the configured source (local data is left in place). */
+  removeSharedSource(): Promise<void>;
   cancelPendingQueries(): Promise<void>;
   /** Wipe every backend cache (LRU result cache, column probe cache,
    *  in-flight de-dup map, materialized base table, plus the in-memory

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -101,11 +101,15 @@ export type {
   ConfigBundle,
   ConfigBundleSections,
   ConfigBundleSummary,
+  DataSharingResult,
+  DataSharingStatus,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
   PublishConfigBundleResult,
+  PullSharedSourceResult,
   SharedCostGoblinConfig,
   SharedProviderConfig,
+  SharedSourceInfo,
 } from './sharing.js';
 export { CONFIG_BUNDLE_KIND, CONFIG_BUNDLE_SCHEMA_VERSION, CONFIG_BEACON_KEY } from './sharing.js';
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -105,13 +105,19 @@ export type {
   DataSharingStatus,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
+  PreviewSharedSourceResult,
   PublishConfigBundleResult,
   PullSharedSourceResult,
   SharedCostGoblinConfig,
+  SharedDataTier,
   SharedProviderConfig,
   SharedPullPhase,
   SharedPullProgress,
+  SharedPullSelection,
   SharedSourceInfo,
+  SharedSourcePreview,
+  SharedSourceTier,
+  SharedSourceTierAvailability,
 } from './sharing.js';
 export { CONFIG_BUNDLE_KIND, CONFIG_BUNDLE_SCHEMA_VERSION, CONFIG_BEACON_KEY } from './sharing.js';
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -109,6 +109,8 @@ export type {
   PullSharedSourceResult,
   SharedCostGoblinConfig,
   SharedProviderConfig,
+  SharedPullPhase,
+  SharedPullProgress,
   SharedSourceInfo,
 } from './sharing.js';
 export { CONFIG_BUNDLE_KIND, CONFIG_BUNDLE_SCHEMA_VERSION, CONFIG_BEACON_KEY } from './sharing.js';

--- a/packages/core/src/types/sharing.ts
+++ b/packages/core/src/types/sharing.ts
@@ -130,6 +130,23 @@ export interface DataSharingStatus {
   readonly hosts: readonly string[];
   /** Short fingerprint of this machine's identity, for out-of-band comparison. */
   readonly fingerprint: string | null;
+  /** When a peer last fetched anything this sharing session (ISO), or null. */
+  readonly lastServedAt: string | null;
+  /** Data files served to peers this sharing session. */
+  readonly filesServed: number;
+  /** Address of the most recent peer to connect, or null. */
+  readonly lastPeer: string | null;
+}
+
+export type SharedPullPhase = 'idle' | 'connecting' | 'downloading' | 'importing' | 'done';
+
+/** Live progress of a consumer pull, polled by the UI while it runs. */
+export interface SharedPullProgress {
+  readonly active: boolean;
+  readonly phase: SharedPullPhase;
+  readonly filesDone: number;
+  readonly filesTotal: number;
+  readonly currentPeriod: string | null;
 }
 
 export type DataSharingResult =

--- a/packages/core/src/types/sharing.ts
+++ b/packages/core/src/types/sharing.ts
@@ -136,9 +136,15 @@ export interface DataSharingStatus {
   readonly filesServed: number;
   /** Address of the most recent peer to connect, or null. */
   readonly lastPeer: string | null;
+  /** Total bytes served to peers this sharing session. */
+  readonly bytesServed: number;
+  /** Peers currently connected (TLS-PSK handshake completed). */
+  readonly connectedClients: number;
+  /** Recent serving throughput in bytes/second (trailing window), 0 when idle. */
+  readonly bytesPerSecond: number;
 }
 
-export type SharedPullPhase = 'idle' | 'connecting' | 'downloading' | 'importing' | 'done';
+export type SharedPullPhase = 'idle' | 'connecting' | 'downloading' | 'importing' | 'done' | 'error';
 
 /** Live progress of a consumer pull, polled by the UI while it runs. */
 export interface SharedPullProgress {
@@ -147,7 +153,53 @@ export interface SharedPullProgress {
   readonly filesDone: number;
   readonly filesTotal: number;
   readonly currentPeriod: string | null;
+  /** Bytes downloaded so far / total to download (filtered to the selection). */
+  readonly bytesDone: number;
+  readonly bytesTotal: number;
+  /** Set when `phase === 'error'`; the failure message to surface. */
+  readonly error: string | null;
 }
+
+/** The selectable parts of a shared snapshot. `config` gates the config +
+ *  enrichment bundle; the rest are data tiers, gated and period-filtered. */
+export type SharedSourceTier = 'config' | 'daily' | 'hourly' | 'cost-optimization';
+
+/** A data tier (no `config`). */
+export type SharedDataTier = 'daily' | 'hourly' | 'cost-optimization';
+
+/** What the consumer chooses to pull. Omitting it pulls everything (the
+ *  default, preserving refresh-without-choosing behaviour). */
+export interface SharedPullSelection {
+  /** Tiers to pull. Includes 'config' to apply the config/enrichment bundle. */
+  readonly sources: readonly SharedSourceTier[];
+  /** Explicit YYYY-MM periods to include for the data tiers, mirroring the
+   *  sync month picker. Omit (undefined) to pull every available period. */
+  readonly periods?: readonly string[] | undefined;
+}
+
+/** Per-tier availability derived from a teammate's signed manifest, so the UI
+ *  can offer a month picker before committing to a download. */
+export interface SharedSourceTierAvailability {
+  readonly tier: SharedDataTier;
+  /** Distinct YYYY-MM periods available for this tier, sorted ascending. */
+  readonly periods: readonly string[];
+  readonly fileCount: number;
+  readonly bytes: number;
+}
+
+/** What a teammate is offering, fetched + verified without downloading data. */
+export interface SharedSourcePreview {
+  readonly label: string;
+  readonly fingerprint: string;
+  readonly hasConfig: boolean;
+  /** Digest of the bundled config, when present, for the "what will I apply?" card. */
+  readonly configSummary: ConfigBundleSummary | null;
+  readonly tiers: readonly SharedSourceTierAvailability[];
+}
+
+export type PreviewSharedSourceResult =
+  | { readonly status: 'ok'; readonly preview: SharedSourcePreview }
+  | { readonly status: 'error'; readonly message: string };
 
 export type DataSharingResult =
   | { readonly status: 'ok'; readonly sharing: DataSharingStatus }
@@ -161,6 +213,8 @@ export interface SharedSourceInfo {
   readonly port: number;
   readonly lastPulledAt: string | null;
   readonly periods: readonly string[];
+  /** The tiers/periods chosen on the last pull, for pre-seeding a reconnect. */
+  readonly selection?: SharedPullSelection | undefined;
 }
 
 export type PullSharedSourceResult =

--- a/packages/core/src/types/sharing.ts
+++ b/packages/core/src/types/sharing.ts
@@ -112,3 +112,40 @@ export type CheckConfigBeaconResult =
   | { readonly status: 'found'; readonly location: string; readonly content: string; readonly summary: ConfigBundleSummary }
   | { readonly status: 'none' }
   | { readonly status: 'error'; readonly message: string };
+
+// ---------------------------------------------------------------------------
+// Peer data sharing — LAN, TLS-PSK (see packages/core/src/peer/). Lets a
+// teammate with zero AWS access pull a teammate's billing data + config from
+// one pasted "sharing key", with no S3 and no server.
+// ---------------------------------------------------------------------------
+
+/** Publisher-side state. When `enabled`, `sharingKey` is the CGSHARE1 token a
+ *  teammate pastes to connect — it packs the host(s), port, this machine's
+ *  public key, and the access secret. */
+export interface DataSharingStatus {
+  readonly enabled: boolean;
+  readonly sharingKey: string | null;
+  readonly label: string;
+  readonly port: number | null;
+  readonly hosts: readonly string[];
+  /** Short fingerprint of this machine's identity, for out-of-band comparison. */
+  readonly fingerprint: string | null;
+}
+
+export type DataSharingResult =
+  | { readonly status: 'ok'; readonly sharing: DataSharingStatus }
+  | { readonly status: 'error'; readonly message: string };
+
+/** Consumer-side: the single shared source this machine pulls from. */
+export interface SharedSourceInfo {
+  readonly label: string;
+  readonly fingerprint: string;
+  readonly host: string;
+  readonly port: number;
+  readonly lastPulledAt: string | null;
+  readonly periods: readonly string[];
+}
+
+export type PullSharedSourceResult =
+  | { readonly status: 'ok'; readonly source: SharedSourceInfo; readonly filesDownloaded: number }
+  | { readonly status: 'error'; readonly message: string };

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/handlers/bundle-io.ts
+++ b/packages/desktop/src/main/handlers/bundle-io.ts
@@ -1,0 +1,88 @@
+import { app as electronApp } from 'electron';
+import {
+  buildConfigBundle,
+  bundleConfigWithProfile,
+  bundleSectionIds,
+  costGoblinConfigToYaml,
+  costScopeToYaml,
+  dimensionsConfigToYaml,
+  orgTreeToYaml,
+  parseConfigBundle,
+  viewsConfigToYaml,
+} from '@costgoblin/core';
+import type { BundleSectionId, ConfigBundle, ConfigBundleSections } from '@costgoblin/core';
+import type { AppContext, IpcContext } from './context.js';
+
+/** Assemble a bundle from whatever org config exists locally. Config and
+ *  dimensions are mandatory; the optional files are skipped when missing or
+ *  unreadable instead of failing the whole export. */
+export async function buildCurrentBundle(app: AppContext): Promise<ConfigBundle> {
+  const config = await app.getConfig();
+  const dimensions = await app.getDimensions();
+  const orgTree = await app.getOrgTreeConfig().catch(() => undefined);
+  const costScope = await app.getCostScope().catch(() => undefined);
+  const views = await app.getViews().catch(() => undefined);
+  return buildConfigBundle({ config, dimensions, orgTree, costScope, views, appVersion: electronApp.getVersion() });
+}
+
+/** Copy whichever org config files exist into config/backups/<timestamp>/ so
+ *  an import is always one folder-copy away from being undone. */
+export async function backupExistingConfig(ctx: IpcContext): Promise<string | null> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const configDir = path.dirname(ctx.configPath);
+  const candidates = [ctx.configPath, ctx.dimensionsPath, ctx.orgTreePath, ctx.costScopePath, ctx.viewsPath];
+  const existing: string[] = [];
+  for (const file of candidates) {
+    try {
+      await fs.access(file);
+      existing.push(file);
+    } catch {
+      // not present — nothing to back up
+    }
+  }
+  if (existing.length === 0) return null;
+  const stamp = new Date().toISOString().replaceAll(':', '-');
+  const backupDir = path.join(configDir, 'backups', stamp);
+  await fs.mkdir(backupDir, { recursive: true });
+  for (const file of existing) {
+    await fs.copyFile(file, path.join(backupDir, path.basename(file)));
+  }
+  return backupDir;
+}
+
+export interface AppliedBundle {
+  readonly sections: ConfigBundleSections;
+  readonly sectionIds: readonly BundleSectionId[];
+  readonly backupDir: string | null;
+}
+
+/** Re-parse + re-validate a bundle (never trust an earlier preview) and write
+ *  its sections to the config directory, backing up existing files first. The
+ *  chosen AWS profile is injected into every provider. Does NOT clear caches —
+ *  the caller decides when. */
+export async function applyBundleSectionsToDisk(ctx: IpcContext, content: string, profile: string): Promise<AppliedBundle> {
+  const parsed = parseConfigBundle(content);
+  const { sections } = parsed.bundle;
+
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const { stringify } = await import('yaml');
+  await fs.mkdir(path.dirname(ctx.configPath), { recursive: true });
+  const backupDir = await backupExistingConfig(ctx);
+
+  const config = bundleConfigWithProfile(sections.config, profile);
+  await fs.writeFile(ctx.configPath, stringify(costGoblinConfigToYaml(config)), 'utf-8');
+  await fs.writeFile(ctx.dimensionsPath, stringify(dimensionsConfigToYaml(sections.dimensions)), 'utf-8');
+  if (sections.orgTree !== undefined) {
+    await fs.writeFile(ctx.orgTreePath, stringify(orgTreeToYaml(sections.orgTree)), 'utf-8');
+  }
+  if (sections.costScope !== undefined) {
+    await fs.writeFile(ctx.costScopePath, stringify(costScopeToYaml(sections.costScope)), 'utf-8');
+  }
+  if (sections.views !== undefined) {
+    await fs.writeFile(ctx.viewsPath, stringify(viewsConfigToYaml(sections.views)), 'utf-8');
+  }
+
+  return { sections, sectionIds: bundleSectionIds(sections), backupDir };
+}

--- a/packages/desktop/src/main/handlers/data-sharing.ts
+++ b/packages/desktop/src/main/handlers/data-sharing.ts
@@ -1,0 +1,358 @@
+import { ipcMain } from 'electron';
+import { networkInterfaces } from 'node:os';
+import {
+  encodeSharingKey,
+  fetchFile,
+  fetchManifest,
+  isSafePackPath,
+  logger,
+  parseSharingKey,
+  parseSignedManifest,
+  publicKeyFingerprint,
+  serializeConfigBundle,
+  serializeSignedManifest,
+  sha256Hex,
+  signManifest,
+  startSharingServer,
+  verifyManifestSignature,
+  PACK_MANIFEST_VERSION,
+  SHARING_KEY_VERSION,
+} from '@costgoblin/core';
+import type {
+  DataSharingResult,
+  DataSharingStatus,
+  IdentityKeyPair,
+  PackEnrichment,
+  PackFileEntry,
+  PackManifest,
+  PeerEndpoint,
+  PullSharedSourceResult,
+  SharedSourceInfo,
+  SharingKeyPayload,
+  SharingServer,
+} from '@costgoblin/core';
+import type { AppContext } from './context.js';
+import { applyBundleSectionsToDisk, buildCurrentBundle } from './bundle-io.js';
+import {
+  clearSharedSource,
+  loadOrCreateIdentity,
+  loadOrCreateSharingSecret,
+  loadSharedSource,
+  rotateSharingSecret,
+  saveSharedSource,
+  type StoredSharedSource,
+} from './peer-store.js';
+
+/** Fixed port so a handed-out sharing key stays valid across restarts (the
+ *  user accepted re-sharing on the rarer IP change). */
+const SHARING_PORT = 53178;
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Non-internal IPv4 addresses of this machine, with loopback as a fallback
+ *  so publisher and consumer can also be tested on one machine. */
+function lanHosts(): string[] {
+  const hosts: string[] = [];
+  for (const addrs of Object.values(networkInterfaces())) {
+    for (const addr of addrs ?? []) {
+      if (addr.family === 'IPv4' && !addr.internal) hosts.push(addr.address);
+    }
+  }
+  if (hosts.length === 0) hosts.push('127.0.0.1');
+  return hosts;
+}
+
+function extractPeriodFromPath(path: string): string | null {
+  const m = /\/[a-z-]+-(\d{4}-\d{2})/.exec(path);
+  return m?.[1] ?? null;
+}
+
+export function registerDataSharingHandlers(app: AppContext): void {
+  const { ctx, clearAllCaches } = app;
+  let server: SharingServer | null = null;
+
+  async function readEnrichment(): Promise<PackEnrichment> {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const base = path.dirname(ctx.dataDir);
+    const read = async (name: string): Promise<string | null> => {
+      try {
+        return await fs.readFile(path.join(base, name), 'utf-8');
+      } catch {
+        return null;
+      }
+    };
+    return {
+      orgAccounts: await read('org-accounts.json'),
+      regionNames: await read('region-names.json'),
+      orgAccountTags: await read('org-account-tags.json'),
+    };
+  }
+
+  async function writeEnrichment(enrichment: PackEnrichment): Promise<void> {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const base = path.dirname(ctx.dataDir);
+    await fs.mkdir(base, { recursive: true });
+    const write = async (name: string, content: string | null): Promise<void> => {
+      if (content !== null) await fs.writeFile(path.join(base, name), content, 'utf-8');
+    };
+    await write('org-accounts.json', enrichment.orgAccounts);
+    await write('region-names.json', enrichment.regionNames);
+    await write('org-account-tags.json', enrichment.orgAccountTags);
+  }
+
+  /** Scan local Parquet, hash every file, and bundle config + enrichment into
+   *  a signed manifest. Rebuilt on each request so a peer always sees fresh
+   *  data (fine at fixture scale; large datasets are a future optimization). */
+  async function buildLocalManifest(identity: IdentityKeyPair, label: string): Promise<PackManifest> {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
+    const files: PackFileEntry[] = [];
+    let dirs: string[] = [];
+    try {
+      dirs = await fs.readdir(rawDir);
+    } catch {
+      dirs = [];
+    }
+    for (const dir of dirs) {
+      let names: string[] = [];
+      try {
+        names = await fs.readdir(path.join(rawDir, dir));
+      } catch {
+        continue;
+      }
+      for (const name of names) {
+        if (!name.endsWith('.parquet')) continue;
+        const rel = `aws/raw/${dir}/${name}`;
+        if (!isSafePackPath(rel)) continue;
+        const buf = await fs.readFile(path.join(rawDir, dir, name));
+        files.push({ path: rel, size: buf.length, sha256: sha256Hex(buf) });
+      }
+    }
+    return {
+      v: PACK_MANIFEST_VERSION,
+      createdAt: new Date().toISOString(),
+      publisher: identity.publicKey,
+      label,
+      configBundle: serializeConfigBundle(await buildCurrentBundle(app)),
+      enrichment: await readEnrichment(),
+      files,
+    };
+  }
+
+  function currentStatus(): DataSharingStatus {
+    const identity = loadOrCreateIdentity(ctx.configPath);
+    const secret = loadOrCreateSharingSecret(ctx.configPath);
+    const fingerprint = publicKeyFingerprint(identity.publicKey);
+    if (server === null) {
+      return { enabled: false, sharingKey: null, label: secret.label, port: null, hosts: [], fingerprint };
+    }
+    const hosts = lanHosts();
+    const sharingKey = encodeSharingKey({
+      v: SHARING_KEY_VERSION,
+      hosts,
+      port: server.port,
+      pub: identity.publicKey,
+      psk: secret.psk,
+      label: secret.label,
+    });
+    return { enabled: true, sharingKey, label: secret.label, port: server.port, hosts, fingerprint };
+  }
+
+  async function enable(): Promise<DataSharingStatus> {
+    if (server !== null) return currentStatus();
+    const identity = loadOrCreateIdentity(ctx.configPath);
+    const secret = loadOrCreateSharingSecret(ctx.configPath);
+    server = await startSharingServer(
+      { psk: Buffer.from(secret.psk, 'base64url'), port: SHARING_PORT },
+      {
+        getManifest: async () =>
+          serializeSignedManifest(signManifest(await buildLocalManifest(identity, secret.label), identity.privateKey)),
+        readFile: async (p) => {
+          const fs = await import('node:fs/promises');
+          const path = await import('node:path');
+          return fs.readFile(path.join(ctx.dataDir, p));
+        },
+      },
+    );
+    logger.info('Data sharing enabled', { port: server.port });
+    return currentStatus();
+  }
+
+  async function disable(): Promise<DataSharingStatus> {
+    if (server !== null) {
+      await server.close();
+      server = null;
+      logger.info('Data sharing disabled');
+    }
+    return currentStatus();
+  }
+
+  async function pull(payload: SharingKeyPayload): Promise<{
+    filesDownloaded: number;
+    periods: string[];
+    label: string;
+    fingerprint: string;
+    host: string;
+  }> {
+    const psk = Buffer.from(payload.psk, 'base64url');
+    let endpoint: PeerEndpoint | null = null;
+    let signed = null;
+    let lastError: unknown = null;
+    for (const host of payload.hosts) {
+      try {
+        const candidate: PeerEndpoint = { host, port: payload.port, psk };
+        signed = parseSignedManifest(await fetchManifest(candidate));
+        endpoint = candidate;
+        break;
+      } catch (err: unknown) {
+        lastError = err;
+      }
+    }
+    if (endpoint === null || signed === null) {
+      throw new Error(`Could not reach the shared source. ${errorMessage(lastError)}`);
+    }
+    if (!verifyManifestSignature(signed)) {
+      throw new Error('Snapshot signature is invalid — refusing to import.');
+    }
+    if (signed.manifest.publisher !== payload.pub) {
+      throw new Error('Snapshot publisher does not match the sharing key — refusing to import.');
+    }
+
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    let downloaded = 0;
+    for (const entry of signed.manifest.files) {
+      const dest = path.join(ctx.dataDir, entry.path);
+      try {
+        const existing = await fs.readFile(dest);
+        if (existing.length === entry.size && sha256Hex(existing) === entry.sha256) continue;
+      } catch {
+        // not present locally — fetch it
+      }
+      const buf = await fetchFile(endpoint, entry.path);
+      if (sha256Hex(buf) !== entry.sha256) {
+        throw new Error(`Checksum mismatch for ${entry.path} — refusing to import.`);
+      }
+      await fs.mkdir(path.dirname(dest), { recursive: true });
+      await fs.writeFile(dest, buf);
+      downloaded++;
+    }
+
+    if (signed.manifest.configBundle !== null) {
+      await applyBundleSectionsToDisk(ctx, signed.manifest.configBundle, 'default');
+    }
+    await writeEnrichment(signed.manifest.enrichment);
+    await clearAllCaches();
+
+    const periods = [...new Set(
+      signed.manifest.files.map(f => extractPeriodFromPath(f.path)).filter((p): p is string => p !== null),
+    )].sort();
+    logger.info('Pulled shared snapshot', { from: endpoint.host, files: downloaded, periods: periods.length });
+    return {
+      filesDownloaded: downloaded,
+      periods,
+      label: signed.manifest.label,
+      fingerprint: publicKeyFingerprint(signed.manifest.publisher),
+      host: endpoint.host,
+    };
+  }
+
+  function toInfo(source: StoredSharedSource): SharedSourceInfo {
+    return {
+      label: source.label,
+      fingerprint: source.fingerprint,
+      host: source.host,
+      port: source.port,
+      lastPulledAt: source.lastPulledAt,
+      periods: source.periods,
+    };
+  }
+
+  ipcMain.handle('data-sharing:status', (): DataSharingStatus => currentStatus());
+
+  ipcMain.handle('data-sharing:enable', async (): Promise<DataSharingResult> => {
+    try {
+      return { status: 'ok', sharing: await enable() };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:disable', async (): Promise<DataSharingResult> => {
+    try {
+      return { status: 'ok', sharing: await disable() };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:rotate', async (): Promise<DataSharingResult> => {
+    try {
+      rotateSharingSecret(ctx.configPath);
+      if (server !== null) {
+        await server.close();
+        server = null;
+        await enable();
+      }
+      return { status: 'ok', sharing: currentStatus() };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:add-source', async (_event, raw: unknown): Promise<PullSharedSourceResult> => {
+    if (typeof raw !== 'string') return { status: 'error', message: 'Invalid sharing key' };
+    try {
+      const payload = parseSharingKey(raw);
+      const result = await pull(payload);
+      const source: StoredSharedSource = {
+        key: raw,
+        label: result.label,
+        fingerprint: result.fingerprint,
+        host: result.host,
+        port: payload.port,
+        lastPulledAt: new Date().toISOString(),
+        periods: result.periods,
+      };
+      saveSharedSource(ctx.configPath, source);
+      return { status: 'ok', source: toInfo(source), filesDownloaded: result.filesDownloaded };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:get-source', (): SharedSourceInfo | null => {
+    const stored = loadSharedSource(ctx.configPath);
+    return stored === null ? null : toInfo(stored);
+  });
+
+  ipcMain.handle('data-sharing:refresh-source', async (): Promise<PullSharedSourceResult> => {
+    const stored = loadSharedSource(ctx.configPath);
+    if (stored === null) return { status: 'error', message: 'No shared source configured' };
+    try {
+      const payload = parseSharingKey(stored.key);
+      const result = await pull(payload);
+      const updated: StoredSharedSource = {
+        ...stored,
+        label: result.label,
+        fingerprint: result.fingerprint,
+        host: result.host,
+        lastPulledAt: new Date().toISOString(),
+        periods: result.periods,
+      };
+      saveSharedSource(ctx.configPath, updated);
+      return { status: 'ok', source: toInfo(updated), filesDownloaded: result.filesDownloaded };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:remove-source', (): void => {
+    clearSharedSource(ctx.configPath);
+  });
+}

--- a/packages/desktop/src/main/handlers/data-sharing.ts
+++ b/packages/desktop/src/main/handlers/data-sharing.ts
@@ -27,6 +27,7 @@ import type {
   PackManifest,
   PeerEndpoint,
   PullSharedSourceResult,
+  SharedPullProgress,
   SharedSourceInfo,
   SharingKeyPayload,
   SharingServer,
@@ -72,6 +73,14 @@ function extractPeriodFromPath(path: string): string | null {
 export function registerDataSharingHandlers(app: AppContext): void {
   const { ctx, clearAllCaches } = app;
   let server: SharingServer | null = null;
+
+  // Publisher-side activity, reset each time sharing is enabled.
+  let lastServedAt: string | null = null;
+  let filesServed = 0;
+  let lastPeer: string | null = null;
+
+  // Consumer-side pull progress, polled by the UI while a pull is running.
+  let pullProgress: SharedPullProgress = { active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null };
 
   async function readEnrichment(): Promise<PackEnrichment> {
     const fs = await import('node:fs/promises');
@@ -149,7 +158,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
     const secret = loadOrCreateSharingSecret(ctx.configPath);
     const fingerprint = publicKeyFingerprint(identity.publicKey);
     if (server === null) {
-      return { enabled: false, sharingKey: null, label: secret.label, port: null, hosts: [], fingerprint };
+      return { enabled: false, sharingKey: null, label: secret.label, port: null, hosts: [], fingerprint, lastServedAt: null, filesServed: 0, lastPeer: null };
     }
     const hosts = lanHosts();
     const sharingKey = encodeSharingKey({
@@ -160,15 +169,26 @@ export function registerDataSharingHandlers(app: AppContext): void {
       psk: secret.psk,
       label: secret.label,
     });
-    return { enabled: true, sharingKey, label: secret.label, port: server.port, hosts, fingerprint };
+    return { enabled: true, sharingKey, label: secret.label, port: server.port, hosts, fingerprint, lastServedAt, filesServed, lastPeer };
   }
 
   async function enable(): Promise<DataSharingStatus> {
     if (server !== null) return currentStatus();
     const identity = loadOrCreateIdentity(ctx.configPath);
     const secret = loadOrCreateSharingSecret(ctx.configPath);
+    lastServedAt = null;
+    filesServed = 0;
+    lastPeer = null;
     server = await startSharingServer(
-      { psk: Buffer.from(secret.psk, 'base64url'), port: SHARING_PORT },
+      {
+        psk: Buffer.from(secret.psk, 'base64url'),
+        port: SHARING_PORT,
+        onAccess: (event) => {
+          lastServedAt = new Date().toISOString();
+          lastPeer = event.remoteAddress;
+          if (event.kind === 'file') filesServed++;
+        },
+      },
       {
         getManifest: async () =>
           serializeSignedManifest(signManifest(await buildLocalManifest(identity, secret.label), identity.privateKey)),
@@ -200,66 +220,80 @@ export function registerDataSharingHandlers(app: AppContext): void {
     host: string;
   }> {
     const psk = Buffer.from(payload.psk, 'base64url');
-    let endpoint: PeerEndpoint | null = null;
-    let signed = null;
-    let lastError: unknown = null;
-    for (const host of payload.hosts) {
-      try {
-        const candidate: PeerEndpoint = { host, port: payload.port, psk };
-        signed = parseSignedManifest(await fetchManifest(candidate));
-        endpoint = candidate;
-        break;
-      } catch (err: unknown) {
-        lastError = err;
+    pullProgress = { active: true, phase: 'connecting', filesDone: 0, filesTotal: 0, currentPeriod: null };
+    try {
+      let endpoint: PeerEndpoint | null = null;
+      let signed = null;
+      let lastError: unknown = null;
+      for (const host of payload.hosts) {
+        try {
+          const candidate: PeerEndpoint = { host, port: payload.port, psk };
+          signed = parseSignedManifest(await fetchManifest(candidate));
+          endpoint = candidate;
+          break;
+        } catch (err: unknown) {
+          lastError = err;
+        }
       }
-    }
-    if (endpoint === null || signed === null) {
-      throw new Error(`Could not reach the shared source. ${errorMessage(lastError)}`);
-    }
-    if (!verifyManifestSignature(signed)) {
-      throw new Error('Snapshot signature is invalid — refusing to import.');
-    }
-    if (signed.manifest.publisher !== payload.pub) {
-      throw new Error('Snapshot publisher does not match the sharing key — refusing to import.');
-    }
-
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-    let downloaded = 0;
-    for (const entry of signed.manifest.files) {
-      const dest = path.join(ctx.dataDir, entry.path);
-      try {
-        const existing = await fs.readFile(dest);
-        if (existing.length === entry.size && sha256Hex(existing) === entry.sha256) continue;
-      } catch {
-        // not present locally — fetch it
+      if (endpoint === null || signed === null) {
+        throw new Error(`Could not reach the shared source. ${errorMessage(lastError)}`);
       }
-      const buf = await fetchFile(endpoint, entry.path);
-      if (sha256Hex(buf) !== entry.sha256) {
-        throw new Error(`Checksum mismatch for ${entry.path} — refusing to import.`);
+      if (!verifyManifestSignature(signed)) {
+        throw new Error('Snapshot signature is invalid — refusing to import.');
       }
-      await fs.mkdir(path.dirname(dest), { recursive: true });
-      await fs.writeFile(dest, buf);
-      downloaded++;
-    }
+      if (signed.manifest.publisher !== payload.pub) {
+        throw new Error('Snapshot publisher does not match the sharing key — refusing to import.');
+      }
 
-    if (signed.manifest.configBundle !== null) {
-      await applyBundleSectionsToDisk(ctx, signed.manifest.configBundle, 'default');
-    }
-    await writeEnrichment(signed.manifest.enrichment);
-    await clearAllCaches();
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const total = signed.manifest.files.length;
+      pullProgress = { active: true, phase: 'downloading', filesDone: 0, filesTotal: total, currentPeriod: null };
+      let downloaded = 0;
+      let done = 0;
+      for (const entry of signed.manifest.files) {
+        pullProgress = { active: true, phase: 'downloading', filesDone: done, filesTotal: total, currentPeriod: extractPeriodFromPath(entry.path) };
+        const dest = path.join(ctx.dataDir, entry.path);
+        try {
+          const existing = await fs.readFile(dest);
+          if (existing.length === entry.size && sha256Hex(existing) === entry.sha256) {
+            done++;
+            continue;
+          }
+        } catch {
+          // not present locally — fetch it
+        }
+        const buf = await fetchFile(endpoint, entry.path);
+        if (sha256Hex(buf) !== entry.sha256) {
+          throw new Error(`Checksum mismatch for ${entry.path} — refusing to import.`);
+        }
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.writeFile(dest, buf);
+        downloaded++;
+        done++;
+      }
 
-    const periods = [...new Set(
-      signed.manifest.files.map(f => extractPeriodFromPath(f.path)).filter((p): p is string => p !== null),
-    )].sort();
-    logger.info('Pulled shared snapshot', { from: endpoint.host, files: downloaded, periods: periods.length });
-    return {
-      filesDownloaded: downloaded,
-      periods,
-      label: signed.manifest.label,
-      fingerprint: publicKeyFingerprint(signed.manifest.publisher),
-      host: endpoint.host,
-    };
+      pullProgress = { active: true, phase: 'importing', filesDone: done, filesTotal: total, currentPeriod: null };
+      if (signed.manifest.configBundle !== null) {
+        await applyBundleSectionsToDisk(ctx, signed.manifest.configBundle, 'default');
+      }
+      await writeEnrichment(signed.manifest.enrichment);
+      await clearAllCaches();
+
+      const periods = [...new Set(
+        signed.manifest.files.map(f => extractPeriodFromPath(f.path)).filter((p): p is string => p !== null),
+      )].sort();
+      logger.info('Pulled shared snapshot', { from: endpoint.host, files: downloaded, periods: periods.length });
+      return {
+        filesDownloaded: downloaded,
+        periods,
+        label: signed.manifest.label,
+        fingerprint: publicKeyFingerprint(signed.manifest.publisher),
+        host: endpoint.host,
+      };
+    } finally {
+      pullProgress = { ...pullProgress, active: false, phase: 'done' };
+    }
   }
 
   function toInfo(source: StoredSharedSource): SharedSourceInfo {
@@ -330,6 +364,8 @@ export function registerDataSharingHandlers(app: AppContext): void {
     const stored = loadSharedSource(ctx.configPath);
     return stored === null ? null : toInfo(stored);
   });
+
+  ipcMain.handle('data-sharing:pull-progress', (): SharedPullProgress => pullProgress);
 
   ipcMain.handle('data-sharing:refresh-source', async (): Promise<PullSharedSourceResult> => {
     const stored = loadSharedSource(ctx.configPath);

--- a/packages/desktop/src/main/handlers/data-sharing.ts
+++ b/packages/desktop/src/main/handlers/data-sharing.ts
@@ -1,11 +1,13 @@
 import { ipcMain } from 'electron';
 import { networkInterfaces } from 'node:os';
 import {
+  classifyPackPath,
   encodeSharingKey,
   fetchFile,
   fetchManifest,
   isSafePackPath,
   logger,
+  parseConfigBundle,
   parseSharingKey,
   parseSignedManifest,
   publicKeyFingerprint,
@@ -14,11 +16,13 @@ import {
   sha256Hex,
   signManifest,
   startSharingServer,
+  summarizeConfigBundle,
   verifyManifestSignature,
   PACK_MANIFEST_VERSION,
   SHARING_KEY_VERSION,
 } from '@costgoblin/core';
 import type {
+  ConfigBundleSummary,
   DataSharingResult,
   DataSharingStatus,
   IdentityKeyPair,
@@ -26,11 +30,17 @@ import type {
   PackFileEntry,
   PackManifest,
   PeerEndpoint,
+  PreviewSharedSourceResult,
   PullSharedSourceResult,
+  SharedDataTier,
   SharedPullProgress,
+  SharedPullSelection,
   SharedSourceInfo,
+  SharedSourcePreview,
+  SharedSourceTierAvailability,
   SharingKeyPayload,
   SharingServer,
+  SignedPackManifest,
 } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 import { applyBundleSectionsToDisk, buildCurrentBundle } from './bundle-io.js';
@@ -39,6 +49,7 @@ import {
   loadOrCreateIdentity,
   loadOrCreateSharingSecret,
   loadSharedSource,
+  parseSharedPullSelection,
   rotateSharingSecret,
   saveSharedSource,
   type StoredSharedSource,
@@ -66,9 +77,16 @@ function lanHosts(): string[] {
 }
 
 function extractPeriodFromPath(path: string): string | null {
-  const m = /\/[a-z-]+-(\d{4}-\d{2})/.exec(path);
-  return m?.[1] ?? null;
+  return classifyPackPath(path)?.period ?? null;
 }
+
+/** Trailing window over which serving throughput is averaged for the banner. */
+const THROUGHPUT_WINDOW_MS = 5000;
+/** A peer counts as "connected" if it fetched within this trailing window.
+ *  The client opens a fresh socket per request (keep-alive off), so a raw
+ *  open-socket count flaps 0↔1 during a pull; a short activity window keyed by
+ *  address is a stable, meaningful "currently pulling" gauge. */
+const ACTIVE_PEER_WINDOW_MS = 8000;
 
 export function registerDataSharingHandlers(app: AppContext): void {
   const { ctx, clearAllCaches } = app;
@@ -78,9 +96,41 @@ export function registerDataSharingHandlers(app: AppContext): void {
   let lastServedAt: string | null = null;
   let filesServed = 0;
   let lastPeer: string | null = null;
+  let bytesServed = 0;
+  // Distinct peers (by address) that fetched within ACTIVE_PEER_WINDOW_MS.
+  let peerActivity = new Map<string, number>();
+  // Rolling (timestamp, bytes) samples, pruned to THROUGHPUT_WINDOW_MS, used to
+  // estimate live serving throughput for the banner.
+  let byteSamples: { t: number; bytes: number }[] = [];
+
+  function recordServed(bytes: number, remoteAddress: string | null): void {
+    const now = Date.now();
+    bytesServed += bytes;
+    byteSamples.push({ t: now, bytes });
+    byteSamples = byteSamples.filter(s => s.t >= now - THROUGHPUT_WINDOW_MS);
+    if (remoteAddress !== null) peerActivity.set(remoteAddress, now);
+  }
+
+  function bytesPerSecond(): number {
+    const now = Date.now();
+    const live = byteSamples.filter(s => s.t >= now - THROUGHPUT_WINDOW_MS);
+    if (live.length === 0) return 0;
+    const sum = live.reduce((n, s) => n + s.bytes, 0);
+    const oldest = live.reduce((min, s) => Math.min(min, s.t), now);
+    const spanSec = Math.max((now - oldest) / 1000, 0.5);
+    return Math.round(sum / spanSec);
+  }
+
+  function activePeerCount(): number {
+    const cutoff = Date.now() - ACTIVE_PEER_WINDOW_MS;
+    for (const [addr, t] of peerActivity) {
+      if (t < cutoff) peerActivity.delete(addr);
+    }
+    return peerActivity.size;
+  }
 
   // Consumer-side pull progress, polled by the UI while a pull is running.
-  let pullProgress: SharedPullProgress = { active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null };
+  let pullProgress: SharedPullProgress = { active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null, bytesDone: 0, bytesTotal: 0, error: null };
 
   async function readEnrichment(): Promise<PackEnrichment> {
     const fs = await import('node:fs/promises');
@@ -158,7 +208,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
     const secret = loadOrCreateSharingSecret(ctx.configPath);
     const fingerprint = publicKeyFingerprint(identity.publicKey);
     if (server === null) {
-      return { enabled: false, sharingKey: null, label: secret.label, port: null, hosts: [], fingerprint, lastServedAt: null, filesServed: 0, lastPeer: null };
+      return { enabled: false, sharingKey: null, label: secret.label, port: null, hosts: [], fingerprint, lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 };
     }
     const hosts = lanHosts();
     const sharingKey = encodeSharingKey({
@@ -169,7 +219,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
       psk: secret.psk,
       label: secret.label,
     });
-    return { enabled: true, sharingKey, label: secret.label, port: server.port, hosts, fingerprint, lastServedAt, filesServed, lastPeer };
+    return { enabled: true, sharingKey, label: secret.label, port: server.port, hosts, fingerprint, lastServedAt, filesServed, lastPeer, bytesServed, connectedClients: activePeerCount(), bytesPerSecond: bytesPerSecond() };
   }
 
   async function enable(): Promise<DataSharingStatus> {
@@ -179,6 +229,9 @@ export function registerDataSharingHandlers(app: AppContext): void {
     lastServedAt = null;
     filesServed = 0;
     lastPeer = null;
+    bytesServed = 0;
+    peerActivity = new Map();
+    byteSamples = [];
     server = await startSharingServer(
       {
         psk: Buffer.from(secret.psk, 'base64url'),
@@ -187,6 +240,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
           lastServedAt = new Date().toISOString();
           lastPeer = event.remoteAddress;
           if (event.kind === 'file') filesServed++;
+          recordServed(event.bytes, event.remoteAddress);
         },
       },
       {
@@ -212,52 +266,123 @@ export function registerDataSharingHandlers(app: AppContext): void {
     return currentStatus();
   }
 
-  async function pull(payload: SharingKeyPayload): Promise<{
+  /** Reach a host from the sharing key, fetch its manifest, and verify both
+   *  the signature and that the publisher matches the pinned key. Shared by
+   *  preview (no download) and pull (download). */
+  async function connect(payload: SharingKeyPayload): Promise<{ endpoint: PeerEndpoint; signed: SignedPackManifest }> {
+    const psk = Buffer.from(payload.psk, 'base64url');
+    let endpoint: PeerEndpoint | null = null;
+    let signed: SignedPackManifest | null = null;
+    let lastError: unknown = null;
+    for (const host of payload.hosts) {
+      try {
+        const candidate: PeerEndpoint = { host, port: payload.port, psk };
+        signed = parseSignedManifest(await fetchManifest(candidate));
+        endpoint = candidate;
+        break;
+      } catch (err: unknown) {
+        lastError = err;
+      }
+    }
+    if (endpoint === null || signed === null) {
+      throw new Error(`Could not reach the shared source. ${errorMessage(lastError)}`);
+    }
+    if (!verifyManifestSignature(signed)) {
+      throw new Error('Snapshot signature is invalid — refusing to import.');
+    }
+    if (signed.manifest.publisher !== payload.pub) {
+      throw new Error('Snapshot publisher does not match the sharing key — refusing to import.');
+    }
+    return { endpoint, signed };
+  }
+
+  /** Summarize what a verified manifest offers — per-tier months/counts/bytes
+   *  plus the config digest — so the UI can show a month picker before pulling. */
+  function buildPreview(signed: SignedPackManifest): SharedSourcePreview {
+    const byTier = new Map<SharedDataTier, { periods: Set<string>; fileCount: number; bytes: number }>();
+    for (const f of signed.manifest.files) {
+      const c = classifyPackPath(f.path);
+      if (c === null) continue;
+      const entry = byTier.get(c.tier) ?? { periods: new Set<string>(), fileCount: 0, bytes: 0 };
+      entry.periods.add(c.period);
+      entry.fileCount++;
+      entry.bytes += f.size;
+      byTier.set(c.tier, entry);
+    }
+    const tierOrder: readonly SharedDataTier[] = ['daily', 'hourly', 'cost-optimization'];
+    const tiers: SharedSourceTierAvailability[] = [];
+    for (const tier of tierOrder) {
+      const e = byTier.get(tier);
+      if (e === undefined) continue;
+      tiers.push({ tier, periods: [...e.periods].sort((a, b) => a.localeCompare(b)), fileCount: e.fileCount, bytes: e.bytes });
+    }
+    let configSummary: ConfigBundleSummary | null = null;
+    if (signed.manifest.configBundle !== null) {
+      try { configSummary = summarizeConfigBundle(parseConfigBundle(signed.manifest.configBundle)); }
+      catch { configSummary = null; }
+    }
+    return {
+      label: signed.manifest.label,
+      fingerprint: publicKeyFingerprint(signed.manifest.publisher),
+      hasConfig: signed.manifest.configBundle !== null,
+      configSummary,
+      tiers,
+    };
+  }
+
+  /** Profile to stamp onto an imported config. The bundle never carries one,
+   *  so reuse this machine's configured profile; fall back to 'default' on a
+   *  fresh install where no config exists yet (the no-AWS peer-import case). */
+  async function resolveImportProfile(): Promise<string> {
+    try {
+      const config = await app.getConfig();
+      const profile = config.providers[0]?.credentials.profile;
+      if (typeof profile === 'string' && profile.length > 0) return profile;
+    } catch {
+      // No config on disk yet — fall through to the default.
+    }
+    return 'default';
+  }
+
+  async function pull(payload: SharingKeyPayload, selection?: SharedPullSelection): Promise<{
     filesDownloaded: number;
     periods: string[];
     label: string;
     fingerprint: string;
     host: string;
   }> {
-    const psk = Buffer.from(payload.psk, 'base64url');
-    pullProgress = { active: true, phase: 'connecting', filesDone: 0, filesTotal: 0, currentPeriod: null };
+    pullProgress = { active: true, phase: 'connecting', filesDone: 0, filesTotal: 0, currentPeriod: null, bytesDone: 0, bytesTotal: 0, error: null };
     try {
-      let endpoint: PeerEndpoint | null = null;
-      let signed = null;
-      let lastError: unknown = null;
-      for (const host of payload.hosts) {
-        try {
-          const candidate: PeerEndpoint = { host, port: payload.port, psk };
-          signed = parseSignedManifest(await fetchManifest(candidate));
-          endpoint = candidate;
-          break;
-        } catch (err: unknown) {
-          lastError = err;
-        }
-      }
-      if (endpoint === null || signed === null) {
-        throw new Error(`Could not reach the shared source. ${errorMessage(lastError)}`);
-      }
-      if (!verifyManifestSignature(signed)) {
-        throw new Error('Snapshot signature is invalid — refusing to import.');
-      }
-      if (signed.manifest.publisher !== payload.pub) {
-        throw new Error('Snapshot publisher does not match the sharing key — refusing to import.');
-      }
+      const { endpoint, signed } = await connect(payload);
+      const wantConfig = selection === undefined || selection.sources.includes('config');
+      const periodSet = selection?.periods === undefined ? null : new Set(selection.periods);
+      // Filter the (already-signed) file list to the chosen tiers + months.
+      // No protocol change: the manifest signature covers the whole set; we
+      // simply choose which signed entries to download.
+      const files = signed.manifest.files.filter(entry => {
+        const c = classifyPackPath(entry.path);
+        if (c === null) return false;
+        if (selection !== undefined && !selection.sources.includes(c.tier)) return false;
+        if (periodSet !== null && !periodSet.has(c.period)) return false;
+        return true;
+      });
 
       const fs = await import('node:fs/promises');
       const path = await import('node:path');
-      const total = signed.manifest.files.length;
-      pullProgress = { active: true, phase: 'downloading', filesDone: 0, filesTotal: total, currentPeriod: null };
+      const total = files.length;
+      const bytesTotal = files.reduce((n, f) => n + f.size, 0);
+      pullProgress = { active: true, phase: 'downloading', filesDone: 0, filesTotal: total, currentPeriod: null, bytesDone: 0, bytesTotal, error: null };
       let downloaded = 0;
       let done = 0;
-      for (const entry of signed.manifest.files) {
-        pullProgress = { active: true, phase: 'downloading', filesDone: done, filesTotal: total, currentPeriod: extractPeriodFromPath(entry.path) };
+      let bytesDone = 0;
+      for (const entry of files) {
+        pullProgress = { active: true, phase: 'downloading', filesDone: done, filesTotal: total, currentPeriod: extractPeriodFromPath(entry.path), bytesDone, bytesTotal, error: null };
         const dest = path.join(ctx.dataDir, entry.path);
         try {
           const existing = await fs.readFile(dest);
           if (existing.length === entry.size && sha256Hex(existing) === entry.sha256) {
             done++;
+            bytesDone += entry.size;
             continue;
           }
         } catch {
@@ -271,19 +396,23 @@ export function registerDataSharingHandlers(app: AppContext): void {
         await fs.writeFile(dest, buf);
         downloaded++;
         done++;
+        bytesDone += entry.size;
       }
 
-      pullProgress = { active: true, phase: 'importing', filesDone: done, filesTotal: total, currentPeriod: null };
-      if (signed.manifest.configBundle !== null) {
-        await applyBundleSectionsToDisk(ctx, signed.manifest.configBundle, 'default');
+      pullProgress = { active: true, phase: 'importing', filesDone: done, filesTotal: total, currentPeriod: null, bytesDone, bytesTotal, error: null };
+      if (wantConfig && signed.manifest.configBundle !== null) {
+        await applyBundleSectionsToDisk(ctx, signed.manifest.configBundle, await resolveImportProfile());
       }
+      // Enrichment (account/region names) is reference data that makes the
+      // pulled rows readable, so it always lands regardless of the config toggle.
       await writeEnrichment(signed.manifest.enrichment);
       await clearAllCaches();
 
       const periods = [...new Set(
-        signed.manifest.files.map(f => extractPeriodFromPath(f.path)).filter((p): p is string => p !== null),
-      )].sort();
+        files.map(f => extractPeriodFromPath(f.path)).filter((p): p is string => p !== null),
+      )].sort((a, b) => a.localeCompare(b));
       logger.info('Pulled shared snapshot', { from: endpoint.host, files: downloaded, periods: periods.length });
+      pullProgress = { active: false, phase: 'done', filesDone: done, filesTotal: total, currentPeriod: null, bytesDone, bytesTotal, error: null };
       return {
         filesDownloaded: downloaded,
         periods,
@@ -291,8 +420,9 @@ export function registerDataSharingHandlers(app: AppContext): void {
         fingerprint: publicKeyFingerprint(signed.manifest.publisher),
         host: endpoint.host,
       };
-    } finally {
-      pullProgress = { ...pullProgress, active: false, phase: 'done' };
+    } catch (err: unknown) {
+      pullProgress = { ...pullProgress, active: false, phase: 'error', error: errorMessage(err) };
+      throw err;
     }
   }
 
@@ -304,6 +434,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
       port: source.port,
       lastPulledAt: source.lastPulledAt,
       periods: source.periods,
+      ...(source.selection === undefined ? {} : { selection: source.selection }),
     };
   }
 
@@ -339,11 +470,33 @@ export function registerDataSharingHandlers(app: AppContext): void {
     }
   });
 
-  ipcMain.handle('data-sharing:add-source', async (_event, raw: unknown): Promise<PullSharedSourceResult> => {
+  ipcMain.handle('data-sharing:preview-source', async (_event, raw: unknown): Promise<PreviewSharedSourceResult> => {
+    if (typeof raw !== 'string') return { status: 'error', message: 'Invalid sharing key' };
+    try {
+      const { signed } = await connect(parseSharingKey(raw));
+      return { status: 'ok', preview: buildPreview(signed) };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:preview-stored-source', async (): Promise<PreviewSharedSourceResult> => {
+    const stored = loadSharedSource(ctx.configPath);
+    if (stored === null) return { status: 'error', message: 'No shared source configured' };
+    try {
+      const { signed } = await connect(parseSharingKey(stored.key));
+      return { status: 'ok', preview: buildPreview(signed) };
+    } catch (err: unknown) {
+      return { status: 'error', message: errorMessage(err) };
+    }
+  });
+
+  ipcMain.handle('data-sharing:add-source', async (_event, raw: unknown, rawSelection: unknown): Promise<PullSharedSourceResult> => {
     if (typeof raw !== 'string') return { status: 'error', message: 'Invalid sharing key' };
     try {
       const payload = parseSharingKey(raw);
-      const result = await pull(payload);
+      const selection = parseSharedPullSelection(rawSelection);
+      const result = await pull(payload, selection);
       const source: StoredSharedSource = {
         key: raw,
         label: result.label,
@@ -352,6 +505,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
         port: payload.port,
         lastPulledAt: new Date().toISOString(),
         periods: result.periods,
+        ...(selection === undefined ? {} : { selection }),
       };
       saveSharedSource(ctx.configPath, source);
       return { status: 'ok', source: toInfo(source), filesDownloaded: result.filesDownloaded };
@@ -367,12 +521,12 @@ export function registerDataSharingHandlers(app: AppContext): void {
 
   ipcMain.handle('data-sharing:pull-progress', (): SharedPullProgress => pullProgress);
 
-  ipcMain.handle('data-sharing:refresh-source', async (): Promise<PullSharedSourceResult> => {
+  ipcMain.handle('data-sharing:refresh-source', async (_event, rawSelection: unknown): Promise<PullSharedSourceResult> => {
     const stored = loadSharedSource(ctx.configPath);
     if (stored === null) return { status: 'error', message: 'No shared source configured' };
     try {
-      const payload = parseSharingKey(stored.key);
-      const result = await pull(payload);
+      const selection = parseSharedPullSelection(rawSelection) ?? stored.selection;
+      const result = await pull(parseSharingKey(stored.key), selection);
       const updated: StoredSharedSource = {
         ...stored,
         label: result.label,
@@ -380,6 +534,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
         host: result.host,
         lastPulledAt: new Date().toISOString(),
         periods: result.periods,
+        ...(selection === undefined ? {} : { selection }),
       };
       saveSharedSource(ctx.configPath, updated);
       return { status: 'ok', source: toInfo(updated), filesDownloaded: result.filesDownloaded };

--- a/packages/desktop/src/main/handlers/peer-store.ts
+++ b/packages/desktop/src/main/handlers/peer-store.ts
@@ -1,0 +1,112 @@
+import { randomBytes } from 'node:crypto';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { hostname } from 'node:os';
+import { dirname, join } from 'node:path';
+import { generateIdentityKeyPair, isStringRecord, type IdentityKeyPair } from '@costgoblin/core';
+
+/** Peer-sharing secrets live alongside the YAML config, owner-only (0600). */
+function configDir(configPath: string): string {
+  return dirname(configPath);
+}
+
+function readJson(path: string): Readonly<Record<string, unknown>> | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    return isStringRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSecret(path: string, value: object): void {
+  mkdirSync(dirname(path), { recursive: true });
+  // 0o600: only the current user can read the private key / access secret.
+  writeFileSync(path, JSON.stringify(value, null, 2), { mode: 0o600 });
+}
+
+function defaultLabel(): string {
+  const host = hostname();
+  return host.length > 0 ? `${host} · CostGoblin` : 'CostGoblin';
+}
+
+/** This machine's persistent Ed25519 identity, created on first use. The
+ *  private key never leaves disk; the public key is what peers pin. */
+export function loadOrCreateIdentity(configPath: string): IdentityKeyPair {
+  const file = join(configDir(configPath), 'peer-identity.json');
+  const existing = readJson(file);
+  if (existing !== null && typeof existing['publicKey'] === 'string' && typeof existing['privateKey'] === 'string') {
+    return { publicKey: existing['publicKey'], privateKey: existing['privateKey'] };
+  }
+  const identity = generateIdentityKeyPair();
+  writeSecret(file, identity);
+  return identity;
+}
+
+export interface SharingSecret {
+  readonly psk: string;
+  readonly label: string;
+}
+
+/** The access secret + friendly label advertised to peers. Stable across
+ *  restarts so a handed-out sharing key keeps working until rotation. */
+export function loadOrCreateSharingSecret(configPath: string): SharingSecret {
+  const file = join(configDir(configPath), 'peer-sharing.json');
+  const existing = readJson(file);
+  if (existing !== null && typeof existing['psk'] === 'string' && typeof existing['label'] === 'string') {
+    return { psk: existing['psk'], label: existing['label'] };
+  }
+  const secret: SharingSecret = { psk: randomBytes(32).toString('base64url'), label: defaultLabel() };
+  writeSecret(file, secret);
+  return secret;
+}
+
+/** Replace the access secret — any outstanding sharing key stops working. */
+export function rotateSharingSecret(configPath: string): SharingSecret {
+  const file = join(configDir(configPath), 'peer-sharing.json');
+  const existing = readJson(file);
+  const label = existing !== null && typeof existing['label'] === 'string' ? existing['label'] : defaultLabel();
+  const secret: SharingSecret = { psk: randomBytes(32).toString('base64url'), label };
+  writeSecret(file, secret);
+  return secret;
+}
+
+/** The single shared source a consumer pulls from. The full sharing key is
+ *  kept so a refresh can reconnect without re-pasting it. */
+export interface StoredSharedSource {
+  readonly key: string;
+  readonly label: string;
+  readonly fingerprint: string;
+  readonly host: string;
+  readonly port: number;
+  readonly lastPulledAt: string | null;
+  readonly periods: readonly string[];
+}
+
+export function loadSharedSource(configPath: string): StoredSharedSource | null {
+  const r = readJson(join(configDir(configPath), 'peer-source.json'));
+  if (r === null) return null;
+  if (
+    typeof r['key'] !== 'string' ||
+    typeof r['label'] !== 'string' ||
+    typeof r['fingerprint'] !== 'string' ||
+    typeof r['host'] !== 'string' ||
+    typeof r['port'] !== 'number'
+  ) {
+    return null;
+  }
+  const periods = Array.isArray(r['periods']) ? r['periods'].filter((p: unknown): p is string => typeof p === 'string') : [];
+  const lastPulledAt = typeof r['lastPulledAt'] === 'string' ? r['lastPulledAt'] : null;
+  return { key: r['key'], label: r['label'], fingerprint: r['fingerprint'], host: r['host'], port: r['port'], lastPulledAt, periods };
+}
+
+export function saveSharedSource(configPath: string, source: StoredSharedSource): void {
+  writeSecret(join(configDir(configPath), 'peer-source.json'), source);
+}
+
+export function clearSharedSource(configPath: string): void {
+  try {
+    rmSync(join(configDir(configPath), 'peer-source.json'));
+  } catch {
+    // already gone
+  }
+}

--- a/packages/desktop/src/main/handlers/peer-store.ts
+++ b/packages/desktop/src/main/handlers/peer-store.ts
@@ -2,7 +2,26 @@ import { randomBytes } from 'node:crypto';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { dirname, join } from 'node:path';
-import { generateIdentityKeyPair, isStringRecord, type IdentityKeyPair } from '@costgoblin/core';
+import { generateIdentityKeyPair, isStringRecord, type IdentityKeyPair, type SharedPullSelection, type SharedSourceTier } from '@costgoblin/core';
+
+const SHARED_SOURCE_TIERS: readonly SharedSourceTier[] = ['config', 'daily', 'hourly', 'cost-optimization'];
+
+/** Parse/validate an untrusted selection (from a persisted file or the
+ *  renderer), tolerating absence → undefined ("pull everything", the
+ *  back-compatible default). */
+export function parseSharedPullSelection(raw: unknown): SharedPullSelection | undefined {
+  // Absent (not an object) means "no choice made" → pull everything. A present
+  // object with zero valid sources is a real, if empty, selection → pull
+  // nothing; we must NOT collapse it back to "everything".
+  if (!isStringRecord(raw)) return undefined;
+  const sources = Array.isArray(raw['sources'])
+    ? raw['sources'].filter((s: unknown): s is SharedSourceTier => typeof s === 'string' && (SHARED_SOURCE_TIERS as readonly string[]).includes(s))
+    : [];
+  const periods = Array.isArray(raw['periods'])
+    ? raw['periods'].filter((p: unknown): p is string => typeof p === 'string')
+    : undefined;
+  return periods === undefined ? { sources } : { sources, periods };
+}
 
 /** Peer-sharing secrets live alongside the YAML config, owner-only (0600). */
 function configDir(configPath: string): string {
@@ -80,6 +99,8 @@ export interface StoredSharedSource {
   readonly port: number;
   readonly lastPulledAt: string | null;
   readonly periods: readonly string[];
+  /** The tiers/periods last chosen, reused on refresh. Undefined = everything. */
+  readonly selection?: SharedPullSelection | undefined;
 }
 
 export function loadSharedSource(configPath: string): StoredSharedSource | null {
@@ -96,7 +117,11 @@ export function loadSharedSource(configPath: string): StoredSharedSource | null 
   }
   const periods = Array.isArray(r['periods']) ? r['periods'].filter((p: unknown): p is string => typeof p === 'string') : [];
   const lastPulledAt = typeof r['lastPulledAt'] === 'string' ? r['lastPulledAt'] : null;
-  return { key: r['key'], label: r['label'], fingerprint: r['fingerprint'], host: r['host'], port: r['port'], lastPulledAt, periods };
+  const selection = parseSharedPullSelection(r['selection']);
+  return {
+    key: r['key'], label: r['label'], fingerprint: r['fingerprint'], host: r['host'], port: r['port'], lastPulledAt, periods,
+    ...(selection === undefined ? {} : { selection }),
+  };
 }
 
 export function saveSharedSource(configPath: string, source: StoredSharedSource): void {

--- a/packages/desktop/src/main/handlers/sharing.ts
+++ b/packages/desktop/src/main/handlers/sharing.ts
@@ -1,32 +1,24 @@
-import { app as electronApp, dialog, ipcMain } from 'electron';
+import { dialog, ipcMain } from 'electron';
 import {
   CONFIG_BEACON_KEY,
   ConfigValidationError,
-  buildConfigBundle,
-  bundleConfigWithProfile,
-  bundleSectionIds,
-  costGoblinConfigToYaml,
-  costScopeToYaml,
-  dimensionsConfigToYaml,
   isStringRecord,
   logger,
-  orgTreeToYaml,
   parseConfigBundle,
   serializeConfigBundle,
   splitS3Location,
   suggestedConfigBeaconLocation,
   summarizeConfigBundle,
-  viewsConfigToYaml,
 } from '@costgoblin/core';
 import type {
   ApplyConfigBundleResult,
   CheckConfigBeaconResult,
-  ConfigBundle,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
   PublishConfigBundleResult,
 } from '@costgoblin/core';
 import type { AppContext } from './context.js';
+import { applyBundleSectionsToDisk, buildCurrentBundle } from './bundle-io.js';
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -41,30 +33,11 @@ function isBeaconAbsence(err: unknown): boolean {
 }
 
 export function registerSharingHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, getOrgTreeConfig, getViews, getCostScope, clearAllCaches } = app;
-
-  /** Assemble a bundle from whatever org config exists locally. Config and
-   *  dimensions are mandatory; the optional files are skipped when missing
-   *  or unreadable instead of failing the whole export. */
-  async function buildCurrentBundle(): Promise<ConfigBundle> {
-    const config = await getConfig();
-    const dimensions = await getDimensions();
-    const orgTree = await getOrgTreeConfig().catch(() => undefined);
-    const costScope = await getCostScope().catch(() => undefined);
-    const views = await getViews().catch(() => undefined);
-    return buildConfigBundle({
-      config,
-      dimensions,
-      orgTree,
-      costScope,
-      views,
-      appVersion: electronApp.getVersion(),
-    });
-  }
+  const { ctx, getConfig, clearAllCaches } = app;
 
   ipcMain.handle('sharing:export-bundle', async (): Promise<ExportConfigBundleResult> => {
     try {
-      const bundle = await buildCurrentBundle();
+      const bundle = await buildCurrentBundle(app);
       const result = await dialog.showSaveDialog({
         title: 'Export CostGoblin configuration',
         defaultPath: `costgoblin-config-${new Date().toISOString().slice(0, 10)}.yaml`,
@@ -101,69 +74,17 @@ export function registerSharingHandlers(app: AppContext): void {
     }
   });
 
-  /** Copy whichever org config files exist into config/backups/<timestamp>/
-   *  so an import is always one folder-copy away from being undone. */
-  async function backupExistingConfig(): Promise<string | null> {
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-    const configDir = path.dirname(ctx.configPath);
-    const candidates = [ctx.configPath, ctx.dimensionsPath, ctx.orgTreePath, ctx.costScopePath, ctx.viewsPath];
-    const existing: string[] = [];
-    for (const file of candidates) {
-      try {
-        await fs.access(file);
-        existing.push(file);
-      } catch {
-        // not present — nothing to back up
-      }
-    }
-    if (existing.length === 0) return null;
-    const stamp = new Date().toISOString().replaceAll(':', '-');
-    const backupDir = path.join(configDir, 'backups', stamp);
-    await fs.mkdir(backupDir, { recursive: true });
-    for (const file of existing) {
-      await fs.copyFile(file, path.join(backupDir, path.basename(file)));
-    }
-    return backupDir;
-  }
-
   ipcMain.handle('sharing:apply-bundle', async (_event, raw: unknown): Promise<ApplyConfigBundleResult> => {
     if (!isStringRecord(raw) || typeof raw['content'] !== 'string' || typeof raw['profile'] !== 'string' || raw['profile'].length === 0) {
       return { status: 'error', message: 'Invalid import parameters' };
     }
-    const content = raw['content'];
-    const profile = raw['profile'];
     try {
-      // Never trust the renderer's earlier preview — re-parse and
-      // re-validate here, in the process that writes the files.
-      const parsed = parseConfigBundle(content);
-      const { sections } = parsed.bundle;
-
-      const fs = await import('node:fs/promises');
-      const path = await import('node:path');
-      const { stringify } = await import('yaml');
-      await fs.mkdir(path.dirname(ctx.configPath), { recursive: true });
-      const backupDir = await backupExistingConfig();
-
-      const config = bundleConfigWithProfile(sections.config, profile);
-      await fs.writeFile(ctx.configPath, stringify(costGoblinConfigToYaml(config)), 'utf-8');
-      await fs.writeFile(ctx.dimensionsPath, stringify(dimensionsConfigToYaml(sections.dimensions)), 'utf-8');
-      if (sections.orgTree !== undefined) {
-        await fs.writeFile(ctx.orgTreePath, stringify(orgTreeToYaml(sections.orgTree)), 'utf-8');
-      }
-      if (sections.costScope !== undefined) {
-        await fs.writeFile(ctx.costScopePath, stringify(costScopeToYaml(sections.costScope)), 'utf-8');
-      }
-      if (sections.views !== undefined) {
-        await fs.writeFile(ctx.viewsPath, stringify(viewsConfigToYaml(sections.views)), 'utf-8');
-      }
-
+      // Never trust the renderer's earlier preview — applyBundleSectionsToDisk
+      // re-parses and re-validates in the process that writes the files.
+      const { sectionIds, backupDir } = await applyBundleSectionsToDisk(ctx, raw['content'], raw['profile']);
       await clearAllCaches();
-      logger.info('Applied configuration bundle', {
-        sections: bundleSectionIds(sections).join(','),
-        backupDir: backupDir ?? 'none',
-      });
-      return { status: 'applied', sections: bundleSectionIds(sections), backupDir };
+      logger.info('Applied configuration bundle', { sections: sectionIds.join(','), backupDir: backupDir ?? 'none' });
+      return { status: 'applied', sections: sectionIds, backupDir };
     } catch (err: unknown) {
       return { status: 'error', message: errorMessage(err) };
     }
@@ -186,7 +107,7 @@ export function registerSharingHandlers(app: AppContext): void {
       if (target === null) {
         return { status: 'error', message: 'Invalid S3 location — expected s3://bucket/path/to/org-config.yaml' };
       }
-      const body = serializeConfigBundle(await buildCurrentBundle());
+      const body = serializeConfigBundle(await buildCurrentBundle(app));
 
       const { S3Client, PutObjectCommand } = await import('@aws-sdk/client-s3');
       // Publishing needs s3:PutObject, which day-to-day read-only profiles

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -1,6 +1,7 @@
 import { ipcMain, shell } from 'electron';
 import {
   getDataInventory,
+  getLocalDataInventory,
   getEtagFileName,
   getRawDirPrefix,
   parseEtagsJson,
@@ -112,6 +113,13 @@ export function registerSyncHandlers(app: AppContext): void {
     try {
       return await getDataInventory(bucket, provider.credentials.profile, ctx.dataDir, t);
     } catch (err: unknown) {
+      // A consumer that imported a shared snapshot has no S3 access — fall back
+      // to a disk-only inventory so the Sync view still renders the data it has.
+      const local = await getLocalDataInventory(ctx.dataDir, t);
+      if (local.totalLocalPeriods > 0) {
+        logger.info('S3 inventory unavailable — using local-only inventory', { tier: t });
+        return local;
+      }
       throw toUserFriendlyError(err, provider.credentials.profile);
     }
   });

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { registerAutoSyncHandlers } from './handlers/auto-sync.js';
 import { registerViewsHandlers } from './handlers/views.js';
 import { registerCostScopeHandlers } from './handlers/cost-scope.js';
 import { registerSharingHandlers } from './handlers/sharing.js';
+import { registerDataSharingHandlers } from './handlers/data-sharing.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
 import { registerDebugHandlers } from './handlers/debug.js';
 import { registerMcpHandlers } from './handlers/mcp-handler.js';
@@ -31,6 +32,7 @@ export function registerIpcHandlers(ctx: IpcContext): AppContext {
   registerViewsHandlers(app);
   registerCostScopeHandlers(app);
   registerSharingHandlers(app);
+  registerDataSharingHandlers(app);
   registerExplorerHandlers(app);
   registerDebugHandlers(app);
   registerMcpHandlers(app);

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -50,6 +50,7 @@ import type {
   PreviewConfigBundleResult,
   PublishConfigBundleResult,
   PullSharedSourceResult,
+  SharedPullProgress,
   SharedSourceInfo,
 } from '@costgoblin/core';
 
@@ -326,6 +327,9 @@ const api: CostApi = {
   },
   getSharedSource(): Promise<SharedSourceInfo | null> {
     return invoke<SharedSourceInfo | null>('data-sharing:get-source');
+  },
+  getSharedPullProgress(): Promise<SharedPullProgress> {
+    return invoke<SharedPullProgress>('data-sharing:pull-progress');
   },
   refreshSharedSource(): Promise<PullSharedSourceResult> {
     return invoke<PullSharedSourceResult>('data-sharing:refresh-source');

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -44,9 +44,13 @@ import type {
   ApplyConfigBundleResult,
   CheckConfigBeaconParams,
   CheckConfigBeaconResult,
+  DataSharingResult,
+  DataSharingStatus,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
   PublishConfigBundleResult,
+  PullSharedSourceResult,
+  SharedSourceInfo,
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
@@ -304,6 +308,30 @@ const api: CostApi = {
   },
   checkConfigBeacon(params: CheckConfigBeaconParams): Promise<CheckConfigBeaconResult> {
     return invoke<CheckConfigBeaconResult>('sharing:check-beacon', params);
+  },
+  getDataSharingStatus(): Promise<DataSharingStatus> {
+    return invoke<DataSharingStatus>('data-sharing:status');
+  },
+  enableDataSharing(): Promise<DataSharingResult> {
+    return invoke<DataSharingResult>('data-sharing:enable');
+  },
+  disableDataSharing(): Promise<DataSharingResult> {
+    return invoke<DataSharingResult>('data-sharing:disable');
+  },
+  rotateDataSharingKey(): Promise<DataSharingResult> {
+    return invoke<DataSharingResult>('data-sharing:rotate');
+  },
+  addSharedSource(key: string): Promise<PullSharedSourceResult> {
+    return invoke<PullSharedSourceResult>('data-sharing:add-source', key);
+  },
+  getSharedSource(): Promise<SharedSourceInfo | null> {
+    return invoke<SharedSourceInfo | null>('data-sharing:get-source');
+  },
+  refreshSharedSource(): Promise<PullSharedSourceResult> {
+    return invoke<PullSharedSourceResult>('data-sharing:refresh-source');
+  },
+  removeSharedSource(): Promise<void> {
+    return invoke<undefined>('data-sharing:remove-source').then(() => undefined);
   },
   cancelPendingQueries(): Promise<void> {
     void invoke<undefined>('debug:clear-completed');

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -48,9 +48,11 @@ import type {
   DataSharingStatus,
   ExportConfigBundleResult,
   PreviewConfigBundleResult,
+  PreviewSharedSourceResult,
   PublishConfigBundleResult,
   PullSharedSourceResult,
   SharedPullProgress,
+  SharedPullSelection,
   SharedSourceInfo,
 } from '@costgoblin/core';
 
@@ -322,8 +324,14 @@ const api: CostApi = {
   rotateDataSharingKey(): Promise<DataSharingResult> {
     return invoke<DataSharingResult>('data-sharing:rotate');
   },
-  addSharedSource(key: string): Promise<PullSharedSourceResult> {
-    return invoke<PullSharedSourceResult>('data-sharing:add-source', key);
+  previewSharedSource(key: string): Promise<PreviewSharedSourceResult> {
+    return invoke<PreviewSharedSourceResult>('data-sharing:preview-source', key);
+  },
+  previewStoredSource(): Promise<PreviewSharedSourceResult> {
+    return invoke<PreviewSharedSourceResult>('data-sharing:preview-stored-source');
+  },
+  addSharedSource(key: string, selection?: SharedPullSelection): Promise<PullSharedSourceResult> {
+    return invoke<PullSharedSourceResult>('data-sharing:add-source', key, selection);
   },
   getSharedSource(): Promise<SharedSourceInfo | null> {
     return invoke<SharedSourceInfo | null>('data-sharing:get-source');
@@ -331,8 +339,8 @@ const api: CostApi = {
   getSharedPullProgress(): Promise<SharedPullProgress> {
     return invoke<SharedPullProgress>('data-sharing:pull-progress');
   },
-  refreshSharedSource(): Promise<PullSharedSourceResult> {
-    return invoke<PullSharedSourceResult>('data-sharing:refresh-source');
+  refreshSharedSource(selection?: SharedPullSelection): Promise<PullSharedSourceResult> {
+    return invoke<PullSharedSourceResult>('data-sharing:refresh-source', selection);
   },
   removeSharedSource(): Promise<void> {
     return invoke<undefined>('data-sharing:remove-source').then(() => undefined);

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, ImportConfigDialog, ShareConfigDialog } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, ImportConfigDialog, ShareConfigDialog, SharingActiveBanner } from '@costgoblin/ui';
 import type { NavItem } from '@costgoblin/ui';
-import type { CostApi, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
+import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
 import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
@@ -350,6 +350,33 @@ function useSyncPolling(
   return { syncError, setSyncError, syncActivity, syncFilesRemaining };
 }
 
+/** Poll publisher-side sharing status app-wide so the activity banner can show
+ *  on every view while sharing is on. Polls faster when sharing is active (to
+ *  keep the live throughput fresh) and backs off when it's off. */
+function useDataSharingPolling(api: CostApi, setupCheck: SetupCheck): {
+  sharingStatus: DataSharingStatus | null;
+  setSharingStatus: React.Dispatch<React.SetStateAction<DataSharingStatus | null>>;
+} {
+  const [sharingStatus, setSharingStatus] = useState<DataSharingStatus | null>(null);
+  const enabled = sharingStatus?.enabled === true;
+
+  useEffect(() => {
+    if (setupCheck.status !== 'ready') return undefined;
+    let cancelled = false;
+    async function tick(): Promise<void> {
+      try {
+        const status = await api.getDataSharingStatus();
+        if (!cancelled) setSharingStatus(status);
+      } catch { /* transient */ }
+    }
+    tick().catch(() => undefined);
+    const timer = setInterval(() => { tick().catch(() => undefined); }, enabled ? 2_000 : 10_000);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [api, setupCheck, enabled]);
+
+  return { sharingStatus, setSharingStatus };
+}
+
 const SPLASH_IMAGES = ['splash-1.png', 'splash-2.png', 'splash-3.png', 'splash-4.png', 'splash-5.png', 'splash-6.png', 'splash-7.png', 'splash-8.png', 'splash-9.png', 'splash-10.png'];
 const SPLASH_INTERVAL = 500;
 
@@ -441,6 +468,8 @@ function AppShell(): React.JSX.Element {
   const [splashStep, setSplashStep] = useState('Connecting...');
   const [viewsConfig, setViewsConfig] = useState<ViewsConfig | null>(null);
   const { syncError, setSyncError, syncActivity, syncFilesRemaining } = useSyncPolling(api, setupCheck);
+  const { sharingStatus, setSharingStatus } = useDataSharingPolling(api, setupCheck);
+  const [stoppingSharing, setStoppingSharing] = useState(false);
   const [debugOpen, setDebugOpen] = useState(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [clearingCache, setClearingCache] = useState(false);
@@ -685,6 +714,14 @@ function AppShell(): React.JSX.Element {
     return views.views.find(v => v.id === id) ?? null;
   }
 
+  function handleStopSharing(): void {
+    setStoppingSharing(true);
+    api.disableDataSharing()
+      .then(result => { if (result.status === 'ok') setSharingStatus(result.sharing); })
+      .catch(() => undefined)
+      .finally(() => { setStoppingSharing(false); });
+  }
+
   return (
     <PaletteProvider palette={palette}>
       <CommandPalette items={paletteItems} onNavigate={handleNavClick} />
@@ -697,6 +734,9 @@ function AppShell(): React.JSX.Element {
         />
         {/* Title bar + nav */}
         <div ref={headerRef} className="sticky top-0 z-50 bg-bg-primary/80 backdrop-blur-sm border-b border-border [-webkit-app-region:drag]">
+        {sharingStatus?.enabled === true && (
+          <SharingActiveBanner status={sharingStatus} onStop={handleStopSharing} stopping={stoppingSharing} />
+        )}
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center px-4 pt-7 pb-2">
           <nav className="flex items-center gap-1" aria-label="Dashboards and analysis">
             {(() => {

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -30,9 +30,13 @@ import {
   type CheckConfigBeaconParams,
   type CheckConfigBeaconResult,
   type ConfigBundleSummary,
+  type DataSharingResult,
+  type DataSharingStatus,
   type ExportConfigBundleResult,
   type PreviewConfigBundleResult,
   type PublishConfigBundleResult,
+  type PullSharedSourceResult,
+  type SharedSourceInfo,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
 
@@ -407,7 +411,40 @@ export class MockCostApi implements CostApi {
   // functions.
   checkConfigBeacon: (params: CheckConfigBeaconParams) => Promise<CheckConfigBeaconResult> =
     () => Promise.resolve({ status: 'none' });
+  getDataSharingStatus(): Promise<DataSharingStatus> {
+    return Promise.resolve({ enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789' });
+  }
+  enableDataSharing(): Promise<DataSharingResult> {
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789' } });
+  }
+  disableDataSharing(): Promise<DataSharingResult> {
+    return Promise.resolve({ status: 'ok', sharing: { enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789' } });
+  }
+  rotateDataSharingKey(): Promise<DataSharingResult> {
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789' } });
+  }
+  // Property-style so the declared type keeps the param (see checkConfigBeacon).
+  addSharedSource: (key: string) => Promise<PullSharedSourceResult> =
+    () => Promise.resolve({ status: 'ok', source: MOCK_SHARED_SOURCE, filesDownloaded: 3 });
+  getSharedSource(): Promise<SharedSourceInfo | null> {
+    return Promise.resolve(null);
+  }
+  refreshSharedSource(): Promise<PullSharedSourceResult> {
+    return Promise.resolve({ status: 'ok', source: MOCK_SHARED_SOURCE, filesDownloaded: 0 });
+  }
+  removeSharedSource(): Promise<void> {
+    return Promise.resolve();
+  }
 }
+
+export const MOCK_SHARED_SOURCE: SharedSourceInfo = {
+  label: 'Etienne · CostGoblin',
+  fingerprint: 'ABCD-EF01-2345-6789',
+  host: '192.168.1.42',
+  port: 53178,
+  lastPulledAt: '2026-06-21T09:00:00.000Z',
+  periods: ['2026-05', '2026-06'],
+};
 
 export const MOCK_BUNDLE_SUMMARY: ConfigBundleSummary = {
   schemaVersion: 1,

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -36,6 +36,7 @@ import {
   type PreviewConfigBundleResult,
   type PublishConfigBundleResult,
   type PullSharedSourceResult,
+  type SharedPullProgress,
   type SharedSourceInfo,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
@@ -412,16 +413,19 @@ export class MockCostApi implements CostApi {
   checkConfigBeacon: (params: CheckConfigBeaconParams) => Promise<CheckConfigBeaconResult> =
     () => Promise.resolve({ status: 'none' });
   getDataSharingStatus(): Promise<DataSharingStatus> {
-    return Promise.resolve({ enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789' });
+    return Promise.resolve({ enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null });
   }
   enableDataSharing(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789' } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null } });
   }
   disableDataSharing(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789' } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null } });
   }
   rotateDataSharingKey(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789' } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null } });
+  }
+  getSharedPullProgress(): Promise<SharedPullProgress> {
+    return Promise.resolve({ active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null });
   }
   // Property-style so the declared type keeps the param (see checkConfigBeacon).
   addSharedSource: (key: string) => Promise<PullSharedSourceResult> =

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -34,9 +34,12 @@ import {
   type DataSharingStatus,
   type ExportConfigBundleResult,
   type PreviewConfigBundleResult,
+  type PreviewSharedSourceResult,
   type PublishConfigBundleResult,
   type PullSharedSourceResult,
   type SharedPullProgress,
+  type SharedPullSelection,
+  type SharedSourcePreview,
   type SharedSourceInfo,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
@@ -413,29 +416,33 @@ export class MockCostApi implements CostApi {
   checkConfigBeacon: (params: CheckConfigBeaconParams) => Promise<CheckConfigBeaconResult> =
     () => Promise.resolve({ status: 'none' });
   getDataSharingStatus(): Promise<DataSharingStatus> {
-    return Promise.resolve({ enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null });
+    return Promise.resolve({ enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 });
   }
   enableDataSharing(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
   }
   disableDataSharing(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
   }
   rotateDataSharingKey(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: ['192.168.1.42'], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
   }
   getSharedPullProgress(): Promise<SharedPullProgress> {
-    return Promise.resolve({ active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null });
+    return Promise.resolve({ active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null, bytesDone: 0, bytesTotal: 0, error: null });
   }
-  // Property-style so the declared type keeps the param (see checkConfigBeacon).
-  addSharedSource: (key: string) => Promise<PullSharedSourceResult> =
+  // Property-style so the declared type keeps the params (see checkConfigBeacon).
+  previewSharedSource: (key: string) => Promise<PreviewSharedSourceResult> =
+    () => Promise.resolve({ status: 'ok', preview: MOCK_SHARED_SOURCE_PREVIEW });
+  previewStoredSource(): Promise<PreviewSharedSourceResult> {
+    return Promise.resolve({ status: 'ok', preview: MOCK_SHARED_SOURCE_PREVIEW });
+  }
+  addSharedSource: (key: string, selection?: SharedPullSelection) => Promise<PullSharedSourceResult> =
     () => Promise.resolve({ status: 'ok', source: MOCK_SHARED_SOURCE, filesDownloaded: 3 });
   getSharedSource(): Promise<SharedSourceInfo | null> {
     return Promise.resolve(null);
   }
-  refreshSharedSource(): Promise<PullSharedSourceResult> {
-    return Promise.resolve({ status: 'ok', source: MOCK_SHARED_SOURCE, filesDownloaded: 0 });
-  }
+  refreshSharedSource: (selection?: SharedPullSelection) => Promise<PullSharedSourceResult> =
+    () => Promise.resolve({ status: 'ok', source: MOCK_SHARED_SOURCE, filesDownloaded: 0 });
   removeSharedSource(): Promise<void> {
     return Promise.resolve();
   }
@@ -448,6 +455,18 @@ export const MOCK_SHARED_SOURCE: SharedSourceInfo = {
   port: 53178,
   lastPulledAt: '2026-06-21T09:00:00.000Z',
   periods: ['2026-05', '2026-06'],
+};
+
+export const MOCK_SHARED_SOURCE_PREVIEW: SharedSourcePreview = {
+  label: 'Etienne · CostGoblin',
+  fingerprint: 'ABCD-EF01-2345-6789',
+  hasConfig: true,
+  configSummary: null,
+  tiers: [
+    { tier: 'daily', periods: ['2026-04', '2026-05', '2026-06'], fileCount: 6, bytes: 24_000_000 },
+    { tier: 'hourly', periods: ['2026-05', '2026-06'], fileCount: 4, bytes: 80_000_000 },
+    { tier: 'cost-optimization', periods: ['2026-06'], fileCount: 1, bytes: 1_200_000 },
+  ],
 };
 
 export const MOCK_BUNDLE_SUMMARY: ConfigBundleSummary = {

--- a/packages/ui/src/__tests__/config-sharing.test.tsx
+++ b/packages/ui/src/__tests__/config-sharing.test.tsx
@@ -1,9 +1,11 @@
 import { asBucketPath } from '@costgoblin/core/browser';
+import type { DataSharingStatus } from '@costgoblin/core/browser';
 import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { BundleSummaryCard, ImportConfigDialog, ShareConfigDialog } from '../components/config-sharing.js';
-import { MOCK_BUNDLE_SUMMARY, MockCostApi } from '../__fixtures__/mock-api.js';
+import { SharingActiveBanner } from '../components/sharing-active-banner.js';
+import { MOCK_BUNDLE_SUMMARY, MOCK_SHARED_SOURCE, MockCostApi } from '../__fixtures__/mock-api.js';
 import { CostApiProvider } from '../hooks/use-cost-api.js';
 
 /** Config whose sync profile differs from the alphabetical-first AWS
@@ -310,5 +312,101 @@ describe('ImportConfigDialog', () => {
       expect(screen.getByText('disk full')).toBeDefined();
     });
     expect(screen.getByText('Apply configuration')).toBeDefined();
+  });
+});
+
+describe('SharingActiveBanner', () => {
+  const activeStatus: DataSharingStatus = {
+    enabled: true,
+    sharingKey: 'CGSHARE1-active',
+    label: 'My Mac · CostGoblin',
+    port: 53178,
+    hosts: ['192.168.1.5'],
+    fingerprint: 'ABCD-1234',
+    lastServedAt: '2026-06-21T09:00:00.000Z',
+    filesServed: 12,
+    lastPeer: '192.168.1.9',
+    bytesServed: 5_000_000,
+    connectedClients: 2,
+    bytesPerSecond: 1_500_000,
+  };
+
+  it('shows connected peers, files + bytes served, and throughput', () => {
+    render(<SharingActiveBanner status={activeStatus} onStop={() => undefined} />);
+    expect(screen.getByText('2 connected')).toBeDefined();
+    expect(screen.getByText('12 files · 4.8 MB')).toBeDefined();
+    expect(screen.getByText('1.4 MB/s')).toBeDefined();
+  });
+
+  it('hides throughput when idle and fires onStop', async () => {
+    const onStop = vi.fn();
+    const user = userEvent.setup();
+    render(<SharingActiveBanner status={{ ...activeStatus, connectedClients: 0, bytesPerSecond: 0 }} onStop={onStop} />);
+    expect(screen.queryByText(/\/s$/)).toBeNull();
+    await user.click(screen.getByText('Stop sharing'));
+    expect(onStop).toHaveBeenCalledOnce();
+  });
+});
+
+describe('ImportConfigDialog — pull from a teammate', () => {
+  it('reconnects to a saved teammate, lets you deselect a month, and refreshes with that selection', async () => {
+    const api = new MockCostApi();
+    api.getSharedSource = () => Promise.resolve(MOCK_SHARED_SOURCE);
+    const refreshSpy = vi.spyOn(api, 'refreshSharedSource');
+    const user = userEvent.setup();
+    renderWithApi(api, <ImportConfigDialog onClose={() => undefined} onApplied={() => undefined} />);
+
+    await user.click(await screen.findByText('Reconnect'));
+    // Preview resolves to the month picker.
+    await waitFor(() => { expect(screen.getByText('2026-04')).toBeDefined(); });
+    // Drop one month from the (all-selected-by-default) set, then pull.
+    await user.click(screen.getByText('2026-04'));
+    await user.click(screen.getByText('Pull'));
+
+    await waitFor(() => { expect(refreshSpy).toHaveBeenCalled(); });
+    const selection = refreshSpy.mock.calls[0]?.[0];
+    expect(selection?.periods).not.toContain('2026-04');
+    expect(selection?.periods).toContain('2026-05');
+    expect(selection?.sources).toContain('daily');
+  });
+
+  it('previews a pasted key and pulls the chosen sources', async () => {
+    const api = new MockCostApi();
+    const addSpy = vi.spyOn(api, 'addSharedSource');
+    const user = userEvent.setup();
+    renderWithApi(api, <ImportConfigDialog onClose={() => undefined} onApplied={() => undefined} />);
+
+    await user.type(screen.getByLabelText('Sharing key from a teammate'), 'CGSHARE1-teammate');
+    await user.click(screen.getByText('Continue'));
+    await waitFor(() => { expect(screen.getByText('Daily CUR')).toBeDefined(); });
+    // Drop the cost-optimization tier, keep the rest, and pull.
+    await user.click(screen.getByText('Cost optimization'));
+    await user.click(screen.getByText('Pull'));
+
+    await waitFor(() => { expect(addSpy).toHaveBeenCalled(); });
+    const [key, selection] = addSpy.mock.calls[0] ?? [];
+    expect(key).toBe('CGSHARE1-teammate');
+    expect(selection?.sources).toContain('daily');
+    expect(selection?.sources).not.toContain('cost-optimization');
+  });
+
+  it('locks the dialog shut while a pull is in flight', async () => {
+    const api = new MockCostApi();
+    // Hold the pull pending so the blocking state is observable.
+    api.addSharedSource = () => new Promise<never>(() => { /* never resolves */ });
+    const user = userEvent.setup();
+    renderWithApi(api, <ImportConfigDialog onClose={() => undefined} onApplied={() => undefined} />);
+
+    await user.type(screen.getByLabelText('Sharing key from a teammate'), 'CGSHARE1-teammate');
+    await user.click(screen.getByText('Continue'));
+    await waitFor(() => { expect(screen.getByText('Pull')).toBeDefined(); });
+    await user.click(screen.getByText('Pull'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Keep this window open until the transfer finishes.')).toBeDefined();
+    });
+    // No close affordance and the other import options are hidden.
+    expect(screen.queryByLabelText('Close')).toBeNull();
+    expect(screen.queryByText('Choose bundle file…')).toBeNull();
   });
 });

--- a/packages/ui/src/__tests__/format.test.ts
+++ b/packages/ui/src/__tests__/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '../components/format.js';
+
+describe('formatBytes', () => {
+  it('formats within each unit with sensible precision', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(5_000_000)).toBe('4.8 MB');
+    expect(formatBytes(1_500_000)).toBe('1.4 MB');
+    // Large values within a unit drop the decimal.
+    expect(formatBytes(150 * 1024 * 1024)).toBe('150 MB');
+  });
+
+  it('rolls over to the next unit instead of rendering "1024 MB"', () => {
+    // Just under 1 GiB rounds up at MB precision — must promote to GB.
+    expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe('1.0 GB');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+  });
+
+  it('never returns a negative size', () => {
+    expect(formatBytes(-100)).toBe('0 B');
+  });
+});

--- a/packages/ui/src/__tests__/setup-wizard.test.tsx
+++ b/packages/ui/src/__tests__/setup-wizard.test.tsx
@@ -146,7 +146,20 @@ describe('SetupWizard', () => {
 
   it('opens the import dialog from the welcome step', async () => {
     const { user } = renderWizard();
-    await user.click(screen.getByText(/Have a configuration file from a teammate/));
+    await user.click(screen.getByText('Import from a teammate'));
     await waitFor(() => { expect(screen.getByText('Choose bundle file…')).toBeDefined(); });
+  });
+
+  it('returns to the welcome screen from a wizard step via the close button', async () => {
+    const { user } = renderWizard();
+    await user.click(screen.getByText('Get Started'));
+    await waitFor(() => { expect(screen.getByText('default')).toBeDefined(); });
+    await user.click(screen.getByLabelText('Back to welcome'));
+    await waitFor(() => { expect(screen.getByText('Import from a teammate')).toBeDefined(); });
+  });
+
+  it('does not show the close button on the welcome step', () => {
+    renderWizard();
+    expect(screen.queryByLabelText('Back to welcome')).toBeNull();
   });
 });

--- a/packages/ui/src/components/config-sharing.tsx
+++ b/packages/ui/src/components/config-sharing.tsx
@@ -5,6 +5,7 @@ import type {
   ExportConfigBundleResult,
   PublishConfigBundleResult,
   PullSharedSourceResult,
+  SharedPullProgress,
 } from '@costgoblin/core/browser';
 import { isDiscoverableBeaconLocation, splitS3Location, suggestedConfigBeaconLocation } from '@costgoblin/core/browser';
 import { Check, CloudDownload, CloudUpload, Copy, FileDown, FileUp, Network, Plug, RotateCw, TriangleAlert } from 'lucide-react';
@@ -120,6 +121,13 @@ function ShareDataSection(): React.JSX.Element {
     api.getDataSharingStatus().then(setStatus).catch(() => undefined);
   }, [api]);
 
+  // While sharing, poll so the "who pulled" activity stays live.
+  useEffect(() => {
+    if (status?.enabled !== true) return;
+    const id = setInterval(() => { api.getDataSharingStatus().then(setStatus).catch(() => undefined); }, 3000);
+    return () => { clearInterval(id); };
+  }, [api, status?.enabled]);
+
   function run(action: () => Promise<DataSharingResult>): void {
     setBusy(true);
     setError(null);
@@ -185,6 +193,14 @@ function ShareDataSection(): React.JSX.Element {
           <p className="text-xs text-text-muted">
             Reachable at <span className="font-mono">{status.hosts.join(', ')}:{status.port}</span> · fingerprint <span className="font-mono">{status.fingerprint}</span>. Re-share if this machine&apos;s IP changes.
           </p>
+          <div className="flex items-center gap-2 rounded-md bg-bg-tertiary/40 px-2.5 py-1.5">
+            <span className={`inline-block h-2 w-2 rounded-full ${status.lastServedAt === null ? 'bg-text-muted' : 'bg-positive animate-pulse'}`} aria-hidden="true" />
+            <p className="text-xs text-text-secondary">
+              {status.lastServedAt === null
+                ? 'Waiting for a teammate to connect…'
+                : `Last pull from ${status.lastPeer ?? 'a peer'} · ${String(status.filesServed)} file${status.filesServed === 1 ? '' : 's'} served`}
+            </p>
+          </div>
         </div>
       )}
       {error !== null && <p className="text-xs text-negative">{error}</p>}
@@ -201,6 +217,14 @@ function AddSharedSourceSection({ onPulled }: Readonly<{ onPulled: () => void }>
   const [key, setKey] = useState('');
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<PullSharedSourceResult | null>(null);
+  const [progress, setProgress] = useState<SharedPullProgress | null>(null);
+
+  // Poll live pull progress while connecting/downloading.
+  useEffect(() => {
+    if (!busy) { setProgress(null); return; }
+    const id = setInterval(() => { api.getSharedPullProgress().then(setProgress).catch(() => undefined); }, 300);
+    return () => { clearInterval(id); };
+  }, [api, busy]);
 
   function handleConnect(): void {
     if (busy || key.trim().length === 0) return;
@@ -228,6 +252,18 @@ function AddSharedSourceSection({ onPulled }: Readonly<{ onPulled: () => void }>
         <Plug size={16} className="mr-1.5" />
         {busy ? 'Connecting…' : 'Connect & pull'}
       </Button>
+      {busy && progress !== null && progress.filesTotal > 0 && (
+        <div className="flex flex-col gap-1">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-tertiary">
+            <div className="h-full bg-accent transition-all" style={{ width: `${String(Math.round((progress.filesDone / progress.filesTotal) * 100))}%` }} />
+          </div>
+          <p className="text-xs text-text-muted">
+            {progress.phase === 'importing'
+              ? 'Importing…'
+              : `Downloading ${String(progress.filesDone)}/${String(progress.filesTotal)}${progress.currentPeriod !== null ? ` · ${progress.currentPeriod}` : ''}`}
+          </p>
+        </div>
+      )}
       {result?.status === 'ok' && (
         <div className="rounded-lg border border-positive/40 bg-bg-tertiary/20 px-3 py-2 flex flex-col gap-2">
           <p className="text-xs text-positive">

--- a/packages/ui/src/components/config-sharing.tsx
+++ b/packages/ui/src/components/config-sharing.tsx
@@ -4,15 +4,27 @@ import type {
   DataSharingStatus,
   ExportConfigBundleResult,
   PublishConfigBundleResult,
-  PullSharedSourceResult,
+  SharedDataTier,
   SharedPullProgress,
+  SharedPullSelection,
+  SharedSourceInfo,
+  SharedSourcePreview,
+  SharedSourceTier,
 } from '@costgoblin/core/browser';
 import { isDiscoverableBeaconLocation, splitS3Location, suggestedConfigBeaconLocation } from '@costgoblin/core/browser';
 import { Check, CloudDownload, CloudUpload, Copy, FileDown, FileUp, Network, Plug, RotateCw, TriangleAlert } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
+import { formatBytes } from './format.js';
 import { ProfilePicker } from './profile-picker.js';
 import { Button } from './ui/button.js';
+
+const DATA_TIER_LABELS: Record<SharedDataTier, string> = {
+  'daily': 'Daily CUR',
+  'hourly': 'Hourly CUR',
+  'cost-optimization': 'Cost optimization',
+};
+const DATA_TIERS: readonly SharedDataTier[] = ['daily', 'hourly', 'cost-optimization'];
 
 // ---------------------------------------------------------------------------
 // Bundle summary — shared by the import dialog and the setup wizard's
@@ -71,33 +83,43 @@ export function BundleSummaryCard({ summary }: Readonly<{ summary: ConfigBundleS
 // Shared dialog chrome — same overlay pattern as ConfirmModal.
 // ---------------------------------------------------------------------------
 
-function SharingModal({ title, onClose, children }: Readonly<{
+function SharingModal({ title, onClose, children, dismissable = true }: Readonly<{
   title: string;
   onClose: () => void;
   children: React.ReactNode;
+  /** When false, the modal cannot be dismissed (no Escape, no backdrop click,
+   *  no ✕) — used to hold the window open during an in-progress pull. */
+  dismissable?: boolean;
 }>): React.JSX.Element {
   useEffect(() => {
+    if (!dismissable) return undefined;
     function handleKey(e: KeyboardEvent): void {
       if (e.key === 'Escape') onClose();
     }
     document.addEventListener('keydown', handleKey);
     return () => { document.removeEventListener('keydown', handleKey); };
-  }, [onClose]);
+  }, [onClose, dismissable]);
 
   return (
     <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        {...(dismissable ? { onClick: onClose } : {})}
+        aria-hidden="true"
+      />
       <div className="relative rounded-xl border border-border bg-bg-secondary p-6 shadow-2xl max-w-md w-full mx-4 max-h-[85vh] overflow-y-auto">
         <div className="flex items-center justify-between">
           <h3 className="text-base font-semibold text-text-primary">{title}</h3>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md px-2 py-1 text-sm text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
-            aria-label="Close"
-          >
-            ✕
-          </button>
+          {dismissable && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-2 py-1 text-sm text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          )}
         </div>
         <div className="mt-4 flex flex-col gap-4">{children}</div>
       </div>
@@ -209,36 +231,262 @@ function ShareDataSection(): React.JSX.Element {
 }
 
 // ---------------------------------------------------------------------------
-// Add a shared data source — paste a teammate's sharing key, pull the snapshot.
+// Add a shared data source — reconnect to a saved teammate or paste a key,
+// preview what's on offer, pick tiers + months, then pull (locked) the snapshot.
 // ---------------------------------------------------------------------------
 
-function AddSharedSourceSection({ onPulled }: Readonly<{ onPulled: () => void }>): React.JSX.Element {
+type AddState =
+  | { kind: 'entry'; error: string | null }
+  | { kind: 'previewing' }
+  | { kind: 'choosing'; mode: 'key' | 'stored'; preview: SharedSourcePreview }
+  | { kind: 'pulling' }
+  | { kind: 'done'; source: SharedSourceInfo; filesDownloaded: number }
+  | { kind: 'error'; message: string };
+
+function pullPhaseLabel(progress: SharedPullProgress | null): string {
+  switch (progress?.phase) {
+    case 'downloading': return 'Downloading…';
+    case 'importing': return 'Importing…';
+    default: return 'Connecting…';
+  }
+}
+
+function availablePeriods(preview: SharedSourcePreview): string[] {
+  return [...new Set(preview.tiers.flatMap(t => t.periods))].sort((a, b) => a.localeCompare(b));
+}
+
+function AddSharedSourceSection({ onPulled, onBusyChange }: Readonly<{
+  onPulled: () => void;
+  /** Notifies the parent dialog so it can lock itself while a pull runs. */
+  onBusyChange?: (busy: boolean) => void;
+}>): React.JSX.Element {
   const api = useCostApi();
   const [key, setKey] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [result, setResult] = useState<PullSharedSourceResult | null>(null);
+  const [stored, setStored] = useState<SharedSourceInfo | null>(null);
+  const [state, setState] = useState<AddState>({ kind: 'entry', error: null });
+  const [mode, setMode] = useState<'key' | 'stored'>('key');
+  const [tiers, setTiers] = useState<ReadonlySet<SharedSourceTier>>(new Set());
+  const [periods, setPeriods] = useState<ReadonlySet<string>>(new Set());
   const [progress, setProgress] = useState<SharedPullProgress | null>(null);
 
-  // Poll live pull progress while connecting/downloading.
+  useEffect(() => { api.getSharedSource().then(setStored).catch(() => undefined); }, [api]);
+
+  // Poll live progress only while a pull is running.
   useEffect(() => {
-    if (!busy) { setProgress(null); return; }
+    if (state.kind !== 'pulling') return undefined;
     const id = setInterval(() => { api.getSharedPullProgress().then(setProgress).catch(() => undefined); }, 300);
     return () => { clearInterval(id); };
-  }, [api, busy]);
+  }, [api, state.kind]);
 
-  function handleConnect(): void {
-    if (busy || key.trim().length === 0) return;
-    setBusy(true);
-    setResult(null);
-    api.addSharedSource(key.trim())
-      .then(setResult)
-      .catch((e: unknown) => { setResult({ status: 'error', message: e instanceof Error ? e.message : String(e) }); })
-      .finally(() => { setBusy(false); });
+  // Hold the parent modal open while pulling.
+  useEffect(() => { onBusyChange?.(state.kind === 'pulling'); }, [state.kind, onBusyChange]);
+
+  function startPreview(m: 'key' | 'stored'): void {
+    setMode(m);
+    setState({ kind: 'previewing' });
+    const request = m === 'key' ? api.previewSharedSource(key.trim()) : api.previewStoredSource();
+    request.then(res => {
+      if (res.status === 'error') { setState({ kind: 'entry', error: res.message }); return; }
+      const seed = m === 'stored' ? stored?.selection : undefined;
+      const defaultTiers: SharedSourceTier[] = [
+        ...(res.preview.hasConfig ? (['config'] satisfies SharedSourceTier[]) : []),
+        ...res.preview.tiers.map(t => t.tier),
+      ];
+      setTiers(new Set(seed?.sources ?? defaultTiers));
+      setPeriods(new Set(seed?.periods ?? availablePeriods(res.preview)));
+      setState({ kind: 'choosing', mode: m, preview: res.preview });
+    }).catch((e: unknown) => { setState({ kind: 'entry', error: e instanceof Error ? e.message : String(e) }); });
   }
 
+  function toggleTier(t: SharedSourceTier): void {
+    setTiers(prev => { const next = new Set(prev); if (next.has(t)) next.delete(t); else next.add(t); return next; });
+  }
+  function togglePeriod(p: string): void {
+    setPeriods(prev => { const next = new Set(prev); if (next.has(p)) next.delete(p); else next.add(p); return next; });
+  }
+
+  function startPull(): void {
+    const selection: SharedPullSelection = { sources: [...tiers], periods: [...periods].sort((a, b) => a.localeCompare(b)) };
+    setProgress(null);
+    setState({ kind: 'pulling' });
+    const request = mode === 'key' ? api.addSharedSource(key.trim(), selection) : api.refreshSharedSource(selection);
+    request.then(res => {
+      if (res.status === 'ok') {
+        setStored(res.source);
+        setState({ kind: 'done', source: res.source, filesDownloaded: res.filesDownloaded });
+      } else {
+        setState({ kind: 'error', message: res.message });
+      }
+    }).catch((e: unknown) => { setState({ kind: 'error', message: e instanceof Error ? e.message : String(e) }); });
+  }
+
+  function handleForget(): void {
+    api.removeSharedSource().then(() => { setStored(null); }).catch(() => undefined);
+  }
+
+  if (state.kind === 'previewing') {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-border border-t-accent" />
+        <span className="ml-2 text-sm text-text-secondary">Connecting to teammate…</span>
+      </div>
+    );
+  }
+
+  if (state.kind === 'pulling') {
+    const pct = progress !== null && progress.bytesTotal > 0
+      ? Math.round((progress.bytesDone / progress.bytesTotal) * 100)
+      : 0;
+    return (
+      <div className="flex flex-col gap-3 py-1">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-border border-t-accent" />
+          <span className="text-sm text-text-primary">{pullPhaseLabel(progress)}</span>
+        </div>
+        {progress !== null && progress.bytesTotal > 0 && (
+          <div className="flex flex-col gap-1">
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-tertiary">
+              <div className="h-full bg-accent transition-all" style={{ width: `${String(pct)}%` }} />
+            </div>
+            <p className="text-xs text-text-muted">
+              {formatBytes(progress.bytesDone)} / {formatBytes(progress.bytesTotal)} · {progress.filesDone}/{progress.filesTotal} files{progress.currentPeriod !== null ? ` · ${progress.currentPeriod}` : ''}
+            </p>
+          </div>
+        )}
+        <p className="text-xs text-text-muted">Keep this window open until the transfer finishes.</p>
+      </div>
+    );
+  }
+
+  if (state.kind === 'done') {
+    return (
+      <div className="flex flex-col gap-2 rounded-lg border border-positive/40 bg-bg-tertiary/20 px-3 py-2">
+        <p className="text-xs text-positive">
+          Pulled {state.filesDownloaded} file{state.filesDownloaded === 1 ? '' : 's'} from {state.source.label} · {state.source.periods.length} period{state.source.periods.length === 1 ? '' : 's'}.
+        </p>
+        <Button onClick={onPulled} className="bg-accent hover:bg-accent-hover text-white self-end">Done</Button>
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="flex flex-col gap-2 rounded-lg border border-negative/50 bg-negative-muted px-3 py-2">
+        <p className="text-xs text-negative">{state.message}</p>
+        <div className="flex items-center gap-2 self-end">
+          <button type="button" onClick={() => { setState({ kind: 'entry', error: null }); }} className="text-xs text-text-muted hover:text-text-secondary">Start over</button>
+          <Button onClick={startPull} className="bg-accent hover:bg-accent-hover text-white">Retry</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.kind === 'choosing') {
+    const months = availablePeriods(state.preview);
+    const hasData = DATA_TIERS.some(t => tiers.has(t));
+    const canPull = tiers.has('config') || (hasData && periods.size > 0);
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-text-primary">
+          From <span className="font-medium">{state.preview.label}</span> — choose what to pull.
+        </p>
+
+        {state.preview.hasConfig && (
+          <label className="flex items-start gap-2 rounded-lg border border-border bg-bg-tertiary/20 px-3 py-2 cursor-pointer">
+            <input type="checkbox" checked={tiers.has('config')} onChange={() => { toggleTier('config'); }} className="mt-0.5 accent-accent" />
+            <span>
+              <span className="text-sm text-text-primary">Configuration</span>
+              <span className="block text-xs text-text-muted">Dimensions, dashboards, cost scope &amp; org tree — applied under your AWS profile.</span>
+            </span>
+          </label>
+        )}
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-text-muted uppercase tracking-wider">Data</span>
+          <div className="flex flex-wrap gap-2">
+            {state.preview.tiers.map(t => (
+              <button
+                key={t.tier}
+                type="button"
+                onClick={() => { toggleTier(t.tier); }}
+                className={[
+                  'rounded-md border px-2.5 py-1.5 text-xs transition-colors',
+                  tiers.has(t.tier) ? 'border-accent bg-accent-muted text-accent' : 'border-border bg-bg-tertiary/20 text-text-secondary hover:text-text-primary',
+                ].join(' ')}
+              >
+                {DATA_TIER_LABELS[t.tier]} <span className="opacity-70">· {formatBytes(t.bytes)}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {months.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-muted uppercase tracking-wider">Months</span>
+              <div className="flex items-center gap-2 text-xs">
+                <button type="button" onClick={() => { setPeriods(new Set(months)); }} className="text-text-muted hover:text-text-secondary">All</button>
+                <button type="button" onClick={() => { setPeriods(new Set()); }} className="text-text-muted hover:text-text-secondary">None</button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {months.map(m => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => { togglePeriod(m); }}
+                  className={[
+                    'rounded-md border px-2 py-1 font-mono text-xs transition-colors',
+                    periods.has(m) ? 'border-accent bg-accent-muted text-accent' : 'border-border bg-bg-tertiary/20 text-text-secondary hover:text-text-primary',
+                  ].join(' ')}
+                >
+                  {m}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between pt-1">
+          <button type="button" onClick={() => { setState({ kind: 'entry', error: null }); }} className="text-sm text-text-muted hover:text-text-secondary">← Back</button>
+          <Button onClick={startPull} disabled={!canPull} className="bg-accent hover:bg-accent-hover text-white">
+            <CloudDownload size={16} className="mr-1.5" />
+            Pull
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // state.kind === 'entry'
   return (
-    <div className="flex flex-col gap-1.5">
-      <label htmlFor="cg-add-source-key" className="text-xs text-text-muted uppercase tracking-wider">Sharing key from a teammate</label>
+    <div className="flex flex-col gap-2">
+      {stored !== null && (
+        <div className="flex flex-col gap-2 rounded-lg border border-border bg-bg-tertiary/20 px-3 py-2">
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate text-sm text-text-primary">Reconnect to <span className="font-medium">{stored.label}</span></p>
+              <p className="text-xs text-text-muted">
+                {stored.lastPulledAt !== null ? `Last pulled ${stored.lastPulledAt.slice(0, 10)}` : 'Saved source'} · fingerprint <span className="font-mono">{stored.fingerprint.slice(0, 8)}</span>
+              </p>
+            </div>
+            <Button onClick={() => { startPreview('stored'); }} className="bg-accent hover:bg-accent-hover text-white shrink-0">
+              <RotateCw size={14} className="mr-1.5" />
+              Reconnect
+            </Button>
+          </div>
+          <button type="button" onClick={handleForget} className="self-start text-xs text-text-muted hover:text-text-secondary underline underline-offset-2">
+            Forget this teammate
+          </button>
+        </div>
+      )}
+
+      <label htmlFor="cg-add-source-key" className="text-xs text-text-muted uppercase tracking-wider">
+        {stored !== null ? 'Or a key from someone else' : 'Sharing key from a teammate'}
+      </label>
+      <p className="text-xs text-text-muted">
+        Your teammate creates this by clicking <span className="font-medium text-text-secondary">Start sharing</span> in their CostGoblin (under <span className="font-medium text-text-secondary">Share configuration…</span>). Their app needs to stay open on the same network while you connect.
+      </p>
       <textarea
         id="cg-add-source-key"
         value={key}
@@ -248,31 +496,11 @@ function AddSharedSourceSection({ onPulled }: Readonly<{ onPulled: () => void }>
         spellCheck={false}
         className="w-full rounded-lg border border-border bg-bg-primary px-3 py-2 font-mono text-xs text-text-primary placeholder:text-text-muted resize-none focus:outline-none focus:border-accent/50"
       />
-      <Button onClick={handleConnect} disabled={busy || key.trim().length === 0} className="bg-accent hover:bg-accent-hover text-white self-start">
+      {state.error !== null && <p className="text-xs text-negative">{state.error}</p>}
+      <Button onClick={() => { startPreview('key'); }} disabled={key.trim().length === 0} className="bg-accent hover:bg-accent-hover text-white self-start">
         <Plug size={16} className="mr-1.5" />
-        {busy ? 'Connecting…' : 'Connect & pull'}
+        Continue
       </Button>
-      {busy && progress !== null && progress.filesTotal > 0 && (
-        <div className="flex flex-col gap-1">
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-tertiary">
-            <div className="h-full bg-accent transition-all" style={{ width: `${String(Math.round((progress.filesDone / progress.filesTotal) * 100))}%` }} />
-          </div>
-          <p className="text-xs text-text-muted">
-            {progress.phase === 'importing'
-              ? 'Importing…'
-              : `Downloading ${String(progress.filesDone)}/${String(progress.filesTotal)}${progress.currentPeriod !== null ? ` · ${progress.currentPeriod}` : ''}`}
-          </p>
-        </div>
-      )}
-      {result?.status === 'ok' && (
-        <div className="rounded-lg border border-positive/40 bg-bg-tertiary/20 px-3 py-2 flex flex-col gap-2">
-          <p className="text-xs text-positive">
-            Pulled {result.filesDownloaded} file{result.filesDownloaded === 1 ? '' : 's'} from {result.source.label} · {result.source.periods.length} period{result.source.periods.length === 1 ? '' : 's'}.
-          </p>
-          <Button onClick={onPulled} className="bg-accent hover:bg-accent-hover text-white self-end">Done</Button>
-        </div>
-      )}
-      {result?.status === 'error' && <p className="text-xs text-negative">{result.message}</p>}
     </div>
   );
 }
@@ -468,6 +696,8 @@ export function ImportConfigDialog({ onClose, onApplied }: Readonly<{
 }>): React.JSX.Element {
   const api = useCostApi();
   const [state, setState] = useState<ImportPhase>({ phase: 'pick', error: null });
+  // True while a teammate pull is in flight — locks the modal shut.
+  const [pullBusy, setPullBusy] = useState(false);
   // Ambient resources for the "fetch from S3" source. Profiles double as
   // the apply-step picker options. The location prefills with the team's
   // published beacon when a config exists (the "pull team updates" case);
@@ -578,9 +808,11 @@ export function ImportConfigDialog({ onClose, onApplied }: Readonly<{
   }
 
   return (
-    <SharingModal title="Import configuration" onClose={state.phase === 'done' ? onApplied : onClose}>
+    <SharingModal title="Import configuration" onClose={state.phase === 'done' ? onApplied : onClose} dismissable={!pullBusy}>
       {state.phase === 'pick' && (
         <>
+          {!pullBusy && (
+          <>
           <p className="text-sm text-text-secondary">
             Apply a configuration bundle from a teammate — choose an exported file, or fetch one straight from S3. You&apos;ll see exactly what it contains before anything is written, and your current configuration is backed up first.
           </p>
@@ -643,7 +875,9 @@ export function ImportConfigDialog({ onClose, onApplied }: Readonly<{
             <span className="text-xs text-text-muted">or pull from a teammate on your network</span>
             <div className="h-px flex-1 bg-border" />
           </div>
-          <AddSharedSourceSection onPulled={onApplied} />
+          </>
+          )}
+          <AddSharedSourceSection onPulled={onApplied} onBusyChange={setPullBusy} />
         </>
       )}
 

--- a/packages/ui/src/components/config-sharing.tsx
+++ b/packages/ui/src/components/config-sharing.tsx
@@ -1,10 +1,13 @@
 import type {
   ConfigBundleSummary,
+  DataSharingResult,
+  DataSharingStatus,
   ExportConfigBundleResult,
   PublishConfigBundleResult,
+  PullSharedSourceResult,
 } from '@costgoblin/core/browser';
 import { isDiscoverableBeaconLocation, splitS3Location, suggestedConfigBeaconLocation } from '@costgoblin/core/browser';
-import { CloudDownload, CloudUpload, FileDown, FileUp, TriangleAlert } from 'lucide-react';
+import { Check, CloudDownload, CloudUpload, Copy, FileDown, FileUp, Network, Plug, RotateCw, TriangleAlert } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { ProfilePicker } from './profile-picker.js';
@@ -98,6 +101,143 @@ function SharingModal({ title, onClose, children }: Readonly<{
         <div className="mt-4 flex flex-col gap-4">{children}</div>
       </div>
     </dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Share data on the local network (peer-to-peer, TLS-PSK). Lets a teammate
+// with zero AWS access pull this machine's data + config from one pasted key.
+// ---------------------------------------------------------------------------
+
+function ShareDataSection(): React.JSX.Element {
+  const api = useCostApi();
+  const [status, setStatus] = useState<DataSharingStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    api.getDataSharingStatus().then(setStatus).catch(() => undefined);
+  }, [api]);
+
+  function run(action: () => Promise<DataSharingResult>): void {
+    setBusy(true);
+    setError(null);
+    action()
+      .then(r => { if (r.status === 'ok') setStatus(r.sharing); else setError(r.message); })
+      .catch((e: unknown) => { setError(e instanceof Error ? e.message : String(e)); })
+      .finally(() => { setBusy(false); });
+  }
+
+  function copyKey(): void {
+    if (status === null || status.sharingKey === null) return;
+    void navigator.clipboard.writeText(status.sharingKey);
+    setCopied(true);
+    setTimeout(() => { setCopied(false); }, 1500);
+  }
+
+  const enabled = status?.enabled === true;
+
+  return (
+    <div className="rounded-lg border border-border bg-bg-tertiary/20 px-4 py-3 flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Network size={16} className="text-text-secondary" />
+          <div>
+            <p className="text-sm font-medium text-text-primary">Share data on this network</p>
+            <p className="text-xs text-text-muted">Teammates without S3 access paste your key to pull your data — encrypted, peer-to-peer.</p>
+          </div>
+        </div>
+        {enabled ? (
+          <Button onClick={() => { run(() => api.disableDataSharing()); }} disabled={busy} className="bg-bg-tertiary hover:bg-bg-tertiary/70 text-text-primary shrink-0">
+            {busy ? 'Stopping…' : 'Stop'}
+          </Button>
+        ) : (
+          <Button onClick={() => { run(() => api.enableDataSharing()); }} disabled={busy} className="bg-accent hover:bg-accent-hover text-white shrink-0">
+            {busy ? 'Starting…' : 'Start sharing'}
+          </Button>
+        )}
+      </div>
+
+      {status !== null && status.enabled && status.sharingKey !== null && (
+        <div className="flex flex-col gap-2">
+          <label htmlFor="cg-sharing-key" className="text-xs text-text-muted uppercase tracking-wider">Sharing key</label>
+          <textarea
+            id="cg-sharing-key"
+            readOnly
+            value={status.sharingKey}
+            rows={3}
+            className="w-full rounded-lg border border-border bg-bg-primary px-3 py-2 font-mono text-xs text-text-primary resize-none focus:outline-none focus:border-accent/50"
+          />
+          <div className="flex items-center gap-2">
+            <Button onClick={copyKey} className="bg-accent hover:bg-accent-hover text-white">
+              {copied ? <><Check size={14} className="mr-1.5" />Copied</> : <><Copy size={14} className="mr-1.5" />Copy key</>}
+            </Button>
+            <button
+              type="button"
+              onClick={() => { run(() => api.rotateDataSharingKey()); }}
+              disabled={busy}
+              className="inline-flex items-center rounded-md px-2.5 py-1.5 text-xs text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+            >
+              <RotateCw size={13} className="mr-1.5" />Rotate (revokes old key)
+            </button>
+          </div>
+          <p className="text-xs text-text-muted">
+            Reachable at <span className="font-mono">{status.hosts.join(', ')}:{status.port}</span> · fingerprint <span className="font-mono">{status.fingerprint}</span>. Re-share if this machine&apos;s IP changes.
+          </p>
+        </div>
+      )}
+      {error !== null && <p className="text-xs text-negative">{error}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add a shared data source — paste a teammate's sharing key, pull the snapshot.
+// ---------------------------------------------------------------------------
+
+function AddSharedSourceSection({ onPulled }: Readonly<{ onPulled: () => void }>): React.JSX.Element {
+  const api = useCostApi();
+  const [key, setKey] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<PullSharedSourceResult | null>(null);
+
+  function handleConnect(): void {
+    if (busy || key.trim().length === 0) return;
+    setBusy(true);
+    setResult(null);
+    api.addSharedSource(key.trim())
+      .then(setResult)
+      .catch((e: unknown) => { setResult({ status: 'error', message: e instanceof Error ? e.message : String(e) }); })
+      .finally(() => { setBusy(false); });
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor="cg-add-source-key" className="text-xs text-text-muted uppercase tracking-wider">Sharing key from a teammate</label>
+      <textarea
+        id="cg-add-source-key"
+        value={key}
+        onChange={(e) => { setKey(e.target.value); }}
+        rows={3}
+        placeholder="CGSHARE1-…  (no AWS access needed — pulls data + config over your network)"
+        spellCheck={false}
+        className="w-full rounded-lg border border-border bg-bg-primary px-3 py-2 font-mono text-xs text-text-primary placeholder:text-text-muted resize-none focus:outline-none focus:border-accent/50"
+      />
+      <Button onClick={handleConnect} disabled={busy || key.trim().length === 0} className="bg-accent hover:bg-accent-hover text-white self-start">
+        <Plug size={16} className="mr-1.5" />
+        {busy ? 'Connecting…' : 'Connect & pull'}
+      </Button>
+      {result?.status === 'ok' && (
+        <div className="rounded-lg border border-positive/40 bg-bg-tertiary/20 px-3 py-2 flex flex-col gap-2">
+          <p className="text-xs text-positive">
+            Pulled {result.filesDownloaded} file{result.filesDownloaded === 1 ? '' : 's'} from {result.source.label} · {result.source.periods.length} period{result.source.periods.length === 1 ? '' : 's'}.
+          </p>
+          <Button onClick={onPulled} className="bg-accent hover:bg-accent-hover text-white self-end">Done</Button>
+        </div>
+      )}
+      {result?.status === 'error' && <p className="text-xs text-negative">{result.message}</p>}
+    </div>
   );
 }
 
@@ -261,6 +401,8 @@ export function ShareConfigDialog({ onClose }: Readonly<{ onClose: () => void }>
           <p className="text-xs text-negative">{publishResult.message}</p>
         )}
       </div>
+
+      <ShareDataSection />
     </SharingModal>
   );
 }
@@ -459,6 +601,13 @@ export function ImportConfigDialog({ onClose, onApplied }: Readonly<{
             <CloudDownload size={16} className="mr-1.5" />
             {fetching ? 'Fetching…' : 'Fetch from S3'}
           </Button>
+
+          <div className="flex items-center gap-3" aria-hidden="true">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs text-text-muted">or pull from a teammate on your network</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+          <AddSharedSourceSection onPulled={onApplied} />
         </>
       )}
 

--- a/packages/ui/src/components/format.ts
+++ b/packages/ui/src/components/format.ts
@@ -8,6 +8,25 @@ export function formatDollars(amount: number): string {
   return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
+export function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = Math.max(bytes, 0);
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  let digits = unit === 0 || value >= 100 ? 0 : 1;
+  // Rounding can push e.g. 1023.7 MB to "1024 MB"; roll over to the next unit.
+  if (Number(value.toFixed(digits)) >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+    digits = value >= 100 ? 0 : 1;
+  }
+  const label = units[unit] ?? 'B';
+  return `${value.toFixed(digits)} ${label}`;
+}
+
 export function formatPercent(value: number): string {
   const sign = value >= 0 ? '+' : '';
   return `${sign}${value.toFixed(1)}%`;

--- a/packages/ui/src/components/sharing-active-banner.tsx
+++ b/packages/ui/src/components/sharing-active-banner.tsx
@@ -1,0 +1,45 @@
+import type { DataSharingStatus } from '@costgoblin/core/browser';
+import { Network, Square } from 'lucide-react';
+import { formatBytes } from './format.js';
+
+/** App-wide banner shown while this machine is sharing its data on the LAN.
+ *  Surfaces live activity (connected peers, files + bytes served, throughput)
+ *  and a one-click Stop. Purely presentational — the parent owns the status
+ *  poll and the disable action. */
+export function SharingActiveBanner({ status, onStop, stopping = false }: Readonly<{
+  status: DataSharingStatus;
+  onStop: () => void;
+  stopping?: boolean;
+}>): React.JSX.Element {
+  const live = status.connectedClients > 0;
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-accent/30 bg-accent/10 px-4 py-1.5 [-webkit-app-region:no-drag]">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className={`relative inline-flex h-2 w-2 shrink-0 rounded-full ${live ? 'bg-positive' : 'bg-accent'}`}>
+          {live && <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-positive opacity-75" aria-hidden="true" />}
+        </span>
+        <Network size={15} className="shrink-0 text-accent" />
+        <span className="shrink-0 text-sm font-medium text-text-primary">Sharing your data</span>
+        <span className="truncate text-xs text-text-muted">· {status.label}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-3 text-xs text-text-secondary sm:gap-4">
+        <span>{status.connectedClients} connected</span>
+        <span className="hidden md:inline">
+          {status.filesServed} file{status.filesServed === 1 ? '' : 's'} · {formatBytes(status.bytesServed)}
+        </span>
+        {status.bytesPerSecond > 0 && (
+          <span className="font-medium text-accent">{formatBytes(status.bytesPerSecond)}/s</span>
+        )}
+        <button
+          type="button"
+          onClick={onStop}
+          disabled={stopping}
+          className="inline-flex items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 font-medium text-text-primary transition-colors hover:bg-bg-tertiary/70 disabled:opacity-50"
+        >
+          <Square size={11} className="fill-current" />
+          {stopping ? 'Stopping…' : 'Stop sharing'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -23,6 +23,7 @@ export { CostTable } from './components/cost-table.js';
 export { EntityPopup } from './components/entity-popup.js';
 export { ConfirmModal } from './components/confirm-modal.js';
 export { BundleSummaryCard, ImportConfigDialog, ShareConfigDialog } from './components/config-sharing.js';
+export { SharingActiveBanner } from './components/sharing-active-banner.js';
 export { ProfilePicker, filterProfiles } from './components/profile-picker.js';
 export { CsvExport } from './components/csv-export.js';
 export { SyncStatusIndicator } from './components/sync-status.js';

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -39,19 +39,25 @@ function WelcomeStep({ onNext, onImport }: Readonly<{ onNext: () => void; onImpo
       <p className="text-text-muted text-sm max-w-md">
         Connect your AWS billing data to get started. CostGoblin syncs CUR (Cost and Usage Report) data from S3, stores it locally, and lets you slice costs by any dimension.
       </p>
-      <Button
-        onClick={onNext}
-        className="bg-accent hover:bg-accent-hover text-white px-8"
-      >
-        Get Started
-      </Button>
-      <button
-        type="button"
-        onClick={onImport}
-        className="text-xs text-text-muted hover:text-text-secondary underline underline-offset-2"
-      >
-        Have a configuration file from a teammate? Import it
-      </button>
+      <div className="flex w-full max-w-xs flex-col gap-3">
+        <Button
+          onClick={onNext}
+          className="bg-accent hover:bg-accent-hover text-white"
+        >
+          Get Started
+        </Button>
+        <div className="flex items-center gap-3 text-xs text-text-muted">
+          <span className="h-px flex-1 bg-border" />
+          or
+          <span className="h-px flex-1 bg-border" />
+        </div>
+        <Button variant="outline" onClick={onImport}>
+          Import from a teammate
+        </Button>
+        <p className="text-text-muted text-xs">
+          Pull config and data from a teammate — a bundle file, from S3, or straight over your network. No AWS access needed.
+        </p>
+      </div>
       <p className="text-text-muted text-xs">
         {"Don't have a CUR yet? "}
         <a
@@ -517,6 +523,11 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     goToProfileStep();
   }
 
+  function handleReturnToWelcome() {
+    setCollectedPaths({ daily: '', hourly: '', costOpt: '' });
+    setWizard({ step: 'welcome' });
+  }
+
   function handleProfileSelect(profile: string) {
     startBucketStep(profile, 'daily');
   }
@@ -645,7 +656,17 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
 
   return (
     <div className="min-h-screen bg-bg-primary flex items-center justify-center p-4">
-      <Card className="w-full max-w-lg border-border bg-bg-secondary">
+      <Card className="relative w-full max-w-lg border-border bg-bg-secondary">
+        {!isSourceMode && wizard.step !== 'welcome' && (
+          <button
+            type="button"
+            onClick={handleReturnToWelcome}
+            className="absolute right-3 top-3 z-10 rounded-md px-2 py-1 text-sm text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+            aria-label="Back to welcome"
+          >
+            ✕
+          </button>
+        )}
         <CardContent className="p-8">
           <div className="flex justify-center mb-6">
             <img src="goblin.png" alt="CostGoblin" className="h-16 w-auto" />


### PR DESCRIPTION
## Peer data sharing (LAN, TLS-PSK)

Lets a teammate with **zero AWS/S3 access** pull another user's billing **data + config** from a single pasted **sharing key** — peer-to-peer over the local network. No broadcast, no server to host, no certificates.

### Flow
- **Publisher** (has the data): *Options → Share configuration… → "Share data on this network" → Start sharing*, then copy the `CGSHARE1-…` key.
- **Consumer** (no AWS): *Options → Import configuration… → "pull from a teammate on your network"*, paste the key → **Connect & pull**. Data lands locally and is queried in place; the Sync view shows the imported periods.

### How it works
- The sharing key packs `{ hosts, port, publisher Ed25519 key, psk, label }`, handed over out-of-band — so the key exchange needs no broadcast/discovery.
- Transport is **TLS-PSK** (TLS 1.2, `ECDHE-PSK-CHACHA20-POLY1305`): encrypted, mutually authenticated (a peer without the psk can't complete the handshake), and forward-secret. No certificate generation, no new dependencies — Node built-ins only.
- Snapshots are **Ed25519-signed** and the publisher key is **pinned from the sharing key**, so a rogue peer can't impersonate the source or tamper with the data. Every file is **SHA-256 verified** and confined to the data tree (no path traversal). Already-present files with a matching hash are skipped (delta pull).
- Pulled Parquet is dropped byte-identical into `aws/raw/{tier}-{period}/` (query-in-place, no ETL); the config bundle (#354) and per-machine enrichment JSON ride along so the consumer sees real account/region **names**.

### Security hardening
- `validateBuiltInDimension` now rejects `builtIn.field`/`displayField` unless they are bare SQL identifiers — closing a raw-interpolation injection vector that becomes reachable once configs are shareable.

### Structure
- `packages/core/src/peer/` — identity, sharing-key token, signed pack manifest, TLS-PSK server/client (unit + integration tested over a real localhost socket).
- Desktop: `peer-store` (identity/psk/source persistence, 0600), `data-sharing` handlers (publisher server + consumer pull/import), `bundle-io` (extracted and shared with the existing config-apply path), plus a local-only data-inventory fallback so an S3-less consumer's Sync view renders.
- UI: two sections added to the existing Share / Import dialogs.

### Known MVP limitations
- Publisher rebuilds + re-hashes all Parquet on each manifest request (fine at current scale; wants a size/mtime cache for large datasets).
- No auto-refresh — the consumer re-pulls manually (`refreshSharedSource` exists, not yet surfaced as a button).
- One shared source per consumer; consumer config applied with the `default` profile.
- Targets co-located, trusted networks (per design); dynamic-network / large-org sharing is the future enterprise tier.

All packages pass `tsc + eslint + tests` (639 total).
