### PR TITLE
perf: memory-aware DuckDB memory_limit + configurable threads (Performance settings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -13174,7 +13174,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1063.0",
         "@aws-sdk/client-s3": "^3.1063.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -52,6 +52,26 @@ export interface UIPreferences {
   readonly theme: 'dark' | 'light';
   readonly palette: 'standard' | 'colorblind';
   readonly defaultViewId?: string | undefined;
+  readonly performance?: PerformanceSettings | undefined;
+}
+
+/** User overrides for DuckDB resource tuning. `null` means "auto" — use the
+ *  machine-derived default. */
+export interface PerformanceSettings {
+  readonly memoryLimitGB: number | null;
+  readonly threads: number | null;
+}
+
+/** Performance tuning context for the settings UI: the machine-derived defaults
+ *  and valid ranges, plus the user's current overrides. */
+export interface PerformanceInfo {
+  readonly defaultMemoryGB: number;
+  readonly defaultThreads: number;
+  readonly totalMemoryGB: number;
+  readonly maxThreads: number;
+  readonly minMemoryGB: number;
+  readonly maxMemoryGB: number;
+  readonly current: PerformanceSettings;
 }
 
 export interface OrgAccount {
@@ -272,6 +292,11 @@ export interface CostApi {
    *  the background. The renderer should follow up with its own view
    *  refresh so the user sees fresh data. */
   clearAllCaches(): Promise<void>;
+  /** Machine-derived DuckDB tuning defaults + ranges + the user's current
+   *  overrides, for the performance settings UI. */
+  getPerformanceInfo(): Promise<PerformanceInfo>;
+  /** Persist DuckDB tuning overrides (null = auto) and apply them live. */
+  setPerformanceSettings(perf: PerformanceSettings): Promise<void>;
   getMcpServerRunning(): Promise<boolean>;
   setMcpServerRunning(enabled: boolean): Promise<void>;
   /** The shared secret a client must send (as `Authorization: Bearer <token>`

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,7 +65,7 @@ export type {
 } from './query.js';
 export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/__tests__/duckdb-tuning.test.ts
+++ b/packages/desktop/src/__tests__/duckdb-tuning.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_MEMORY_GB,
+  MIN_MEMORY_GB,
+  clampMemoryGB,
+  clampThreads,
+  computeDefaultMemoryGB,
+  computeDefaultThreads,
+  maxThreads,
+  resolveMemoryGB,
+  resolveThreads,
+  totalMemoryGB,
+} from '../main/duckdb-tuning.js';
+
+describe('duckdb-tuning defaults', () => {
+  it('memory default stays within [MIN, MAX] and never exceeds total RAM', () => {
+    const def = computeDefaultMemoryGB();
+    expect(def).toBeGreaterThanOrEqual(MIN_MEMORY_GB);
+    expect(def).toBeLessThanOrEqual(MAX_MEMORY_GB);
+    expect(def).toBeLessThanOrEqual(totalMemoryGB());
+  });
+
+  it('thread default is at least 1 and at most the logical core count', () => {
+    const def = computeDefaultThreads();
+    expect(def).toBeGreaterThanOrEqual(1);
+    expect(def).toBeLessThanOrEqual(maxThreads());
+  });
+});
+
+describe('clampMemoryGB', () => {
+  it('floors at MIN_MEMORY_GB', () => {
+    expect(clampMemoryGB(0)).toBe(MIN_MEMORY_GB);
+    expect(clampMemoryGB(-10)).toBe(MIN_MEMORY_GB);
+  });
+  it('caps at min(MAX_MEMORY_GB, total RAM)', () => {
+    const ceiling = Math.min(MAX_MEMORY_GB, totalMemoryGB());
+    expect(clampMemoryGB(10_000)).toBe(ceiling);
+  });
+  it('rounds and passes through in-range values', () => {
+    const ceiling = Math.min(MAX_MEMORY_GB, totalMemoryGB());
+    if (ceiling >= 3) expect(clampMemoryGB(3)).toBe(3);
+    expect(clampMemoryGB(2.4)).toBe(2);
+  });
+});
+
+describe('clampThreads', () => {
+  it('floors at 1 and caps at the logical core count', () => {
+    expect(clampThreads(0)).toBe(1);
+    expect(clampThreads(-3)).toBe(1);
+    expect(clampThreads(10_000)).toBe(maxThreads());
+  });
+});
+
+describe('resolve* (override ?? default)', () => {
+  it('uses the computed default when override is null/undefined', () => {
+    expect(resolveMemoryGB(null)).toBe(computeDefaultMemoryGB());
+    expect(resolveMemoryGB(undefined)).toBe(computeDefaultMemoryGB());
+    expect(resolveThreads(null)).toBe(computeDefaultThreads());
+    expect(resolveThreads(undefined)).toBe(computeDefaultThreads());
+  });
+  it('uses the clamped override when provided', () => {
+    expect(resolveMemoryGB(10_000)).toBe(clampMemoryGB(10_000));
+    expect(resolveThreads(10_000)).toBe(clampThreads(10_000));
+  });
+});

--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -6,7 +6,7 @@ export interface DuckDBClient {
   runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]>;
   runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]>;
   cancelPendingQueries(): void;
-  configure(tempDir: string): void;
+  configure(settings: { tempDir?: string; memoryGB?: number; threads?: number }): void;
   terminate(): Promise<void>;
 }
 
@@ -85,8 +85,8 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
     cancelPendingQueries(): void {
       worker.postMessage({ kind: 'cancel-pending' });
     },
-    configure(tempDir: string): void {
-      worker.postMessage({ kind: 'configure', tempDir });
+    configure(settings: { tempDir?: string; memoryGB?: number; threads?: number }): void {
+      worker.postMessage({ kind: 'configure', ...settings });
     },
     async terminate(): Promise<void> {
       await worker.terminate();

--- a/packages/desktop/src/main/duckdb-tuning.ts
+++ b/packages/desktop/src/main/duckdb-tuning.ts
@@ -1,0 +1,56 @@
+import { cpus, totalmem } from 'node:os';
+
+/** DuckDB resource tuning — shared by the worker (to apply SET memory_limit /
+ *  SET threads) and the main process (to compute the defaults shown in the UI
+ *  and to resolve user overrides). Kept framework-free and side-effect-free so
+ *  it bundles cleanly into the worker. */
+
+export const MIN_MEMORY_GB = 1;
+/** Ceiling so we never starve the OS + Electron (main/renderer/GPU/workers) +
+ *  the user's other apps on very large machines. */
+export const MAX_MEMORY_GB = 24;
+
+export function totalMemoryGB(): number {
+  return Math.max(1, Math.round(totalmem() / (1024 * 1024 * 1024)));
+}
+
+export function maxThreads(): number {
+  return Math.max(1, cpus().length);
+}
+
+/** Default DuckDB memory_limit: ~half of physical RAM, clamped to
+ *  [MIN_MEMORY_GB, MAX_MEMORY_GB]. The previous hard 4GB cap throttled large
+ *  machines (a multi-GB in-memory cost_base plus concurrent aggregations spill
+ *  to disk at 4GB); this scales with RAM while staying conservative. No-op on
+ *  <=8GB laptops. */
+export function computeDefaultMemoryGB(): number {
+  const totalGB = totalmem() / (1024 * 1024 * 1024);
+  return Math.round(Math.min(MAX_MEMORY_GB, Math.max(MIN_MEMORY_GB, totalGB * 0.5)));
+}
+
+/** Default DuckDB intra-query parallelism: all available logical cores (DuckDB's
+ *  own default), surfaced explicitly so users can lower it to reduce contention. */
+export function computeDefaultThreads(): number {
+  return maxThreads();
+}
+
+/** Clamp a user-supplied memory override to a safe range. */
+export function clampMemoryGB(gb: number): number {
+  const ceiling = Math.max(MIN_MEMORY_GB, Math.min(MAX_MEMORY_GB, totalMemoryGB()));
+  return Math.min(ceiling, Math.max(MIN_MEMORY_GB, Math.round(gb)));
+}
+
+/** Clamp a user-supplied thread override to [1, logical cores]. */
+export function clampThreads(n: number): number {
+  return Math.min(maxThreads(), Math.max(1, Math.round(n)));
+}
+
+/** Resolve the effective values to apply: a clamped override, or the computed
+ *  default when the override is null/undefined ("auto"). */
+export function resolveMemoryGB(override: number | null | undefined): number {
+  return override === null || override === undefined ? computeDefaultMemoryGB() : clampMemoryGB(override);
+}
+
+export function resolveThreads(override: number | null | undefined): number {
+  return override === null || override === undefined ? computeDefaultThreads() : clampThreads(override);
+}

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,8 +1,9 @@
 import { parentPort } from 'node:worker_threads';
-import { cpus, totalmem } from 'node:os';
+import { cpus } from 'node:os';
 import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
 import { createResourcePool } from './connection-pool.js';
 import type { ResourcePool } from './connection-pool.js';
+import { computeDefaultMemoryGB, computeDefaultThreads } from './duckdb-tuning.js';
 
 interface DuckDBModule {
   DuckDBInstance: { create: () => Promise<DuckDBInstance> };
@@ -13,16 +14,23 @@ async function createDuckDB(): Promise<DuckDBInstance> {
   return duckdb.DuckDBInstance.create();
 }
 
-function computeMemoryLimitGB(): number {
-  const totalGB = totalmem() / (1024 * 1024 * 1024);
-  return Math.min(4, Math.max(1, Math.round(totalGB * 0.5)));
+interface DuckDBSettings {
+  readonly tempDir?: string | undefined;
+  readonly memoryGB?: number | undefined;
+  readonly threads?: number | undefined;
 }
 
-async function configureDuckDB(conn: DuckDBConnection, tempDir: string | undefined): Promise<void> {
-  const memGB = computeMemoryLimitGB();
+async function configureDuckDB(conn: DuckDBConnection, settings: DuckDBSettings): Promise<void> {
+  // memory_limit and threads are instance-global in DuckDB, so applying them on
+  // any connection affects the whole instance. Callers pass the resolved
+  // effective values (user override or computed default); absent fields fall
+  // back to the computed defaults so a partial message never under-provisions.
+  const memGB = settings.memoryGB ?? computeDefaultMemoryGB();
+  const threads = settings.threads ?? computeDefaultThreads();
   await conn.run(`SET memory_limit = '${String(memGB)}GB'`);
-  if (tempDir !== undefined) {
-    await conn.run(`SET temp_directory = '${tempDir.replaceAll("'", "''")}'`);
+  await conn.run(`SET threads = ${String(threads)}`);
+  if (settings.tempDir !== undefined) {
+    await conn.run(`SET temp_directory = '${settings.tempDir.replaceAll("'", "''")}'`);
   }
 }
 
@@ -56,9 +64,13 @@ function isCancelRequest(msg: unknown): msg is { kind: 'cancel-pending' } {
   return msg['kind'] === 'cancel-pending';
 }
 
-function isConfigureRequest(msg: unknown): msg is { kind: 'configure'; tempDir: string } {
+function isConfigureRequest(msg: unknown): msg is { kind: 'configure'; tempDir?: string; memoryGB?: number; threads?: number } {
   if (!hasProps(msg)) return false;
-  return msg['kind'] === 'configure' && typeof msg['tempDir'] === 'string';
+  if (msg['kind'] !== 'configure') return false;
+  if (msg['tempDir'] !== undefined && typeof msg['tempDir'] !== 'string') return false;
+  if (msg['memoryGB'] !== undefined && typeof msg['memoryGB'] !== 'number') return false;
+  if (msg['threads'] !== undefined && typeof msg['threads'] !== 'number') return false;
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,7 +185,7 @@ function getPool(): Promise<ResourcePool<DuckDBConnection>> {
     // connection. The temp_directory is set later via the 'configure'
     // message once the main thread knows the userData path.
     const initConn = await db.connect();
-    await configureDuckDB(initConn, undefined);
+    await configureDuckDB(initConn, {});
     initConn.disconnectSync();
     return createResourcePool(parsePoolSize(), () => db.connect());
   });
@@ -310,11 +322,11 @@ function handleCancelPending(): void {
   }
 }
 
-async function handleConfigure(req: { kind: 'configure'; tempDir: string }): Promise<void> {
+async function handleConfigure(req: { kind: 'configure'; tempDir?: string; memoryGB?: number; threads?: number }): Promise<void> {
   if (dbInstance === null) return;
   const conn = await dbInstance.connect();
   try {
-    await conn.run(`SET temp_directory = '${req.tempDir.replaceAll("'", "''")}'`);
+    await configureDuckDB(conn, { tempDir: req.tempDir, memoryGB: req.memoryGB, threads: req.threads });
   } finally {
     conn.disconnectSync();
   }

--- a/packages/desktop/src/main/handlers/ui.ts
+++ b/packages/desktop/src/main/handlers/ui.ts
@@ -1,34 +1,89 @@
 import { ipcMain } from 'electron';
-import { parseJsonObject } from '@costgoblin/core';
-import type { UIPreferences } from '@costgoblin/core';
+import { parseJsonObject, isStringRecord } from '@costgoblin/core';
+import type { UIPreferences, PerformanceInfo, PerformanceSettings } from '@costgoblin/core';
 import { type AppContext, prefsPath } from './context.js';
+import {
+  MAX_MEMORY_GB,
+  MIN_MEMORY_GB,
+  clampMemoryGB,
+  clampThreads,
+  computeDefaultMemoryGB,
+  computeDefaultThreads,
+  maxThreads,
+  resolveMemoryGB,
+  resolveThreads,
+  totalMemoryGB,
+} from '../duckdb-tuning.js';
+
+function parsePerformance(parsed: Record<string, unknown> | null): PerformanceSettings | undefined {
+  const perf = parsed?.['performance'];
+  if (!isStringRecord(perf)) return undefined;
+  const mem = perf['memoryLimitGB'];
+  const threads = perf['threads'];
+  return {
+    memoryLimitGB: typeof mem === 'number' ? mem : null,
+    threads: typeof threads === 'number' ? threads : null,
+  };
+}
 
 export function registerUIHandlers(app: AppContext): void {
   const { ctx } = app;
 
   const uiPrefsPath = () => prefsPath(ctx.dataDir, 'ui-preferences');
 
-  ipcMain.handle('ui:get-preferences', async (): Promise<UIPreferences> => {
+  async function readPrefs(): Promise<Record<string, unknown> | null> {
     const fs = await import('node:fs/promises');
     try {
-      const raw = await fs.readFile(await uiPrefsPath(), 'utf-8');
-      const parsed = parseJsonObject(raw);
-      const theme = parsed?.['theme'];
-      const palette = parsed?.['palette'];
-      const defaultViewId = parsed?.['defaultViewId'];
-      return {
-        theme: theme === 'light' || theme === 'dark' ? theme : 'dark',
-        palette: palette === 'standard' || palette === 'colorblind' ? palette : 'standard',
-        defaultViewId: typeof defaultViewId === 'string' ? defaultViewId : undefined,
-      };
+      return parseJsonObject(await fs.readFile(await uiPrefsPath(), 'utf-8'));
     } catch {
-      // file doesn't exist yet
+      return null;
     }
-    return { theme: 'dark', palette: 'standard' };
+  }
+
+  ipcMain.handle('ui:get-preferences', async (): Promise<UIPreferences> => {
+    const parsed = await readPrefs();
+    const theme = parsed?.['theme'];
+    const palette = parsed?.['palette'];
+    const defaultViewId = parsed?.['defaultViewId'];
+    return {
+      theme: theme === 'light' || theme === 'dark' ? theme : 'dark',
+      palette: palette === 'standard' || palette === 'colorblind' ? palette : 'standard',
+      defaultViewId: typeof defaultViewId === 'string' ? defaultViewId : undefined,
+      performance: parsePerformance(parsed),
+    };
   });
 
   ipcMain.handle('ui:save-preferences', async (_event, prefs: UIPreferences): Promise<void> => {
     const fs = await import('node:fs/promises');
-    await fs.writeFile(await uiPrefsPath(), JSON.stringify(prefs, null, 2));
+    // Merge into the existing file so saving (e.g.) theme never clobbers the
+    // separately-managed `performance` block, and vice versa.
+    const existing = (await readPrefs()) ?? {};
+    const merged = { ...existing, ...prefs };
+    await fs.writeFile(await uiPrefsPath(), JSON.stringify(merged, null, 2));
+  });
+
+  ipcMain.handle('perf:get-info', async (): Promise<PerformanceInfo> => {
+    const current = parsePerformance(await readPrefs()) ?? { memoryLimitGB: null, threads: null };
+    return {
+      defaultMemoryGB: computeDefaultMemoryGB(),
+      defaultThreads: computeDefaultThreads(),
+      totalMemoryGB: totalMemoryGB(),
+      maxThreads: maxThreads(),
+      minMemoryGB: MIN_MEMORY_GB,
+      maxMemoryGB: MAX_MEMORY_GB,
+      current,
+    };
+  });
+
+  ipcMain.handle('perf:set', async (_event, perf: PerformanceSettings): Promise<void> => {
+    const fs = await import('node:fs/promises');
+    const memoryLimitGB = typeof perf.memoryLimitGB === 'number' ? clampMemoryGB(perf.memoryLimitGB) : null;
+    const threads = typeof perf.threads === 'number' ? clampThreads(perf.threads) : null;
+    const existing = (await readPrefs()) ?? {};
+    const merged = { ...existing, performance: { memoryLimitGB, threads } };
+    await fs.writeFile(await uiPrefsPath(), JSON.stringify(merged, null, 2));
+    // Apply live — memory_limit and threads are instance-global in DuckDB, so a
+    // configure on a fresh connection re-tunes the whole instance.
+    ctx.db.configure({ memoryGB: resolveMemoryGB(memoryLimitGB), threads: resolveThreads(threads) });
   });
 }

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -1,16 +1,17 @@
 import { app, BrowserWindow, ipcMain, session, shell } from 'electron';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { Session } from 'node:inspector';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { logger } from '@costgoblin/core';
+import { logger, parseJsonObject, isStringRecord } from '@costgoblin/core';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import type { LogEntry } from '@costgoblin/core';
 import { createDuckDBClient } from './duckdb-client.js';
 import type { DuckDBClient } from './duckdb-client.js';
+import { resolveMemoryGB, resolveThreads } from './duckdb-tuning.js';
 import { createSyncClient } from './sync-client.js';
 import type { SyncClient } from './sync-client.js';
 import { registerIpcHandlers } from './ipc.js';
@@ -146,6 +147,27 @@ function installCSP(): void {
   });
 }
 
+/** Read the user's DuckDB performance overrides from ui-preferences.json (the
+ *  same file the UI writes). Returns nulls ("auto") when absent/unreadable so
+ *  the worker falls back to the computed defaults. */
+function readPerformanceOverrides(userDataPath: string): { memoryLimitGB: number | null; threads: number | null } {
+  try {
+    const dataDir = process.env['COSTGOBLIN_DATA_DIR'] ?? join(userDataPath, 'data');
+    const prefsFile = join(dirname(dataDir), 'ui-preferences.json');
+    const parsed = parseJsonObject(readFileSync(prefsFile, 'utf-8'));
+    const perf = parsed?.['performance'];
+    if (isStringRecord(perf)) {
+      return {
+        memoryLimitGB: typeof perf['memoryLimitGB'] === 'number' ? perf['memoryLimitGB'] : null,
+        threads: typeof perf['threads'] === 'number' ? perf['threads'] : null,
+      };
+    }
+  } catch {
+    // no prefs file yet, or unreadable — use computed defaults
+  }
+  return { memoryLimitGB: null, threads: null };
+}
+
 async function createWindow(db: DuckDBClient, syncClient: SyncClient): Promise<void> {
   const userDataPath = app.getPath('userData');
   const dataDir = process.env['COSTGOBLIN_DATA_DIR'] ?? join(userDataPath, 'data');
@@ -230,7 +252,12 @@ async function main(): Promise<void> {
   const userDataPath = app.getPath('userData');
   const tempDir = join(userDataPath, 'temp');
   mkdirSync(tempDir, { recursive: true });
-  db.configure(tempDir);
+  const perf = readPerformanceOverrides(userDataPath);
+  db.configure({
+    tempDir,
+    memoryGB: resolveMemoryGB(perf.memoryLimitGB),
+    threads: resolveThreads(perf.threads),
+  });
 
   logger.info('DuckDB worker ready');
 

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -21,6 +21,8 @@ import type {
   AccountMappingStatus,
   SavingsPreferences,
   UIPreferences,
+  PerformanceInfo,
+  PerformanceSettings,
   DimensionsConfig,
   NormalizationRule,
   OrgSyncResult,
@@ -352,6 +354,12 @@ const api: CostApi = {
   },
   clearAllCaches(): Promise<void> {
     return invoke<undefined>('cache:clear-all').then(() => undefined);
+  },
+  getPerformanceInfo(): Promise<PerformanceInfo> {
+    return invoke<PerformanceInfo>('perf:get-info');
+  },
+  setPerformanceSettings(perf: PerformanceSettings): Promise<void> {
+    return invoke<undefined>('perf:set', perf).then(() => undefined);
   },
   getMcpServerRunning(): Promise<boolean> {
     return invoke<boolean>('mcp:get-running');

--- a/packages/desktop/src/renderer/top-menu/options-menu.tsx
+++ b/packages/desktop/src/renderer/top-menu/options-menu.tsx
@@ -14,6 +14,7 @@ import {
 import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
 import type { UpdateStatus } from '@costgoblin/core/browser';
 import { CollapsibleSection } from './collapsible-section.js';
+import { PerformanceSettings } from './performance-settings.js';
 
 interface Props {
   isDark: boolean;
@@ -173,6 +174,9 @@ export function OptionsMenu({
             active={activeNavId === 'views-editor'}
             label="Views Editor"
           />
+        </CollapsibleSection>
+        <CollapsibleSection title="Performance">
+          <PerformanceSettings />
         </CollapsibleSection>
         <CollapsibleSection title="Sharing">
           <MenuItem

--- a/packages/desktop/src/renderer/top-menu/performance-settings.tsx
+++ b/packages/desktop/src/renderer/top-menu/performance-settings.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { useCostApi } from '@costgoblin/ui';
+import type { PerformanceInfo } from '@costgoblin/core/browser';
+
+/** Parse a numeric settings field. Empty/invalid → null ("auto"). */
+function parseField(raw: string): number | null {
+  const t = raw.trim();
+  if (t === '') return null;
+  const n = Number.parseInt(t, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/** Self-contained DuckDB performance controls (memory limit + threads) for the
+ *  options menu. Reads the machine-derived defaults/ranges + current overrides
+ *  from the backend, and persists + applies changes live. Blank = "auto". */
+export function PerformanceSettings(): React.JSX.Element {
+  const api = useCostApi();
+  const [info, setInfo] = useState<PerformanceInfo | null>(null);
+  const [mem, setMem] = useState('');
+  const [threads, setThreads] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getPerformanceInfo().then((i) => {
+      if (cancelled) return;
+      setInfo(i);
+      setMem(i.current.memoryLimitGB === null ? '' : String(i.current.memoryLimitGB));
+      setThreads(i.current.threads === null ? '' : String(i.current.threads));
+    }).catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [api]);
+
+  if (info === null) {
+    return <div className="px-2 py-1.5 text-xs text-text-muted">Loading…</div>;
+  }
+
+  const memCeiling = Math.min(info.maxMemoryGB, info.totalMemoryGB);
+
+  function commit(nextMem: string, nextThreads: string): void {
+    void api.setPerformanceSettings({
+      memoryLimitGB: parseField(nextMem),
+      threads: parseField(nextThreads),
+    }).catch(() => undefined);
+  }
+
+  const inputCls = 'w-20 rounded-md border border-border bg-bg-tertiary px-2 py-1 text-right text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-accent';
+
+  return (
+    <div className="space-y-3 px-2 py-1.5">
+      <p className="text-xs text-text-muted">Leave blank for Auto. Changes apply immediately.</p>
+
+      <div className="space-y-1">
+        <label className="flex items-center justify-between gap-2 text-sm text-text-secondary">
+          <span>Memory limit (GB)</span>
+          <input
+            type="number"
+            min={info.minMemoryGB}
+            max={memCeiling}
+            inputMode="numeric"
+            className={inputCls}
+            placeholder={`Auto (${String(info.defaultMemoryGB)})`}
+            value={mem}
+            onChange={(e) => { setMem(e.target.value); }}
+            onBlur={() => { commit(mem, threads); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.currentTarget.blur(); } }}
+          />
+        </label>
+        <p className="text-[11px] text-text-muted">
+          Auto: {info.defaultMemoryGB} GB · range {info.minMemoryGB}–{memCeiling} · {info.totalMemoryGB} GB detected
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <label className="flex items-center justify-between gap-2 text-sm text-text-secondary">
+          <span>DuckDB threads</span>
+          <input
+            type="number"
+            min={1}
+            max={info.maxThreads}
+            inputMode="numeric"
+            className={inputCls}
+            placeholder={`Auto (${String(info.defaultThreads)})`}
+            value={threads}
+            onChange={(e) => { setThreads(e.target.value); }}
+            onBlur={() => { commit(mem, threads); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.currentTarget.blur(); } }}
+          />
+        </label>
+        <p className="text-[11px] text-text-muted">
+          Auto: {info.defaultThreads} · range 1–{info.maxThreads} cores
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -6,6 +6,7 @@ import {
   asEntityRef,
   type AccountMappingStatus,
   type CostApi,
+  type PerformanceInfo,
   type CostResult,
   type DailyCostsResult,
   type DataInventoryResult,
@@ -389,6 +390,8 @@ export class MockCostApi implements CostApi {
   acceptSuggestion(): Promise<void> { return Promise.resolve(); }
   cancelPendingQueries(): Promise<void> { return Promise.resolve(); }
   clearAllCaches(): Promise<void> { return Promise.resolve(); }
+  getPerformanceInfo(): Promise<PerformanceInfo> { return Promise.resolve({ defaultMemoryGB: 8, defaultThreads: 8, totalMemoryGB: 16, maxThreads: 8, minMemoryGB: 1, maxMemoryGB: 24, current: { memoryLimitGB: null, threads: null } }); }
+  setPerformanceSettings(): Promise<void> { return Promise.resolve(); }
   getMcpServerRunning(): Promise<boolean> { return Promise.resolve(true); }
   setMcpServerRunning(): Promise<void> { return Promise.resolve(); }
   getMcpToken(): Promise<string> { return Promise.resolve('mock-token-abc123'); }


### PR DESCRIPTION
## Summary

Makes DuckDB resource tuning **memory-aware and user-configurable**, replacing the hard `Math.min(4, …)` `memory_limit` cap that throttled large machines regardless of RAM, and adding an explicit thread setting.

## What changed

- **`duckdb-tuning.ts`** (new, shared by the worker and main):
  - `memory_limit` default = ~half of physical RAM, clamped to **[1, 24] GB** (was a hard 4 GB; no-op on ≤8 GB laptops).
  - `threads` default = logical core count, surfaced explicitly so it can be lowered to reduce contention.
  - `clamp*` / `resolve*` helpers (override ?? computed default).
- **Worker** applies `SET threads` alongside `SET memory_limit`; the `configure` message now carries optional `memoryGB` / `threads` (both instance-global in DuckDB), so tuning can be (re)applied without a restart.
- **Main** reads saved overrides from `ui-preferences.json` at startup and configures the worker with the effective values before warmup.
- **Settings UI** — a new **Performance** section in the options menu shows the machine-derived defaults + valid ranges and lets you override memory limit and threads (**blank = Auto**). Persisted via a new `perf:get-info` / `perf:set` IPC pair; `perf:set` applies the change **live**.

## Defaults (memory)

| Total RAM | Old cap | New default |
|---|---|---|
| 8 GB | 4 | 4 |
| 16 GB | 4 | 8 |
| 32 GB | 4 | 16 |
| 64 GB | **4** | **24** |

## Honest scoping

The 4 GB cap was **measured non-causal** for the "Loading dimensions" startup hang (that was prewarm contention, fixed in the separate startup PR). This PR targets the *other* win: heavy Explorer / hourly-tier / large group-by queries that spilled at 4 GB on big machines — plus it gives users a tuning knob.

## Test plan

- `npm run check` green: tsc + eslint + **656 tests** (incl. new `duckdb-tuning.test.ts` covering defaults within range, clamping, and override resolution).
- The existing `duckdb-worker` test spawns the worker and exercises the `configure` path, so the new `SET memory_limit` / `SET threads` SQL is validated at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
