### PR TITLE
perf: make startup dimension prewarm non-blocking (kills the ~13s splash tail)

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -540,8 +540,13 @@ function AppShell(): React.JSX.Element {
 
       setSplashStep('Preparing cost data...');
       await api.awaitMaterializedBase(BASE_READY_TIMEOUT_MS);
-      await prewarmDimensions(api, setSplashStep);
+      // Reveal the app as soon as the in-memory base is ready. The dimension
+      // filter-value prewarm previously blocked the splash here for ~13s (~8
+      // concurrent probes). Run it in the background instead: with cost_base
+      // ready those probes hit the in-memory table, and filter dropdowns also
+      // load fast on demand — so there's no reason to hold the splash for them.
       setSetupCheck({ status: 'ready' });
+      void prewarmDimensions(api, () => undefined);
     }
     initialize().catch(() => undefined);
   }, [api]);


### PR DESCRIPTION
Stacked on #372 (gate prewarm on the materialized base). **Base this on #372; retarget to `main` once #372 merges.**

## Problem
After #372, the splash still waits ~13s between `cost_base` being ready and the app appearing — that gap is `prewarmDimensions` firing ~8 `getFilterValues` probes via `Promise.all` and the splash `await`ing them.

## Fix
Reveal the app as soon as `cost_base` is ready; run the dimension prewarm in the **background** (non-blocking). With `cost_base` ready those probes hit the in-memory table, and filter dropdowns also load fast on demand — so there is no reason to hold the splash for them.

```diff
 await api.awaitMaterializedBase(BASE_READY_TIMEOUT_MS);
-await prewarmDimensions(api, setSplashStep);
-setSetupCheck({ status: 'ready' });
+setSetupCheck({ status: 'ready' });
+void prewarmDimensions(api, () => undefined);
```

## Impact
Splash clears at base-ready (~4–5s) instead of ~18s. Combined with #372: original ~45s → ~5s.

## Test plan
- `npm run check` green (tsc + eslint + 655 tests).

> Note: the background prewarm + the dashboard's own mount queries still briefly run together; bounding that burst (viewport/ordered widget loading) is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)