### PR TITLE
perf(ui): lazy dashboard widgets — load only when visible, in order, capped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -12945,7 +12945,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1073.0",
         "@aws-sdk/client-s3": "^3.1073.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/ui/src/__tests__/setup.ts
+++ b/packages/ui/src/__tests__/setup.ts
@@ -17,6 +17,35 @@ globalThis.ResizeObserver = class ResizeObserver {
   disconnect() { /* noop */ }
 };
 
+// jsdom has no IntersectionObserver. Dashboard widgets defer mounting until
+// their slot is in view (use-query / widget-load-scheduler), so report every
+// observed element as immediately intersecting — keeps tests rendering all
+// widgets as before.
+globalThis.IntersectionObserver = class IntersectionObserver {
+  private readonly cb: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) { this.cb = cb; }
+  observe(target: Element): void {
+    const rect = target.getBoundingClientRect();
+    const entry: IntersectionObserverEntry = {
+      isIntersecting: true,
+      target,
+      intersectionRatio: 1,
+      time: 0,
+      boundingClientRect: rect,
+      intersectionRect: rect,
+      rootBounds: null,
+    };
+    this.cb([entry], this);
+  }
+  unobserve(): void { /* noop */ }
+  disconnect(): void { /* noop */ }
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly scrollMargin = '';
+  readonly thresholds = [];
+};
+
 Element.prototype.scrollIntoView = () => { /* noop */ };
 
 afterEach(() => {

--- a/packages/ui/src/__tests__/widget-load-scheduler.test.tsx
+++ b/packages/ui/src/__tests__/widget-load-scheduler.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { LazyWidgetSlot, WidgetSchedulerProvider, useWidgetSlot } from '../hooks/widget-load-scheduler.js';
+
+// A test widget that renders its label once mounted and frees its scheduler
+// slot when clicked (standing in for "its query settled").
+function Child({ label }: Readonly<{ label: string }>): React.JSX.Element {
+  const slot = useWidgetSlot();
+  return <button type="button" onClick={() => { slot?.onSettled(); }}>{label}</button>;
+}
+
+describe('WidgetSchedulerProvider + LazyWidgetSlot', () => {
+  // The global test setup mocks IntersectionObserver as always-intersecting, so
+  // every slot requests a mount immediately; the scheduler then gates them.
+  it('mounts in priority order, capped, releasing as each settles', async () => {
+    const user = userEvent.setup();
+    render(
+      <WidgetSchedulerProvider maxConcurrent={1}>
+        {/* DOM order is c, a, b — but priority (0,1,2) decides load order */}
+        <LazyWidgetSlot id="c" priority={2} minHeight={10}><Child label="c" /></LazyWidgetSlot>
+        <LazyWidgetSlot id="a" priority={0} minHeight={10}><Child label="a" /></LazyWidgetSlot>
+        <LazyWidgetSlot id="b" priority={1} minHeight={10}><Child label="b" /></LazyWidgetSlot>
+      </WidgetSchedulerProvider>,
+    );
+
+    // cap=1 → only the highest-priority widget (a) mounts first
+    expect(await screen.findByText('a')).toBeDefined();
+    expect(screen.queryByText('b')).toBeNull();
+    expect(screen.queryByText('c')).toBeNull();
+
+    // a settles → b (next priority) mounts
+    await user.click(screen.getByText('a'));
+    expect(await screen.findByText('b')).toBeDefined();
+    expect(screen.queryByText('c')).toBeNull();
+
+    // b settles → c mounts
+    await user.click(screen.getByText('b'));
+    expect(await screen.findByText('c')).toBeDefined();
+  });
+
+  it('mounts multiple concurrently up to the cap', async () => {
+    render(
+      <WidgetSchedulerProvider maxConcurrent={2}>
+        <LazyWidgetSlot id="a" priority={0} minHeight={10}><Child label="a" /></LazyWidgetSlot>
+        <LazyWidgetSlot id="b" priority={1} minHeight={10}><Child label="b" /></LazyWidgetSlot>
+        <LazyWidgetSlot id="c" priority={2} minHeight={10}><Child label="c" /></LazyWidgetSlot>
+      </WidgetSchedulerProvider>,
+    );
+    expect(await screen.findByText('a')).toBeDefined();
+    expect(await screen.findByText('b')).toBeDefined();
+    // third stays deferred until one of the first two settles
+    expect(screen.queryByText('c')).toBeNull();
+  });
+});

--- a/packages/ui/src/hooks/use-query.ts
+++ b/packages/ui/src/hooks/use-query.ts
@@ -1,5 +1,6 @@
-import { startTransition, useEffect, useState } from 'react';
+import { startTransition, useEffect, useRef, useState } from 'react';
 import type { QueryState } from '@costgoblin/core/browser';
+import { useWidgetSlot } from './widget-load-scheduler.js';
 
 const MAX_CANCEL_RETRIES = 2;
 
@@ -37,6 +38,13 @@ export function useQuery<T>(
   const [state, setState] = useState<QueryState<T>>({ status: 'idle' });
   const [retryCount, setRetryCount] = useState(0);
 
+  // Report query completion to the surrounding dashboard widget slot (if any)
+  // so the load scheduler can free a concurrency slot for the next widget.
+  // Null outside a LazyWidgetSlot, so this is a no-op for non-widget queries.
+  const slot = useWidgetSlot();
+  const slotRef = useRef(slot);
+  slotRef.current = slot;
+
   useEffect(() => {
     const cancelled = { current: false };
 
@@ -57,7 +65,8 @@ export function useQuery<T>(
           // above stays urgent so spinners still appear instantly.
           startTransition(() => { handleFetchSuccess(data, cancelled, setState); });
         })
-        .catch((err: unknown) => { handleFetchError(err, cancelled, retryCount, setState, setRetryCount); });
+        .catch((err: unknown) => { handleFetchError(err, cancelled, retryCount, setState, setRetryCount); })
+        .finally(() => { slotRef.current?.onSettled(); });
     }, delay);
 
     return () => {

--- a/packages/ui/src/hooks/widget-load-scheduler.tsx
+++ b/packages/ui/src/hooks/widget-load-scheduler.tsx
@@ -1,0 +1,198 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Dashboard widget load coordination.
+ *
+ * A view can render ~8+ widgets, each of which fires its own query on mount.
+ * Mounting them all at once means a burst of concurrent queries (and chart
+ * renders) on a single DuckDB instance. This module makes widgets:
+ *   1. mount only when their slot scrolls near the viewport (IntersectionObserver), and
+ *   2. among the ones that want to mount, activate in display order with a
+ *      small concurrency cap — a slot frees up as soon as its widget's query
+ *      settles (reported via `useWidgetSlot()` from the shared `useQuery` hook).
+ *
+ * Off-screen widgets never query until scrolled to; visible ones load
+ * top-to-bottom a few at a time instead of all at once.
+ */
+
+const DEFAULT_MAX_CONCURRENT = 3;
+/** Preload a bit before the slot is actually on screen so scrolling feels instant. */
+const DEFAULT_ROOT_MARGIN = '400px';
+/** Safety net: if a mounted widget never reports settled (no query, or it
+ *  hangs), free its concurrency slot anyway so the queue can't stall. */
+const SLOT_RELEASE_FALLBACK_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Per-slot handle — the shared useQuery hook calls onSettled() once the
+// widget's query resolves, freeing a concurrency slot for the next widget.
+// ---------------------------------------------------------------------------
+export interface WidgetSlotHandle {
+  readonly onSettled: () => void;
+}
+
+const WidgetSlotContext = createContext<WidgetSlotHandle | null>(null);
+
+/** Read the current widget slot (null outside a `LazyWidgetSlot`). The shared
+ *  `useQuery` hook uses this to report query completion to the scheduler. */
+export function useWidgetSlot(): WidgetSlotHandle | null {
+  return useContext(WidgetSlotContext);
+}
+
+// ---------------------------------------------------------------------------
+// Viewport observation
+// ---------------------------------------------------------------------------
+/** Become (and stay) true once the referenced element scrolls within
+ *  `rootMargin` of the viewport. Falls back to true when IntersectionObserver
+ *  is unavailable (SSR / very old engines) so content never gets stuck hidden. */
+export function useInViewport(rootMargin: string = DEFAULT_ROOT_MARGIN): {
+  ref: React.RefObject<HTMLDivElement | null>;
+  inView: boolean;
+} {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (inView) return undefined;
+    const el = ref.current;
+    if (el === null) return undefined;
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return undefined;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+          break;
+        }
+      }
+    }, { rootMargin });
+    observer.observe(el);
+    return () => { observer.disconnect(); };
+  }, [inView, rootMargin]);
+
+  return { ref, inView };
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
+interface SchedulerApi {
+  /** ids that have been granted a mount (sticky — stays mounted once granted). */
+  readonly mounted: ReadonlySet<string>;
+  /** Ask to mount `id`; granted in ascending `priority` up to the concurrency cap. */
+  readonly request: (id: string, priority: number) => void;
+  /** Free `id`'s concurrency slot (it stays mounted). Idempotent. */
+  readonly release: (id: string) => void;
+}
+
+const SchedulerContext = createContext<SchedulerApi | null>(null);
+
+export function WidgetSchedulerProvider({
+  maxConcurrent = DEFAULT_MAX_CONCURRENT,
+  children,
+}: Readonly<{ maxConcurrent?: number; children: ReactNode }>): React.JSX.Element {
+  const [mounted, setMounted] = useState<ReadonlySet<string>>(() => new Set<string>());
+  const [version, setVersion] = useState(0);
+  const mountedRef = useRef<Set<string>>(new Set());   // granted to mount (sticky)
+  const activeRef = useRef<Set<string>>(new Set());    // occupying a concurrency slot
+  const pendingRef = useRef<Map<string, number>>(new Map()); // id -> priority
+  const settledRef = useRef<Set<string>>(new Set());   // released (slot freed)
+
+  const pump = useCallback(() => {
+    let changed = false;
+    while (activeRef.current.size < maxConcurrent && pendingRef.current.size > 0) {
+      let bestId: string | null = null;
+      let bestPriority = Number.POSITIVE_INFINITY;
+      for (const [id, priority] of pendingRef.current) {
+        if (priority < bestPriority) { bestPriority = priority; bestId = id; }
+      }
+      if (bestId === null) break;
+      pendingRef.current.delete(bestId);
+      activeRef.current.add(bestId);
+      mountedRef.current.add(bestId);
+      changed = true;
+    }
+    if (changed) setMounted(new Set(mountedRef.current));
+  }, [maxConcurrent]);
+
+  // Pump after the commit, so all slot requests from this render are collected
+  // before granting — that lets the scheduler honor `priority` rather than
+  // whichever slot's effect happened to run first.
+  useEffect(() => { pump(); }, [version, pump]);
+
+  const request = useCallback((id: string, priority: number) => {
+    if (mountedRef.current.has(id) || pendingRef.current.has(id)) return;
+    pendingRef.current.set(id, priority);
+    setVersion(v => v + 1);
+  }, []);
+
+  const release = useCallback((id: string) => {
+    if (settledRef.current.has(id)) return;
+    settledRef.current.add(id);
+    pendingRef.current.delete(id);
+    activeRef.current.delete(id); // free the slot; id stays in mountedRef
+    setVersion(v => v + 1);
+  }, []);
+
+  const value = useMemo<SchedulerApi>(() => ({ mounted, request, release }), [mounted, request, release]);
+  return <SchedulerContext.Provider value={value}>{children}</SchedulerContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Slot
+// ---------------------------------------------------------------------------
+/** A widget slot that defers mounting `children` until the slot scrolls into
+ *  view and the scheduler grants it a turn. Reserves `minHeight` while deferred
+ *  so layout doesn't jump (and charts get a sized container on mount). */
+export function LazyWidgetSlot({
+  id,
+  priority,
+  minHeight,
+  className,
+  style,
+  children,
+}: Readonly<{
+  id: string;
+  priority: number;
+  minHeight: number;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}>): React.JSX.Element {
+  const scheduler = useContext(SchedulerContext);
+  const { ref, inView } = useInViewport();
+  const requestedRef = useRef(false);
+
+  // Without a scheduler (e.g. a standalone render), fall back to pure viewport gating.
+  const isMounted = scheduler === null ? inView : scheduler.mounted.has(id);
+
+  useEffect(() => {
+    if (scheduler === null || !inView || requestedRef.current) return;
+    requestedRef.current = true;
+    scheduler.request(id, priority);
+  }, [scheduler, inView, id, priority]);
+
+  // Free the concurrency slot once the widget's query settles.
+  const slotHandle = useMemo<WidgetSlotHandle>(
+    () => ({ onSettled: () => { scheduler?.release(id); } }),
+    [scheduler, id],
+  );
+
+  // Safety net so a non-settling widget can't block the queue forever.
+  useEffect(() => {
+    if (!isMounted || scheduler === null) return undefined;
+    const timer = setTimeout(() => { scheduler.release(id); }, SLOT_RELEASE_FALLBACK_MS);
+    return () => { clearTimeout(timer); };
+  }, [isMounted, scheduler, id]);
+
+  return (
+    <div ref={ref} className={className} style={style}>
+      {isMounted
+        ? <WidgetSlotContext.Provider value={slotHandle}>{children}</WidgetSlotContext.Provider>
+        : <div aria-hidden style={{ minHeight }} />}
+    </div>
+  );
+}

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -38,6 +38,15 @@ import {
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
 import { WIDGET_REGISTRY } from '../widgets/registry.js';
 import { widgetFlexBasis } from '../widgets/widget.js';
+import { LazyWidgetSlot, WidgetSchedulerProvider } from '../hooks/widget-load-scheduler.js';
+
+/** Reserve roughly a widget's eventual height while its slot is deferred, so
+ *  the page doesn't jump when it mounts (and charts get a sized container). */
+function placeholderMinHeight(type: string): number {
+  if (type === 'summary') return 150;
+  if (type === 'table') return 360;
+  return 300;
+}
 
 interface CustomViewProps {
   readonly spec: ViewSpec;
@@ -286,33 +295,42 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
         <div className="text-sm text-text-secondary">Loading...</div>
       )}
 
-      {spec.rows.map((row) => (
-        <div key={row.widgets.map(w => w.id).join('-')} className="flex gap-4 items-stretch min-w-0">
-          {row.widgets.map((w) => {
-            const Renderer = WIDGET_REGISTRY[w.type];
-            return (
-              <div
-                key={w.id}
-                className="min-w-0 flex flex-col"
-                style={{ flexBasis: widgetFlexBasis(w.size), flexGrow: 1, flexShrink: 1 }}
-              >
-                <Renderer
-                  spec={w}
-                  dateRange={dateRange}
-                  previousDateRange={previousDateRange}
-                  compareEnabled={compareEnabled}
-                  granularity={granularity}
-                  globalFilters={filters}
-                  dimensions={dimensions}
-                  onSetFilter={handleSetFilter}
-                  onEntityClick={handleEntityClick}
-                  onDateRangeChange={handleDateRangeChange}
-                />
-              </div>
-            );
-          })}
-        </div>
-      ))}
+      <WidgetSchedulerProvider>
+        {spec.rows.map((row, rowIdx) => {
+          // Flat display order across rows = load priority (top-left first).
+          const offset = spec.rows.slice(0, rowIdx).reduce((n, r) => n + r.widgets.length, 0);
+          return (
+            <div key={row.widgets.map(w => w.id).join('-')} className="flex gap-4 items-stretch min-w-0">
+              {row.widgets.map((w, colIdx) => {
+                const Renderer = WIDGET_REGISTRY[w.type];
+                return (
+                  <LazyWidgetSlot
+                    key={w.id}
+                    id={w.id}
+                    priority={offset + colIdx}
+                    minHeight={placeholderMinHeight(w.type)}
+                    className="min-w-0 flex flex-col"
+                    style={{ flexBasis: widgetFlexBasis(w.size), flexGrow: 1, flexShrink: 1 }}
+                  >
+                    <Renderer
+                      spec={w}
+                      dateRange={dateRange}
+                      previousDateRange={previousDateRange}
+                      compareEnabled={compareEnabled}
+                      granularity={granularity}
+                      globalFilters={filters}
+                      dimensions={dimensions}
+                      onSetFilter={handleSetFilter}
+                      onEntityClick={handleEntityClick}
+                      onDateRangeChange={handleDateRangeChange}
+                    />
+                  </LazyWidgetSlot>
+                );
+              })}
+            </div>
+          );
+        })}
+      </WidgetSchedulerProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Dashboard views render ~8+ widgets that each fire their own query on mount, so opening a view dispatched a burst of concurrent queries (and chart renders) against the single DuckDB instance. This makes widgets **load only when visible, in display order, with a concurrency cap** — directly bounding the startup query burst.

## Behavior

- **Viewport-gated:** a widget mounts (and queries) only when its slot scrolls within ~400px of the viewport (`IntersectionObserver`). Off-screen widgets never query until reached.
- **Ordered + capped:** among widgets that want to mount, the scheduler activates them in **display order** (top-left first) up to a small **concurrency cap** (default 3), freeing a slot as soon as each widget's query settles.
- **No layout shift:** each deferred slot reserves a min-height placeholder, so the page doesn't jump and charts mount into an already-sized container.

## How it works

- `hooks/widget-load-scheduler.tsx` (new):
  - `useInViewport` — sticky IntersectionObserver hook (falls back to visible if IO is unavailable).
  - `WidgetSchedulerProvider` — priority + concurrency scheduler. Grants are **pumped after commit** so all slot requests in a render are collected first and `priority` is honored (not whichever effect ran first).
  - `LazyWidgetSlot` — placeholder until granted, then mounts the widget; frees its slot when the widget's query settles (with a safety-net timeout so a non-settling widget can't stall the queue).
- `hooks/use-query.ts` — reports query settle to the surrounding slot via context (no-op outside a slot, so non-widget queries are unaffected).
- `views/custom-view.tsx` — wraps the rows in the provider and renders each widget in a `LazyWidgetSlot` with `priority = flat display index`.

## Test plan

- `npm run check` green (tsc + eslint + **665 tests**).
- New `widget-load-scheduler.test.tsx`: asserts widgets mount in priority order (not DOM order), respect the concurrency cap, and release on settle.
- Test setup mocks `IntersectionObserver` as always-intersecting, so existing dashboard tests (`cost-overview`, `custom-view`, …) still render every widget and pass unchanged.

> Note: verified via the test suite; a live visual pass (charts sizing correctly after deferred mount, no placeholder gaps) is still worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
