### PR TITLE
feat(sync): enforce retention via Prune action and Auto-prune toggle

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -629,12 +629,14 @@ Background CUR sync while the app is open.
 - When enabled, periodically (default 60 minutes — configurable in `costgoblin.yaml`) checks the inventory for missing or stale periods within the retention window and downloads them.
 - Status surfaced in the title bar: `disabled`, `idle`, `checking`, `syncing` (with phase + progress), or `error`.
 - Single-instance gate: only one auto-sync run at a time; manual sync interlocks.
+- **Auto-prune** is a separate toggle (off by default; persisted as `autoPrune` in `preferences.json`). On each scheduler run it deletes local periods that have fallen outside each configured tier's retention window. It shares the auto-sync scheduler — the scheduler runs whenever auto-sync *or* auto-prune is on. Pruning is local-only, so it still reclaims disk even when S3 is unreachable, and it runs before the download pass.
 
 #### Feature: Sync View / Data Inventory (MVP)
 
 Replaces the spec's earlier "sync status indicator." A full view showing:
 - Per-tier table of months (daily, hourly, cost-optimization) with local status (`missing`, `repartitioned`, `stale`).
 - Per-month sync, delete, and inspect actions.
+- A **Prune** action (with confirmation) removes, in one click, every local period that has fallen outside its tier's retention window across all configured tiers. Retention is thus enforced as deletion of stale local data, not merely as a download cutoff. A guard ignores a non-positive `retentionDays` so a misconfiguration can never wipe everything.
 - Disk usage, oldest/newest period, total remote vs. local sizes.
 - A nav badge on "Sync" shows the count of missing periods within the retention window.
 - AWS Organizations panel (sync, view accounts, browse OU paths, inspect account tags).

--- a/SPEC.md
+++ b/SPEC.md
@@ -625,11 +625,11 @@ Pulls account/OU/tag metadata from the AWS Organizations API. Used for:
 Background CUR sync while the app is open.
 
 **Behavior:**
-- Toggleable from the Sync view; persisted in `preferences.json`.
-- When enabled, periodically (default 60 minutes — configurable in `costgoblin.yaml`) checks the inventory for missing or stale periods within the retention window and downloads them.
+- Toggleable from the top menu (left side), alongside auto-prune and the shared schedule interval; persisted in `preferences.json`.
+- When enabled, periodically checks the inventory for missing or stale periods within the retention window and downloads them. The interval is chosen in the top menu (Hourly / Daily / Weekly / Monthly; default Daily) and clamped server-side to [1 hour, 1 month].
 - Status surfaced in the title bar: `disabled`, `idle`, `checking`, `syncing` (with phase + progress), or `error`.
 - Single-instance gate: only one auto-sync run at a time; manual sync interlocks.
-- **Auto-prune** is a separate toggle (off by default; persisted as `autoPrune` in `preferences.json`). On each scheduler run it deletes local periods that have fallen outside each configured tier's retention window. It shares the auto-sync scheduler — the scheduler runs whenever auto-sync *or* auto-prune is on. Pruning is local-only, so it still reclaims disk even when S3 is unreachable, and it runs before the download pass.
+- **Auto-prune** is a separate toggle (off by default; persisted as `autoPrune` in `preferences.json`). On each scheduler run it deletes local periods that have fallen outside each configured tier's retention window. It shares the auto-sync scheduler and interval — the scheduler runs whenever auto-sync *or* auto-prune is on. Pruning is local-only, so it still reclaims disk even when S3 is unreachable, and it runs before the download pass.
 
 #### Feature: Sync View / Data Inventory (MVP)
 

--- a/e2e/views-config.test.ts
+++ b/e2e/views-config.test.ts
@@ -45,21 +45,14 @@ test.describe('Data Management', () => {
     await expect(page.getByText('S3 sync and local data inventory')).toBeVisible();
   });
 
-  test('shows action buttons: Auto-sync, Delete All, Open Folder, Refresh', async () => {
-    await expect(page.getByText('Auto-sync')).toBeVisible();
+  test('shows action buttons: Prune, Delete All, Open Folder, Refresh', async () => {
+    // Auto-sync / auto-prune / interval moved to the top-menu SchedulerControls
+    // (shown outside settings mode), so they're no longer Data Management
+    // actions. The view keeps the one-off Prune button and the rest.
+    await expect(page.getByRole('button', { name: /Prune/ })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Delete All Data' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Open Folder' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
-  });
-
-  test('auto-sync toggle clicks without crash', async () => {
-    // find the toggle — it's the rounded-full button near "Auto-sync" text
-    const toggle = page.locator('button.rounded-full').filter({ has: page.locator('span.rounded-full') });
-    const count = await toggle.count();
-    if (count > 0) {
-      await toggle.first().click();
-      await toggle.first().click();
-    }
   });
 
   test('org section is visible (either synced or prompt)', async () => {

--- a/packages/core/src/__tests__/retention.test.ts
+++ b/packages/core/src/__tests__/retention.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  retentionCutoffPeriod,
+  periodsOutsideRetention,
+  configuredTierRetentions,
+} from '../sync/retention.js';
+
+// Fixed "now" so the month math is deterministic: 2026-06-23.
+const NOW = Date.UTC(2026, 5, 23);
+
+describe('retentionCutoffPeriod', () => {
+  it('365 days back lands in the prior year', () => {
+    expect(retentionCutoffPeriod(365, NOW)).toBe('2025-06');
+  });
+
+  it('30 days back stays within the boundary month', () => {
+    // 2026-06-23 minus 30 days = 2026-05-24 → cutoff month 2026-05.
+    expect(retentionCutoffPeriod(30, NOW)).toBe('2026-05');
+  });
+
+  it('pads single-digit months', () => {
+    // 2026-06-23 minus ~150 days lands in January.
+    expect(retentionCutoffPeriod(150, NOW)).toBe('2026-01');
+  });
+});
+
+describe('periodsOutsideRetention', () => {
+  const local = ['2025-01', '2025-06', '2026-04', '2026-05', '2026-06'];
+
+  it('returns periods strictly older than the cutoff month, oldest first', () => {
+    // 365d cutoff is 2025-06 → only 2025-01 is strictly older.
+    expect(periodsOutsideRetention(local, 365, NOW)).toEqual(['2025-01']);
+  });
+
+  it('keeps the boundary month (symmetric with the download cutoff)', () => {
+    // 30d cutoff is 2026-05; 2026-05 is kept, everything before it pruned.
+    expect(periodsOutsideRetention(local, 30, NOW)).toEqual(['2025-01', '2025-06', '2026-04']);
+  });
+
+  it('returns nothing when all local data is within retention', () => {
+    expect(periodsOutsideRetention(['2026-05', '2026-06'], 365, NOW)).toEqual([]);
+  });
+
+  it('guards against retentionDays = 0 — never reports everything as expired', () => {
+    expect(periodsOutsideRetention(local, 0, NOW)).toEqual([]);
+  });
+
+  it('guards against negative and non-finite retention', () => {
+    expect(periodsOutsideRetention(local, -5, NOW)).toEqual([]);
+    expect(periodsOutsideRetention(local, Number.NaN, NOW)).toEqual([]);
+    expect(periodsOutsideRetention(local, Number.POSITIVE_INFINITY, NOW)).toEqual([]);
+  });
+
+  it('handles an empty local set', () => {
+    expect(periodsOutsideRetention([], 30, NOW)).toEqual([]);
+  });
+});
+
+describe('configuredTierRetentions', () => {
+  it('always includes daily, with its default when unset', () => {
+    expect(configuredTierRetentions({ daily: {} })).toEqual([
+      { tier: 'daily', retentionDays: 365 },
+    ]);
+  });
+
+  it('uses configured values and includes optional tiers when present', () => {
+    expect(
+      configuredTierRetentions({
+        daily: { retentionDays: 400 },
+        hourly: { retentionDays: 14 },
+        costOptimization: {},
+      }),
+    ).toEqual([
+      { tier: 'daily', retentionDays: 400 },
+      { tier: 'hourly', retentionDays: 14 },
+      { tier: 'cost-optimization', retentionDays: 90 },
+    ]);
+  });
+
+  it('omits tiers that are not configured', () => {
+    const tiers = configuredTierRetentions({ daily: { retentionDays: 365 }, hourly: { retentionDays: 30 } });
+    expect(tiers.map(t => t.tier)).toEqual(['daily', 'hourly']);
+  });
+});

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -29,6 +29,13 @@ export {
 } from './selective-sync.js';
 
 export {
+  type TierRetention,
+  retentionCutoffPeriod,
+  periodsOutsideRetention,
+  configuredTierRetentions,
+} from './retention.js';
+
+export {
   type ExpectedDataType,
   extractDate,
   extractPeriod,

--- a/packages/core/src/sync/retention.ts
+++ b/packages/core/src/sync/retention.ts
@@ -1,0 +1,64 @@
+import type { DataTier } from '../types/api.js';
+
+/** The earliest billing month (YYYY-MM) still inside the retention window.
+ *  Periods strictly older than this are eligible for pruning; periods at or
+ *  after it are kept. This mirrors the auto-sync download cutoff exactly
+ *  (download keeps `period >= cutoff`, prune deletes `period < cutoff`), so a
+ *  boundary month is never downloaded-then-immediately-pruned. */
+export function retentionCutoffPeriod(retentionDays: number, now: number = Date.now()): string {
+  const d = new Date(now - retentionDays * 24 * 60 * 60 * 1000);
+  return `${String(d.getFullYear())}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Local billing periods (YYYY-MM) that have fallen outside the retention
+ *  window and can be safely deleted, sorted oldest-first.
+ *
+ *  Returns an empty list when `retentionDays` is not a positive, finite number
+ *  — a deliberate guard so a misconfigured `retentionDays: 0` (or a negative /
+ *  NaN value) can never be interpreted as "everything is expired" and wipe the
+ *  whole local cache. */
+export function periodsOutsideRetention(
+  localPeriods: readonly string[],
+  retentionDays: number,
+  now: number = Date.now(),
+): string[] {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return [];
+  const cutoff = retentionCutoffPeriod(retentionDays, now);
+  return localPeriods
+    .filter(period => period < cutoff)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export interface TierRetention {
+  readonly tier: DataTier;
+  readonly retentionDays: number;
+}
+
+/** Minimal structural view of a provider's `sync` config — kept local so this
+ *  pure module doesn't depend on the full config type. */
+interface SyncRetentionConfig {
+  readonly daily: { readonly retentionDays?: number | undefined };
+  readonly hourly?: { readonly retentionDays?: number | undefined } | undefined;
+  readonly costOptimization?: { readonly retentionDays?: number | undefined } | undefined;
+}
+
+/** Default retention windows, matching the values used across the app
+ *  (setup wizard, auto-sync, and the Data Management UI). */
+const DEFAULT_RETENTION_DAYS = { daily: 365, hourly: 30, costOptimization: 90 } as const;
+
+/** Retention window for every configured tier. Daily is always present; hourly
+ *  and cost-optimization only appear when that tier is configured. Used by both
+ *  the manual prune action and the auto-prune scheduler pass so they stay in
+ *  lockstep. */
+export function configuredTierRetentions(sync: SyncRetentionConfig): TierRetention[] {
+  const tiers: TierRetention[] = [
+    { tier: 'daily', retentionDays: sync.daily.retentionDays ?? DEFAULT_RETENTION_DAYS.daily },
+  ];
+  if (sync.hourly !== undefined) {
+    tiers.push({ tier: 'hourly', retentionDays: sync.hourly.retentionDays ?? DEFAULT_RETENTION_DAYS.hourly });
+  }
+  if (sync.costOptimization !== undefined) {
+    tiers.push({ tier: 'cost-optimization', retentionDays: sync.costOptimization.retentionDays ?? DEFAULT_RETENTION_DAYS.costOptimization });
+  }
+  return tiers;
+}

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -125,6 +125,10 @@ export interface DataInventoryResult {
   };
 }
 
+export interface PruneResult {
+  readonly deleted: readonly { readonly tier: DataTier; readonly period: string }[];
+}
+
 export interface CostApi {
   queryCosts(params: CostQueryParams): Promise<CostResult>;
   queryDailyCosts(params: DailyCostsParams): Promise<DailyCostsResult>;
@@ -194,6 +198,15 @@ export interface CostApi {
   getAutoSyncIntervalMinutes(): Promise<number>;
   setAutoSyncIntervalMinutes(minutes: number): Promise<void>;
   getAutoSyncStatus(): Promise<AutoSyncStatus>;
+  /** Whether the scheduler automatically prunes out-of-retention local data on
+   *  each run. Off by default. Shares the auto-sync scheduler — enabling it
+   *  starts the scheduler even when auto-download is off. */
+  getAutoPruneEnabled(): Promise<boolean>;
+  setAutoPruneEnabled(enabled: boolean): Promise<void>;
+  /** Delete every local billing period that has fallen outside its tier's
+   *  retention window, across all configured tiers. Returns what was removed.
+   *  Local-only — no S3 access required. */
+  pruneNow(): Promise<PruneResult>;
   syncOrgAccounts(profile: string): Promise<OrgSyncResult>;
   getOrgSyncResult(): Promise<OrgSyncResult | null>;
   getOrgSyncProgress(): Promise<OrgSyncProgress | null>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,7 +65,7 @@ export type {
 } from './query.js';
 export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -25,10 +25,10 @@ let running = false;
 let currentIntervalMs = 24 * 60 * 60 * 1000;
 
 /** Minimum / maximum interval the UI can request. Anything sub-hour risks
- *  hammering S3 for a typical multi-tier sync and anything beyond a week
- *  stops feeling like "auto" to the user. */
+ *  hammering S3 for a typical multi-tier sync and the upper bound (one month)
+ *  is the slowest cadence the UI offers ("Monthly"). */
 export const MIN_AUTO_SYNC_INTERVAL_MINUTES = 60;
-export const MAX_AUTO_SYNC_INTERVAL_MINUTES = 7 * 24 * 60;
+export const MAX_AUTO_SYNC_INTERVAL_MINUTES = 31 * 24 * 60;
 export const DEFAULT_AUTO_SYNC_INTERVAL_MINUTES = 24 * 60;
 
 export function getAutoSyncStatus(): AutoSyncStatus {

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -1,11 +1,19 @@
-import { logger, parseJsonObject } from '@costgoblin/core';
+import { logger, parseJsonObject, configuredTierRetentions, periodsOutsideRetention, retentionCutoffPeriod } from '@costgoblin/core';
 import type { AutoSyncStatus } from '@costgoblin/core';
 
 export interface AutoSyncDeps {
   getPrefsPath: () => Promise<string>;
-  getConfig: () => Promise<{ providers: { sync: { daily: { retentionDays?: number | undefined }; hourly?: { retentionDays?: number | undefined } | undefined } }[] }>;
+  getConfig: () => Promise<{ providers: { sync: {
+    daily: { retentionDays?: number | undefined };
+    hourly?: { retentionDays?: number | undefined } | undefined;
+    costOptimization?: { retentionDays?: number | undefined } | undefined;
+  } }[] }>;
   getInventory: (tier: string) => Promise<{ periods: { period: string; localStatus: string; files: { key: string; contentHash: string; size: number }[] }[] }>;
   syncPeriods: (files: { key: string; contentHash: string; size: number }[], tier: string) => Promise<{ filesDownloaded: number }>;
+  /** On-disk billing periods (YYYY-MM) for a tier — drives the auto-prune pass. */
+  getLocalPeriods: (tier: string) => Promise<string[]>;
+  /** Delete the given local periods for a tier (auto-prune). */
+  deletePeriods: (periods: readonly string[], tier: string) => Promise<void>;
 }
 
 let status: AutoSyncStatus = { state: 'disabled' };
@@ -52,6 +60,31 @@ export async function writeAutoSyncEnabled(prefsPath: string, enabled: boolean):
   await fs.writeFile(prefsPath, JSON.stringify(existing, null, 2));
 }
 
+export async function readAutoPruneEnabled(prefsPath: string): Promise<boolean> {
+  const fs = await import('node:fs/promises');
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    return parseJsonObject(raw)?.['autoPrune'] === true;
+  } catch {
+    // file doesn't exist
+  }
+  return false;
+}
+
+export async function writeAutoPruneEnabled(prefsPath: string, enabled: boolean): Promise<void> {
+  const fs = await import('node:fs/promises');
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(prefsPath, 'utf-8');
+    const parsed = parseJsonObject(raw);
+    if (parsed !== null) {
+      existing = { ...parsed };
+    }
+  } catch { /* */ }
+  existing['autoPrune'] = enabled;
+  await fs.writeFile(prefsPath, JSON.stringify(existing, null, 2));
+}
+
 export async function readAutoSyncIntervalMinutes(prefsPath: string): Promise<number> {
   const fs = await import('node:fs/promises');
   try {
@@ -85,11 +118,6 @@ function clampInterval(minutes: number): number {
   return Math.max(MIN_AUTO_SYNC_INTERVAL_MINUTES, Math.min(MAX_AUTO_SYNC_INTERVAL_MINUTES, Math.round(minutes)));
 }
 
-function retentionCutoff(days: number): string {
-  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-  return `${String(d.getFullYear())}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-}
-
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -98,7 +126,7 @@ async function syncTier(
   deps: AutoSyncDeps,
   tier: { name: string; retention: number },
 ): Promise<'ok' | 'skip' | 'error'> {
-  const cutoff = retentionCutoff(tier.retention);
+  const cutoff = retentionCutoffPeriod(tier.retention);
   let inventory: Awaited<ReturnType<typeof deps.getInventory>>;
   try {
     inventory = await deps.getInventory(tier.name);
@@ -130,21 +158,48 @@ async function syncTier(
   }
 }
 
+/** Delete out-of-retention local data for every configured tier. Local-only
+ *  and best-effort: per-tier read/delete failures are logged and skipped so one
+ *  bad tier never aborts the whole pass. */
+async function prunePass(
+  deps: AutoSyncDeps,
+  provider: { sync: Parameters<typeof configuredTierRetentions>[0] },
+): Promise<void> {
+  for (const { tier, retentionDays } of configuredTierRetentions(provider.sync)) {
+    let local: string[];
+    try {
+      local = await deps.getLocalPeriods(tier);
+    } catch (err: unknown) {
+      logger.info(`Auto-prune: failed to read ${tier} local data — ${errorMessage(err)}`);
+      continue;
+    }
+    const expired = periodsOutsideRetention(local, retentionDays);
+    if (expired.length === 0) continue;
+    logger.info(`Auto-prune: ${tier} — removing ${String(expired.length)} period(s) outside ${String(retentionDays)}d retention: ${expired.join(', ')}`);
+    try {
+      await deps.deletePeriods(expired, tier);
+    } catch (err: unknown) {
+      logger.info(`Auto-prune: ${tier} — delete failed: ${errorMessage(err)}`);
+    }
+  }
+}
+
 async function runOnce(deps: AutoSyncDeps): Promise<void> {
   if (running) return;
   running = true;
 
   try {
     const prefsPath = await deps.getPrefsPath();
-    const enabled = await readAutoSyncEnabled(prefsPath);
-    if (!enabled) {
+    const syncEnabled = await readAutoSyncEnabled(prefsPath);
+    const pruneEnabled = await readAutoPruneEnabled(prefsPath);
+    if (!syncEnabled && !pruneEnabled) {
       status = { state: 'disabled' };
       running = false;
       return;
     }
 
     status = { state: 'checking' };
-    logger.info('Auto-sync: checking for missing data');
+    logger.info('Auto-sync: checking');
 
     const config = await deps.getConfig();
     const provider = config.providers[0];
@@ -154,18 +209,26 @@ async function runOnce(deps: AutoSyncDeps): Promise<void> {
       return;
     }
 
-    const tiers: { name: string; retention: number }[] = [
-      { name: 'daily', retention: provider.sync.daily.retentionDays ?? 365 },
-    ];
-    if (provider.sync.hourly !== undefined) {
-      tiers.push({ name: 'hourly', retention: provider.sync.hourly.retentionDays ?? 30 });
+    // Prune first — it's local-only, so it still frees space even when S3 is
+    // unreachable and the download pass below would fail.
+    if (pruneEnabled) {
+      await prunePass(deps, provider);
     }
 
-    for (const tier of tiers) {
-      const tierResult = await syncTier(deps, tier);
-      if (tierResult === 'error') {
-        running = false;
-        return;
+    if (syncEnabled) {
+      const tiers: { name: string; retention: number }[] = [
+        { name: 'daily', retention: provider.sync.daily.retentionDays ?? 365 },
+      ];
+      if (provider.sync.hourly !== undefined) {
+        tiers.push({ name: 'hourly', retention: provider.sync.hourly.retentionDays ?? 30 });
+      }
+
+      for (const tier of tiers) {
+        const tierResult = await syncTier(deps, tier);
+        if (tierResult === 'error') {
+          running = false;
+          return;
+        }
       }
     }
 

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { getDataInventory } from '@costgoblin/core';
+import { getDataInventory, getLocalDataInventory } from '@costgoblin/core';
 import type { AutoSyncStatus } from '@costgoblin/core';
 import {
   startAutoSync,
@@ -7,9 +7,12 @@ import {
   getAutoSyncStatus,
   readAutoSyncEnabled,
   writeAutoSyncEnabled,
+  readAutoPruneEnabled,
+  writeAutoPruneEnabled,
   readAutoSyncIntervalMinutes,
   writeAutoSyncIntervalMinutes,
 } from '../auto-sync.js';
+import { deleteLocalPeriodFiles } from './sync.js';
 import { type AppContext, prefsPath } from './context.js';
 import type { SyncClient } from '../sync-client.js';
 
@@ -97,7 +100,30 @@ export function registerAutoSyncHandlers(app: AppContext): void {
           throw err;
         }
       },
+      getLocalPeriods: async (tier: string) => {
+        const inv = await getLocalDataInventory(ctx.dataDir, asTier(tier));
+        return [...inv.local.periods];
+      },
+      deletePeriods: async (periods: readonly string[], tier: string) => {
+        for (const period of periods) {
+          await deleteLocalPeriodFiles(ctx.dataDir, period, asTier(tier));
+        }
+      },
     };
+  }
+
+  // The scheduler is shared by auto-sync and auto-prune: it must run whenever
+  // EITHER is enabled, and stop only when both are off. Re-read both flags and
+  // (re)start or stop accordingly. Call after any toggle/interval change.
+  async function refreshScheduler(path: string): Promise<void> {
+    const syncOn = await readAutoSyncEnabled(path);
+    const pruneOn = await readAutoPruneEnabled(path);
+    if (syncOn || pruneOn) {
+      const minutes = await readAutoSyncIntervalMinutes(path);
+      startAutoSync(buildAutoSyncDeps(ctx.syncClient), minutes);
+    } else {
+      stopAutoSync();
+    }
   }
 
   ipcMain.handle('auto-sync:get-enabled', async (): Promise<boolean> => {
@@ -105,14 +131,19 @@ export function registerAutoSyncHandlers(app: AppContext): void {
   });
 
   ipcMain.handle('auto-sync:set-enabled', async (_event, enabled: boolean): Promise<void> => {
-    const prefsPath = await autoSyncPrefsPath();
-    await writeAutoSyncEnabled(prefsPath, enabled);
-    if (enabled) {
-      const minutes = await readAutoSyncIntervalMinutes(prefsPath);
-      startAutoSync(buildAutoSyncDeps(ctx.syncClient), minutes);
-    } else {
-      stopAutoSync();
-    }
+    const path = await autoSyncPrefsPath();
+    await writeAutoSyncEnabled(path, enabled);
+    await refreshScheduler(path);
+  });
+
+  ipcMain.handle('auto-prune:get-enabled', async (): Promise<boolean> => {
+    return readAutoPruneEnabled(await autoSyncPrefsPath());
+  });
+
+  ipcMain.handle('auto-prune:set-enabled', async (_event, enabled: boolean): Promise<void> => {
+    const path = await autoSyncPrefsPath();
+    await writeAutoPruneEnabled(path, enabled);
+    await refreshScheduler(path);
   });
 
   ipcMain.handle('auto-sync:get-interval', async (): Promise<number> => {
@@ -120,28 +151,18 @@ export function registerAutoSyncHandlers(app: AppContext): void {
   });
 
   ipcMain.handle('auto-sync:set-interval', async (_event, minutes: number): Promise<void> => {
-    const prefsPath = await autoSyncPrefsPath();
-    await writeAutoSyncIntervalMinutes(prefsPath, minutes);
-    // Only restart the scheduler if auto-sync is actually on — otherwise
-    // saving the preference is enough; the new interval will be picked up
-    // next time the user flips the toggle.
-    const enabled = await readAutoSyncEnabled(prefsPath);
-    if (enabled) {
-      const stored = await readAutoSyncIntervalMinutes(prefsPath);
-      startAutoSync(buildAutoSyncDeps(ctx.syncClient), stored);
-    }
+    const path = await autoSyncPrefsPath();
+    await writeAutoSyncIntervalMinutes(path, minutes);
+    // Restart only if the scheduler is actually running (auto-sync or
+    // auto-prune on) so the new interval takes effect; otherwise saving the
+    // preference is enough and it'll be picked up next time one is enabled.
+    await refreshScheduler(path);
   });
 
   ipcMain.handle('auto-sync:get-status', (): AutoSyncStatus => {
     return getAutoSyncStatus();
   });
 
-  // Start auto-sync on launch if previously enabled
-  void autoSyncPrefsPath().then(async (prefsPath) => {
-    const enabled = await readAutoSyncEnabled(prefsPath);
-    if (enabled) {
-      const minutes = await readAutoSyncIntervalMinutes(prefsPath);
-      startAutoSync(buildAutoSyncDeps(ctx.syncClient), minutes);
-    }
-  }).catch(() => { /* auto-sync startup failure is non-fatal */ });
+  // Start the scheduler on launch if auto-sync or auto-prune was left enabled
+  void autoSyncPrefsPath().then(refreshScheduler).catch(() => { /* auto-sync startup failure is non-fatal */ });
 }

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -5,14 +5,18 @@ import {
   getEtagFileName,
   getRawDirPrefix,
   parseEtagsJson,
+  configuredTierRetentions,
+  periodsOutsideRetention,
   logger,
 } from '@costgoblin/core';
 import type {
   CostGoblinConfig,
   DataInventory,
+  DataTier,
   ManifestFileEntry,
   AccountMappingStatus,
   AccountMappingEntry,
+  PruneResult,
   SyncStatus,
 } from '@costgoblin/core';
 import {
@@ -95,6 +99,38 @@ async function pruneEtagFile(
   }
 }
 
+const PERIOD_RE = /^\d{4}-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?$/;
+
+/** Remove a single local billing period (raw dirs + etag entries) for a tier.
+ *  Shared by the manual delete handler, the prune handler, and auto-prune so
+ *  they all delete data identically. Returns whether any files were removed. */
+export async function deleteLocalPeriodFiles(
+  dataDir: string,
+  period: string,
+  tier: ExpectedDataType,
+): Promise<boolean> {
+  if (!PERIOD_RE.test(period)) {
+    throw new Error(`Invalid period format: "${period}" — expected YYYY-MM or YYYY-MM-DD`);
+  }
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+
+  const prefix = getRawDirPrefix(tier);
+  const rawDir = path.join(dataDir, 'aws', 'raw');
+
+  const removedAny = await removeMatchingDirs(rawDir, prefix, period, fs, path);
+  if (removedAny) {
+    logger.info(`Deleted local data (${tier}): ${prefix}-${period}*`);
+  }
+
+  await pruneEtagFile(path.join(dataDir, getEtagFileName(tier)), period, fs);
+
+  if (!removedAny) {
+    logger.info(`Delete (${tier}) for ${period}: nothing matched ${prefix}-${period}*`);
+  }
+  return removedAny;
+}
+
 export function registerSyncHandlers(app: AppContext): void {
   const { ctx, state, getConfig } = app;
   const syncWorkerIds = new Map<string, number>();
@@ -125,25 +161,31 @@ export function registerSyncHandlers(app: AppContext): void {
   });
 
   ipcMain.handle('data:delete-period', async (_event, period: string, tier: ExpectedDataType = 'daily'): Promise<void> => {
-    if (!/^\d{4}-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?$/.test(period)) {
-      throw new Error(`Invalid period format: "${period}" — expected YYYY-MM or YYYY-MM-DD`);
+    await deleteLocalPeriodFiles(ctx.dataDir, period, tier);
+  });
+
+  // Manual prune: drop every local period that has fallen outside its tier's
+  // retention window, across all configured tiers. Local-only — derives the
+  // on-disk period list from getLocalDataInventory, so it works without any S3
+  // access. Returns what was removed so the UI can report it.
+  ipcMain.handle('data:prune', async (): Promise<PruneResult> => {
+    const config = await getConfig();
+    const provider = config.providers[0];
+    if (provider === undefined) throw new Error('No provider configured');
+
+    const deleted: { tier: DataTier; period: string }[] = [];
+    for (const { tier, retentionDays } of configuredTierRetentions(provider.sync)) {
+      const local = await getLocalDataInventory(ctx.dataDir, tier);
+      const expired = periodsOutsideRetention(local.local.periods, retentionDays);
+      for (const period of expired) {
+        const removed = await deleteLocalPeriodFiles(ctx.dataDir, period, tier);
+        if (removed) deleted.push({ tier, period });
+      }
     }
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-
-    const prefix = getRawDirPrefix(tier);
-    const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
-
-    const removedAny = await removeMatchingDirs(rawDir, prefix, period, fs, path);
-    if (removedAny) {
-      logger.info(`Deleted local data (${tier}): ${prefix}-${period}*`);
+    if (deleted.length > 0) {
+      logger.info(`Prune: removed ${String(deleted.length)} period(s) outside retention`);
     }
-
-    await pruneEtagFile(path.join(ctx.dataDir, getEtagFileName(tier)), period, fs);
-
-    if (!removedAny) {
-      logger.info(`Delete (${tier}) for ${period}: nothing matched ${prefix}-${period}*`);
-    }
+    return { deleted };
   });
 
   ipcMain.handle('data:sync-periods', async (_event, fileEntries: ManifestFileEntry[], syncId: string = 'default'): Promise<{ filesDownloaded: number; rowsProcessed: number }> => {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -28,6 +28,7 @@ import type {
   OrgSyncResult,
   OrgSyncProgress,
   AutoSyncStatus,
+  PruneResult,
   ViewsConfig,
   CostScopeCapabilities,
   CostScopeConfig,
@@ -241,6 +242,15 @@ const api: CostApi = {
   },
   getAutoSyncStatus(): Promise<AutoSyncStatus> {
     return invoke<AutoSyncStatus>('auto-sync:get-status');
+  },
+  getAutoPruneEnabled(): Promise<boolean> {
+    return invoke<boolean>('auto-prune:get-enabled');
+  },
+  setAutoPruneEnabled(enabled: boolean): Promise<void> {
+    return invoke<undefined>('auto-prune:set-enabled', enabled).then(() => undefined);
+  },
+  pruneNow(): Promise<PruneResult> {
+    return invoke<PruneResult>('data:prune');
   },
   getViewsConfig(): Promise<ViewsConfig> {
     return invoke<ViewsConfig>('views:get-config');

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, SharingActiveBanner, SettingsShell, SETTINGS_TABS, isSettingsTabId } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, SharingActiveBanner, SettingsShell, SETTINGS_TABS, isSettingsTabId, SchedulerControls } from '@costgoblin/ui';
 import type { NavItem, SettingsTabId } from '@costgoblin/ui';
 import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
@@ -838,6 +838,7 @@ function AppShell(): React.JSX.Element {
         )}
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center px-4 pt-7 pb-2">
           {settingsTab === null ? (
+          <div className="flex items-center gap-3 min-w-0">
           <nav className="flex items-center gap-1" aria-label="Dashboards and analysis">
             {(() => {
               const isActiveDefault = view.page === 'custom' && view.viewId === defaultViewId;
@@ -888,6 +889,8 @@ function AppShell(): React.JSX.Element {
               );
             })}
           </nav>
+            <SchedulerControls />
+          </div>
           ) : (
             <div className="flex items-center gap-2 [-webkit-app-region:no-drag]">
               <button

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -14,6 +14,7 @@ import {
   type EntityDetailResult,
   type MissingTagsResult,
   type OrgNode,
+  type PruneResult,
   type SavingsResult,
   type SyncStatus,
   type TrendResult,
@@ -284,6 +285,9 @@ export class MockCostApi implements CostApi {
   getAutoSyncIntervalMinutes(): Promise<number> { return Promise.resolve(24 * 60); }
   setAutoSyncIntervalMinutes(): Promise<void> { return Promise.resolve(); }
   getAutoSyncStatus(): Promise<{ state: 'disabled' }> { return Promise.resolve({ state: 'disabled' }); }
+  getAutoPruneEnabled(): Promise<boolean> { return Promise.resolve(false); }
+  setAutoPruneEnabled(): Promise<void> { return Promise.resolve(); }
+  pruneNow(): Promise<PruneResult> { return Promise.resolve({ deleted: [] }); }
   getViewsConfig(): Promise<ViewsConfig> { return Promise.resolve(MOCK_VIEWS_CONFIG); }
   saveViewsConfig(): Promise<void> { return Promise.resolve(); }
   resetViewsConfig(): Promise<ViewsConfig> { return Promise.resolve(MOCK_VIEWS_CONFIG); }

--- a/packages/ui/src/__tests__/data-management.test.tsx
+++ b/packages/ui/src/__tests__/data-management.test.tsx
@@ -94,17 +94,6 @@ describe('DataManagement', () => {
     });
   });
 
-  it('auto-prune toggle persists the new state', async () => {
-    const api = new MockCostApi();
-    const spy = vi.spyOn(api, 'setAutoPruneEnabled');
-    const { user } = renderDataManagement(api);
-    const toggle = await screen.findByRole('button', { name: 'Toggle auto-prune' });
-    await user.click(toggle);
-    await waitFor(() => {
-      expect(spy).toHaveBeenCalledWith(true);
-    });
-  });
-
   it('prune button is disabled when no local data is outside retention', async () => {
     renderDataManagement();
     const pruneBtn = await screen.findByRole('button', { name: /^Prune$/ });

--- a/packages/ui/src/__tests__/data-management.test.tsx
+++ b/packages/ui/src/__tests__/data-management.test.tsx
@@ -93,4 +93,59 @@ describe('DataManagement', () => {
       expect(screen.getByText('Delete all local data')).toBeDefined();
     });
   });
+
+  it('auto-prune toggle persists the new state', async () => {
+    const api = new MockCostApi();
+    const spy = vi.spyOn(api, 'setAutoPruneEnabled');
+    const { user } = renderDataManagement(api);
+    const toggle = await screen.findByRole('button', { name: 'Toggle auto-prune' });
+    await user.click(toggle);
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('prune button is disabled when no local data is outside retention', async () => {
+    renderDataManagement();
+    const pruneBtn = await screen.findByRole('button', { name: /^Prune$/ });
+    expect(pruneBtn).toHaveProperty('disabled', true);
+  });
+
+  it('prune button shows confirmation when data is outside retention', async () => {
+    const api = new MockCostApi();
+    // Daily retention in the mock config is 90 days; a 2020 period is well
+    // outside it, so the Prune action should offer to remove it.
+    api.getDataInventory = () => Promise.resolve({
+      periods: [],
+      totalRemoteSize: 0,
+      totalLocalPeriods: 1,
+      totalRemotePeriods: 0,
+      local: { periods: ['2020-01'], diskBytes: 1024, oldestPeriod: '2020-01', newestPeriod: '2020-01' },
+    });
+    const { user } = renderDataManagement(api);
+    const pruneBtn = await screen.findByRole('button', { name: /Prune \(1\)/ });
+    await user.click(pruneBtn);
+    await waitFor(() => {
+      expect(screen.getByText('Prune old data')).toBeDefined();
+    });
+  });
+
+  it('confirming prune calls pruneNow and refreshes inventory', async () => {
+    const api = new MockCostApi();
+    api.getDataInventory = () => Promise.resolve({
+      periods: [],
+      totalRemoteSize: 0,
+      totalLocalPeriods: 1,
+      totalRemotePeriods: 0,
+      local: { periods: ['2020-01'], diskBytes: 1024, oldestPeriod: '2020-01', newestPeriod: '2020-01' },
+    });
+    const spy = vi.spyOn(api, 'pruneNow');
+    const { user } = renderDataManagement(api);
+    const pruneBtn = await screen.findByRole('button', { name: /Prune \(1\)/ });
+    await user.click(pruneBtn);
+    await user.click(await screen.findByRole('button', { name: /^Prune$/ }));
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/ui/src/__tests__/scheduler-controls.test.tsx
+++ b/packages/ui/src/__tests__/scheduler-controls.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { SchedulerControls } from '../components/scheduler-controls.js';
+
+function renderControls(api?: MockCostApi) {
+  const mockApi = api ?? new MockCostApi();
+  const user = userEvent.setup();
+  return {
+    api: mockApi,
+    user,
+    ...render(
+      <CostApiProvider value={mockApi}>
+        <SchedulerControls />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('SchedulerControls', () => {
+  it('renders auto-sync, auto-prune and the interval selector', async () => {
+    renderControls();
+    await waitFor(() => {
+      expect(screen.getByText('Auto-sync')).toBeDefined();
+      expect(screen.getByText('Auto-prune')).toBeDefined();
+    });
+    // Interval options are the four clean cadences.
+    for (const label of ['Hourly', 'Daily', 'Weekly', 'Monthly']) {
+      expect(screen.getByRole('option', { name: label })).toBeDefined();
+    }
+  });
+
+  it('toggling auto-sync persists the new state', async () => {
+    const api = new MockCostApi();
+    const spy = vi.spyOn(api, 'setAutoSyncEnabled');
+    const { user } = renderControls(api);
+    await user.click(await screen.findByRole('button', { name: 'Toggle auto-sync' }));
+    await waitFor(() => { expect(spy).toHaveBeenCalledWith(true); });
+  });
+
+  it('toggling auto-prune persists the new state', async () => {
+    const api = new MockCostApi();
+    const spy = vi.spyOn(api, 'setAutoPruneEnabled');
+    const { user } = renderControls(api);
+    await user.click(await screen.findByRole('button', { name: 'Toggle auto-prune' }));
+    await waitFor(() => { expect(spy).toHaveBeenCalledWith(true); });
+  });
+
+  it('the interval selector is disabled until a schedule is enabled', async () => {
+    const api = new MockCostApi();
+    api.getAutoSyncEnabled = () => Promise.resolve(false);
+    api.getAutoPruneEnabled = () => Promise.resolve(false);
+    renderControls(api);
+    const select = await screen.findByRole('combobox');
+    await waitFor(() => { expect(select).toHaveProperty('disabled', true); });
+  });
+
+  it('changing the interval persists the chosen cadence', async () => {
+    const api = new MockCostApi();
+    api.getAutoSyncEnabled = () => Promise.resolve(true);
+    const spy = vi.spyOn(api, 'setAutoSyncIntervalMinutes');
+    const { user } = renderControls(api);
+    const select = await screen.findByRole('combobox');
+    await waitFor(() => { expect(select).toHaveProperty('disabled', false); });
+    await user.selectOptions(select, 'Monthly');
+    await waitFor(() => { expect(spy).toHaveBeenCalledWith(43200); });
+  });
+});

--- a/packages/ui/src/components/scheduler-controls.tsx
+++ b/packages/ui/src/components/scheduler-controls.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useCostApi } from '../hooks/use-cost-api.js';
+import { useQuery } from '../hooks/use-query.js';
+
+/** Cadences for the shared auto-sync / auto-prune schedule, in minutes.
+ *  Must stay within the backend clamp [MIN, MAX] in auto-sync.ts —
+ *  "Monthly" relies on the max being at least one month. */
+const INTERVAL_OPTIONS: readonly { value: number; label: string }[] = [
+  { value: 60, label: 'Hourly' },
+  { value: 1440, label: 'Daily' },
+  { value: 10080, label: 'Weekly' },
+  { value: 43200, label: 'Monthly' },
+];
+
+interface ToggleProps {
+  on: boolean;
+  label: string;
+  ariaLabel?: string | undefined;
+  title?: string | undefined;
+  onToggle: () => void;
+}
+
+function Toggle({ on, label, ariaLabel, title, onToggle }: Readonly<ToggleProps>) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-xs text-text-secondary">{label}</span>
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        title={title}
+        onClick={onToggle}
+        className={['relative h-5 w-9 rounded-full transition-colors [-webkit-app-region:no-drag]', on ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
+      >
+        <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', on ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
+      </button>
+    </div>
+  );
+}
+
+/** Auto-sync + auto-prune toggles and the shared schedule interval. Lives in
+ *  the top menu (not the Sync view) because the schedule runs app-wide. The
+ *  interval drives both auto-sync and auto-prune, so it stays enabled whenever
+ *  either is on. */
+export function SchedulerControls() {
+  const api = useCostApi();
+  const autoSyncQuery = useQuery(() => api.getAutoSyncEnabled(), []);
+  const autoPruneQuery = useQuery(() => api.getAutoPruneEnabled(), []);
+  const intervalQuery = useQuery(() => api.getAutoSyncIntervalMinutes(), []);
+
+  const [autoSync, setAutoSync] = useState(false);
+  const [autoSyncLoaded, setAutoSyncLoaded] = useState(false);
+  const [autoPrune, setAutoPrune] = useState(false);
+  const [autoPruneLoaded, setAutoPruneLoaded] = useState(false);
+  const [intervalMinutes, setIntervalMinutes] = useState(1440);
+  const [intervalLoaded, setIntervalLoaded] = useState(false);
+
+  if (!autoSyncLoaded && autoSyncQuery.status === 'success') {
+    setAutoSyncLoaded(true);
+    setAutoSync(autoSyncQuery.data);
+  }
+  if (!autoPruneLoaded && autoPruneQuery.status === 'success') {
+    setAutoPruneLoaded(true);
+    setAutoPrune(autoPruneQuery.data);
+  }
+  if (!intervalLoaded && intervalQuery.status === 'success') {
+    setIntervalLoaded(true);
+    setIntervalMinutes(intervalQuery.data);
+  }
+
+  // The interval drives the shared schedule, so it's meaningful whenever
+  // either auto-sync or auto-prune is enabled.
+  const scheduleOff = !autoSync && !autoPrune;
+
+  return (
+    <div className="flex items-center gap-3 [-webkit-app-region:no-drag]">
+      <Toggle
+        on={autoSync}
+        label="Auto-sync"
+        ariaLabel="Toggle auto-sync"
+        title="Periodically download data that's missing within each tier's retention window."
+        onToggle={() => { const next = !autoSync; setAutoSync(next); api.setAutoSyncEnabled(next).catch(() => undefined); }}
+      />
+      <Toggle
+        on={autoPrune}
+        label="Auto-prune"
+        ariaLabel="Toggle auto-prune"
+        title="Periodically delete local data older than each tier's retention window. Off by default."
+        onToggle={() => { const next = !autoPrune; setAutoPrune(next); api.setAutoPruneEnabled(next).catch(() => undefined); }}
+      />
+      <select
+        value={String(intervalMinutes)}
+        disabled={scheduleOff}
+        onChange={e => {
+          const next = Number(e.target.value);
+          setIntervalMinutes(next);
+          api.setAutoSyncIntervalMinutes(next).catch(() => undefined);
+        }}
+        title="How often the schedule runs — drives both auto-sync and auto-prune. Each run hits S3."
+        className="rounded-md border border-border bg-bg-secondary px-2 py-1 text-xs text-text-secondary disabled:opacity-40 [-webkit-app-region:no-drag]"
+      >
+        {INTERVAL_OPTIONS.map(o => (
+          <option key={o.value} value={String(o.value)}>{o.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -39,6 +39,7 @@ export { TreemapChart } from './components/treemap-chart.js';
 export { HeatmapChart } from './components/heatmap-chart.js';
 export { FilterActiveBanner } from './components/filter-active-banner.js';
 export { CoinRainLoader } from './components/coin-rain-loader.js';
+export { SchedulerControls } from './components/scheduler-controls.js';
 export { useCostFocus, useCostFocusDispatch, useCostFocusReducer, CostFocusProvider, CostFocusDispatchProvider } from './hooks/use-cost-focus.js';
 
 export { WIDGET_REGISTRY, WIDGET_CATALOG } from './widgets/registry.js';

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -449,46 +449,51 @@ export function DataManagement() {
           <p className="text-sm text-text-secondary mt-0.5">S3 sync and local data inventory</p>
         </div>
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-text-secondary">Auto-sync</span>
-            <button
-              type="button"
-              onClick={() => { const next = !autoSync; setAutoSync(next); api.setAutoSyncEnabled(next).catch(() => undefined); }}
-              className={['relative h-5 w-9 rounded-full transition-colors', autoSync ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
-            >
-              <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
-            </button>
-            <select
-              value={String(autoSyncInterval)}
-              disabled={!autoSync}
-              onChange={e => {
-                const next = Number(e.target.value);
-                setAutoSyncInterval(next);
-                api.setAutoSyncIntervalMinutes(next).catch(() => undefined);
-              }}
-              title="How often auto-sync runs. Keep this at least a day unless you're debugging — each run hits S3."
-              className="rounded-md border border-border bg-bg-tertiary/50 px-2 py-1 text-xs text-text-secondary disabled:opacity-40"
-            >
-              <option value="60">Every hour</option>
-              <option value="180">Every 3 hours</option>
-              <option value="360">Every 6 hours</option>
-              <option value="720">Every 12 hours</option>
-              <option value="1440">Once a day</option>
-              <option value="4320">Every 3 days</option>
-              <option value="10080">Once a week</option>
-            </select>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-text-secondary">Auto-prune</span>
-            <button
-              type="button"
-              aria-label="Toggle auto-prune"
-              title="Automatically delete local data older than each tier's retention window whenever the scheduler runs. Off by default."
-              onClick={() => { const next = !autoPrune; setAutoPrune(next); api.setAutoPruneEnabled(next).catch(() => undefined); }}
-              className={['relative h-5 w-9 rounded-full transition-colors', autoPrune ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
-            >
-              <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoPrune ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
-            </button>
+          {/* Scheduler block: auto-sync + its interval and auto-prune share the
+              same background to signal they run together on one schedule. */}
+          <div className="flex items-center gap-3 rounded-lg border border-border bg-bg-tertiary/30 px-3 py-1.5" title="These run together on one schedule: each run downloads missing data (auto-sync) and/or deletes data outside retention (auto-prune).">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-text-secondary">Auto-sync</span>
+              <button
+                type="button"
+                onClick={() => { const next = !autoSync; setAutoSync(next); api.setAutoSyncEnabled(next).catch(() => undefined); }}
+                className={['relative h-5 w-9 rounded-full transition-colors', autoSync ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
+              >
+                <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
+              </button>
+              <select
+                value={String(autoSyncInterval)}
+                disabled={!autoSync}
+                onChange={e => {
+                  const next = Number(e.target.value);
+                  setAutoSyncInterval(next);
+                  api.setAutoSyncIntervalMinutes(next).catch(() => undefined);
+                }}
+                title="How often the schedule runs (drives both auto-sync and auto-prune). Keep this at least a day unless you're debugging — each run hits S3."
+                className="rounded-md border border-border bg-bg-secondary px-2 py-1 text-xs text-text-secondary disabled:opacity-40"
+              >
+                <option value="60">Every hour</option>
+                <option value="180">Every 3 hours</option>
+                <option value="360">Every 6 hours</option>
+                <option value="720">Every 12 hours</option>
+                <option value="1440">Once a day</option>
+                <option value="4320">Every 3 days</option>
+                <option value="10080">Once a week</option>
+              </select>
+            </div>
+            <div className="h-5 w-px bg-border" aria-hidden="true" />
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-text-secondary">Auto-prune</span>
+              <button
+                type="button"
+                aria-label="Toggle auto-prune"
+                title="Automatically delete local data older than each tier's retention window whenever the schedule runs. Off by default."
+                onClick={() => { const next = !autoPrune; setAutoPrune(next); api.setAutoPruneEnabled(next).catch(() => undefined); }}
+                className={['relative h-5 w-9 rounded-full transition-colors', autoPrune ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
+              >
+                <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoPrune ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
+              </button>
+            </div>
           </div>
           <button
             type="button"

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -73,15 +73,6 @@ export function DataManagement() {
   const [dailySyncState, setDailySyncState] = useState<SyncState>({ status: 'idle' });
   const [hourlySyncState, setHourlySyncState] = useState<SyncState>({ status: 'idle' });
   const [costOptSyncState, setCostOptSyncState] = useState<SyncState>({ status: 'idle' });
-  const autoSyncQuery = useQuery(() => api.getAutoSyncEnabled(), []);
-  const autoSyncIntervalQuery = useQuery(() => api.getAutoSyncIntervalMinutes(), []);
-  const [autoSync, setAutoSync] = useState(false);
-  const [autoSyncLoaded, setAutoSyncLoaded] = useState(false);
-  const [autoSyncInterval, setAutoSyncInterval] = useState(24 * 60);
-  const [autoSyncIntervalLoaded, setAutoSyncIntervalLoaded] = useState(false);
-  const autoPruneQuery = useQuery(() => api.getAutoPruneEnabled(), []);
-  const [autoPrune, setAutoPrune] = useState(false);
-  const [autoPruneLoaded, setAutoPruneLoaded] = useState(false);
 
   // Track the previous server-side status per tier so the poller can detect a
   // syncing→completed/failed transition. Without it, a background auto-sync that
@@ -136,18 +127,6 @@ export function DataManagement() {
     return () => { cancelled = true; clearInterval(timer); };
   }, [api]);
 
-  if (!autoSyncLoaded && autoSyncQuery.status === 'success') {
-    setAutoSyncLoaded(true);
-    setAutoSync(autoSyncQuery.data);
-  }
-  if (!autoSyncIntervalLoaded && autoSyncIntervalQuery.status === 'success') {
-    setAutoSyncIntervalLoaded(true);
-    setAutoSyncInterval(autoSyncIntervalQuery.data);
-  }
-  if (!autoPruneLoaded && autoPruneQuery.status === 'success') {
-    setAutoPruneLoaded(true);
-    setAutoPrune(autoPruneQuery.data);
-  }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [showPrune, setShowPrune] = useState(false);
   const [pruneNotice, setPruneNotice] = useState<string | null>(null);
@@ -449,52 +428,6 @@ export function DataManagement() {
           <p className="text-sm text-text-secondary mt-0.5">S3 sync and local data inventory</p>
         </div>
         <div className="flex items-center gap-4">
-          {/* Scheduler block: auto-sync + its interval and auto-prune share the
-              same background to signal they run together on one schedule. */}
-          <div className="flex items-center gap-3 rounded-lg border border-border bg-bg-tertiary/30 px-3 py-1.5" title="These run together on one schedule: each run downloads missing data (auto-sync) and/or deletes data outside retention (auto-prune).">
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-text-secondary">Auto-sync</span>
-              <button
-                type="button"
-                onClick={() => { const next = !autoSync; setAutoSync(next); api.setAutoSyncEnabled(next).catch(() => undefined); }}
-                className={['relative h-5 w-9 rounded-full transition-colors', autoSync ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
-              >
-                <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoSync ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
-              </button>
-              <select
-                value={String(autoSyncInterval)}
-                disabled={!autoSync}
-                onChange={e => {
-                  const next = Number(e.target.value);
-                  setAutoSyncInterval(next);
-                  api.setAutoSyncIntervalMinutes(next).catch(() => undefined);
-                }}
-                title="How often the schedule runs (drives both auto-sync and auto-prune). Keep this at least a day unless you're debugging — each run hits S3."
-                className="rounded-md border border-border bg-bg-secondary px-2 py-1 text-xs text-text-secondary disabled:opacity-40"
-              >
-                <option value="60">Every hour</option>
-                <option value="180">Every 3 hours</option>
-                <option value="360">Every 6 hours</option>
-                <option value="720">Every 12 hours</option>
-                <option value="1440">Once a day</option>
-                <option value="4320">Every 3 days</option>
-                <option value="10080">Once a week</option>
-              </select>
-            </div>
-            <div className="h-5 w-px bg-border" aria-hidden="true" />
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-text-secondary">Auto-prune</span>
-              <button
-                type="button"
-                aria-label="Toggle auto-prune"
-                title="Automatically delete local data older than each tier's retention window whenever the schedule runs. Off by default."
-                onClick={() => { const next = !autoPrune; setAutoPrune(next); api.setAutoPruneEnabled(next).catch(() => undefined); }}
-                className={['relative h-5 w-9 rounded-full transition-colors', autoPrune ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
-              >
-                <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoPrune ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
-              </button>
-            </div>
-          </div>
           <button
             type="button"
             onClick={() => { setShowPrune(true); }}

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -79,6 +79,9 @@ export function DataManagement() {
   const [autoSyncLoaded, setAutoSyncLoaded] = useState(false);
   const [autoSyncInterval, setAutoSyncInterval] = useState(24 * 60);
   const [autoSyncIntervalLoaded, setAutoSyncIntervalLoaded] = useState(false);
+  const autoPruneQuery = useQuery(() => api.getAutoPruneEnabled(), []);
+  const [autoPrune, setAutoPrune] = useState(false);
+  const [autoPruneLoaded, setAutoPruneLoaded] = useState(false);
 
   // Track the previous server-side status per tier so the poller can detect a
   // syncing→completed/failed transition. Without it, a background auto-sync that
@@ -141,7 +144,13 @@ export function DataManagement() {
     setAutoSyncIntervalLoaded(true);
     setAutoSyncInterval(autoSyncIntervalQuery.data);
   }
+  if (!autoPruneLoaded && autoPruneQuery.status === 'success') {
+    setAutoPruneLoaded(true);
+    setAutoPrune(autoPruneQuery.data);
+  }
   const [showDeleteAll, setShowDeleteAll] = useState(false);
+  const [showPrune, setShowPrune] = useState(false);
+  const [pruneNotice, setPruneNotice] = useState<string | null>(null);
   const [configureSource, setConfigureSource] = useState<'daily' | 'hourly' | 'costOptimization' | null>(null);
   // Lightweight profile-only swap: a tiny modal that lists ~/.aws profiles
   // and rewrites only credentials.profile in costgoblin.yaml. Useful when
@@ -268,6 +277,34 @@ export function DataManagement() {
   const costOptRetentionDays = provider?.sync.costOptimization?.retentionDays ?? 90;
   const costOptCutoffPeriod = retentionCutoffPeriod(costOptRetentionDays);
   const costOptMissing = missingWithinCutoff(costOptInventory, costOptCutoffPeriod);
+
+  // Local periods that have fallen outside their tier's retention window. Mirrors
+  // the backend's `periodsOutsideRetention` (period strictly older than the
+  // cutoff month) — including its guard against a non-positive retention, so a
+  // misconfigured `retentionDays: 0` is never treated as "everything expired".
+  const prunable = (localPeriods: readonly string[] | undefined, cutoff: string, days: number): string[] =>
+    Number.isFinite(days) && days > 0 ? (localPeriods ?? []).filter(p => p < cutoff) : [];
+  const dailyPrunable = prunable(inventory?.local.periods, dailyCutoffPeriod, retentionDays);
+  const hourlyPrunable = prunable(hourlyInventory?.local.periods, hourlyCutoffPeriod, hourlyRetentionDays);
+  const costOptPrunable = prunable(costOptInventory?.local.periods, costOptCutoffPeriod, costOptRetentionDays);
+  const prunableTotal = dailyPrunable.length + hourlyPrunable.length + costOptPrunable.length;
+
+  function handlePrune() {
+    setShowPrune(false);
+    api.pruneNow().then((result) => {
+      setPruneNotice(
+        result.deleted.length === 0
+          ? 'Nothing to prune — all local data is within retention.'
+          : `Pruned ${String(result.deleted.length)} period(s) outside retention.`,
+      );
+      setDailyRefreshKey(k => k + 1);
+      setHourlyRefreshKey(k => k + 1);
+      setCostOptRefreshKey(k => k + 1);
+      setTimeout(() => { setPruneNotice(null); }, 6000);
+    }).catch((err: unknown) => {
+      setPruneNotice(`Prune failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
 
   const [hourlyInitialized, setHourlyInitialized] = useState(false);
   useEffect(() => {
@@ -441,6 +478,27 @@ export function DataManagement() {
               <option value="10080">Once a week</option>
             </select>
           </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-secondary">Auto-prune</span>
+            <button
+              type="button"
+              aria-label="Toggle auto-prune"
+              title="Automatically delete local data older than each tier's retention window whenever the scheduler runs. Off by default."
+              onClick={() => { const next = !autoPrune; setAutoPrune(next); api.setAutoPruneEnabled(next).catch(() => undefined); }}
+              className={['relative h-5 w-9 rounded-full transition-colors', autoPrune ? 'bg-accent' : 'bg-bg-tertiary'].join(' ')}
+            >
+              <span className={['absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform', autoPrune ? 'translate-x-4' : 'translate-x-0'].join(' ')} />
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => { setShowPrune(true); }}
+            disabled={prunableTotal === 0}
+            title={prunableTotal === 0 ? 'No local data is outside the retention window' : `Delete ${String(prunableTotal)} period(s) outside the retention window`}
+            className="rounded-md border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {prunableTotal === 0 ? 'Prune' : `Prune (${String(prunableTotal)})`}
+          </button>
           <button
             type="button"
             onClick={() => { setShowProfileSwap(true); }}
@@ -464,6 +522,12 @@ export function DataManagement() {
           </button>
         </div>
       </div>
+
+      {pruneNotice !== null && (
+        <div className="rounded-lg border border-accent/50 bg-positive-muted px-4 py-2 text-xs text-accent">
+          {pruneNotice}
+        </div>
+      )}
 
       {/* Account mapping */}
       <OrgAccountsSection profile={awsProfile} />
@@ -563,6 +627,17 @@ export function DataManagement() {
           destructive
           onConfirm={handleDeleteAll}
           onCancel={() => { setShowDeleteAll(false); }}
+        />
+      )}
+
+      {showPrune && (
+        <ConfirmModal
+          title="Prune old data"
+          message={`Remove ${String(prunableTotal)} local period(s) that fall outside each tier's retention window? This data can be re-downloaded from S3 anytime.`}
+          confirmLabel="Prune"
+          destructive
+          onConfirm={handlePrune}
+          onCancel={() => { setShowPrune(false); }}
         />
       )}
 


### PR DESCRIPTION
## Why

`retentionDays` was only ever a **download cutoff** — auto-sync skipped downloading periods older than the window, but **nothing ever deleted data already on disk**. Old periods (and data left over after lowering retention) accumulated forever, so local storage grew unbounded and the configured retention was effectively ignored. This was visible as e.g. 18 months of Daily data with a 365-day retention, and Apr-2026 Hourly data still present under a 30-day retention.

## What

Retention is now **enforced as deletion**, not just a download cutoff.

- **core — pure, unit-tested helpers** (`packages/core/src/sync/retention.ts`)
  - `retentionCutoffPeriod` / `periodsOutsideRetention`: prune deletes `period < cutoff`, symmetric with the download cutoff's `period >= cutoff`, so a boundary month is never downloaded-then-immediately-pruned.
  - A guard returns nothing for a non-positive / non-finite `retentionDays`, so a misconfiguration (e.g. `retentionDays: 0`) can never wipe everything.
  - `configuredTierRetentions`: daily + hourly + cost-optimization when configured.
- **Manual "Prune" button** (`data:prune` IPC → `pruneNow()`): deletes every local period outside its tier's retention window, across all configured tiers. Local-only (no S3 access needed), with a confirmation dialog showing the count and a result notice afterward.
- **"Auto-prune" toggle** (off by default; persisted as `autoPrune` in `preferences.json`): runs on each auto-sync scheduler tick. The scheduler now runs when auto-sync **or** auto-prune is enabled, and prunes **before** downloading so it reclaims disk even when S3 is unreachable.
- Extracted `deleteLocalPeriodFiles` so manual delete, prune, and auto-prune delete identically.
- Wired through `CostApi` / preload / `MockCostApi`; documented in `SPEC.md`.

## Behavior notes

- Auto-prune is **opt-in** and off by default; manual Prune is one click + confirm.
- Prune covers cost-optimization too (auto-*download* still only handles daily+hourly — a pre-existing limitation, unchanged here).
- No version bump: `package.json` is already at `0.3.5`, exactly one ahead of the latest release `v0.3.4`.

## Testing

- `npm run check` green: tsc + eslint + **681 tests pass**.
- New core tests (`retention.test.ts`) cover cutoff math, prune/download symmetry at the boundary month, and the non-positive/NaN/Infinity guards.
- New UI tests cover the Auto-prune toggle persistence, the Prune button enabled/disabled state, the confirmation dialog, and that confirming calls `pruneNow()` + refreshes inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5UfaK4B4cYUUaeiWGPFmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5UfaK4B4cYUUaeiWGPFmw)_