### PR TITLE
refactor(ui): move auto-sync/auto-prune schedule into Settings → Data & Sync

### DIFF
--- a/e2e/views-config.test.ts
+++ b/e2e/views-config.test.ts
@@ -45,14 +45,16 @@ test.describe('Data Management', () => {
     await expect(page.getByText('S3 sync and local data inventory')).toBeVisible();
   });
 
-  test('shows action buttons: Prune, Delete All, Open Folder, Refresh', async () => {
-    // Auto-sync / auto-prune / interval moved to the top-menu SchedulerControls
-    // (shown outside settings mode), so they're no longer Data Management
-    // actions. The view keeps the one-off Prune button and the rest.
+  test('shows action buttons and the automatic schedule controls', async () => {
+    // One-off actions plus the auto-sync / auto-prune schedule, which lives
+    // here (not the top toolbar) since it automates these very controls.
     await expect(page.getByRole('button', { name: /Prune/ })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Delete All Data' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Open Folder' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+    await expect(page.getByText('Automatic schedule')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Toggle auto-sync' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Toggle auto-prune' })).toBeVisible();
   });
 
   test('org section is visible (either synced or prompt)', async () => {

--- a/e2e/views-core.test.ts
+++ b/e2e/views-core.test.ts
@@ -257,8 +257,8 @@ test.describe('Cost Overview', () => {
   });
 
   test('pie chart dimension dropdown switches the dimension', async () => {
-    // Only target visible, enabled selects (pie chart dropdowns) — skip
-    // hidden/disabled selects from other views (e.g. auto-sync interval).
+    // Only target visible, enabled selects (pie chart dropdowns) — guard
+    // against any hidden/disabled selects other widgets might render.
     const selects = page.locator('select:not([disabled])');
     const visibleSelects: typeof selects[] = [];
     for (let i = 0; i < await selects.count(); i++) {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Profiler } from 'react';
-import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, SharingActiveBanner, SettingsShell, SETTINGS_TABS, isSettingsTabId, SchedulerControls } from '@costgoblin/ui';
+import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, SharingActiveBanner, SettingsShell, SETTINGS_TABS, isSettingsTabId } from '@costgoblin/ui';
 import type { NavItem, SettingsTabId } from '@costgoblin/ui';
 import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
@@ -889,7 +889,6 @@ function AppShell(): React.JSX.Element {
               );
             })}
           </nav>
-            <SchedulerControls />
           </div>
           ) : (
             <div className="flex items-center gap-2 [-webkit-app-region:no-drag]">

--- a/packages/ui/src/components/scheduler-controls.tsx
+++ b/packages/ui/src/components/scheduler-controls.tsx
@@ -38,7 +38,8 @@ function Toggle({ on, label, ariaLabel, title, onToggle }: Readonly<ToggleProps>
 }
 
 /** Auto-sync + auto-prune toggles and the shared schedule interval. Lives in
- *  the top menu (not the Sync view) because the schedule runs app-wide. The
+ *  Settings → Data & Sync alongside the manual sync/prune controls it automates
+ *  (not the dashboard toolbar — the schedule isn't a per-view concern). The
  *  interval drives both auto-sync and auto-prune, so it stays enabled whenever
  *  either is on. */
 export function SchedulerControls() {

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -9,6 +9,7 @@ import { OrgAccountsSection } from './data-management-org.js';
 import { SsmParameterSection } from './data-management-ssm.js';
 import { TierPanel, type SyncState } from './data-management-tier.js';
 import { SsoLoginButton } from '../components/sso-login-button.js';
+import { SchedulerControls } from '../components/scheduler-controls.js';
 
 function syncStatusToState(s: SyncStatus): SyncState | null {
   if (s.status === 'syncing') {
@@ -466,6 +467,19 @@ export function DataManagement() {
           {pruneNotice}
         </div>
       )}
+
+      {/* Automatic schedule — drives the background auto-sync + auto-prune, so
+          it lives with the rest of the Data & Sync controls rather than the
+          top toolbar. */}
+      <div className="flex items-center justify-between rounded-xl border border-border bg-bg-secondary/50 px-4 py-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary">Automatic schedule</h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            Run sync (and optionally prune) in the background on a fixed cadence. The interval drives both and is disabled while both are off.
+          </p>
+        </div>
+        <SchedulerControls />
+      </div>
 
       {/* Account mapping */}
       <OrgAccountsSection profile={awsProfile} />


### PR DESCRIPTION
The **Auto-sync** / **Auto-prune** toggles and the shared **frequency** selector currently sit on the dashboard toolbar, where they have nothing to do with viewing cost data. They're app-wide background automation, not a per-view control.

This moves `SchedulerControls` out of the App header into **Settings → Data & Sync**, in an "Automatic schedule" card next to the manual sync/prune controls it automates. The component itself is unchanged — only its mount point.

### Changes
- `App.tsx` — drop `SchedulerControls` from the header (and its import).
- `data-management.tsx` — render it in an "Automatic schedule" section.
- `scheduler-controls.tsx` — update the now-stale "lives in the top menu" doc comment.
- e2e — `views-config` now asserts the schedule controls render in Data & Sync; dropped the stale "auto-sync interval on the dashboard" note in `views-core`.

`npm run check` green; e2e collects clean.