### PR TITLE
feat(cost): re-attribute AWS Marketplace line items to real services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__tests__/cost-scope.test.ts
+++ b/packages/core/src/__tests__/cost-scope.test.ts
@@ -5,8 +5,9 @@ import {
 } from '../query/builder.js';
 import type { DimensionsConfig } from '../types/config.js';
 import type { CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
-import { DEFAULT_COST_SCOPE, BUILTIN_EXCLUSION_RULES, mergeBuiltInExclusionRules } from '../config/cost-scope-seed.js';
+import { DEFAULT_COST_SCOPE, DEFAULT_MARKETPLACE_ATTRIBUTION, BUILTIN_EXCLUSION_RULES, mergeBuiltInExclusionRules } from '../config/cost-scope-seed.js';
 import { validateCostScope } from '../config/cost-scope-validator.js';
+import { costScopeToYaml } from '../config/cost-scope-serialize.js';
 import { asDimensionId, asDateString } from '../types/branded.js';
 
 const dimensions: DimensionsConfig = {
@@ -411,6 +412,70 @@ describe('validateCostScope: blended migration', () => {
 
   it('rejects truly unknown costMetric values', () => {
     expect(() => validateCostScope({ costMetric: 'nonsense', rules: [] })).toThrow(/costScope.costMetric must be one of/);
+  });
+});
+
+describe('marketplace attribution: SQL rewrite', () => {
+  const bedrock = DEFAULT_MARKETPLACE_ATTRIBUTION;
+  const matchPred = "COALESCE(product_servicecode, '') = '' AND line_item_operation IN ('InvokeModelInference', 'InvokeModelStreamingInference')";
+
+  it('re-attributes matched empty-servicecode rows to the target service', () => {
+    const sql = buildQuery({ costMetric: 'unblended', rules: [], marketplaceAttribution: bedrock });
+    expect(sql).toContain(`CASE WHEN ${matchPred} THEN 'AmazonBedrock' ELSE COALESCE(product_servicecode, '') END AS service`);
+  });
+
+  it('leaves service untouched when disabled', () => {
+    const sql = buildQuery({ costMetric: 'unblended', rules: [], marketplaceAttribution: { enabled: false, rules: bedrock.rules } });
+    expect(sql).toContain("COALESCE(product_servicecode, '') AS service");
+    expect(sql).not.toContain('AmazonBedrock');
+  });
+
+  it('leaves service untouched when no costScope is supplied', () => {
+    const sql = buildQuery();
+    expect(sql).toContain("COALESCE(product_servicecode, '') AS service");
+    expect(sql).not.toContain('AmazonBedrock');
+  });
+
+  it('substitutes unblended for the $0 list price on the list metric', () => {
+    const sql = buildQuery({ costMetric: 'list', rules: [], marketplaceAttribution: bedrock });
+    expect(sql).toContain(`CASE WHEN ${matchPred} THEN COALESCE(line_item_unblended_cost, 0) ELSE COALESCE(pricing_public_on_demand_cost, 0) END AS cost`);
+  });
+
+  it('does NOT rewrite cost on unblended (the real charge is already there)', () => {
+    const sql = buildQuery({ costMetric: 'unblended', rules: [], marketplaceAttribution: bedrock });
+    expect(sql).toContain('COALESCE(line_item_unblended_cost, 0) AS cost');
+    expect(sql).not.toContain('END AS cost');
+  });
+});
+
+describe('validateCostScope: marketplace attribution', () => {
+  it('defaults to the shipped enabled rule when the block is absent', () => {
+    const r = validateCostScope({ costMetric: 'unblended', rules: [] });
+    expect(r.marketplaceAttribution).toEqual(DEFAULT_MARKETPLACE_ATTRIBUTION);
+  });
+
+  it('honors an explicit disabled block (opt-out)', () => {
+    const r = validateCostScope({ costMetric: 'unblended', rules: [], marketplaceAttribution: { enabled: false, rules: [] } });
+    expect(r.marketplaceAttribution).toEqual({ enabled: false, rules: [] });
+  });
+
+  it('rejects a rule with no operations', () => {
+    expect(() => validateCostScope({
+      costMetric: 'unblended', rules: [],
+      marketplaceAttribution: { enabled: true, rules: [{ service: 'X', operations: [] }] },
+    })).toThrow(/operations must have at least one/);
+  });
+
+  it('rejects a rule with an empty service', () => {
+    expect(() => validateCostScope({
+      costMetric: 'unblended', rules: [],
+      marketplaceAttribution: { enabled: true, rules: [{ service: '', operations: ['Op'] }] },
+    })).toThrow(/service must be a non-empty/);
+  });
+
+  it('round-trips through YAML serialization', () => {
+    const cfg = validateCostScope({ costMetric: 'unblended', rules: [] });
+    expect(validateCostScope(costScopeToYaml(cfg))).toEqual(cfg);
   });
 });
 

--- a/packages/core/src/__tests__/marketplace-attribution.integration.test.ts
+++ b/packages/core/src/__tests__/marketplace-attribution.integration.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { mkdtemp, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildSource } from '../query/builder.js';
+import type { DimensionsConfig } from '../types/config.js';
+import type { MarketplaceAttributionConfig } from '../types/cost-scope.js';
+import { DEFAULT_MARKETPLACE_ATTRIBUTION } from '../config/cost-scope-seed.js';
+import { asDimensionId } from '../types/branded.js';
+
+const dimensions: DimensionsConfig = {
+  builtIn: [{ name: asDimensionId('service'), label: 'Service', field: 'service' }],
+  tags: [],
+};
+
+type Conn = Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>;
+
+async function serviceTotals(
+  conn: Conn,
+  dataDir: string,
+  costMetric: 'unblended' | 'list',
+  marketplaceAttribution: MarketplaceAttributionConfig | undefined,
+): Promise<Record<string, number>> {
+  const source = buildSource({ dataDir, tier: 'daily', dimensions, costMetric, marketplaceAttribution });
+  const result = await conn.run(`SELECT service, SUM(cost) AS cost FROM ${source} GROUP BY service`);
+  const rows = await result.getRowObjects();
+  const out: Record<string, number> = {};
+  for (const r of rows) out[String(r['service'])] = Number(r['cost']);
+  return out;
+}
+
+describe('marketplace attribution (DuckDB end-to-end)', () => {
+  let conn: Conn;
+  let dataDir: string;
+
+  beforeAll(async () => {
+    const db = await DuckDBInstance.create();
+    conn = await db.connect();
+    dataDir = await mkdtemp(join(tmpdir(), 'cg-mkt-'));
+    const partDir = join(dataDir, 'aws', 'raw', 'daily-2026-05');
+    await mkdir(partDir, { recursive: true });
+
+    await conn.run(`
+      CREATE TABLE cur (
+        line_item_usage_start_date TIMESTAMP,
+        line_item_usage_account_id VARCHAR,
+        line_item_usage_account_name VARCHAR,
+        product_region_code VARCHAR,
+        product_servicecode VARCHAR,
+        product_product_family VARCHAR,
+        line_item_line_item_description VARCHAR,
+        line_item_resource_id VARCHAR,
+        line_item_usage_amount DOUBLE,
+        line_item_unblended_cost DOUBLE,
+        pricing_public_on_demand_cost DOUBLE,
+        line_item_line_item_type VARCHAR,
+        line_item_operation VARCHAR,
+        line_item_usage_type VARCHAR
+      )
+    `);
+    // Row 1: third-party Marketplace Bedrock (Claude) — empty servicecode, real
+    //         cost only in unblended, $0 on-demand.
+    // Row 2: first-party Bedrock (Titan) — already tagged, both costs populated.
+    // Row 3: ordinary EC2 usage — control row, must never be rewritten.
+    await conn.run(`INSERT INTO cur VALUES
+      (TIMESTAMP '2026-05-02', '111', 'acct', 'eu-central-1', '', '', 'Claude', 'r1', 1, 10.0, 0.0, 'Usage', 'InvokeModelInference', 'EUC1-InputTokenCount'),
+      (TIMESTAMP '2026-05-02', '111', 'acct', 'eu-central-1', 'AmazonBedrock', '', 'Titan', 'r2', 1, 5.0, 5.0, 'Usage', 'InvokeModelInference', 'EUC1-TitanTokens'),
+      (TIMESTAMP '2026-05-02', '111', 'acct', 'eu-central-1', 'AmazonEC2', '', 'EC2', 'r3', 1, 20.0, 25.0, 'Usage', 'RunInstances', 'EUC1-BoxUsage')
+    `);
+    await conn.run(`COPY (SELECT * FROM cur) TO '${join(partDir, 'data.parquet')}' (FORMAT PARQUET)`);
+  });
+
+  it('unblended: re-attributes the Marketplace row to AmazonBedrock, keeps its dollars', async () => {
+    const totals = await serviceTotals(conn, dataDir, 'unblended', DEFAULT_MARKETPLACE_ATTRIBUTION);
+    // Claude ($10, re-attributed) + Titan ($5) collapse into AmazonBedrock.
+    expect(totals['AmazonBedrock']).toBe(15);
+    expect(totals['AmazonEC2']).toBe(20);
+    expect(totals['']).toBeUndefined(); // no blank-service bucket
+  });
+
+  it('unblended + disabled: dollars survive but land under a blank service', async () => {
+    const totals = await serviceTotals(conn, dataDir, 'unblended', { enabled: false, rules: DEFAULT_MARKETPLACE_ATTRIBUTION.rules });
+    expect(totals['']).toBe(10); // Claude stranded under blank service
+    expect(totals['AmazonBedrock']).toBe(5); // only Titan
+  });
+
+  it('list: the bug — disabled drops the Marketplace dollars to $0', async () => {
+    const totals = await serviceTotals(conn, dataDir, 'list', { enabled: false, rules: [] });
+    expect(totals['']).toBe(0); // Claude invisible on the list metric
+    expect(totals['AmazonBedrock']).toBe(5); // Titan on-demand
+    expect(totals['AmazonEC2']).toBe(25);
+  });
+
+  it('list + enabled: substitutes unblended for the $0 list price and re-attributes', async () => {
+    const totals = await serviceTotals(conn, dataDir, 'list', DEFAULT_MARKETPLACE_ATTRIBUTION);
+    // Claude now counts at unblended $10, folded into AmazonBedrock with Titan's $5.
+    expect(totals['AmazonBedrock']).toBe(15);
+    expect(totals['AmazonEC2']).toBe(25); // unaffected: real on-demand price kept
+    expect(totals['']).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/rollup-signature.test.ts
+++ b/packages/core/src/__tests__/rollup-signature.test.ts
@@ -78,6 +78,29 @@ describe('computeShapeSignature', () => {
     // rules are on `service`, not the tag → the tag's aliases never enter the signature
     expect(sig({ dimensions: dimsWithTeamAliases({ architects: ['arch', 'foo'] }) })).toBe(sig());
   });
+
+  describe('marketplace attribution', () => {
+    const bedrock = { enabled: true, rules: [{ service: 'AmazonBedrock', operations: ['InvokeModelInference', 'InvokeModelStreamingInference'] }] };
+
+    it('CHANGES when enabled (rewrites service/cost bytes)', () => {
+      expect(sig({ marketplaceAttribution: bedrock })).not.toBe(sig());
+    });
+
+    it('disabled hashes identically to absent (no spurious re-roll)', () => {
+      expect(sig({ marketplaceAttribution: { enabled: false, rules: bedrock.rules } })).toBe(sig());
+      expect(sig({ marketplaceAttribution: { enabled: true, rules: [] } })).toBe(sig());
+    });
+
+    it('ignores operation order within a rule', () => {
+      const reversed = { enabled: true, rules: [{ service: 'AmazonBedrock', operations: ['InvokeModelStreamingInference', 'InvokeModelInference'] }] };
+      expect(sig({ marketplaceAttribution: bedrock })).toBe(sig({ marketplaceAttribution: reversed }));
+    });
+
+    it('CHANGES when the target service differs', () => {
+      const other = { enabled: true, rules: [{ service: 'AmazonSageMaker', operations: ['InvokeModelInference', 'InvokeModelStreamingInference'] }] };
+      expect(sig({ marketplaceAttribution: bedrock })).not.toBe(sig({ marketplaceAttribution: other }));
+    });
+  });
 });
 
 describe('computeOrgAccountsDigest', () => {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -5,4 +5,4 @@ export { validateViews } from './config/views-validator.js';
 export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './config/views-serialize.js';
 export { ConfigValidationError } from './config/validator.js';
 export { isDiscoverableBeaconLocation, splitS3Location, suggestedConfigBeaconLocation } from './config/sharing-location.js';
-export { DEFAULT_COST_SCOPE, BUILTIN_EXCLUSION_RULES } from './config/cost-scope-seed.js';
+export { DEFAULT_COST_SCOPE, DEFAULT_MARKETPLACE_ATTRIBUTION, BUILTIN_EXCLUSION_RULES } from './config/cost-scope-seed.js';

--- a/packages/core/src/config/cost-scope-seed.ts
+++ b/packages/core/src/config/cost-scope-seed.ts
@@ -1,5 +1,5 @@
 import { asDimensionId } from '../types/branded.js';
-import type { CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
+import type { CostScopeConfig, ExclusionRule, MarketplaceAttributionConfig } from '../types/cost-scope.js';
 
 export const BUILTIN_EXCLUSION_RULES: readonly ExclusionRule[] = [
   {
@@ -70,9 +70,25 @@ const RETIRED_BUILTIN_RULE_IDS: ReadonlySet<string> = new Set([
   'builtin:commitment-covered-usage',
 ]);
 
+/** Shipped Marketplace re-attribution. Bedrock third-party model inference is
+ *  the one AWS "service" that consistently arrives as a blank-product_servicecode
+ *  Marketplace row with real cost only in unblended; Tax and RI/SP fees are the
+ *  other blank-servicecode populations and are intentionally NOT here (they're
+ *  not per-service usage and the `list` metric already filters fee rows out). */
+export const DEFAULT_MARKETPLACE_ATTRIBUTION: MarketplaceAttributionConfig = {
+  enabled: true,
+  rules: [
+    {
+      service: 'AmazonBedrock',
+      operations: ['InvokeModelInference', 'InvokeModelStreamingInference'],
+    },
+  ],
+};
+
 export const DEFAULT_COST_SCOPE: CostScopeConfig = {
   costMetric: 'unblended',
   rules: BUILTIN_EXCLUSION_RULES,
+  marketplaceAttribution: DEFAULT_MARKETPLACE_ATTRIBUTION,
 };
 
 /** Merge shipped built-in rules into a loaded config. Mirrors

--- a/packages/core/src/config/cost-scope-serialize.ts
+++ b/packages/core/src/config/cost-scope-serialize.ts
@@ -11,11 +11,15 @@ interface YamlRule {
   conditions: YamlCondition[];
 }
 
+interface YamlMarketplaceRule { service: string; operations: string[] }
+interface YamlMarketplaceAttribution { enabled: boolean; rules: YamlMarketplaceRule[] }
+
 export interface YamlCostScope {
   costMetric: string;
   costPerspective?: string;
   lagDays?: number;
   rules: YamlRule[];
+  marketplaceAttribution?: YamlMarketplaceAttribution;
 }
 
 function conditionToYaml(c: ExclusionCondition): YamlCondition {
@@ -44,5 +48,16 @@ export function costScopeToYaml(cfg: CostScopeConfig): YamlCostScope {
       : { costPerspective: cfg.costPerspective }),
     ...(lagDays === DEFAULT_LAG_DAYS ? {} : { lagDays }),
     rules: cfg.rules.map(ruleToYaml),
+    ...(cfg.marketplaceAttribution === undefined
+      ? {}
+      : {
+          marketplaceAttribution: {
+            enabled: cfg.marketplaceAttribution.enabled,
+            rules: cfg.marketplaceAttribution.rules.map(r => ({
+              service: r.service,
+              operations: [...r.operations],
+            })),
+          },
+        }),
   };
 }

--- a/packages/core/src/config/cost-scope-validator.ts
+++ b/packages/core/src/config/cost-scope-validator.ts
@@ -7,8 +7,11 @@ import type {
   CostScopeConfig,
   ExclusionCondition,
   ExclusionRule,
+  MarketplaceAttributionConfig,
+  MarketplaceAttributionRule,
 } from '../types/cost-scope.js';
 import { COST_METRICS, COST_PERSPECTIVES } from '../types/cost-scope.js';
+import { DEFAULT_MARKETPLACE_ATTRIBUTION } from './cost-scope-seed.js';
 
 function isCostMetric(v: string): v is CostMetric {
   return (COST_METRICS as readonly string[]).includes(v);
@@ -59,6 +62,37 @@ function validateRule(raw: unknown, ctx: string): ExclusionRule {
   };
 }
 
+function validateMarketplaceRule(raw: unknown, ctx: string): MarketplaceAttributionRule {
+  assertObject(raw, ctx);
+  assertString(raw['service'], `${ctx}.service`);
+  if (raw['service'].length === 0) {
+    throw new ConfigValidationError(`${ctx}.service must be a non-empty service code`);
+  }
+  assertArray(raw['operations'], `${ctx}.operations`);
+  const operations = raw['operations'].map((o, i) => {
+    assertString(o, `${ctx}.operations[${String(i)}]`);
+    return o;
+  });
+  if (operations.length === 0) {
+    throw new ConfigValidationError(`${ctx}.operations must have at least one entry`);
+  }
+  return { service: raw['service'], operations };
+}
+
+/** Parse the optional `marketplaceAttribution` block. Absent → the shipped
+ *  default (enabled), so existing on-disk configs adopt the fix automatically;
+ *  pass an explicit `{ enabled: false }` to opt out. */
+function validateMarketplaceAttribution(raw: unknown): MarketplaceAttributionConfig {
+  if (raw === undefined) return DEFAULT_MARKETPLACE_ATTRIBUTION;
+  assertObject(raw, 'costScope.marketplaceAttribution');
+  const enabled = raw['enabled'] === true;
+  assertArray(raw['rules'], 'costScope.marketplaceAttribution.rules');
+  const rules = raw['rules'].map((r, i) =>
+    validateMarketplaceRule(r, `costScope.marketplaceAttribution.rules[${String(i)}]`),
+  );
+  return { enabled, rules };
+}
+
 export function validateCostScope(raw: unknown): CostScopeConfig {
   assertObject(raw, 'costScope');
   assertString(raw['costMetric'], 'costScope.costMetric');
@@ -99,10 +133,12 @@ export function validateCostScope(raw: unknown): CostScopeConfig {
 
   assertArray(raw['rules'], 'costScope.rules');
   const rules = raw['rules'].map((r, i) => validateRule(r, `costScope.rules[${String(i)}]`));
+  const marketplaceAttribution = validateMarketplaceAttribution(raw['marketplaceAttribution']);
   return {
     costMetric: costMetricRaw,
     ...(costPerspective === undefined ? {} : { costPerspective }),
     ...(lagDays === undefined ? {} : { lagDays }),
     rules,
+    marketplaceAttribution,
   };
 }

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PLACEHOLDER_PATTERNS } from '../types/query.js';
 import type { DimensionId } from '../types/branded.js';
 import { tagDimColumn } from '../types/branded.js';
 import { OU_PATH_SOURCE_KEY } from '../types/config.js';
-import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule } from '../types/cost-scope.js';
+import type { CostMetric, CostPerspective, CostScopeConfig, ExclusionRule, MarketplaceAttributionConfig, MarketplaceAttributionRule } from '../types/cost-scope.js';
 import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { costExprFor, LIST_METRIC_LINE_ITEM_TYPES } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
@@ -338,6 +338,55 @@ export interface BuildSourceOptions {
    *  description, usage_amount, list_cost. Used by the materialized base
    *  to keep the in-memory table small. */
   readonly slim?: boolean | undefined;
+  /** Re-attributes empty-product_servicecode AWS Marketplace rows to a real
+   *  service (and, on the `list` metric, swaps the $0 list price for unblended
+   *  cost). Omitted/disabled → raw CUR attribution. */
+  readonly marketplaceAttribution?: MarketplaceAttributionConfig | undefined;
+}
+
+/** Active marketplace rules: only when enabled, dropping malformed entries. */
+function activeMarketplaceRules(
+  cfg: MarketplaceAttributionConfig | undefined,
+): readonly MarketplaceAttributionRule[] {
+  if (cfg === undefined || !cfg.enabled) return [];
+  return cfg.rules.filter(r => r.service.length > 0 && r.operations.length > 0);
+}
+
+/** SQL predicate matching any active rule's Marketplace rows (empty
+ *  product_servicecode + matching operation). Null when nothing is active. */
+function marketplaceMatchPredicate(
+  prefix: string,
+  rules: readonly MarketplaceAttributionRule[],
+): string | null {
+  if (rules.length === 0) return null;
+  const ops = [...new Set(rules.flatMap(r => r.operations))]
+    .map(o => `'${sqlEscapeString(o)}'`)
+    .join(', ');
+  return `COALESCE(${prefix}product_servicecode, '') = '' AND ${prefix}line_item_operation IN (${ops})`;
+}
+
+/** Wraps the base service expression in a CASE that rewrites each rule's
+ *  empty-servicecode Marketplace rows to its target service code. */
+function marketplaceServiceExpr(
+  prefix: string,
+  base: string,
+  rules: readonly MarketplaceAttributionRule[],
+): string {
+  if (rules.length === 0) return base;
+  const branches = rules.map(r => {
+    const ops = r.operations.map(o => `'${sqlEscapeString(o)}'`).join(', ');
+    return `WHEN COALESCE(${prefix}product_servicecode, '') = '' AND ${prefix}line_item_operation IN (${ops}) THEN '${sqlEscapeString(r.service)}'`;
+  });
+  return `CASE ${branches.join(' ')} ELSE ${base} END`;
+}
+
+/** Marketplace rows have a $0 public-on-demand price, so any expression keyed
+ *  on it (the `list` metric, the `list_cost` column) reports them as free.
+ *  Substitute unblended cost — the only real figure AWS gives these rows —
+ *  for matched rows. No-op when the predicate is null. */
+function marketplaceListFallback(prefix: string, base: string, matchPredicate: string | null): string {
+  if (matchPredicate === null) return base;
+  return `CASE WHEN ${matchPredicate} THEN COALESCE(${prefix}line_item_unblended_cost, 0) ELSE ${base} END`;
 }
 
 function buildRawTagSelects(dimensions: DimensionsConfig): string[] {
@@ -404,12 +453,33 @@ export function buildSource(opts: BuildSourceOptions): string {
     ? buildFromClause(parquetSource, dimensions, orgAccountsPath)
     : parquetSource;
   const tablePrefix = needsOrgJoin ? 'cur.' : '';
-  const costExpr = costExprFor(costMetric, tablePrefix, costPerspective, availableColumns);
 
+  // Marketplace re-attribution: matched rows get a real service code, and on
+  // the `list` metric their $0 public-on-demand price is replaced with
+  // unblended cost (see marketplaceListFallback).
+  const mktRules = activeMarketplaceRules(opts.marketplaceAttribution);
+  const mktMatch = marketplaceMatchPredicate(tablePrefix, mktRules);
+
+  const baseCostExpr = costExprFor(costMetric, tablePrefix, costPerspective, availableColumns);
+  const costExpr = costMetric === 'list'
+    ? marketplaceListFallback(tablePrefix, baseCostExpr, mktMatch)
+    : baseCostExpr;
+
+  const serviceExpr = marketplaceServiceExpr(
+    tablePrefix,
+    `COALESCE(${tablePrefix}product_servicecode, '')`,
+    mktRules,
+  );
+
+  const listCostExpr = marketplaceListFallback(
+    tablePrefix,
+    `COALESCE(${tablePrefix}pricing_public_on_demand_cost, 0)`,
+    mktMatch,
+  );
   const flexColumns = slim === true ? '' : `
       COALESCE(${tablePrefix}line_item_line_item_description, '') AS description,
       COALESCE(${tablePrefix}line_item_usage_amount, 0) AS usage_amount,
-      COALESCE(${tablePrefix}pricing_public_on_demand_cost, 0) AS list_cost,`;
+      ${listCostExpr} AS list_cost,`;
 
   // The `list` metric reports on-demand list price for usage that actually
   // happened. RI/SP fee rows (RIFee, SavingsPlanRecurringFee, etc.) have no
@@ -426,7 +496,7 @@ export function buildSource(opts: BuildSourceOptions): string {
       ${tablePrefix}line_item_usage_account_id AS account_id,
       COALESCE(${tablePrefix}line_item_usage_account_name, '') AS account_name,
       COALESCE(${tablePrefix}product_region_code, '') AS region,
-      COALESCE(${tablePrefix}product_servicecode, '') AS service,
+      ${serviceExpr} AS service,
       COALESCE(${tablePrefix}product_product_family, '') AS service_family,${flexColumns}
       COALESCE(${tablePrefix}line_item_resource_id, '') AS resource_id,
       ${costExpr} AS cost,
@@ -537,7 +607,7 @@ function setupQuery(
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(params.dateRange, availablePeriods);
   const resolvedTier = effectiveTier(tier, params.dateRange);
-  const source = buildSource({ dataDir, tier: resolvedTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, ...extraSourceOpts });
+  const source = buildSource({ dataDir, tier: resolvedTier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, marketplaceAttribution: costScope?.marketplaceAttribution, ...extraSourceOpts });
   return { qb, filterClauses, exclusionClauses, source, costMetric };
 }
 
@@ -634,7 +704,7 @@ export function buildTrendQuery(
     const previousPeriods = computePeriodsInRange({ start: prevStartIso, end: prevEndIso });
     const required = [...new Set([...currentPeriods, ...previousPeriods])].sort((a, b) => a.localeCompare(b));
     const periods = availablePeriods === undefined ? required : required.filter(p => availablePeriods.includes(p));
-    source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective });
+    source = buildSource({ dataDir, tier: 'daily', dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, marketplaceAttribution: costScope?.marketplaceAttribution });
   } else {
     source = materializedSource;
     exclusionClauses = [];
@@ -942,7 +1012,7 @@ export function buildMaterializeBaseQuery(
   const costMetric = costScope?.costMetric ?? 'unblended';
   const costPerspective = costScope?.costPerspective ?? 'gross';
   const periods = resolveQueryPeriods(dateRange, availablePeriods);
-  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, includeRawTags: true, slim: true });
+  const source = buildSource({ dataDir, tier, dimensions, orgAccountsPath, periods, costMetric, availableColumns, costPerspective, marketplaceAttribution: costScope?.marketplaceAttribution, includeRawTags: true, slim: true });
 
   assertDateString(dateRange.start);
   assertDateString(dateRange.end);
@@ -995,7 +1065,9 @@ export function buildRollupPartitionQuery(
 
   const source = buildSource({
     dataDir, tier, dimensions, orgAccountsPath, periods: [period],
-    costMetric, availableColumns, costPerspective, includeRawTags: false, slim: true,
+    costMetric, availableColumns, costPerspective,
+    marketplaceAttribution: costScope?.marketplaceAttribution,
+    includeRawTags: false, slim: true,
   });
 
   const exclusionClauses: string[] = [];

--- a/packages/core/src/rollup/shape-signature.ts
+++ b/packages/core/src/rollup/shape-signature.ts
@@ -1,5 +1,5 @@
 import type { BuiltInDimension, DimensionsConfig, TagDimension } from '../types/config.js';
-import type { CostMetric, CostPerspective, ExclusionRule } from '../types/cost-scope.js';
+import type { CostMetric, CostPerspective, ExclusionRule, MarketplaceAttributionConfig } from '../types/cost-scope.js';
 import { tagDimColumn } from '../types/branded.js';
 import { normalizeTagValue, resolveAlias } from '../normalize/normalize.js';
 import { canonicalJson, sha256Hex } from './digest.js';
@@ -33,6 +33,10 @@ export interface ShapeSignatureInput {
   readonly costPerspective: CostPerspective;
   /** All exclusion rules; only enabled ones contribute to the signature. */
   readonly rules: readonly ExclusionRule[];
+  /** Marketplace re-attribution. Rewrites the `service` column (and `cost` on
+   *  the list metric) at BUILD time, so it changes stored bytes and must feed
+   *  the signature. Disabled/absent contributes nothing (matches pre-feature). */
+  readonly marketplaceAttribution?: MarketplaceAttributionConfig | undefined;
   /** Digest of org-accounts.json content — see {@link computeOrgAccountsDigest}. */
   readonly orgAccountsDigest: string;
   /** Columns the build probed in the user's Parquet. */
@@ -54,6 +58,20 @@ export function enabledGrainColumns(dims: DimensionsConfig): string[] {
  *  Excludes query-time concerns (value aliases, normalize, lagDays, labels,
  *  order, defaultFilterValues, display-name resolution) so editing those never
  *  forces a re-roll. */
+/** Canonical, order-independent shape of the marketplace config for the digest.
+ *  Null when it contributes no rewrite (disabled or no usable rules) so toggling
+ *  it off yields the same signature as a pre-feature build. */
+function marketplaceForSignature(
+  cfg: MarketplaceAttributionConfig | undefined,
+): { service: string; operations: string[] }[] | null {
+  if (cfg === undefined || !cfg.enabled) return null;
+  const rules = cfg.rules
+    .filter(r => r.service.length > 0 && r.operations.length > 0)
+    .map(r => ({ service: r.service, operations: [...r.operations].sort((a, b) => a.localeCompare(b)) }))
+    .sort((a, b) => a.service.localeCompare(b.service));
+  return rules.length === 0 ? null : rules;
+}
+
 export function computeShapeSignature(input: ShapeSignatureInput): string {
   const { dimensions, costMetric, costPerspective, rules, orgAccountsDigest, availableColumns } = input;
 
@@ -85,6 +103,11 @@ export function computeShapeSignature(input: ShapeSignatureInput): string {
   // Order-independent: rules are a set, not a sequence.
   exclusionRules.sort((a, b) => canonicalJson(a).localeCompare(canonicalJson(b)));
 
+  // Omit the key entirely when it contributes nothing, so a disabled/absent
+  // config hashes identically to a pre-feature build (no spurious re-roll);
+  // only an active config shifts the signature.
+  const marketplace = marketplaceForSignature(input.marketplaceAttribution);
+
   return sha256Hex(canonicalJson({
     schemaVersion: ROLLUP_SCHEMA_VERSION,
     builtinDims,
@@ -92,6 +115,7 @@ export function computeShapeSignature(input: ShapeSignatureInput): string {
     costMetric,
     costPerspective,
     exclusionRules,
+    ...(marketplace === null ? {} : { marketplaceAttribution: marketplace }),
     orgAccountsDigest,
     availableColumns: [...availableColumns].sort((a, b) => a.localeCompare(b)),
   }));

--- a/packages/core/src/types/cost-scope.ts
+++ b/packages/core/src/types/cost-scope.ts
@@ -61,6 +61,34 @@ export interface ExclusionRule {
   readonly conditions: readonly ExclusionCondition[];
 }
 
+/** One re-attribution rule for AWS Marketplace line items. AWS bills
+ *  third-party Marketplace usage (foundation models like Claude, partner AMIs,
+ *  etc.) with an EMPTY `product_servicecode` and a $0 `pricing_public_on_demand_cost`
+ *  — the real charge lands only in `line_item_unblended_cost`. A plain
+ *  service-code grouping therefore buckets this spend under a blank service,
+ *  and the `list` metric reports it as $0. This rule matches such rows by their
+ *  billing `operation` and re-attributes them to a real `service` code (and, for
+ *  the `list` metric, substitutes unblended cost for the missing list price).
+ *
+ *  The canonical case is Bedrock model inference (`InvokeModelInference`,
+ *  `InvokeModelStreamingInference`) → `AmazonBedrock`. */
+export interface MarketplaceAttributionRule {
+  /** Service code matched rows are re-attributed to, e.g. `AmazonBedrock`. */
+  readonly service: string;
+  /** `line_item_operation` values identifying this rule's Marketplace rows.
+   *  Only rows that ALSO have an empty `product_servicecode` are rewritten, so
+   *  first-party usage on the same operation is never touched. */
+  readonly operations: readonly string[];
+}
+
+/** Marketplace re-attribution settings. This deliberately rewrites the
+ *  as-billed product code for practical readability, so it is a toggle —
+ *  enabled by default, disable to see the raw CUR attribution. */
+export interface MarketplaceAttributionConfig {
+  readonly enabled: boolean;
+  readonly rules: readonly MarketplaceAttributionRule[];
+}
+
 /** Number of most-recent days to exclude from all date ranges. AWS CUR
  *  data is not consolidated immediately, so the latest day(s) are
  *  typically incomplete. `0` = include today, `1` = end at yesterday,
@@ -76,6 +104,10 @@ export interface CostScopeConfig {
    *  `DEFAULT_LAG_DAYS` (2) when omitted. */
   readonly lagDays?: number | undefined;
   readonly rules: readonly ExclusionRule[];
+  /** Re-attribution of AWS Marketplace line items. Optional on disk; absent
+   *  configs default to {@link DEFAULT_MARKETPLACE_ATTRIBUTION} (enabled) at
+   *  load time so existing installs pick up the fix. */
+  readonly marketplaceAttribution?: MarketplaceAttributionConfig | undefined;
 }
 
 export interface CostScopePreviewRow {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -83,6 +83,8 @@ export type {
   CostPerspective,
   CostScopeCapabilities,
   CostScopeConfig,
+  MarketplaceAttributionConfig,
+  MarketplaceAttributionRule,
   ExclusionRule,
   ExclusionCondition,
   CostScopeDailyRow,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -493,6 +493,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
       costMetric: costScope?.costMetric ?? 'unblended',
       costPerspective: costScope?.costPerspective ?? 'gross',
       rules: costScope?.rules ?? [],
+      marketplaceAttribution: costScope?.marketplaceAttribution,
       orgAccountsDigest: computeOrgAccountsDigest(orgRaw),
       availableColumns: [...availableColumns],
     });

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { applyNormalizationRule, applyStripPatterns, dimensionsConfigToYaml, generateAliasSuggestions, isStringRecord } from '@costgoblin/core';
+import { applyNormalizationRule, applyStripPatterns, buildSource, dimensionsConfigToYaml, generateAliasSuggestions, isStringRecord } from '@costgoblin/core';
 import type { AliasSuggestion, DimensionsConfig, NormalizationRule } from '@costgoblin/core';
 import { type AppContext, loadOrgAccountsMap } from './context.js';
 import { toNum, toStr } from './query-utils.js';
@@ -77,7 +77,7 @@ function filterUncoveredSuggestions(
 }
 
 export function registerDimensionsHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, getRegionMap, invalidateDimensions, runQuery } = app;
+  const { ctx, getConfig, getDimensions, getQueryDimensions, getCostScope, getAvailableColumns, getOrgAccountsPath, getRegionMap, invalidateDimensions, runQuery } = app;
 
   ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
@@ -177,27 +177,25 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const latest = dirs.at(-1);
     if (latest === undefined) return { values: [], distinctCount: 0, period: '' };
 
-    const source = `read_parquet('${ctx.dataDir}/aws/raw/${latest}/*.parquet')`;
-    // The raw CUR columns aren't aliased — we need to map the UI-facing field
-    // back to the underlying column.
-    const RAW_COL: Record<string, string> = {
-      account_id: 'line_item_usage_account_id',
-      account_name: 'line_item_usage_account_name',
-      region: 'product_region_code',
-      service: 'product_servicecode',
-      service_family: 'product_product_family',
-      line_item_type: 'line_item_line_item_type',
-      operation: 'line_item_operation',
-      usage_type: 'line_item_usage_type',
-    };
-    const col = RAW_COL[field];
-    if (col === undefined) return { values: [], distinctCount: 0, period: '' };
+    // Query through buildSource — the same projection the Explorer and rollup
+    // use — so the preview sees aliased columns AND the marketplace
+    // re-attribution (Bedrock etc.), instead of raw product_servicecode. `field`
+    // is already a buildSource output alias (validated against ALLOWED above).
+    const period = latest.replace(/^daily-/, '');
+    const costScope = await getCostScope().catch(() => undefined);
+    const availableColumns = await getAvailableColumns('daily');
+    const orgAccountsPath = await getOrgAccountsPath();
+    const source = buildSource({
+      dataDir: ctx.dataDir, tier: 'daily', dimensions: await getQueryDimensions(),
+      orgAccountsPath, periods: [period], costMetric: 'unblended', availableColumns,
+      marketplaceAttribution: costScope?.marketplaceAttribution,
+    });
 
-    const distinctSql = `SELECT COUNT(DISTINCT ${col}) AS n FROM ${source} WHERE ${col} IS NOT NULL AND ${col} != ''`;
+    const distinctSql = `SELECT COUNT(DISTINCT ${field}) AS n FROM ${source} WHERE ${field} IS NOT NULL AND ${field} != ''`;
     const valuesSql = `
-      SELECT ${col} AS val, SUM(line_item_unblended_cost) AS cost
+      SELECT ${field} AS val, SUM(cost) AS cost
       FROM ${source}
-      WHERE ${col} IS NOT NULL AND ${col} != ''
+      WHERE ${field} IS NOT NULL AND ${field} != ''
       GROUP BY val
       ORDER BY cost DESC
       LIMIT 200

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -244,16 +244,21 @@ async function buildFreshSource(opts: BuildFreshSourceOptions): Promise<{ source
   const orgPath = await getOrgAccountsPath();
   const availableColumns = await getAvailableColumns(tier);
   const applyCostScope = params.applyCostScope === true;
-  const costScope = applyCostScope ? await getCostScope().catch(() => undefined) : undefined;
+  // Marketplace re-attribution fixes which service a cost belongs to (a data
+  // quality fix, not an exclusion), so it follows its own toggle and applies
+  // regardless of the "Apply Cost Scope" checkbox — otherwise the Explorer and
+  // its filter dropdowns would disagree with the dashboard on Bedrock spend.
+  const fullScope = await getCostScope().catch(() => undefined);
+  const scopeForExclusions = applyCostScope ? fullScope : undefined;
   // When the caller applies the cost scope but doesn't override the metric /
   // perspective (every dashboard widget — only the Explorer view sets them
   // explicitly), inherit them from the global scope instead of silently
   // defaulting to unblended/gross. Both stay capability-gated.
-  const metric = resolveScopeMetric(params.costMetric, applyCostScope, costScope, availableColumns);
-  const perspective = resolveScopePerspective(params.costPerspective, applyCostScope, costScope, availableColumns);
+  const metric = resolveScopeMetric(params.costMetric, applyCostScope, scopeForExclusions, availableColumns);
+  const perspective = resolveScopePerspective(params.costPerspective, applyCostScope, scopeForExclusions, availableColumns);
 
-  const source = buildSource({ dataDir: ctx.dataDir, tier, dimensions, orgAccountsPath: orgPath, periods, costMetric: metric, availableColumns, costPerspective: perspective });
-  const exclusions = buildExclusionClauses(costScope, dimensions, accountReverseMap);
+  const source = buildSource({ dataDir: ctx.dataDir, tier, dimensions, orgAccountsPath: orgPath, periods, costMetric: metric, availableColumns, costPerspective: perspective, marketplaceAttribution: fullScope?.marketplaceAttribution });
+  const exclusions = buildExclusionClauses(scopeForExclusions, dimensions, accountReverseMap);
 
   // When the histogram drag-zoom emits hour bounds, swap the day-level
   // BETWEEN for an hour-level filter so the rest of the Explorer (overview,

--- a/packages/ui/src/__tests__/cost-scope-marketplace.test.tsx
+++ b/packages/ui/src/__tests__/cost-scope-marketplace.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import type { CostScopeConfig } from '@costgoblin/core/browser';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { CostScopeView } from '../views/cost-scope.js';
+
+function renderView() {
+  const api = new MockCostApi();
+  const user = userEvent.setup();
+  return {
+    api,
+    user,
+    ...render(
+      <CostApiProvider value={api}>
+        <CostScopeView />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('CostScopeView — marketplace attribution toggle', () => {
+  it('renders the section On by default and lists the Bedrock rule', async () => {
+    renderView();
+    await waitFor(() => { expect(screen.getByText('Marketplace attribution')).toBeDefined(); });
+    expect(screen.getByText('AmazonBedrock')).toBeDefined();
+    expect(screen.getByText(/^On$/)).toBeDefined();
+  });
+
+  it('saves with enabled=false when toggled off', async () => {
+    const { api, user } = renderView();
+    const saveSpy = vi.spyOn(api, 'saveCostScope');
+
+    await waitFor(() => { expect(screen.getByText('Marketplace attribution')).toBeDefined(); });
+
+    // The marketplace checkbox is the one whose label text is "On"/"Off".
+    const onLabel = screen.getByText(/^On$/);
+    const checkbox = onLabel.parentElement?.querySelector('input[type="checkbox"]');
+    expect(checkbox).not.toBeNull();
+    await user.click(checkbox as Element);
+
+    const saveBtn = await screen.findByRole('button', { name: /save/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => { expect(saveSpy).toHaveBeenCalled(); });
+    // The mock's saveCostScope signature drops its arg, so the spy types calls
+    // as []; the runtime arg is still passed — recover it through a cast.
+    const calls = saveSpy.mock.calls as unknown as CostScopeConfig[][];
+    const saved = calls.at(-1)?.[0];
+    expect(saved?.marketplaceAttribution?.enabled).toBe(false);
+    // Rules are preserved so re-enabling restores them.
+    expect(saved?.marketplaceAttribution?.rules.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/views/cost-scope.tsx
+++ b/packages/ui/src/views/cost-scope.tsx
@@ -4,6 +4,7 @@ import type {
   CostPerspective,
   CostScopeCapabilities,
   CostScopeConfig,
+  MarketplaceAttributionConfig,
   CostScopeDailyRow,
   CostScopePreviewResult,
   CostScopePreviewRow,
@@ -12,7 +13,7 @@ import type {
   ExclusionRule,
   Dimension,
 } from '@costgoblin/core/browser';
-import { BUILTIN_EXCLUSION_RULES, DEFAULT_COST_SCOPE, DEFAULT_LAG_DAYS, asDimensionId } from '@costgoblin/core/browser';
+import { BUILTIN_EXCLUSION_RULES, DEFAULT_COST_SCOPE, DEFAULT_LAG_DAYS, DEFAULT_MARKETPLACE_ATTRIBUTION, asDimensionId } from '@costgoblin/core/browser';
 import { getDimensionId } from '../lib/dimensions.js';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
@@ -711,7 +712,11 @@ export function CostScopeView(): React.JSX.Element {
     // the default ('gross') so the serializer writes clean YAML.
     // exactOptionalPropertyTypes forbids writing `undefined`, so we
     // enumerate the retained fields instead of spreading + overwriting.
-    const base: CostScopeConfig = { costMetric: draft.costMetric, rules: draft.rules };
+    const base: CostScopeConfig = {
+      costMetric: draft.costMetric,
+      rules: draft.rules,
+      ...(draft.marketplaceAttribution === undefined ? {} : { marketplaceAttribution: draft.marketplaceAttribution }),
+    };
     updateDraft(perspective === 'gross' ? base : { ...base, costPerspective: perspective });
   }
 
@@ -725,8 +730,20 @@ export function CostScopeView(): React.JSX.Element {
       ...(draft.costPerspective === undefined ? {} : { costPerspective: draft.costPerspective }),
       ...(clamped === DEFAULT_LAG_DAYS ? {} : { lagDays: clamped }),
       rules: draft.rules,
+      ...(draft.marketplaceAttribution === undefined ? {} : { marketplaceAttribution: draft.marketplaceAttribution }),
     };
     updateDraft(next);
+  }
+
+  function handleMarketplaceToggle(enabled: boolean) {
+    // Preserve any custom rules already on disk; fall back to the shipped
+    // default ruleset the first time it's enabled on a config that lacks one.
+    const existing = draft.marketplaceAttribution;
+    const rules = existing === undefined || existing.rules.length === 0
+      ? DEFAULT_MARKETPLACE_ATTRIBUTION.rules
+      : existing.rules;
+    const marketplaceAttribution: MarketplaceAttributionConfig = { enabled, rules };
+    updateDraft({ ...draft, marketplaceAttribution });
   }
 
   function updateRule(index: number, next: ExclusionRule) {
@@ -942,6 +959,46 @@ export function CostScopeView(): React.JSX.Element {
                     <span className="text-xs text-text-muted">days</span>
                   </div>
                 </div>
+              </div>
+
+              {/* Marketplace attribution — re-attributes empty-product_servicecode
+                  AWS Marketplace rows (Bedrock third-party models, etc.) to a
+                  real service. Deliberately rewrites the as-billed product code,
+                  so it's a toggle. */}
+              <div className="pt-2 mt-2 border-t border-border">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-text-primary">Marketplace attribution</div>
+                    <div className="text-xs text-text-muted mt-0.5">
+                      AWS bills third-party Marketplace usage (e.g. Bedrock foundation models)
+                      with no service code and a $0 on-demand price &mdash; so it lands under a
+                      blank service and reads as free on the List metric. Re-attribute it to a
+                      real service using its billing operation.
+                    </div>
+                  </div>
+                  <label className="flex items-center gap-2 shrink-0 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={draft.marketplaceAttribution?.enabled ?? false}
+                      onChange={e => { handleMarketplaceToggle(e.target.checked); }}
+                      className="accent-accent"
+                    />
+                    <span className="text-xs text-text-muted">
+                      {(draft.marketplaceAttribution?.enabled ?? false) ? 'On' : 'Off'}
+                    </span>
+                  </label>
+                </div>
+                {(draft.marketplaceAttribution?.enabled ?? false) && (draft.marketplaceAttribution?.rules.length ?? 0) > 0 && (
+                  <ul className="mt-2 space-y-1">
+                    {draft.marketplaceAttribution?.rules.map(rule => (
+                      <li key={rule.service} className="text-xs text-text-muted">
+                        <code className="text-[11px] text-text-primary">{rule.service}</code>
+                        {' ← '}
+                        {rule.operations.map(op => <code key={op} className="text-[11px] mr-1">{op}</code>)}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Problem

AWS bills third-party **Marketplace** usage — Bedrock foundation models (Claude, etc.), partner AMIs — with an **empty `product_servicecode`** and a **$0 `pricing_public_on_demand_cost`**. The real charge lands only in `line_item_unblended_cost`.

Because cost-goblin derives `service = COALESCE(product_servicecode, '')`, this spend was bucketed under a **blank service**. And on the **`list` metric** (which reads public-on-demand cost) it disappeared entirely — reported as **$0**. This mirrors a bug we recently fixed in the Backstage AWS-cost plugin (#606 there).

Verified on real local CUR data: Bedrock for May was showing **$2.80**; the actual third-party (Claude) inference spend hidden as blank-service Marketplace rows is **~$2,530**.

## Fix

A generic, config-driven **marketplace-attribution** layer in `buildSource`:

- Rows matching an enabled rule (**empty `product_servicecode`** + a configured `line_item_operation`) are re-attributed to a real **service code**.
- On the **`list`** metric, matched rows' missing list price is replaced with **unblended cost** (the only real figure AWS provides for them). `unblended`/`amortized` already carry the charge, so cost is left untouched there.
- Strictly additive — only matching rows change, so totals never double-count, and first-party usage on the same operation (empty-servicecode check) is never touched.

Shipped default (`DEFAULT_MARKETPLACE_ATTRIBUTION`): `InvokeModelInference` + `InvokeModelStreamingInference` → `AmazonBedrock`. **Enabled by default.**

### UI
A toggle in **Settings → Cost Scope** (On/Off, with the active rules listed as `service ← operations`). Editable in `cost-scope.yaml` too:

```yaml
marketplaceAttribution:
  enabled: true
  rules:
    - service: AmazonBedrock
      operations: [InvokeModelInference, InvokeModelStreamingInference]
```

Also fixes `handlePerspectiveChange` / `handleLagDaysChange` in the Cost Scope view, which rebuilt the config from scratch and would have silently dropped `marketplaceAttribution`.

### Why a toggle (and only Bedrock by default)
Re-attribution deliberately rewrites the as-billed product code for readability, so it's opt-out-able. Bedrock is the only AWS *service* that consistently shows up as a blank-servicecode Marketplace row with real per-usage cost — the other blank-servicecode populations are **Tax** and **RI/SP fees**, which are not per-service usage (and `list` already filters fee rows out), so they're intentionally excluded.

## Rollup correctness
The rule rewrites stored `service`/`cost` bytes, so it feeds the rollup **shape signature** — toggling or editing it invalidates stale rollups. Disabled/absent hashes identically to a pre-feature build, so turning it off causes no spurious re-roll.

## Verification
- `npm run check` green (tsc ×4, eslint, 742 tests).
- New DuckDB end-to-end test covering both metrics × enabled/disabled, plus validator/serializer/signature and a UI toggle test.
- Against real local CUR: `AmazonBedrock` (May) **$2.80 → $2,532.85** on the list metric with attribution on.