### PR TITLE
fix(ui): single range calendar for custom date selection

### DIFF
--- a/packages/ui/src/__tests__/date-range-picker.test.tsx
+++ b/packages/ui/src/__tests__/date-range-picker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
@@ -82,7 +82,7 @@ describe('DateRangePicker', () => {
     expect(granularity).toBe('daily');
   });
 
-  it('shows custom range inputs when Custom range is clicked', async () => {
+  it('shows custom range calendar when Custom range is clicked', async () => {
     renderPicker();
     const user = userEvent.setup();
 
@@ -91,5 +91,36 @@ describe('DateRangePicker', () => {
 
     expect(screen.getByText('From')).toBeDefined();
     expect(screen.getByText('To')).toBeDefined();
+    // A single range calendar grid is shown (not two separate date inputs).
+    expect(screen.getByRole('grid')).toBeDefined();
+  });
+
+  it('picking two days in the range calendar commits a full range', async () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText('Last 30 days'));
+    await user.click(screen.getByText('Custom range…'));
+
+    const grid = screen.getByRole('grid');
+    const enabledDays = within(grid)
+      .getAllByRole('button')
+      .filter(btn => !btn.hasAttribute('disabled'));
+
+    const first = enabledDays[0];
+    const last = enabledDays[enabledDays.length - 1];
+    expect(first).toBeDefined();
+    expect(last).toBeDefined();
+    if (first && last) {
+      // First click starts a fresh range (no commit yet); second click completes it.
+      await user.click(first);
+      await user.click(last);
+    }
+
+    expect(onChange).toHaveBeenCalled();
+    const calls = onChange.mock.calls;
+    const range = calls[calls.length - 1]?.[0] as DateRange;
+    expect(range.start <= range.end).toBe(true);
   });
 });

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { CalendarIcon, ChevronDown } from 'lucide-react';
+import type { DateRange as DayPickerRange } from 'react-day-picker';
 import type { DateString, HourString } from '@costgoblin/core/browser';
 import { DEFAULT_LAG_DAYS, asDateString } from '@costgoblin/core/browser';
 import { daysAgo, getThisMonth, getLastMonth, getCurrentQuarter, getLastQuarter, getYTD, getLastYear } from '../lib/dates.js';
@@ -55,6 +56,19 @@ const PRESETS: readonly { section: string; items: readonly Preset[] }[] = [
 
 const ALL_PRESETS = PRESETS.flatMap(s => s.items);
 
+/** Parse a YYYY-MM-DD string to a local-midnight Date — matches the Date objects react-day-picker hands back. */
+function parseDay(s: DateString): Date {
+  return new Date(`${s}T00:00:00`);
+}
+
+/** Format a Date as YYYY-MM-DD from its local calendar fields (avoids the UTC shift of toISOString). */
+function formatDay(d: Date): DateString {
+  const year = String(d.getFullYear());
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return asDateString(`${year}-${month}-${day}`);
+}
+
 export interface DateRange {
   start: DateString;
   end: DateString;
@@ -81,6 +95,10 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
   const hourlyAvailable = hideHourly !== true && hourlyConfigured;
   const [open, setOpen] = useState(false);
   const [showCustom, setShowCustom] = useState(false);
+  // While the user is mid-selection (start picked, end not yet), the committed
+  // value still holds the old range — keep the in-progress range here so the
+  // calendar highlights it. Cleared once a full range commits or the popover closes.
+  const [draftRange, setDraftRange] = useState<DayPickerRange | undefined>(undefined);
   const latestDate = daysAgo(lagDays);
 
   function getPresetRange(preset: Preset): DateRange {
@@ -124,11 +142,18 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
     return compareEnabled === true ? `${base} vs prev` : base;
   }
 
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    // Drop any half-finished selection so reopening reflects the committed value.
+    if (!next) setDraftRange(undefined);
+  }
+
   function handlePreset(preset: Preset) {
     const range = getPresetRange(preset);
     // Picking a preset is an explicit "back to whole-day mode" gesture —
     // don't carry a previous drag's hour bounds onto the new window.
     onChange(range, resolveGranularity(range, preset.granularity));
+    setDraftRange(undefined);
     setShowCustom(false);
     setOpen(false);
   }
@@ -137,6 +162,14 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
     // Same intent as a preset: editing the calendar picks whole days, so any
     // active hour bounds no longer apply.
     onChange(range, resolveGranularity(range, granularity));
+  }
+
+  function handleRangeSelect(range: DayPickerRange | undefined) {
+    setDraftRange(range);
+    // Only commit once both ends are chosen — a lone start shouldn't refire the query.
+    if (range?.from && range.to) {
+      handleCustomRange({ start: formatDay(range.from), end: formatDay(range.to) });
+    }
   }
 
   function handleGranularityToggle(next: Granularity) {
@@ -196,7 +229,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
           </button>
         </div>
       )}
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -207,7 +240,7 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
           <ChevronDown className="h-3 w-3 text-text-muted" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 p-0" align="end">
+      <PopoverContent className="w-72 p-0" align="end">
         <div className="flex flex-col">
           {sections.map(({ section, items }) => (
             <div key={section}>
@@ -253,61 +286,27 @@ export function DateRangePicker({ value, granularity, onChange, hideHourly, lagD
               Custom range…
             </button>
             {showCustom && (
-              <div className="px-3 pb-3 flex flex-col gap-2">
-                <div className="flex flex-col gap-1">
-                  <span className="text-[10px] text-text-muted">From</span>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        className="flex items-center gap-2 rounded border border-border bg-bg-primary px-2 py-1.5 text-xs text-text-primary hover:border-accent transition-colors"
-                      >
-                        <CalendarIcon className="h-3 w-3 text-text-muted" />
-                        {value.start}
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start" side="left">
-                      <Calendar
-                        mode="single"
-                        selected={new Date(value.start + 'T00:00:00')}
-                        onSelect={(date) => {
-                          if (date) {
-                            handleCustomRange({ start: asDateString(date.toISOString().slice(0, 10)), end: value.end });
-                          }
-                        }}
-                        disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
-                        autoFocus
-                      />
-                    </PopoverContent>
-                  </Popover>
+              <div className="pb-2">
+                <div className="flex items-center justify-between px-3 pb-1.5 text-[10px]">
+                  <div className="flex items-center gap-1">
+                    <span className="text-text-muted">From</span>
+                    <span className="font-medium text-text-secondary">{value.start}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span className="text-text-muted">To</span>
+                    <span className="font-medium text-text-secondary">{value.end}</span>
+                  </div>
                 </div>
-                <div className="flex flex-col gap-1">
-                  <span className="text-[10px] text-text-muted">To</span>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        className="flex items-center gap-2 rounded border border-border bg-bg-primary px-2 py-1.5 text-xs text-text-primary hover:border-accent transition-colors"
-                      >
-                        <CalendarIcon className="h-3 w-3 text-text-muted" />
-                        {value.end}
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start" side="left">
-                      <Calendar
-                        mode="single"
-                        selected={new Date(value.end + 'T00:00:00')}
-                        onSelect={(date) => {
-                          if (date) {
-                            handleCustomRange({ start: value.start, end: asDateString(date.toISOString().slice(0, 10)) });
-                          }
-                        }}
-                        disabled={(date) => date.toISOString().slice(0, 10) > latestDate}
-                        autoFocus
-                      />
-                    </PopoverContent>
-                  </Popover>
-                </div>
+                <Calendar
+                  mode="range"
+                  required={false}
+                  resetOnSelect
+                  selected={draftRange ?? { from: parseDay(value.start), to: parseDay(value.end) }}
+                  onSelect={handleRangeSelect}
+                  defaultMonth={parseDay(value.end)}
+                  disabled={(date) => formatDay(date) > latestDate}
+                  autoFocus
+                />
               </div>
             )}
           </div>

--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -33,20 +33,23 @@ export function Calendar({
         weekday:
           'text-text-secondary rounded-md w-9 font-normal text-[0.8rem]',
         week: 'flex w-full mt-2',
-        day: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].range_end)]:rounded-r-md [&:has([aria-selected].outside)]:bg-bg-tertiary/50 [&:has([aria-selected])]:bg-bg-tertiary first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+        day: 'h-9 w-9 text-center text-sm p-0 relative focus-within:relative focus-within:z-20',
         day_button: cn(
           buttonVariants({ variant: 'ghost' }),
           'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
         ),
-        range_end: 'range_end',
         selected:
-          'bg-accent text-white hover:bg-accent-hover hover:text-white focus:bg-accent-hover focus:text-white',
-        today: 'bg-bg-tertiary text-text-primary',
+          'bg-accent text-white rounded-md hover:bg-accent-hover hover:text-white focus:bg-accent-hover focus:text-white',
+        range_start:
+          'aria-selected:rounded-l-md aria-selected:rounded-r-none',
+        range_end:
+          'aria-selected:rounded-r-md aria-selected:rounded-l-none',
+        range_middle:
+          'aria-selected:bg-bg-tertiary aria-selected:text-text-primary aria-selected:rounded-none',
+        today: 'bg-bg-tertiary text-text-primary rounded-md',
         outside:
           'outside text-text-secondary opacity-50 aria-selected:bg-bg-tertiary/50 aria-selected:text-text-secondary aria-selected:opacity-30',
         disabled: 'text-text-secondary opacity-50',
-        range_middle:
-          'aria-selected:bg-bg-tertiary aria-selected:text-text-primary',
         hidden: 'invisible',
         ...classNames,
       }}


### PR DESCRIPTION
## What

The **Custom range…** date picker used two separate single-date calendars (one for *From*, one for *To*), each in its own nested popover with `mode="single"`. Clicking days never produced the expected range-selection feedback — there was no highlight spanning the two endpoints.

This replaces them with **one `react-day-picker` range calendar**: click the start day, click the end day, and the span highlights — the conventional date-range experience.

## Why

Reported UX issue: the picker didn't behave like a normal range calendar (no two-click selection with a highlighted span between days).

## Changes

- **`date-range-picker.tsx`** — inline `mode="range"` calendar replacing the dual From/To popovers.
  - `resetOnSelect` so each new selection starts fresh from the clicked day rather than mutating an endpoint of the seeded range.
  - A `draftRange` state highlights the in-progress selection (start picked, end not yet) before committing; `onChange` fires only once a full range is chosen, so a lone start click doesn't refire the query.
  - Dates round-trip through local calendar fields (`parseDay`/`formatDay`) instead of `toISOString()`, fixing a latent off-by-one in UTC+ timezones.
  - A compact `From … / To …` summary sits above the grid; popover widened (`w-64` → `w-72`) to fit the inline calendar.
- **`ui/calendar.tsx`** — added `range_start` and gave the range a connected start/middle/end span (accent endpoints, tinted middle bar, correct left/right rounding).
- **`date-range-picker.test.tsx`** — added a test that picks two days and asserts a full range commits.

## Notes for reviewers

- `DateRangePicker`'s public props are unchanged; desktop type-checks against it cleanly.
- Full `npm run check` passes (723 tests). Worth a quick visual confirm of the range highlighting in `npm run dev`.