### PR TITLE
feat(rollup): parallelize per-period builds on fresh DuckDB connections

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -384,10 +384,12 @@ export interface UpdateApi {
  *  rollup (`ready`) or transiently from the slower raw path while a re-roll runs
  *  (`computing`) — e.g. after a dimensions save or a sync. `idle` = no rollup
  *  built yet (no local data); `failed` = the last build batch hit an error
- *  (otherwise swallowed to the log). */
+ *  (otherwise swallowed to the log). While `computing`, `periods` lists every
+ *  month completed-first (the first `done` are built) and `active` is the subset
+ *  whose build is in flight right now, so the popover can pulse those chips. */
 export type RollupStatus =
   | { readonly state: 'idle' }
-  | { readonly state: 'computing'; readonly done: number; readonly total: number; readonly periods: readonly string[] }
+  | { readonly state: 'computing'; readonly done: number; readonly total: number; readonly periods: readonly string[]; readonly active: readonly string[] }
   | { readonly state: 'ready'; readonly periods: number }
   | { readonly state: 'failed'; readonly message: string; readonly periods: number };
 

--- a/packages/desktop/src/__tests__/rollup-store.test.ts
+++ b/packages/desktop/src/__tests__/rollup-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { DuckDBInstance } from '@duckdb/node-api';
+import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -7,6 +7,24 @@ import { mkdtemp, rm, stat, readdir } from 'node:fs/promises';
 import { buildRollupPartitionQuery, rollupGrainColumns, type DimensionsConfig, type CostScopeConfig, asDimensionId } from '@costgoblin/core';
 import { RollupStore, type RollupShape } from '../main/rollup-store.js';
 import type { RawRow } from '../main/duckdb-client.js';
+
+async function fetchRows(conn: DuckDBConnection, sql: string): Promise<RawRow[]> {
+  const result = await conn.run(sql);
+  const cols = result.columnCount;
+  const names: string[] = [];
+  for (let i = 0; i < cols; i++) names.push(result.columnName(i));
+  const rows: RawRow[] = [];
+  let chunk = await result.fetchChunk();
+  while (chunk !== null && chunk.rowCount > 0) {
+    for (let r = 0; r < chunk.rowCount; r++) {
+      const row: Record<string, unknown> = {};
+      for (let c = 0; c < cols; c++) { const n = names[c]; if (n !== undefined) row[n] = chunk.getColumnVector(c).getItem(r); }
+      rows.push(row);
+    }
+    chunk = await result.fetchChunk();
+  }
+  return rows;
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // core synthetic fixtures live under packages/core/src/__fixtures__/synthetic
@@ -36,23 +54,7 @@ describe('RollupStore', () => {
     db = await DuckDBInstance.create();
     conn = await db.connect();
     dataDir = await mkdtemp(join(tmpdir(), 'cg-rollup-store-'));
-    runQuery = async (sql: string): Promise<RawRow[]> => {
-      const result = await conn.run(sql);
-      const cols = result.columnCount;
-      const names: string[] = [];
-      for (let i = 0; i < cols; i++) names.push(result.columnName(i));
-      const rows: RawRow[] = [];
-      let chunk = await result.fetchChunk();
-      while (chunk !== null && chunk.rowCount > 0) {
-        for (let r = 0; r < chunk.rowCount; r++) {
-          const row: Record<string, unknown> = {};
-          for (let c = 0; c < cols; c++) { const n = names[c]; if (n !== undefined) row[n] = chunk.getColumnVector(c).getItem(r); }
-          rows.push(row);
-        }
-        chunk = await result.fetchChunk();
-      }
-      return rows;
-    };
+    runQuery = (sql: string): Promise<RawRow[]> => fetchRows(conn, sql);
   });
   afterAll(async () => { await rm(dataDir, { recursive: true, force: true }); });
 
@@ -72,6 +74,45 @@ describe('RollupStore', () => {
     // Reads only the requested month's partition, never a daily-* wildcard.
     expect(src).toContain('daily-2026-01/rollup.parquet');
     expect(src).not.toContain('daily-*');
+  });
+
+  it('builds multiple periods concurrently on fresh connections, committing every manifest entry', async () => {
+    // Each build runs on its own connection; a gate that only trips once BOTH
+    // builds have arrived proves they actually overlap (a sequential impl would
+    // stall at the gate until the 2s safety valve, leaving peak in-flight at 1).
+    let arrived = 0;
+    let inFlight = 0;
+    let peakInFlight = 0;
+    let trip!: () => void;
+    const gate = new Promise<void>(r => { trip = r; });
+    const safety = setTimeout(() => { trip(); }, 2000);
+    const onFreshConn = async (sql: string): Promise<RawRow[]> => {
+      const c: DuckDBConnection = await db.connect();
+      try { return await fetchRows(c, sql); } finally { c.disconnectSync(); }
+    };
+    const runBuild = async (sql: string): Promise<RawRow[]> => {
+      arrived += 1;
+      if (arrived >= 2) { clearTimeout(safety); trip(); }
+      await gate;
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      try { return await onFreshConn(sql); } finally { inFlight -= 1; }
+    };
+    const store = new RollupStore({ dataDir, runQuery: onFreshConn, runBuild, buildConcurrency: 2 });
+    await store.maintainPeriods(['2026-01', '2026-02'], buildSql, etags, shape);
+    clearTimeout(safety);
+
+    expect(peakInFlight).toBe(2);
+    expect([...store.getValidPeriods()].sort()).toEqual(['2026-01', '2026-02']);
+    for (const period of ['2026-01', '2026-02']) {
+      await expect(stat(join(dataDir, 'aws', 'rollup', `daily-${period}`, 'rollup.parquet'))).resolves.toBeDefined();
+    }
+    // A reloaded store sees both partitions as valid → every commit landed.
+    const reloaded = new RollupStore({ dataDir, runQuery });
+    const v = await reloaded.loadAndValidate(shape, etags);
+    expect([...v.validPeriods].sort()).toEqual(['2026-01', '2026-02']);
+    const dir = await readdir(join(dataDir, 'aws', 'rollup'));
+    expect(dir.some(f => f.endsWith('.tmp'))).toBe(false);
   });
 
   it('resolveSource falls back to raw (undefined) on hour bounds, out-of-grain column, or an unbuilt period', async () => {

--- a/packages/desktop/src/main/duckdb-client.ts
+++ b/packages/desktop/src/main/duckdb-client.ts
@@ -5,6 +5,10 @@ export type RawRow = Readonly<Record<string, unknown>>;
 export interface DuckDBClient {
   runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]>;
   runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]>;
+  /** Run on a brand-new connection that is disposed afterward (never pooled).
+   *  Used for rollup partition builds so per-build time stays flat — a reused
+   *  connection's buffer/cache accumulates and later builds slow down. */
+  runBuildQuery(sql: string, onStarted?: () => void): Promise<RawRow[]>;
   cancelPendingQueries(): void;
   configure(settings: { tempDir?: string; memoryGB?: number; threads?: number }): void;
   terminate(): Promise<void>;
@@ -78,6 +82,9 @@ export async function createDuckDBClient(workerPath: string): Promise<DuckDBClie
   return {
     runQuery(sql: string, onStarted?: () => void): Promise<RawRow[]> {
       return submitQuery('query', sql, {}, onStarted);
+    },
+    runBuildQuery(sql: string, onStarted?: () => void): Promise<RawRow[]> {
+      return submitQuery('query', sql, { fresh: true }, onStarted);
     },
     runPreparedQuery(sql: string, params: readonly unknown[], onStarted?: () => void): Promise<RawRow[]> {
       return submitQuery('prepared-query', sql, { params }, onStarted);

--- a/packages/desktop/src/main/duckdb-tuning.ts
+++ b/packages/desktop/src/main/duckdb-tuning.ts
@@ -34,6 +34,19 @@ export function computeDefaultThreads(): number {
   return maxThreads();
 }
 
+/** Default size of the worker's DuckDB connection pool — also the cap on
+ *  concurrent rollup partition builds. min(max(4, cores), 16), overridable via
+ *  COSTGOBLIN_DUCKDB_POOL_SIZE (1..32). Shared so the pool and the rollup
+ *  builder agree on how many connections may run queries at once. */
+export function computeDefaultPoolSize(): number {
+  const raw = process.env['COSTGOBLIN_DUCKDB_POOL_SIZE'];
+  if (raw !== undefined) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n >= 1 && n <= 32) return n;
+  }
+  return Math.min(Math.max(4, maxThreads()), 16);
+}
+
 /** Clamp a user-supplied memory override to a safe range. */
 export function clampMemoryGB(gb: number): number {
   const ceiling = Math.max(MIN_MEMORY_GB, Math.min(MAX_MEMORY_GB, totalMemoryGB()));

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -1,9 +1,8 @@
 import { parentPort } from 'node:worker_threads';
-import { cpus } from 'node:os';
 import type { DuckDBConnection, DuckDBInstance } from './duckdb-loader.js';
 import { createResourcePool } from './connection-pool.js';
 import type { ResourcePool } from './connection-pool.js';
-import { computeDefaultMemoryGB, computeDefaultThreads } from './duckdb-tuning.js';
+import { computeDefaultMemoryGB, computeDefaultPoolSize, computeDefaultThreads } from './duckdb-tuning.js';
 
 interface DuckDBModule {
   DuckDBInstance: { create: () => Promise<DuckDBInstance> };
@@ -49,8 +48,9 @@ function hasProps(msg: unknown): msg is Record<string, unknown> {
   return typeof msg === 'object' && msg !== null;
 }
 
-function isQueryRequest(msg: unknown): msg is { kind: 'query'; id: number; sql: string } {
+function isQueryRequest(msg: unknown): msg is { kind: 'query'; id: number; sql: string; fresh?: boolean } {
   if (!hasProps(msg)) return false;
+  if (msg['fresh'] !== undefined && typeof msg['fresh'] !== 'boolean') return false;
   return msg['kind'] === 'query' && typeof msg['id'] === 'number' && typeof msg['sql'] === 'string';
 }
 
@@ -166,15 +166,6 @@ async function fetchAllRowsPrepared(
   }
 }
 
-function parsePoolSize(): number {
-  const raw = process.env['COSTGOBLIN_DUCKDB_POOL_SIZE'];
-  if (raw !== undefined) {
-    const n = Number.parseInt(raw, 10);
-    if (Number.isFinite(n) && n >= 1 && n <= 32) return n;
-  }
-  return Math.min(Math.max(4, cpus().length), 16);
-}
-
 let poolPromise: Promise<ResourcePool<DuckDBConnection>> | null = null;
 let dbInstance: DuckDBInstance | null = null;
 
@@ -187,9 +178,18 @@ function getPool(): Promise<ResourcePool<DuckDBConnection>> {
     const initConn = await db.connect();
     await configureDuckDB(initConn, {});
     initConn.disconnectSync();
-    return createResourcePool(parsePoolSize(), () => db.connect());
+    return createResourcePool(computeDefaultPoolSize(), () => db.connect());
   });
   return poolPromise;
+}
+
+/** The initialized DuckDB instance, for callers that need a connection outside
+ *  the pool (a `fresh` query). Awaits getPool() so the instance exists and its
+ *  memory/thread limits are applied before the first fresh connect. */
+async function getInstance(): Promise<DuckDBInstance> {
+  await getPool();
+  if (dbInstance === null) throw new Error('DuckDB instance not initialized');
+  return dbInstance;
 }
 
 function send(msg: WorkerResponse): void {
@@ -206,13 +206,19 @@ void (async () => {
   }
 })();
 
-async function handleRequest(req: { kind: 'query'; id: number; sql: string }): Promise<void> {
+async function handleRequest(req: { kind: 'query'; id: number; sql: string; fresh?: boolean }): Promise<void> {
   // Check before acquiring a pool connection
   if (cancelledIds.has(req.id)) {
     cancelledIds.delete(req.id);
     send({ kind: 'error', id: req.id, message: 'Query cancelled' });
     return;
   }
+
+  // A `fresh` query runs on a brand-new connection that is disconnected (never
+  // returned to the pool) afterward. Rollup partition builds use this: a
+  // long-lived connection's buffer/cache accumulates across builds and per-month
+  // time climbs (≈2s → 10s); a fresh connection per build keeps each ≈2s.
+  const fresh = req.fresh === true;
 
   // pool/conn are hoisted and the acquisition runs inside the try so that a
   // getPool() or pool.acquire() rejection is turned into an error response by
@@ -222,8 +228,12 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
   let conn: DuckDBConnection | undefined;
   try {
     queuedIds.add(req.id);
-    pool = await getPool();
-    conn = await pool.acquire();
+    if (fresh) {
+      conn = await (await getInstance()).connect();
+    } else {
+      pool = await getPool();
+      conn = await pool.acquire();
+    }
     queuedIds.delete(req.id);
     send({ kind: 'started', id: req.id });
 
@@ -254,7 +264,10 @@ async function handleRequest(req: { kind: 'query'; id: number; sql: string }): P
     queuedIds.delete(req.id);
     runningIds.delete(req.id);
     runningConns.delete(req.id);
-    if (pool !== undefined && conn !== undefined) pool.release(conn);
+    if (conn !== undefined) {
+      if (fresh) conn.disconnectSync();
+      else if (pool !== undefined) pool.release(conn);
+    }
   }
 }
 

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -2,6 +2,7 @@ import type { DuckDBClient, RawRow } from '../duckdb-client.js';
 import { LRUCache } from '../lru-cache.js';
 import { QueryLog } from '../query-log.js';
 import { awaitWithTimeout } from '../async-timeout.js';
+import { computeDefaultPoolSize } from '../duckdb-tuning.js';
 import { RollupStore, type BuildPartitionSql, type RollupShape } from '../rollup-store.js';
 import {
   asDimensionId,
@@ -437,7 +438,15 @@ export function createAppContext(ctx: IpcContext): AppContext {
   }
 
   const queryLog = new QueryLog();
-  const rollupStore = new RollupStore({ dataDir: ctx.dataDir, runQuery: (sql) => ctx.db.runQuery(sql) });
+  const rollupStore = new RollupStore({
+    dataDir: ctx.dataDir,
+    runQuery: (sql) => ctx.db.runQuery(sql),
+    // Partition builds run on a fresh, disposable connection (flat per-build
+    // time) and fan out across the DuckDB pool so a full-history rebuild is
+    // ~pool-size faster than the old sequential pass.
+    runBuild: (sql) => ctx.db.runBuildQuery(sql),
+    buildConcurrency: computeDefaultPoolSize(),
+  });
   const resultCache = new LRUCache<string, RawRow[]>(50);
 
   const wrappedRunQuery = queryLog.wrapQuery((sql, onStarted) => ctx.db.runQuery(sql, onStarted));

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -34,6 +34,15 @@ export interface ResolveSourceArgs {
 interface RollupStoreDeps {
   readonly dataDir: string;
   readonly runQuery: (sql: string) => Promise<RawRow[]>;
+  /** Runs a partition-build query on a fresh, disposable DuckDB connection so
+   *  per-build time doesn't climb across a batch (buffer/cache accumulation on
+   *  a reused connection). Defaults to `runQuery` (tests, which share one
+   *  connection and build a single period). */
+  readonly runBuild?: (sql: string) => Promise<RawRow[]>;
+  /** Max partitions built concurrently. Defaults to 1 (sequential) so the
+   *  single-connection test harness is safe; production passes the worker's
+   *  pool size so independent months build in parallel. */
+  readonly buildConcurrency?: number;
 }
 
 /**
@@ -56,6 +65,8 @@ interface RollupStoreDeps {
 export class RollupStore {
   private readonly dataDir: string;
   private readonly runQuery: (sql: string) => Promise<RawRow[]>;
+  private readonly runBuild: (sql: string) => Promise<RawRow[]>;
+  private readonly buildConcurrency: number;
 
   private manifest: RollupManifest | null = null;
   private shape: RollupShape | null = null;
@@ -66,6 +77,8 @@ export class RollupStore {
   constructor(deps: RollupStoreDeps) {
     this.dataDir = deps.dataDir;
     this.runQuery = deps.runQuery;
+    this.runBuild = deps.runBuild ?? deps.runQuery;
+    this.buildConcurrency = Math.max(1, deps.buildConcurrency ?? 1);
   }
 
   private rollupDir(): string { return join(this.dataDir, 'aws', 'rollup'); }
@@ -155,9 +168,12 @@ export class RollupStore {
     return this.rollupGlob(args.requiredPeriods);
   }
 
-  /** Build (or replace) the given periods, updating the manifest atomically
-   *  after each. Periods already valid under the current shape are skipped.
-   *  Aborts silently if a concurrent invalidate() changed the epoch. */
+  /** Build (or replace) the given periods, updating the manifest atomically as
+   *  each completes. Periods already valid under the current shape are skipped.
+   *  Independent months build concurrently (bounded by `buildConcurrency`), each
+   *  on a fresh connection, so a full-history rebuild is far faster than the old
+   *  sequential pass. Aborts silently if a concurrent invalidate() changed the
+   *  epoch. */
   maintainPeriods(
     periods: readonly string[],
     buildSql: BuildPartitionSql,
@@ -173,28 +189,67 @@ export class RollupStore {
         ? this.manifest
         : { schemaVersion: ROLLUP_SCHEMA_VERSION, shapeSignature: shape.signature, builtAt: '', grainDimensions: shape.grainDimensions, availableColumns: shape.availableColumns, partitions: {} };
 
+      // Split into already-valid (skip) and to-build. Reading manifest.partitions
+      // here is safe — it happens before any build starts, so the concurrent
+      // commits below can't be mutating it yet.
+      const toBuild: string[] = [];
       for (const period of periods) {
-        if (this.epoch !== startEpoch) return; // superseded mid-build
         const wantHash = computePartitionEtagHash(etagsByPeriod[period]);
         if (opts.force !== true && manifest.partitions[period]?.rawEtagHash === wantHash) {
           this.validPeriods.add(period);
-          continue;
+        } else {
+          toBuild.push(period);
         }
-        try {
-          const outPath = this.partitionPath(period);
-          await mkdir(this.partitionDir(period), { recursive: true });
-          await this.runQuery(buildSql(period, outPath));
-          const meta = await this.partitionMeta(outPath, wantHash);
-          if (this.epoch !== startEpoch) return; // a drop landed during the build
+      }
+      if (toBuild.length === 0) return;
+
+      // Manifest commits are serialized through this chain so concurrent builds
+      // never race on the shared manifest object or its temp file. Each commit
+      // re-checks the epoch so a mid-build invalidate() can't resurrect a
+      // dropped rollup.
+      let commitChain: Promise<void> = Promise.resolve();
+      const commit = (period: string, meta: RollupPartitionMeta): Promise<void> => {
+        const run = commitChain.then(async () => {
+          if (this.epoch !== startEpoch) return;
           manifest = { ...manifest, builtAt: '', partitions: { ...manifest.partitions, [period]: meta } };
           this.manifest = manifest;
           this.validPeriods.add(period);
           await this.writeManifestAtomic(manifest);
+        });
+        commitChain = run.then(() => undefined, () => undefined);
+        return run;
+      };
+
+      const buildOne = async (period: string): Promise<void> => {
+        if (this.epoch !== startEpoch) return; // superseded before we started
+        const wantHash = computePartitionEtagHash(etagsByPeriod[period]);
+        try {
+          const outPath = this.partitionPath(period);
+          await mkdir(this.partitionDir(period), { recursive: true });
+          await this.runBuild(buildSql(period, outPath));
+          if (this.epoch !== startEpoch) return; // a drop landed during the build
+          const meta = await this.partitionMeta(outPath, wantHash);
+          await commit(period, meta);
         } catch (err: unknown) {
           logger.warn(`rollup: build failed for ${period} — ${err instanceof Error ? err.message : String(err)}`);
         }
-      }
+      };
+
+      await this.runBounded(toBuild, buildOne);
     });
+  }
+
+  /** Run `worker` over `items` with at most `buildConcurrency` in flight. */
+  private async runBounded(items: readonly string[], worker: (item: string) => Promise<void>): Promise<void> {
+    let next = 0;
+    const lanes = Math.min(this.buildConcurrency, items.length);
+    const run = async (): Promise<void> => {
+      while (next < items.length) {
+        const item = items[next++];
+        if (item !== undefined) await worker(item);
+      }
+    };
+    await Promise.all(Array.from({ length: lanes }, run));
   }
 
   private async partitionMeta(outPath: string, rawEtagHash: string): Promise<RollupPartitionMeta> {

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -241,9 +241,13 @@ export class RollupStore {
       let failures = 0;
       const completed: string[] = [];
       const completedSet = new Set<string>();
+      // `active` = periods whose build is in flight right now. The popover pulses
+      // these chips, so a parallel batch — where `done` stays 0 until builds land
+      // in a cluster — still visibly shows which months are being worked on.
+      const active = new Set<string>();
       const reportProgress = (): void => {
         const pending = periods.filter(p => !completedSet.has(p));
-        this.setStatus({ state: 'computing', done: completed.length, total, periods: [...completed, ...pending] });
+        this.setStatus({ state: 'computing', done: completed.length, total, periods: [...completed, ...pending], active: [...active] });
       };
       const markDone = (period: string): void => {
         if (!completedSet.has(period)) { completedSet.add(period); completed.push(period); }
@@ -285,19 +289,23 @@ export class RollupStore {
 
         const buildOne = async (period: string): Promise<void> => {
           if (this.epoch !== startEpoch) return; // superseded before we started
+          active.add(period);
+          reportProgress(); // chip starts pulsing the moment this period's build begins
           const wantHash = computePartitionEtagHash(etagsByPeriod[period]);
           try {
             const outPath = this.partitionPath(period);
             await mkdir(this.partitionDir(period), { recursive: true });
             await this.runBuild(buildSql(period, outPath));
-            if (this.epoch !== startEpoch) return; // a drop landed during the build
+            if (this.epoch !== startEpoch) { active.delete(period); return; } // a drop landed during the build
             const meta = await this.partitionMeta(outPath, wantHash);
             await commit(period, meta);
           } catch (err: unknown) {
             failures += 1;
             logger.warn(`rollup: build failed for ${period} — ${err instanceof Error ? err.message : String(err)}`);
           }
-          // Each finished period (built or failed) advances progress.
+          // Each finished period (built or failed) leaves the active set and
+          // advances progress.
+          active.delete(period);
           markDone(period);
         };
 
@@ -359,7 +367,7 @@ export class RollupStore {
     // ensuing warmup either drives this through to `ready` (via maintainPeriods,
     // which fills in the period list) or calls markSettled() when there's
     // nothing to rebuild.
-    this.setStatus({ state: 'computing', done: 0, total: 0, periods: [] });
+    this.setStatus({ state: 'computing', done: 0, total: 0, periods: [], active: [] });
     return this.enqueue(async () => {
       await rm(this.rollupDir(), { recursive: true, force: true });
     });

--- a/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
@@ -37,11 +37,21 @@ function formatMonth(period: string): string {
   return yy === '' ? name : `${name} '${yy}`;
 }
 
-function chipClass(isDone: boolean): string {
-  return isDone
-    ? 'rounded border border-accent/30 bg-accent/15 px-1.5 py-0.5 text-[10px] tabular-nums text-accent'
-    : 'rounded border border-border bg-bg-tertiary/40 px-1.5 py-0.5 text-[10px] tabular-nums text-text-muted';
+type ChipState = 'done' | 'building' | 'pending';
+
+function chipClass(state: ChipState): string {
+  const base = 'rounded border px-1.5 py-0.5 text-[10px] tabular-nums';
+  switch (state) {
+    // `building` is the brighter, pulsing variant — it's the only moving thing
+    // in the popover during a parallel batch, where `done` can sit at 0 for
+    // several seconds while builds run concurrently.
+    case 'building': return `${base} border-accent bg-accent/25 text-accent animate-pulse`;
+    case 'done': return `${base} border-accent/30 bg-accent/15 text-accent`;
+    case 'pending': return `${base} border-border bg-bg-tertiary/40 text-text-muted`;
+  }
 }
+
+const CHIP_TITLE: Record<ChipState, string> = { done: 'Rebuilt', building: 'Building…', pending: 'Pending' };
 
 function KpiRow({ label, value, accent }: Readonly<{ label: string; value: string; accent?: boolean }>): React.JSX.Element {
   return (
@@ -132,11 +142,14 @@ export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Eleme
             )}
             {status.periods.length > 0 && (
               <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto">
-                {status.periods.map((p, i) => (
-                  <span key={p} className={chipClass(i < status.done)} title={i < status.done ? 'Rebuilt' : 'Pending'}>
-                    {formatMonth(p)}
-                  </span>
-                ))}
+                {status.periods.map((p, i) => {
+                  const state: ChipState = i < status.done ? 'done' : status.active.includes(p) ? 'building' : 'pending';
+                  return (
+                    <span key={p} className={chipClass(state)} title={CHIP_TITLE[state]}>
+                      {formatMonth(p)}
+                    </span>
+                  );
+                })}
               </div>
             )}
           </div>


### PR DESCRIPTION
Closes #383.

[#379](https://github.com/etiennechabert/cost-goblin/pull/379) built rollup partitions **sequentially on one long-lived connection**. This makes two changes, matching the Phase 0 findings in the issue:

## 1. Fresh connection per period
Per-month build time *climbed* within a reused DuckDB connection (≈2s → ≈10s) as buffer/cache accumulated. Each partition now builds on a **fresh, disposable connection** that is disconnected (never returned to the pool) right after — so per-period time stays flat across the batch regardless of how many months are built.

- `duckdb-worker`: a `fresh` flag on the query request runs the SQL on a brand-new `instance.connect()` and `disconnectSync()`s it in `finally` instead of releasing to the pool. `getInstance()` exposes the initialized instance for off-pool connects. Fresh connections inherit the instance-global `memory_limit` / `threads` / `temp_directory`, and stay interruptible (still tracked in `runningConns`).
- `duckdb-client`: `runBuildQuery()` submits a fresh-connection query.

## 2. Parallelize across the pool
Independent per-month builds now run concurrently, bounded by the DuckDB pool size. `RollupStore.maintainPeriods` splits periods into already-valid (skipped) and to-build, then fans the builds out with a bounded runner. Manifest commits are **serialized through a chain** so concurrent builds never race on the shared manifest object or its temp file; the `epoch` guards that cancel a stale build are preserved, so a mid-build `invalidate()` still can't resurrect a dropped rollup.

`computeDefaultPoolSize()` is extracted into `duckdb-tuning` and shared by the worker pool and the build concurrency, so they agree on how many connections may run at once. The store defaults `buildConcurrency` to 1 (sequential) so the single-connection test harness stays safe; production passes the pool size.

## Result
A full-history rebuild drops from ~83s sequential toward the ~20s target, with stable per-period build time across the batch. Builds remain background/non-blocking — dashboards just become rollup-backed sooner after a cold build or config change.

A new test builds two months concurrently on fresh connections behind a gate that only trips once both builds are in flight, proving the overlap and that every manifest entry is committed.