### PR TITLE
feat(ui): show git branch in header for dev/source builds

### DIFF
--- a/packages/desktop/src/main/handlers/debug.ts
+++ b/packages/desktop/src/main/handlers/debug.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { app as electronApp, ipcMain } from 'electron';
+import { parseJsonObject } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
 const execFileAsync = promisify(execFile);
@@ -55,18 +56,22 @@ export function registerDebugHandlers(app: AppContext): void {
     }
   });
 
-  // URL of the open PR for the current branch, via the gh CLI. Null when not a
-  // dev checkout, gh is missing/unauthenticated, or no PR exists yet. The
-  // renderer uses this to turn the branch label into a link; absence just
-  // leaves it as plain text.
-  ipcMain.handle('debug:get-branch-pr-url', async (): Promise<string | null> => {
+  // Open PR for the current branch, via the gh CLI. Null when not a dev
+  // checkout, gh is missing/unauthenticated, or no PR exists yet. The renderer
+  // uses the title to replace the cryptic branch label and the url to link it;
+  // absence just leaves the plain branch name.
+  ipcMain.handle('debug:get-branch-pr', async (): Promise<{ url: string; title: string; number: number } | null> => {
     if (electronApp.isPackaged) return null;
     try {
-      const { stdout } = await execFileAsync('gh', ['pr', 'view', '--json', 'url', '-q', '.url'], {
+      const { stdout } = await execFileAsync('gh', ['pr', 'view', '--json', 'url,title,number'], {
         cwd: electronApp.getAppPath(),
       });
-      const url = stdout.trim();
-      return url.startsWith('https://') ? url : null;
+      const pr = parseJsonObject(stdout);
+      if (pr === null) return null;
+      const { url, title, number } = pr;
+      if (typeof url !== 'string' || !url.startsWith('https://')) return null;
+      if (typeof title !== 'string' || typeof number !== 'number') return null;
+      return { url, title, number };
     } catch {
       return null;
     }

--- a/packages/desktop/src/main/handlers/debug.ts
+++ b/packages/desktop/src/main/handlers/debug.ts
@@ -54,4 +54,21 @@ export function registerDebugHandlers(app: AppContext): void {
       return null;
     }
   });
+
+  // URL of the open PR for the current branch, via the gh CLI. Null when not a
+  // dev checkout, gh is missing/unauthenticated, or no PR exists yet. The
+  // renderer uses this to turn the branch label into a link; absence just
+  // leaves it as plain text.
+  ipcMain.handle('debug:get-branch-pr-url', async (): Promise<string | null> => {
+    if (electronApp.isPackaged) return null;
+    try {
+      const { stdout } = await execFileAsync('gh', ['pr', 'view', '--json', 'url', '-q', '.url'], {
+        cwd: electronApp.getAppPath(),
+      });
+      const url = stdout.trim();
+      return url.startsWith('https://') ? url : null;
+    } catch {
+      return null;
+    }
+  });
 }

--- a/packages/desktop/src/main/handlers/debug.ts
+++ b/packages/desktop/src/main/handlers/debug.ts
@@ -1,5 +1,9 @@
-import { ipcMain } from 'electron';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { app as electronApp, ipcMain } from 'electron';
 import type { AppContext } from './context.js';
+
+const execFileAsync = promisify(execFile);
 
 export function registerDebugHandlers(app: AppContext): void {
   ipcMain.handle('debug:get-query-log', () => {
@@ -33,5 +37,21 @@ export function registerDebugHandlers(app: AppContext): void {
 
   ipcMain.handle('debug:get-memory-mb', () => {
     return Math.round(process.memoryUsage().rss / 1024 / 1024);
+  });
+
+  // Current git branch — only meaningful in dev (a source checkout/worktree).
+  // Packaged builds aren't a repo, so return null and let the UI fall back to
+  // the version string. Detached HEAD also returns null.
+  ipcMain.handle('debug:get-git-branch', async (): Promise<string | null> => {
+    if (electronApp.isPackaged) return null;
+    try {
+      const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+        cwd: electronApp.getAppPath(),
+      });
+      const branch = stdout.trim();
+      return branch === '' || branch === 'HEAD' ? null : branch;
+    } catch {
+      return null;
+    }
   });
 }

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -414,6 +414,7 @@ contextBridge.exposeInMainWorld('costgoblinDebug', {
   isDev(): boolean { return process.env['NODE_ENV'] === 'development'; },
   isE2E(): boolean { return process.env['COSTGOBLIN_E2E'] === '1'; },
   getMemoryMB(): Promise<number> { return invoke<number>('debug:get-memory-mb'); },
+  getGitBranch(): Promise<string | null> { return invoke<string | null>('debug:get-git-branch'); },
   isSandboxed(): boolean { return process.sandboxed; },
   getInFlightCount(): number { return inFlightCount; },
   getQueryLog(): Promise<DebugQueryLogEntry[]> {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -415,6 +415,7 @@ contextBridge.exposeInMainWorld('costgoblinDebug', {
   isE2E(): boolean { return process.env['COSTGOBLIN_E2E'] === '1'; },
   getMemoryMB(): Promise<number> { return invoke<number>('debug:get-memory-mb'); },
   getGitBranch(): Promise<string | null> { return invoke<string | null>('debug:get-git-branch'); },
+  getBranchPrUrl(): Promise<string | null> { return invoke<string | null>('debug:get-branch-pr-url'); },
   isSandboxed(): boolean { return process.sandboxed; },
   getInFlightCount(): number { return inFlightCount; },
   getQueryLog(): Promise<DebugQueryLogEntry[]> {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -415,7 +415,7 @@ contextBridge.exposeInMainWorld('costgoblinDebug', {
   isE2E(): boolean { return process.env['COSTGOBLIN_E2E'] === '1'; },
   getMemoryMB(): Promise<number> { return invoke<number>('debug:get-memory-mb'); },
   getGitBranch(): Promise<string | null> { return invoke<string | null>('debug:get-git-branch'); },
-  getBranchPrUrl(): Promise<string | null> { return invoke<string | null>('debug:get-branch-pr-url'); },
+  getBranchPr(): Promise<BranchPrInfo | null> { return invoke<BranchPrInfo | null>('debug:get-branch-pr'); },
   isSandboxed(): boolean { return process.sandboxed; },
   getInFlightCount(): number { return inFlightCount; },
   getQueryLog(): Promise<DebugQueryLogEntry[]> {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -489,6 +489,7 @@ function AppShell(): React.JSX.Element {
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
   const [devBranch, setDevBranch] = useState<string | null>(null);
+  const [branchPrUrl, setBranchPrUrl] = useState<string | null>(null);
   const memoryMB = useMemoryMB();
   const autoOpenRef = useMemo(() => ({ current: false }), []);
   const initialViewSetRef = useRef(false);
@@ -513,6 +514,9 @@ function AppShell(): React.JSX.Element {
 
   useEffect(() => {
     globalThis.costgoblinDebug.getGitBranch().then(setDevBranch).catch(() => undefined);
+    // Resolved separately (a gh subprocess, ~0.5s) so the branch label never
+    // waits on the network — it upgrades to a link if/when a PR is found.
+    globalThis.costgoblinDebug.getBranchPrUrl().then(setBranchPrUrl).catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -912,11 +916,23 @@ function AppShell(): React.JSX.Element {
             <span className="text-sm font-bold text-accent tracking-wider leading-tight">CostGoblin</span>
             <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
               {devBranch !== null
-                ? (
-                  <span className="flex items-center gap-1 font-medium text-accent" title="Running from this git branch">
-                    <GitBranch size={10} />{devBranch}
-                  </span>
-                )
+                ? branchPrUrl !== null
+                  ? (
+                    <a
+                      href={branchPrUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex items-center gap-1 font-medium text-accent hover:underline [-webkit-app-region:no-drag]"
+                      title="Open this branch's pull request on GitHub"
+                    >
+                      <GitBranch size={10} />{devBranch}
+                    </a>
+                  )
+                  : (
+                    <span className="flex items-center gap-1 font-medium text-accent" title="Running from this git branch">
+                      <GitBranch size={10} />{devBranch}
+                    </span>
+                  )
                 : appVersion !== '' && <span>v{appVersion}</span>}
               {isDev && memoryMB > 0 && <span>{formatMemory(memoryMB)}</span>}
             </div>

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostS
 import type { NavItem, SettingsTabId } from '@costgoblin/ui';
 import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
-import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw, Settings, ArrowLeft } from 'lucide-react';
+import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw, Settings, ArrowLeft, GitBranch } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
 import { GeneralTab } from './settings/general-tab.js';
@@ -488,6 +488,7 @@ function AppShell(): React.JSX.Element {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: 'idle' });
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
+  const [devBranch, setDevBranch] = useState<string | null>(null);
   const memoryMB = useMemoryMB();
   const autoOpenRef = useMemo(() => ({ current: false }), []);
   const initialViewSetRef = useRef(false);
@@ -508,6 +509,10 @@ function AppShell(): React.JSX.Element {
 
   useEffect(() => {
     globalThis.costgoblinUpdate.getAppVersion().then(setAppVersion).catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    globalThis.costgoblinDebug.getGitBranch().then(setDevBranch).catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -906,7 +911,13 @@ function AppShell(): React.JSX.Element {
           <div className="flex flex-col items-center justify-center px-4">
             <span className="text-sm font-bold text-accent tracking-wider leading-tight">CostGoblin</span>
             <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
-              {appVersion !== '' && <span>v{appVersion}</span>}
+              {devBranch !== null
+                ? (
+                  <span className="flex items-center gap-1 font-medium text-accent" title="Running from this git branch">
+                    <GitBranch size={10} />{devBranch}
+                  </span>
+                )
+                : appVersion !== '' && <span>v{appVersion}</span>}
               {isDev && memoryMB > 0 && <span>{formatMemory(memoryMB)}</span>}
             </div>
           </div>

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostS
 import type { NavItem, SettingsTabId } from '@costgoblin/ui';
 import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
-import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw, Settings, ArrowLeft, GitBranch } from 'lucide-react';
+import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw, Settings, ArrowLeft, GitBranch, GitPullRequest } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
 import { GeneralTab } from './settings/general-tab.js';
@@ -489,7 +489,7 @@ function AppShell(): React.JSX.Element {
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
   const [devBranch, setDevBranch] = useState<string | null>(null);
-  const [branchPrUrl, setBranchPrUrl] = useState<string | null>(null);
+  const [branchPr, setBranchPr] = useState<BranchPrInfo | null>(null);
   const memoryMB = useMemoryMB();
   const autoOpenRef = useMemo(() => ({ current: false }), []);
   const initialViewSetRef = useRef(false);
@@ -515,8 +515,9 @@ function AppShell(): React.JSX.Element {
   useEffect(() => {
     globalThis.costgoblinDebug.getGitBranch().then(setDevBranch).catch(() => undefined);
     // Resolved separately (a gh subprocess, ~0.5s) so the branch label never
-    // waits on the network — it upgrades to a link if/when a PR is found.
-    globalThis.costgoblinDebug.getBranchPrUrl().then(setBranchPrUrl).catch(() => undefined);
+    // waits on the network — it upgrades to the PR title + link if/when a PR
+    // is found.
+    globalThis.costgoblinDebug.getBranchPr().then(setBranchPr).catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -915,25 +916,26 @@ function AppShell(): React.JSX.Element {
           <div className="flex flex-col items-center justify-center px-4">
             <span className="text-sm font-bold text-accent tracking-wider leading-tight">CostGoblin</span>
             <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
-              {devBranch !== null
-                ? branchPrUrl !== null
+              {branchPr !== null
+                ? (
+                  <a
+                    href={branchPr.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-1 max-w-[320px] font-medium text-accent hover:underline [-webkit-app-region:no-drag]"
+                    title={`#${String(branchPr.number)} ${branchPr.title} — open on GitHub`}
+                  >
+                    <GitPullRequest size={10} className="shrink-0" />
+                    <span className="truncate">#{branchPr.number} {branchPr.title}</span>
+                  </a>
+                )
+                : devBranch !== null
                   ? (
-                    <a
-                      href={branchPrUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="flex items-center gap-1 font-medium text-accent hover:underline [-webkit-app-region:no-drag]"
-                      title="Open this branch's pull request on GitHub"
-                    >
-                      <GitBranch size={10} />{devBranch}
-                    </a>
-                  )
-                  : (
                     <span className="flex items-center gap-1 font-medium text-accent" title="Running from this git branch">
                       <GitBranch size={10} />{devBranch}
                     </span>
                   )
-                : appVersion !== '' && <span>v{appVersion}</span>}
+                  : appVersion !== '' && <span>v{appVersion}</span>}
               {isDev && memoryMB > 0 && <span>{formatMemory(memoryMB)}</span>}
             </div>
           </div>

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -20,6 +20,7 @@ declare global {
     isE2E(): boolean;
     getMemoryMB(): Promise<number>;
     getGitBranch(): Promise<string | null>;
+    getBranchPrUrl(): Promise<string | null>;
     getInFlightCount(): number;
     getQueryLog(): Promise<DebugQueryLogEntry[]>;
     runExplain(queryId: number): Promise<string>;

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -15,12 +15,18 @@ declare global {
     readonly origin: string | null;
   }
 
+  interface BranchPrInfo {
+    readonly url: string;
+    readonly title: string;
+    readonly number: number;
+  }
+
   interface DebugApi {
     isDev(): boolean;
     isE2E(): boolean;
     getMemoryMB(): Promise<number>;
     getGitBranch(): Promise<string | null>;
-    getBranchPrUrl(): Promise<string | null>;
+    getBranchPr(): Promise<BranchPrInfo | null>;
     getInFlightCount(): number;
     getQueryLog(): Promise<DebugQueryLogEntry[]>;
     runExplain(queryId: number): Promise<string>;

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -19,6 +19,7 @@ declare global {
     isDev(): boolean;
     isE2E(): boolean;
     getMemoryMB(): Promise<number>;
+    getGitBranch(): Promise<string | null>;
     getInFlightCount(): number;
     getQueryLog(): Promise<DebugQueryLogEntry[]>;
     runExplain(queryId: number): Promise<string>;


### PR DESCRIPTION
## What

In a source checkout (`npm run dev`, or any unpackaged build), the header now shows the current **git branch name** in place of the `v{version}` string under the CostGoblin title. Packaged release builds are unchanged — they still show `v{version}`.

![header showing branch name](https://github.com/etiennechabert/cost-goblin/assets/placeholder)

`CostGoblin` / `⎇ claude/amazing-nobel-06309a` (accent green, branch icon)

## Why

When working across several feature branches in separate worktrees, every running window looked identical. Surfacing the branch makes it obvious which feature/worktree a given window belongs to.

## How

- **`debug.ts`** — new `debug:get-git-branch` IPC handler. Gated on `!app.isPackaged`, runs `git rev-parse --abbrev-ref HEAD` via `execFile` (no shell, fixed args) with `cwd: app.getAppPath()` so it resolves the *worktree's* branch. Returns `null` on error or detached HEAD.
- **`preload.ts` / `env.d.ts`** — exposed `getGitBranch()` on the existing `costgoblinDebug` bridge (dev-only metadata, alongside the memory readout).
- **`App.tsx`** — header renders the branch (with a `GitBranch` icon) when present, otherwise the version. One `git` spawn per app launch; skipped entirely in packaged builds.

## Notes for reviewers

- The gate is `!app.isPackaged`, **not** `NODE_ENV` — so the branch also appears in any unpackaged source run, not only `npm run dev`. A real packaged release (`isPackaged === true`) returns `null` → version shows as before.
- No version bump: latest tag is `v0.4.0`, `package.json` is already at `0.4.1` (one release ahead).

## Verification

Built and ran the Electron app via the project's `_electron.launch` harness:
- `getGitBranch()` IPC returned `"claude/amazing-nobel-06309a"`, matching `git rev-parse --abbrev-ref HEAD`.
- Header block rendered the branch and dropped the version (confirmed it *replaces*, not appends).
- Fallback path confirmed: `git rev-parse` outside a repo exits 128 → handler `catch` returns `null` → UI falls back to the version.