### PR TITLE
feat(dashboard): "updating…" badge on widgets while a rollup partition re-rolls

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -97,6 +97,17 @@ export type AutoSyncStatus =
   | { readonly state: 'syncing'; readonly tier: string; readonly filesDone: number; readonly filesTotal: number }
   | { readonly state: 'error'; readonly message: string; readonly lastRun: string | null };
 
+/** Background rollup-maintenance state surfaced to the renderer so the dashboard
+ *  can badge affected widgets "updating…" while a partition re-rolls.
+ *  `reRollingPeriods` lists the YYYY-MM months whose ALREADY-BUILT partition is
+ *  currently being rebuilt after a sync changed that month — the old numbers are
+ *  still served meanwhile, so the figure is briefly stale, not wrong. A month
+ *  being built for the FIRST time is deliberately NOT listed: that case keeps the
+ *  widget's normal loading state. */
+export interface RollupStatus {
+  readonly reRollingPeriods: readonly string[];
+}
+
 export interface OrgSyncProgress {
   readonly phase: 'accounts' | 'ous' | 'tags' | 'regions';
   readonly done: number;
@@ -198,6 +209,11 @@ export interface CostApi {
   getAutoSyncIntervalMinutes(): Promise<number>;
   setAutoSyncIntervalMinutes(minutes: number): Promise<void>;
   getAutoSyncStatus(): Promise<AutoSyncStatus>;
+  /** Which already-built rollup partitions (YYYY-MM) are currently being
+   *  re-rolled in the background after a sync changed their month. Polled by the
+   *  dashboard to show an "updating…" badge on affected widgets; empty when no
+   *  re-roll is in flight. First-time builds are not reported here. */
+  getRollupStatus(): Promise<RollupStatus>;
   /** Whether the scheduler automatically prunes out-of-retention local data on
    *  each run. Off by default. Shares the auto-sync scheduler — enabling it
    *  starts the scheduler even when auto-download is off. */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,7 +65,7 @@ export type {
 } from './query.js';
 export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, RollupStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -32,6 +32,7 @@ import type {
   DimensionsConfig,
   OrgNode,
   RegionEnrichment,
+  RollupStatus,
   SyncStatus,
   ViewsConfig,
 } from '@costgoblin/core';
@@ -166,6 +167,9 @@ export interface AppContext {
   readonly warmupBase: () => void;
   /** Re-roll the rollup partitions for the periods a sync changed. */
   readonly maintainRollup: (changedPeriods: readonly string[]) => void;
+  /** Which already-built partitions (YYYY-MM) are mid-re-roll right now. Polled
+   *  by the renderer to badge affected dashboard widgets "updating…". */
+  readonly getRollupStatus: () => RollupStatus;
   /** Resolve once the latest cost_base warmup settles (true if the base is
    *  ready, false if it timed out or no base was built). Lets the renderer
    *  hold the startup prewarm until the in-memory base exists, so those probes
@@ -440,6 +444,20 @@ export function createAppContext(ctx: IpcContext): AppContext {
   const rollupStore = new RollupStore({ dataDir: ctx.dataDir, runQuery: (sql) => ctx.db.runQuery(sql) });
   const resultCache = new LRUCache<string, RawRow[]>(50);
 
+  // YYYY-MM partitions currently being re-rolled after a sync, ref-counted so
+  // overlapping maintain calls don't clear a period's "updating" flag early.
+  // Only periods that ALREADY had a valid partition are tracked — a first-time
+  // build keeps the widget's normal loading state. Surfaced via getRollupStatus
+  // and polled by the dashboard to badge affected widgets.
+  const reRolling = new Map<string, number>();
+  function markReRolling(periods: readonly string[], delta: 1 | -1): void {
+    for (const p of periods) {
+      const next = (reRolling.get(p) ?? 0) + delta;
+      if (next <= 0) reRolling.delete(p);
+      else reRolling.set(p, next);
+    }
+  }
+
   const wrappedRunQuery = queryLog.wrapQuery((sql, onStarted) => ctx.db.runQuery(sql, onStarted));
   const wrappedRunPreparedQuery = queryLog.wrapPreparedQuery((sql, params, onStarted) => ctx.db.runPreparedQuery(sql, params, onStarted));
 
@@ -541,6 +559,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
   // Re-roll only the periods a sync changed (file replace), then drop cached
   // results so dashboards re-render from the fresh partitions.
   async function maintainRollupForPeriods(changed: readonly string[]): Promise<void> {
+    const reRolled: string[] = [];
     try {
       const available = await listLocalMonths(ctx.dataDir, 'daily');
       const periods = changed.filter(p => available.includes(p));
@@ -548,11 +567,19 @@ export function createAppContext(ctx: IpcContext): AppContext {
       const shape = await getRollupShape();
       const etags = await getEtagsByPeriod();
       if (!rollupStore.isReady()) await rollupStore.loadAndValidate(shape, etags);
+      // A period with an existing valid partition is a re-roll: the old numbers
+      // stay served while we rebuild → flag it "updating". A brand-new month is
+      // a first build → no flag, so the widget shows its normal loading state.
+      const valid = rollupStore.getValidPeriods();
+      reRolled.push(...periods.filter(p => valid.has(p)));
+      markReRolling(reRolled, 1);
       const buildSql = await buildRollupSqlFor();
       await rollupStore.maintainPeriods(periods, buildSql, etags, shape, { force: true });
       resultCache.clear();
     } catch (err: unknown) {
       logger.warn(`rollup-maintain: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      markReRolling(reRolled, -1);
     }
   }
 
@@ -592,6 +619,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     invalidateColumnCache: () => { columnCache.clear(); },
     warmupBase: () => { resultCache.clear(); triggerWarmup(); },
     maintainRollup: (changedPeriods: readonly string[]) => { void maintainRollupForPeriods(changedPeriods); },
+    getRollupStatus: (): RollupStatus => ({ reRollingPeriods: [...reRolling.keys()] }),
     awaitWarmup: async (timeoutMs: number): Promise<boolean> => {
       await awaitWithTimeout(warmupInFlight, timeoutMs);
       return rollupStore.isReady();

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -19,6 +19,7 @@ import type {
   AccountMappingStatus,
   AccountMappingEntry,
   PruneResult,
+  RollupStatus,
   SyncStatus,
 } from '@costgoblin/core';
 import {
@@ -157,6 +158,8 @@ export function registerSyncHandlers(app: AppContext): void {
   ipcMain.handle('sync:status', (_event, syncId: string = 'default'): SyncStatus => {
     return state.syncStatuses[syncId] ?? { status: 'idle', lastSync: null };
   });
+
+  ipcMain.handle('rollup:status', (): RollupStatus => app.getRollupStatus());
 
   ipcMain.handle('data:inventory', async (_event, tier?: ExpectedDataType): Promise<DataInventory> => {
     const config = await getConfig();

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -28,6 +28,7 @@ import type {
   OrgSyncResult,
   OrgSyncProgress,
   AutoSyncStatus,
+  RollupStatus,
   PruneResult,
   ViewsConfig,
   CostScopeCapabilities,
@@ -128,6 +129,9 @@ const api: CostApi = {
   },
   getSyncStatus(syncId?: string): Promise<SyncStatus> {
     return invoke<SyncStatus>('sync:status', syncId);
+  },
+  getRollupStatus(): Promise<RollupStatus> {
+    return invoke<RollupStatus>('rollup:status');
   },
   getConfig(): Promise<CostGoblinConfig> {
     return invoke<CostGoblinConfig>('config:get');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -15,6 +15,7 @@ import {
   type MissingTagsResult,
   type OrgNode,
   type PruneResult,
+  type RollupStatus,
   type SavingsResult,
   type SyncStatus,
   type TrendResult,
@@ -247,6 +248,7 @@ export class MockCostApi implements CostApi {
   }
   queryEntityDetail(): Promise<EntityDetailResult> { return Promise.resolve(entityDetailResult); }
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
+  getRollupStatus(): Promise<RollupStatus> { return Promise.resolve({ reRollingPeriods: [] }); }
   getConfig(): Promise<CostGoblinConfig> { return Promise.resolve(config); }
   getDimensions(): Promise<Dimension[]> { return Promise.resolve(mockDimensions); }
   getOrgTree(): Promise<OrgNode[]> { return Promise.resolve(orgTree); }

--- a/packages/ui/src/components/updating-badge.tsx
+++ b/packages/ui/src/components/updating-badge.tsx
@@ -1,0 +1,18 @@
+/** Non-blocking corner badge shown on a dashboard widget while its underlying
+ *  rollup partition re-rolls after a sync. Signals the figure is briefly stale
+ *  (the previous partition's numbers) rather than wrong. */
+export function UpdatingBadge(): React.JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-full border border-border bg-bg-secondary/90 px-2 py-0.5 text-[11px] font-medium text-text-secondary shadow-sm backdrop-blur"
+    >
+      <span
+        aria-hidden="true"
+        className="inline-block h-2.5 w-2.5 animate-spin rounded-full border-2 border-border border-t-accent"
+      />
+      updating…
+    </div>
+  );
+}

--- a/packages/ui/src/hooks/use-rollup-status.ts
+++ b/packages/ui/src/hooks/use-rollup-status.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import type { CostApi } from '@costgoblin/core/browser';
+
+/**
+ * Poll the background rollup-maintenance state so the dashboard can badge
+ * widgets "updating…" while a partition re-rolls after a sync.
+ *
+ * Returns the YYYY-MM months whose existing partition is currently being
+ * re-rolled (empty the rest of the time). Re-rolls are short (a few seconds)
+ * and only follow a sync, so we poll a touch faster while one is in flight and
+ * back off when idle — enough to catch the window and clear promptly without a
+ * constant tight loop. Mounted only on the dashboard, so polling stops on
+ * navigation away.
+ */
+const IDLE_INTERVAL_MS = 2500;
+const ACTIVE_INTERVAL_MS = 1500;
+
+export function useRollupStatus(api: CostApi, enabled = true): readonly string[] {
+  const [periods, setPeriods] = useState<readonly string[]>([]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setPeriods([]);
+      return undefined;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    async function tick(): Promise<void> {
+      let next: readonly string[] = [];
+      try {
+        const status = await api.getRollupStatus();
+        next = status.reRollingPeriods;
+      } catch { /* transient — treat as idle */ }
+      if (cancelled) return;
+      setPeriods(prev => (sameSet(prev, next) ? prev : next));
+      timer = setTimeout(() => { tick().catch(() => undefined); }, next.length > 0 ? ACTIVE_INTERVAL_MS : IDLE_INTERVAL_MS);
+    }
+
+    tick().catch(() => undefined);
+    return () => { cancelled = true; if (timer !== undefined) clearTimeout(timer); };
+  }, [api, enabled]);
+
+  return periods;
+}
+
+/** Stable-identity guard so widgets don't re-render on every idle poll. */
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every(p => set.has(p));
+}

--- a/packages/ui/src/hooks/widget-load-scheduler.tsx
+++ b/packages/ui/src/hooks/widget-load-scheduler.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
+import { UpdatingBadge } from '../components/updating-badge.js';
 
 /**
  * Dashboard widget load coordination.
@@ -153,6 +154,7 @@ export function LazyWidgetSlot({
   minHeight,
   className,
   style,
+  updating = false,
   children,
 }: Readonly<{
   id: string;
@@ -160,6 +162,9 @@ export function LazyWidgetSlot({
   minHeight: number;
   className?: string;
   style?: CSSProperties;
+  /** Overlay an "updating…" badge — the widget's rollup partition is re-rolling
+   *  so its figure is briefly stale. Only shown once the widget is mounted. */
+  updating?: boolean;
   children: ReactNode;
 }>): React.JSX.Element {
   const scheduler = useContext(SchedulerContext);
@@ -189,7 +194,8 @@ export function LazyWidgetSlot({
   }, [isMounted, scheduler, id]);
 
   return (
-    <div ref={ref} className={className} style={style}>
+    <div ref={ref} className={`relative ${className ?? ''}`} style={style}>
+      {updating && isMounted && <UpdatingBadge />}
       {isMounted
         ? <WidgetSlotContext.Provider value={slotHandle}>{children}</WidgetSlotContext.Provider>
         : <div aria-hidden style={{ minHeight }} />}

--- a/packages/ui/src/lib/dates.ts
+++ b/packages/ui/src/lib/dates.ts
@@ -13,6 +13,24 @@ export function daysAgo(days: number): DateString {
   return asDateString(d.toISOString().slice(0, 10));
 }
 
+/** The YYYY-MM months an inclusive `start`..`end` date range touches, in order.
+ *  Used to test whether a date range overlaps a re-rolling rollup partition. */
+export function monthsInRange(start: string, end: string): string[] {
+  const months: string[] = [];
+  const s = new Date(`${start.slice(0, 10)}T00:00:00Z`);
+  const e = new Date(`${end.slice(0, 10)}T00:00:00Z`);
+  let year = s.getUTCFullYear();
+  let month = s.getUTCMonth();
+  const endYear = e.getUTCFullYear();
+  const endMonth = e.getUTCMonth();
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    months.push(`${String(year)}-${String(month + 1).padStart(2, '0')}`);
+    month += 1;
+    if (month > 11) { month = 0; year += 1; }
+  }
+  return months;
+}
+
 /** Format a date as YYYY-MM-DD in UTC. */
 function formatDateUTC(date: Date): DateString {
   const year = String(date.getUTCFullYear());

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -3,7 +3,7 @@ import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser
 import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
-import { daysBetween } from '../lib/dates.js';
+import { daysBetween, monthsInRange } from '../lib/dates.js';
 import type {
   Dimension,
   DimensionId,
@@ -12,8 +12,9 @@ import type {
   TagValue,
   ViewSpec,
 } from '@costgoblin/core/browser';
-import { useCostApi } from '../hooks/use-cost-api.js';
+import { useCostApi, CostApiProvider } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
+import { useRollupStatus } from '../hooks/use-rollup-status.js';
 import { useQuery } from '../hooks/use-query.js';
 import {
   CostFocusDispatchProvider,
@@ -135,6 +136,34 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
     () => previousRangeFor(dateRange),
     [dateRange],
   );
+
+  // While a sync re-rolls a rollup partition this view's range touches, badge
+  // the affected widgets "updating…" — their figure is briefly stale, not wrong.
+  // In compare mode the previous-period months are queried too, so fold them in.
+  const reRollingPeriods = useRollupStatus(api);
+  const rangeMonths = useMemo(() => {
+    const months = monthsInRange(dateRange.start, dateRange.end);
+    if (!compareEnabled) return months;
+    return [...new Set([...months, ...monthsInRange(previousDateRange.start, previousDateRange.end)])];
+  }, [dateRange.start, dateRange.end, compareEnabled, previousDateRange.start, previousDateRange.end]);
+  const rangeIsReRolling = useMemo(
+    () => reRollingPeriods.some(p => rangeMonths.includes(p)),
+    [reRollingPeriods, rangeMonths],
+  );
+
+  // When a re-roll affecting this range finishes, its partition is fresh and the
+  // main-process result cache has been cleared — but the mounted widgets won't
+  // re-query on their own (their deps are query-shaping inputs only). On the
+  // re-rolling→idle transition, hand the widget subtree a fresh CostApi identity:
+  // every widget keys its query on `api`, so this re-runs their fetch in place
+  // against the rebuilt partition (the badge clears in the same render).
+  const [dataEpoch, setDataEpoch] = useState(0);
+  const wasReRollingRef = useRef(false);
+  useEffect(() => {
+    if (wasReRollingRef.current && !rangeIsReRolling) setDataEpoch(e => e + 1);
+    wasReRollingRef.current = rangeIsReRolling;
+  }, [rangeIsReRolling]);
+  const widgetApi = useMemo(() => new Proxy(api, {}), [api, dataEpoch]);
 
   // Cancel in-flight DuckDB queries when query-affecting state changes so
   // stale queries don't hog pool connections while new ones queue behind them.
@@ -295,6 +324,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
         <div className="text-sm text-text-secondary">Loading...</div>
       )}
 
+      <CostApiProvider value={widgetApi}>
       <WidgetSchedulerProvider>
         {spec.rows.map((row, rowIdx) => {
           // Flat display order across rows = load priority (top-left first).
@@ -311,6 +341,9 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
                     minHeight={placeholderMinHeight(w.type)}
                     className="min-w-0 flex flex-col"
                     style={{ flexBasis: widgetFlexBasis(w.size), flexGrow: 1, flexShrink: 1 }}
+                    // The Table widget reads raw (not the rollup), so it isn't
+                    // stale during a re-roll — no badge for it.
+                    updating={rangeIsReRolling && w.type !== 'table'}
                   >
                     <Renderer
                       spec={w}
@@ -331,6 +364,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
           );
         })}
       </WidgetSchedulerProvider>
+      </CostApiProvider>
     </div>
   );
 }


### PR DESCRIPTION
## What

Implements [#384](https://github.com/etiennechabert/cost-goblin/issues/384) (`docs/rollup-design.md` §5 — serve-while-re-rolling, deferred in #379).

When a sync changes a month, that partition re-rolls in the background and the dashboard result cache is cleared. Today widgets serve the previous partition's numbers silently. This surfaces the rollup-maintenance state to the renderer and shows a non-blocking **"updating…"** badge on affected dashboard widgets, so a briefly-stale figure reads as *updating* rather than *wrong*. A true first build keeps its normal loading state.

## How

**Main process**
- `handlers/context.ts` ref-counts which months are mid-re-roll in `maintainRollupForPeriods`. Only periods that **already have a valid partition** are tracked — a first-time build is excluded, so brand-new months keep their loading state (per the acceptance criteria). Exposed via `getRollupStatus()` on `AppContext`.
- New `rollup:status` IPC channel (`handlers/sync.ts`).

**Core / boundary**
- New `RollupStatus` type + `getRollupStatus()` on the `CostApi` interface; implemented in the preload bridge and the mock API.

**Renderer**
- `useRollupStatus` polls `getRollupStatus()` (adaptive 1.5s active / 2.5s idle, mounted only on the dashboard).
- `custom-view.tsx` badges widgets whose date range overlaps a re-rolling month (compare-period months folded in when comparison is on). The Table widget reads raw, not the rollup, so it isn't badged.
- When a re-roll affecting the range completes, the widget subtree is handed a fresh `CostApi` identity (`new Proxy(api, {})`), so the widgets refetch the rebuilt partition in place — the main-process result cache is already cleared at that point.

## Acceptance criteria

- ✅ Badge appears during a sync-triggered re-roll of an existing partition, and clears on completion.
- ✅ First build still shows a loading state (not the badge).

## Reviewer notes

- **No version bump** — `0.4.1` is already one release ahead of the latest tag `v0.4.0`.
- `npm run check` passes (tsc × 4 projects + eslint + vitest, 742 passed / 5 skipped); also enforced by the pre-commit hook.
- Reviewed via an adversarial multi-agent pass; two findings were fixed before this PR: (1) widgets didn't refetch after the re-roll completed → fixed with the scoped `CostApi` identity swap; (2) compare-period months weren't badged → fixed by folding `previousDateRange` months into the overlap test.
- Live-sync verification (a real S3 sync that restates an existing month) wasn't run in this environment; the badge/refetch path is covered by the type system and the existing test suite, and the re-roll trigger reuses the established `maintainRollup` flow.
