### PR TITLE
feat(rollup): grain cost/benefit estimator with raw-only flagging

### DIFF
--- a/packages/core/src/__tests__/rollup-estimator.test.ts
+++ b/packages/core/src/__tests__/rollup-estimator.test.ts
@@ -48,6 +48,11 @@ describe('isDimRawOnly', () => {
   });
   it('keeps a low-cardinality dim', () => {
     expect(isDimRawOnly(38, 2_100_000, 16)).toBe(false);
+    expect(isDimRawOnly(900, 50_000_000, 16)).toBe(false); // just under the high-card floor
+  });
+  it('flags a high-cardinality dim even when it compresses fine alone', () => {
+    // usage_type-class: many values, a primary driver when combined with others.
+    expect(isDimRawOnly(5_000, 50_000_000, 16)).toBe(true);
   });
   it('flags on absolute partition bytes even without a line-item baseline', () => {
     // 4M distinct × 16 bytes = 64 MB > 50 MB threshold.
@@ -62,6 +67,7 @@ describe('computeRollupEstimate', () => {
       months: 12,
       probeGrainRows: 92_000,
       probeLineItems: 2_100_000,
+      rawBytes: 4_900_000_000,
       current: { rows: 1_100_000, bytes: 17_600_000 },
       dimCardinalities: [
         { column: 'account_id', cardinality: 14 },
@@ -74,6 +80,9 @@ describe('computeRollupEstimate', () => {
     expect(e.rawOnly.recommended).toBe(false);
     expect(e.dims.every(d => !d.rawOnly)).toBe(true);
     expect(e.candidate.growthFactor).toBeCloseTo((92_000 * 12) / 1_100_000, 2);
+    // Raw baseline: line items × months, with the actual on-disk byte size.
+    expect(e.raw.rows).toBe(2_100_000 * 12);
+    expect(e.raw.bytes).toBe(4_900_000_000);
   });
 
   it('recommends raw-only when a monthly partition exceeds the byte threshold', () => {
@@ -82,6 +91,7 @@ describe('computeRollupEstimate', () => {
       months: 12,
       probeGrainRows: 5_000_000, // × 16 bytes = 80 MB/partition
       probeLineItems: 6_000_000,
+      rawBytes: 30_000_000_000,
       current: null,
       dimCardinalities: [{ column: 'resource_id', cardinality: 5_000_000 }],
     });
@@ -97,20 +107,23 @@ describe('computeRollupEstimate', () => {
       months: 1,
       probeGrainRows: 300_000, // 4.8 MB/partition — under the byte threshold
       probeLineItems: 1_000_000,
+      rawBytes: 2_000_000_000,
       current: { rows: 100_000, bytes: 1_600_000 },
-      dimCardinalities: [{ column: 'usage_type', cardinality: 5_000 }],
+      // A low-cardinality dim so neither the byte nor the high-card per-dim rule
+      // fires — the recommendation comes purely from the 3× growth.
+      dimCardinalities: [{ column: 'region', cardinality: 200 }],
     });
     expect(e.candidate.perPartitionBytes).toBeLessThan(RAW_ONLY_PARTITION_BYTES);
     expect(e.candidate.growthFactor).toBeCloseTo(3, 1);
     expect(e.rawOnly.recommended).toBe(true);
     expect(e.rawOnly.reason).toContain('×');
-    // The single 5k-cardinality dim is not itself raw-only.
+    // The single 200-cardinality dim is not itself raw-only.
     expect(e.dims[0]?.rawOnly).toBe(false);
   });
 
   it('treats months as at least 1', () => {
     const e = computeRollupEstimate({
-      probePeriod: '2026-04', months: 0, probeGrainRows: 1000, probeLineItems: 10_000, current: null, dimCardinalities: [],
+      probePeriod: '2026-04', months: 0, probeGrainRows: 1000, probeLineItems: 10_000, rawBytes: 0, current: null, dimCardinalities: [],
     });
     expect(e.months).toBe(1);
     expect(e.candidate.rows).toBe(1000);
@@ -122,6 +135,7 @@ describe('emptyRollupEstimate', () => {
     const e = emptyRollupEstimate({ rows: 10, bytes: 160 });
     expect(e.probePeriod).toBe('');
     expect(e.current).toEqual({ rows: 10, bytes: 160 });
+    expect(e.raw).toEqual({ rows: 0, bytes: 0 });
     expect(e.rawOnly.recommended).toBe(false);
     expect(e.dims).toEqual([]);
   });

--- a/packages/core/src/__tests__/rollup-estimator.test.ts
+++ b/packages/core/src/__tests__/rollup-estimator.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeRollupEstimate,
+  emptyRollupEstimate,
+  isDimRawOnly,
+  estimateBytesPerRow,
+  classifySizeBand,
+  classifyRebuildBand,
+  RAW_ONLY_PARTITION_BYTES,
+  DEFAULT_BYTES_PER_ROW,
+} from '../rollup/estimator.js';
+
+const MB = 1024 * 1024;
+
+describe('estimateBytesPerRow', () => {
+  it('derives bytes/row from the current rollup when present', () => {
+    expect(estimateBytesPerRow({ rows: 1000, bytes: 20000 })).toBe(20);
+  });
+  it('falls back to the default when there is no rollup', () => {
+    expect(estimateBytesPerRow(null)).toBe(DEFAULT_BYTES_PER_ROW);
+    expect(estimateBytesPerRow({ rows: 0, bytes: 0 })).toBe(DEFAULT_BYTES_PER_ROW);
+  });
+});
+
+describe('classifySizeBand', () => {
+  it('buckets bytes into bands', () => {
+    expect(classifySizeBand(4 * MB)).toBe('tiny');
+    expect(classifySizeBand(6 * MB)).toBe('small');
+    expect(classifySizeBand(100 * MB)).toBe('moderate');
+    expect(classifySizeBand(500 * MB)).toBe('large');
+    expect(classifySizeBand(2048 * MB)).toBe('huge');
+  });
+});
+
+describe('classifyRebuildBand', () => {
+  it('buckets seconds into bands', () => {
+    expect(classifyRebuildBand(3)).toBe('instant');
+    expect(classifyRebuildBand(10)).toBe('fast');
+    expect(classifyRebuildBand(60)).toBe('moderate');
+    expect(classifyRebuildBand(200)).toBe('slow');
+  });
+});
+
+describe('isDimRawOnly', () => {
+  it('flags a dim whose distinct count approaches the line-item count', () => {
+    // resource_id-class: ~unique per line item destroys compression.
+    expect(isDimRawOnly(1_820_000, 2_100_000, 16)).toBe(true);
+  });
+  it('keeps a low-cardinality dim', () => {
+    expect(isDimRawOnly(38, 2_100_000, 16)).toBe(false);
+  });
+  it('flags on absolute partition bytes even without a line-item baseline', () => {
+    // 4M distinct × 16 bytes = 64 MB > 50 MB threshold.
+    expect(isDimRawOnly(4_000_000, 0, 16)).toBe(true);
+  });
+});
+
+describe('computeRollupEstimate', () => {
+  it('reports a stable grain as not raw-only with healthy compression', () => {
+    const e = computeRollupEstimate({
+      probePeriod: '2026-04',
+      months: 12,
+      probeGrainRows: 92_000,
+      probeLineItems: 2_100_000,
+      current: { rows: 1_100_000, bytes: 17_600_000 },
+      dimCardinalities: [
+        { column: 'account_id', cardinality: 14 },
+        { column: 'service', cardinality: 38 },
+      ],
+    });
+    expect(e.candidate.rows).toBe(92_000 * 12);
+    expect(e.candidate.sizeBand).toBe('small');
+    expect(e.compressionRate).toBeCloseTo(2_100_000 / 92_000, 1);
+    expect(e.rawOnly.recommended).toBe(false);
+    expect(e.dims.every(d => !d.rawOnly)).toBe(true);
+    expect(e.candidate.growthFactor).toBeCloseTo((92_000 * 12) / 1_100_000, 2);
+  });
+
+  it('recommends raw-only when a monthly partition exceeds the byte threshold', () => {
+    const e = computeRollupEstimate({
+      probePeriod: '2026-04',
+      months: 12,
+      probeGrainRows: 5_000_000, // × 16 bytes = 80 MB/partition
+      probeLineItems: 6_000_000,
+      current: null,
+      dimCardinalities: [{ column: 'resource_id', cardinality: 5_000_000 }],
+    });
+    expect(e.candidate.perPartitionBytes).toBeGreaterThan(RAW_ONLY_PARTITION_BYTES);
+    expect(e.rawOnly.recommended).toBe(true);
+    expect(e.rawOnly.reason).toContain('MB');
+    expect(e.dims[0]?.rawOnly).toBe(true);
+  });
+
+  it('recommends raw-only when the grain is more than 2× the current rollup', () => {
+    const e = computeRollupEstimate({
+      probePeriod: '2026-04',
+      months: 1,
+      probeGrainRows: 300_000, // 4.8 MB/partition — under the byte threshold
+      probeLineItems: 1_000_000,
+      current: { rows: 100_000, bytes: 1_600_000 },
+      dimCardinalities: [{ column: 'usage_type', cardinality: 5_000 }],
+    });
+    expect(e.candidate.perPartitionBytes).toBeLessThan(RAW_ONLY_PARTITION_BYTES);
+    expect(e.candidate.growthFactor).toBeCloseTo(3, 1);
+    expect(e.rawOnly.recommended).toBe(true);
+    expect(e.rawOnly.reason).toContain('×');
+    // The single 5k-cardinality dim is not itself raw-only.
+    expect(e.dims[0]?.rawOnly).toBe(false);
+  });
+
+  it('treats months as at least 1', () => {
+    const e = computeRollupEstimate({
+      probePeriod: '2026-04', months: 0, probeGrainRows: 1000, probeLineItems: 10_000, current: null, dimCardinalities: [],
+    });
+    expect(e.months).toBe(1);
+    expect(e.candidate.rows).toBe(1000);
+  });
+});
+
+describe('emptyRollupEstimate', () => {
+  it('carries the current stats but reports no probe', () => {
+    const e = emptyRollupEstimate({ rows: 10, bytes: 160 });
+    expect(e.probePeriod).toBe('');
+    expect(e.current).toEqual({ rows: 10, bytes: 160 });
+    expect(e.rawOnly.recommended).toBe(false);
+    expect(e.dims).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/rollup-probe.test.ts
+++ b/packages/core/src/__tests__/rollup-probe.test.ts
@@ -95,7 +95,7 @@ describe('buildGrainProbeQuery', () => {
     expect(grainRows).toBeLessThan(lineItems);
 
     const estimate = computeRollupEstimate({
-      probePeriod: PERIOD, months: 1, probeGrainRows: grainRows, probeLineItems: lineItems,
+      probePeriod: PERIOD, months: 1, probeGrainRows: grainRows, probeLineItems: lineItems, rawBytes: 0,
       current: null, dimCardinalities: [...cards].map(([column, cardinality]) => ({ column, cardinality })),
     });
     expect(estimate.compressionRate).toBeGreaterThan(1);
@@ -114,7 +114,7 @@ describe('buildGrainProbeQuery', () => {
     expect(resourceCard).toBeGreaterThan(serviceCard * 10);
 
     const estimate = computeRollupEstimate({
-      probePeriod: PERIOD, months: 1, probeGrainRows: withResource.grainRows, probeLineItems: withResource.lineItems,
+      probePeriod: PERIOD, months: 1, probeGrainRows: withResource.grainRows, probeLineItems: withResource.lineItems, rawBytes: 0,
       current: null,
       dimCardinalities: [...withResource.cards].map(([column, cardinality]) => ({ column, cardinality })),
     });

--- a/packages/core/src/__tests__/rollup-probe.test.ts
+++ b/packages/core/src/__tests__/rollup-probe.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildGrainProbeQuery } from '../query/builder.js';
+import { rollupGrainColumns } from '../rollup/grain.js';
+import { computeRollupEstimate } from '../rollup/estimator.js';
+import type { DimensionsConfig } from '../types/config.js';
+import type { CostScopeConfig } from '../types/cost-scope.js';
+import { asDimensionId } from '../types/branded.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SYNTHETIC_DIR = join(__dirname, '..', '__fixtures__', 'synthetic');
+const PERIOD = '2026-01';
+
+const scope: CostScopeConfig = { costMetric: 'unblended', costPerspective: 'gross', rules: [] };
+
+const stableGrain: DimensionsConfig = {
+  builtIn: [
+    { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' },
+    { name: asDimensionId('service'), label: 'Service', field: 'service' },
+    { name: asDimensionId('region'), label: 'Region', field: 'region' },
+  ],
+  tags: [
+    { tagName: 'team', label: 'Team', concept: 'owner' },
+    { tagName: 'environment', label: 'Environment', concept: 'environment' },
+  ],
+};
+
+// Same grain + the high-cardinality resource_id built-in enabled.
+const resourceGrain: DimensionsConfig = {
+  ...stableGrain,
+  builtIn: [...stableGrain.builtIn, { name: asDimensionId('resource_id'), label: 'Resource', field: 'resource_id' }],
+};
+
+interface Row { [k: string]: unknown }
+
+async function queryAll(conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>, sql: string): Promise<Row[]> {
+  const result = await conn.run(sql);
+  const cols = result.columnCount;
+  const names: string[] = [];
+  for (let i = 0; i < cols; i++) names.push(result.columnName(i));
+  const rows: Row[] = [];
+  let chunk = await result.fetchChunk();
+  while (chunk !== null && chunk.rowCount > 0) {
+    for (let r = 0; r < chunk.rowCount; r++) {
+      const row: Row = {};
+      for (let c = 0; c < cols; c++) {
+        const name = names[c];
+        if (name !== undefined) row[name] = chunk.getColumnVector(c).getItem(r);
+      }
+      rows.push(row);
+    }
+    chunk = await result.fetchChunk();
+  }
+  return rows;
+}
+
+function toNum(v: unknown): number {
+  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'number') return v;
+  return 0;
+}
+
+/** Run the probe and return line_items, grain_rows, and a column→cardinality
+ *  map (mirroring the desktop handler's card_<i> decoding). */
+async function probe(
+  conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>,
+  dimensions: DimensionsConfig,
+): Promise<{ lineItems: number; grainRows: number; cards: Map<string, number> }> {
+  const grain = rollupGrainColumns(dimensions);
+  const cardCols = grain.filter(c => c !== 'usage_date');
+  const sql = buildGrainProbeQuery(PERIOD, grain, { dataDir: SYNTHETIC_DIR, dimensions, costScope: scope });
+  const row = (await queryAll(conn, sql))[0];
+  const cards = new Map<string, number>();
+  cardCols.forEach((col, i) => { cards.set(col, toNum(row?.[`card_${String(i)}`])); });
+  return { lineItems: toNum(row?.['line_items']), grainRows: toNum(row?.['grain_rows']), cards };
+}
+
+describe('buildGrainProbeQuery', () => {
+  let db: Awaited<ReturnType<typeof DuckDBInstance.create>>;
+  let conn: Awaited<ReturnType<typeof db.connect>>;
+
+  beforeAll(async () => {
+    db = await DuckDBInstance.create();
+    conn = await db.connect();
+  });
+  afterAll(async () => { /* in-memory db, nothing to clean */ });
+
+  it('a stable grain aggregates well below the line-item count', async () => {
+    const { lineItems, grainRows, cards } = await probe(conn, stableGrain);
+    expect(lineItems).toBeGreaterThan(0);
+    expect(grainRows).toBeGreaterThan(0);
+    // Pre-aggregation must collapse rows — the stable grain compresses raw.
+    expect(grainRows).toBeLessThan(lineItems);
+
+    const estimate = computeRollupEstimate({
+      probePeriod: PERIOD, months: 1, probeGrainRows: grainRows, probeLineItems: lineItems,
+      current: null, dimCardinalities: [...cards].map(([column, cardinality]) => ({ column, cardinality })),
+    });
+    expect(estimate.compressionRate).toBeGreaterThan(1);
+    expect(estimate.dims.find(d => d.column === 'resource_id')).toBeUndefined();
+    expect(estimate.dims.every(d => !d.rawOnly)).toBe(true);
+  });
+
+  it('flags resource_id raw-only: it is near-unique per line item', async () => {
+    const withResource = await probe(conn, resourceGrain);
+
+    // resource_id is ~unique per row, so its distinct count dwarfs every other
+    // dimension and approaches the line-item count — no aggregation to be had.
+    const resourceCard = withResource.cards.get('resource_id') ?? 0;
+    const serviceCard = withResource.cards.get('service') ?? 0;
+    expect(resourceCard).toBeGreaterThan(withResource.lineItems * 0.5);
+    expect(resourceCard).toBeGreaterThan(serviceCard * 10);
+
+    const estimate = computeRollupEstimate({
+      probePeriod: PERIOD, months: 1, probeGrainRows: withResource.grainRows, probeLineItems: withResource.lineItems,
+      current: null,
+      dimCardinalities: [...withResource.cards].map(([column, cardinality]) => ({ column, cardinality })),
+    });
+    // The data-driven verdict: resource_id is raw-only, the others are not.
+    expect(estimate.dims.find(d => d.column === 'resource_id')?.rawOnly).toBe(true);
+    expect(estimate.dims.find(d => d.column === 'service')?.rawOnly).toBe(false);
+    expect(estimate.dims.find(d => d.column === 'account_id')?.rawOnly).toBe(false);
+  });
+});

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -10,6 +10,8 @@ export type {
   RollupGrainEstimate,
   RollupDimEstimate,
   RollupCurrentStats,
+  RollupRawStats,
   RollupSizeBand,
   RollupRebuildBand,
 } from './rollup/estimator.js';
+export { computeRollupEstimate, emptyRollupEstimate, classifySizeBand } from './rollup/estimator.js';

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -6,3 +6,10 @@ export { widgetToYaml, viewToYaml, viewsConfigToYaml } from './config/views-seri
 export { ConfigValidationError } from './config/validator.js';
 export { isDiscoverableBeaconLocation, splitS3Location, suggestedConfigBeaconLocation } from './config/sharing-location.js';
 export { DEFAULT_COST_SCOPE, DEFAULT_MARKETPLACE_ATTRIBUTION, BUILTIN_EXCLUSION_RULES } from './config/cost-scope-seed.js';
+export type {
+  RollupGrainEstimate,
+  RollupDimEstimate,
+  RollupCurrentStats,
+  RollupSizeBand,
+  RollupRebuildBand,
+} from './rollup/estimator.js';

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1093,3 +1093,62 @@ export function buildRollupPartitionQuery(
   const escapedPath = outPath.replaceAll("'", "''");
   return `COPY (${select}) TO '${escapedPath}' (FORMAT PARQUET)`;
 }
+
+/** Build the cardinality probe behind the grain cost/benefit estimator (rollup
+ *  design §8). Over ONE recent month it returns, in a single scan:
+ *   - `line_items`  — COUNT(*) (the rollup's raw input for that month),
+ *   - `grain_rows`  — `approx_count_distinct` of the candidate grain tuple
+ *      (≈ the rollup row count for that month), and
+ *   - `card_<i>`    — `approx_count_distinct` of each non-date grain column,
+ *      so the estimator can flag individual raw-only dims (e.g. resource_id).
+ *
+ *  `grainColumns` come from `rollupGrainColumns` over the candidate dimensions
+ *  (usage_date first) and are projected by `buildSource` — the same trusted set
+ *  `buildRollupPartitionQuery` interpolates. Exclusion rows are dropped so the
+ *  counts match what the rollup would actually store. `chr(31)` (unit separator)
+ *  joins the tuple so distinct values never collide across columns. */
+export function buildGrainProbeQuery(
+  period: string,
+  grainColumns: readonly string[],
+  opts: QueryContextOptions,
+): string {
+  if (!/^\d{4}-\d{2}$/.test(period)) {
+    throw new SecurityError(`Invalid probe period "${period}" — expected YYYY-MM.`);
+  }
+  const { dataDir, dimensions, orgAccountsPath, accountReverseMap, costScope, availableColumns } = opts;
+  const costMetric = costScope?.costMetric ?? 'unblended';
+  const costPerspective = costScope?.costPerspective ?? 'gross';
+
+  const source = buildSource({
+    dataDir, tier: 'daily', dimensions, orgAccountsPath, periods: [period],
+    costMetric, availableColumns, costPerspective,
+    marketplaceAttribution: costScope?.marketplaceAttribution,
+    includeRawTags: false, slim: true,
+  });
+
+  const exclusionClauses: string[] = [];
+  if (costScope !== undefined) {
+    for (const rule of costScope.rules) {
+      if (!rule.enabled) continue;
+      const matchExpr = buildRuleMatchExpr(rule, dimensions, accountReverseMap);
+      if (matchExpr === null) continue;
+      exclusionClauses.push(`NOT (${matchExpr})`);
+    }
+  }
+
+  const start = `${period}-01`;
+  const end = periodUpperBound(period);
+  assertDateString(start);
+  assertDateString(end);
+  const whereConditions = [`usage_date >= '${start}'`, `usage_date < '${end}'`, ...exclusionClauses];
+
+  const grainConcat = `concat_ws(chr(31), ${grainColumns.join(', ')})`;
+  const cardCols = grainColumns.filter(c => c !== 'usage_date');
+  const cardSelects = cardCols.map((c, i) => `CAST(approx_count_distinct(${c}) AS BIGINT) AS card_${String(i)}`);
+  const selects = [
+    `CAST(COUNT(*) AS BIGINT) AS line_items`,
+    `CAST(approx_count_distinct(${grainConcat}) AS BIGINT) AS grain_rows`,
+    ...cardSelects,
+  ];
+  return `SELECT ${selects.join(', ')} FROM ${source} WHERE ${whereConditions.join(' AND ')}`;
+}

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -8,6 +8,7 @@ export {
   buildSource,
   buildMaterializeBaseQuery,
   buildRollupPartitionQuery,
+  buildGrainProbeQuery,
   buildRuleMatchExpr,
   computePeriodsInRange,
 } from './builder.js';

--- a/packages/core/src/rollup/estimator.ts
+++ b/packages/core/src/rollup/estimator.ts
@@ -1,0 +1,182 @@
+/**
+ * Grain cost/benefit estimator (rollup design §8).
+ *
+ * When the user toggles a dashboard dimension the rollup grain changes, which
+ * re-rolls every partition in the background. This module turns a cheap
+ * recent-month cardinality probe (run by the desktop handler) into the
+ * cost/benefit numbers shown before the user commits: estimated size, how much
+ * the rollup compresses the raw line items, an approximate rebuild time, and a
+ * data-driven "raw-only" recommendation for ultra-high-cardinality dims such as
+ * `resource_id`.
+ *
+ * The numbers are deliberately DIRECTIONAL, not exact — the probe samples a
+ * single recent month (≈ −10% on stable grains, ≈ +35% on high-cardinality
+ * dims), so the UI presents bands. The real figure lands after the rebuild.
+ */
+
+const MB = 1024 * 1024;
+
+/** A candidate grain is too expensive for the rollup when a single monthly
+ *  partition would exceed this. Matches §8's "a partition > 50 MB". */
+export const RAW_ONLY_PARTITION_BYTES = 50 * MB;
+/** …or when the candidate grain is more than this multiple of the current
+ *  rollup (§8's "> 2× current rollup"). */
+export const RAW_ONLY_GROWTH_FACTOR = 2;
+/** A single dimension is raw-only when its distinct-value count exceeds this
+ *  fraction of the month's line items — at that point it provides almost no
+ *  aggregation, so it belongs in raw, not the rollup. Catches `resource_id`
+ *  (≈ unique per line item) even on tiny datasets where the byte threshold
+ *  never trips. */
+export const RAW_ONLY_COMPRESSION_FLOOR = 0.5;
+/** Fallback bytes-per-rollup-row when there is no built rollup to measure
+ *  against (≈ the measured 266 MB / 19.6M rows from the design appendix). */
+export const DEFAULT_BYTES_PER_ROW = 16;
+
+const REBUILD_BASE_SECONDS_PER_PARTITION = 2;
+const REBUILD_SECONDS_PER_ROW = 0.0000048;
+
+export type RollupSizeBand = 'tiny' | 'small' | 'moderate' | 'large' | 'huge';
+export type RollupRebuildBand = 'instant' | 'fast' | 'moderate' | 'slow';
+
+export interface RollupCurrentStats {
+  readonly rows: number;
+  readonly bytes: number;
+}
+
+/** Per-dimension cardinality + the raw-only verdict for that column alone. */
+export interface RollupDimEstimate {
+  readonly column: string;
+  readonly cardinality: number;
+  readonly rawOnly: boolean;
+}
+
+export interface RollupGrainEstimate {
+  /** YYYY-MM the candidate was probed from; '' when there is no data on disk. */
+  readonly probePeriod: string;
+  /** Months of raw data on disk — scales the per-month probe to a window total. */
+  readonly months: number;
+  /** Line items in the probe month (the rollup's raw input for that month). */
+  readonly lineItems: number;
+  /** Exact totals summed from the on-disk rollup manifest; null when none built. */
+  readonly current: RollupCurrentStats | null;
+  readonly candidate: {
+    readonly rows: number;
+    readonly bytes: number;
+    readonly perPartitionBytes: number;
+    readonly sizeBand: RollupSizeBand;
+    readonly rebuildSeconds: number;
+    readonly rebuildBand: RollupRebuildBand;
+    /** candidate.rows ÷ current.rows, or null when there is no current rollup. */
+    readonly growthFactor: number | null;
+  };
+  /** Line items ÷ rollup rows — how much the rollup compresses the raw data. */
+  readonly compressionRate: number;
+  readonly rawOnly: { readonly recommended: boolean; readonly reason: string | null };
+  readonly dims: readonly RollupDimEstimate[];
+}
+
+export interface RollupEstimateInput {
+  readonly probePeriod: string;
+  readonly months: number;
+  /** approx_count_distinct over the candidate grain tuple in the probe month. */
+  readonly probeGrainRows: number;
+  /** COUNT(*) in the probe month. */
+  readonly probeLineItems: number;
+  readonly current: RollupCurrentStats | null;
+  readonly dimCardinalities: readonly { readonly column: string; readonly cardinality: number }[];
+}
+
+export function estimateBytesPerRow(current: RollupCurrentStats | null): number {
+  return current !== null && current.rows > 0 ? current.bytes / current.rows : DEFAULT_BYTES_PER_ROW;
+}
+
+/** A single dimension is raw-only when keeping it in the rollup would blow past
+ *  the per-partition byte budget, or when it barely aggregates at all (distinct
+ *  values approach the line-item count). */
+export function isDimRawOnly(cardinality: number, lineItems: number, bytesPerRow: number): boolean {
+  if (cardinality * bytesPerRow > RAW_ONLY_PARTITION_BYTES) return true;
+  if (lineItems > 0 && cardinality > lineItems * RAW_ONLY_COMPRESSION_FLOOR) return true;
+  return false;
+}
+
+export function classifySizeBand(bytes: number): RollupSizeBand {
+  if (bytes < 5 * MB) return 'tiny';
+  if (bytes < 50 * MB) return 'small';
+  if (bytes < 250 * MB) return 'moderate';
+  if (bytes < 1024 * MB) return 'large';
+  return 'huge';
+}
+
+export function classifyRebuildBand(seconds: number): RollupRebuildBand {
+  if (seconds < 5) return 'instant';
+  if (seconds < 30) return 'fast';
+  if (seconds < 120) return 'moderate';
+  return 'slow';
+}
+
+export function computeRollupEstimate(input: RollupEstimateInput): RollupGrainEstimate {
+  const months = Math.max(1, input.months);
+  const bytesPerRow = estimateBytesPerRow(input.current);
+  const perPartitionRows = input.probeGrainRows;
+  const perPartitionBytes = perPartitionRows * bytesPerRow;
+  const rows = perPartitionRows * months;
+  const bytes = rows * bytesPerRow;
+  const rebuildSeconds = months * REBUILD_BASE_SECONDS_PER_PARTITION + rows * REBUILD_SECONDS_PER_ROW;
+  const compressionRate = perPartitionRows > 0 ? input.probeLineItems / perPartitionRows : 0;
+  const growthFactor = input.current !== null && input.current.rows > 0 ? rows / input.current.rows : null;
+
+  const byPartition = perPartitionBytes > RAW_ONLY_PARTITION_BYTES;
+  const byGrowth = growthFactor !== null && growthFactor > RAW_ONLY_GROWTH_FACTOR;
+  const reason = byPartition
+    ? `a monthly partition would be ~${String(Math.round(perPartitionBytes / MB))} MB — over the ${String(Math.round(RAW_ONLY_PARTITION_BYTES / MB))} MB raw-only threshold`
+    : byGrowth
+      ? `this grain is ~${growthFactor.toFixed(1)}× the current rollup`
+      : null;
+
+  const dims = input.dimCardinalities.map(d => ({
+    column: d.column,
+    cardinality: d.cardinality,
+    rawOnly: isDimRawOnly(d.cardinality, input.probeLineItems, bytesPerRow),
+  }));
+
+  return {
+    probePeriod: input.probePeriod,
+    months,
+    lineItems: input.probeLineItems,
+    current: input.current,
+    candidate: {
+      rows,
+      bytes,
+      perPartitionBytes,
+      sizeBand: classifySizeBand(bytes),
+      rebuildSeconds,
+      rebuildBand: classifyRebuildBand(rebuildSeconds),
+      growthFactor,
+    },
+    compressionRate,
+    rawOnly: { recommended: byPartition || byGrowth, reason },
+    dims,
+  };
+}
+
+/** The estimate returned when there is no data on disk to probe. */
+export function emptyRollupEstimate(current: RollupCurrentStats | null): RollupGrainEstimate {
+  return {
+    probePeriod: '',
+    months: 0,
+    lineItems: 0,
+    current,
+    candidate: {
+      rows: 0,
+      bytes: 0,
+      perPartitionBytes: 0,
+      sizeBand: 'tiny',
+      rebuildSeconds: 0,
+      rebuildBand: 'instant',
+      growthFactor: null,
+    },
+    compressionRate: 0,
+    rawOnly: { recommended: false, reason: null },
+    dims: [],
+  };
+}

--- a/packages/core/src/rollup/estimator.ts
+++ b/packages/core/src/rollup/estimator.ts
@@ -28,6 +28,14 @@ export const RAW_ONLY_GROWTH_FACTOR = 2;
  *  (≈ unique per line item) even on tiny datasets where the byte threshold
  *  never trips. */
 export const RAW_ONLY_COMPRESSION_FLOOR = 0.5;
+/** A dimension with at least this many distinct values is a high-cardinality
+ *  driver: it multiplies the grain enough to be a primary contributor to rollup
+ *  size, so it's flagged for the user even when the whole-grain byte/growth
+ *  thresholds are reached by a *combination* of dims rather than this one alone.
+ *  This is what surfaces `resource_id` / `usage_type` / `operation` as the
+ *  dims to consider keeping raw-only — data-driven, not a hardcoded list.
+ *  Navigational dims (account, region, service, tags) sit far below it. */
+export const HIGH_CARDINALITY_VALUES = 1000;
 /** Fallback bytes-per-rollup-row when there is no built rollup to measure
  *  against (≈ the measured 266 MB / 19.6M rows from the design appendix). */
 export const DEFAULT_BYTES_PER_ROW = 16;
@@ -43,7 +51,16 @@ export interface RollupCurrentStats {
   readonly bytes: number;
 }
 
-/** Per-dimension cardinality + the raw-only verdict for that column alone. */
+/** The raw dataset baseline the rollup is derived from — the reference point
+ *  for "how much smaller is the rollup". `rows` is the line-item count over the
+ *  window; `bytes` is the actual on-disk size of the raw daily Parquet. */
+export interface RollupRawStats {
+  readonly rows: number;
+  readonly bytes: number;
+}
+
+/** Per-dimension cardinality + whether it's flagged as a high-cardinality
+ *  driver of rollup size (the amber badge in the UI). */
 export interface RollupDimEstimate {
   readonly column: string;
   readonly cardinality: number;
@@ -57,6 +74,9 @@ export interface RollupGrainEstimate {
   readonly months: number;
   /** Line items in the probe month (the rollup's raw input for that month). */
   readonly lineItems: number;
+  /** The raw dataset the rollup compresses — shown as the size/row baseline so
+   *  the estimated rollup figures are comparable to something concrete. */
+  readonly raw: RollupRawStats;
   /** Exact totals summed from the on-disk rollup manifest; null when none built. */
   readonly current: RollupCurrentStats | null;
   readonly candidate: {
@@ -82,6 +102,8 @@ export interface RollupEstimateInput {
   readonly probeGrainRows: number;
   /** COUNT(*) in the probe month. */
   readonly probeLineItems: number;
+  /** Actual on-disk size of the raw daily Parquet across the whole window. */
+  readonly rawBytes: number;
   readonly current: RollupCurrentStats | null;
   readonly dimCardinalities: readonly { readonly column: string; readonly cardinality: number }[];
 }
@@ -90,12 +112,17 @@ export function estimateBytesPerRow(current: RollupCurrentStats | null): number 
   return current !== null && current.rows > 0 ? current.bytes / current.rows : DEFAULT_BYTES_PER_ROW;
 }
 
-/** A single dimension is raw-only when keeping it in the rollup would blow past
- *  the per-partition byte budget, or when it barely aggregates at all (distinct
- *  values approach the line-item count). */
+/** Whether a single dimension is a high-cardinality driver worth flagging:
+ *  - it alone would blow past the per-partition byte budget, or
+ *  - it barely aggregates (distinct values approach the line-item count — e.g.
+ *    `resource_id`), or
+ *  - it simply has many distinct values, making it a primary contributor to
+ *    rollup size whenever the grain as a whole is heavy (`usage_type`,
+ *    `operation`, …). The navigational dims sit far below `HIGH_CARDINALITY_VALUES`. */
 export function isDimRawOnly(cardinality: number, lineItems: number, bytesPerRow: number): boolean {
   if (cardinality * bytesPerRow > RAW_ONLY_PARTITION_BYTES) return true;
   if (lineItems > 0 && cardinality > lineItems * RAW_ONLY_COMPRESSION_FLOOR) return true;
+  if (cardinality >= HIGH_CARDINALITY_VALUES) return true;
   return false;
 }
 
@@ -125,24 +152,28 @@ export function computeRollupEstimate(input: RollupEstimateInput): RollupGrainEs
   const compressionRate = perPartitionRows > 0 ? input.probeLineItems / perPartitionRows : 0;
   const growthFactor = input.current !== null && input.current.rows > 0 ? rows / input.current.rows : null;
 
+  const dims = input.dimCardinalities.map(d => ({
+    column: d.column,
+    cardinality: d.cardinality,
+    rawOnly: isDimRawOnly(d.cardinality, input.probeLineItems, bytesPerRow),
+  }));
+  const flaggedCount = dims.filter(d => d.rawOnly).length;
+
   const byPartition = perPartitionBytes > RAW_ONLY_PARTITION_BYTES;
   const byGrowth = growthFactor !== null && growthFactor > RAW_ONLY_GROWTH_FACTOR;
+  // Fallback message for a grain that's heavy without any single high-card dim
+  // to point at; when dims ARE flagged the UI names them instead.
   const reason = byPartition
     ? `a monthly partition would be ~${String(Math.round(perPartitionBytes / MB))} MB — over the ${String(Math.round(RAW_ONLY_PARTITION_BYTES / MB))} MB raw-only threshold`
     : byGrowth
       ? `this grain is ~${growthFactor.toFixed(1)}× the current rollup`
       : null;
 
-  const dims = input.dimCardinalities.map(d => ({
-    column: d.column,
-    cardinality: d.cardinality,
-    rawOnly: isDimRawOnly(d.cardinality, input.probeLineItems, bytesPerRow),
-  }));
-
   return {
     probePeriod: input.probePeriod,
     months,
     lineItems: input.probeLineItems,
+    raw: { rows: input.probeLineItems * months, bytes: input.rawBytes },
     current: input.current,
     candidate: {
       rows,
@@ -154,7 +185,7 @@ export function computeRollupEstimate(input: RollupEstimateInput): RollupGrainEs
       growthFactor,
     },
     compressionRate,
-    rawOnly: { recommended: byPartition || byGrowth, reason },
+    rawOnly: { recommended: byPartition || byGrowth || flaggedCount > 0, reason },
     dims,
   };
 }
@@ -165,6 +196,7 @@ export function emptyRollupEstimate(current: RollupCurrentStats | null): RollupG
     probePeriod: '',
     months: 0,
     lineItems: 0,
+    raw: { rows: 0, bytes: 0 },
     current,
     candidate: {
       rows: 0,

--- a/packages/core/src/rollup/index.ts
+++ b/packages/core/src/rollup/index.ts
@@ -1,3 +1,4 @@
 export * from './shape-signature.js';
 export * from './manifest.js';
 export * from './grain.js';
+export * from './estimator.js';

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,4 +1,5 @@
 import type { BuiltInDimension, CostGoblinConfig, DimensionsConfig, NormalizationRule, OrgNode, TagDimension } from './config.js';
+import type { RollupGrainEstimate } from '../rollup/estimator.js';
 import type { AliasSuggestion } from '../normalize/similarity.js';
 import type { ViewsConfig } from './views.js';
 import type { CostScopeCapabilities, CostScopeConfig, CostScopePreviewResult } from './cost-scope.js';
@@ -162,6 +163,11 @@ export interface CostApi {
   discoverColumnValues(field: string, opts?: { useOrgAccounts?: boolean; accountNameFromTag?: string; nameStripPatterns?: readonly string[]; normalize?: NormalizationRule; useRegionNames?: boolean; dimName?: string }): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }>;
   getDimensionsConfig(): Promise<DimensionsConfig>;
   saveDimensionsConfig(config: DimensionsConfig): Promise<void>;
+  /** Estimate the rollup cost/benefit of a candidate dimensions config before
+   *  committing the (background) re-roll: directional size/compression/rebuild
+   *  bands plus per-dimension raw-only flags (rollup design §8). Probes a recent
+   *  month, so it needs data on disk — returns an empty estimate otherwise. */
+  estimateRollupGrain(candidate: DimensionsConfig): Promise<RollupGrainEstimate>;
   /** User-defined dashboard views. Read-modify-write through `saveViewsConfig`.
    *  `resetViewsConfig` overwrites the file with the seed (Cost Overview) view. */
   getViewsConfig(): Promise<ViewsConfig>;

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
-import { applyNormalizationRule, applyStripPatterns, buildSource, dimensionsConfigToYaml, generateAliasSuggestions, isStringRecord } from '@costgoblin/core';
-import type { AliasSuggestion, DimensionsConfig, NormalizationRule } from '@costgoblin/core';
+import { applyNormalizationRule, applyStripPatterns, buildGrainProbeQuery, buildSource, computeRollupEstimate, dimensionsConfigToYaml, emptyRollupEstimate, generateAliasSuggestions, isStringRecord, rollupGrainColumns } from '@costgoblin/core';
+import type { AliasSuggestion, DimensionsConfig, NormalizationRule, RollupGrainEstimate } from '@costgoblin/core';
 import { type AppContext, loadOrgAccountsMap } from './context.js';
 import { toNum, toStr } from './query-utils.js';
 
@@ -77,7 +77,7 @@ function filterUncoveredSuggestions(
 }
 
 export function registerDimensionsHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, getQueryDimensions, getCostScope, getAvailableColumns, getOrgAccountsPath, getRegionMap, invalidateDimensions, runQuery } = app;
+  const { ctx, getConfig, getDimensions, getQueryDimensions, getCostScope, getAvailableColumns, getOrgAccountsPath, getAccountReverseMap, getRegionMap, invalidateDimensions, rollupStore, runQuery } = app;
 
   ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
@@ -229,6 +229,48 @@ export function registerDimensionsHandlers(app: AppContext): void {
 
   ipcMain.handle('dimensions:save-config', async (_event, config: DimensionsConfig): Promise<void> => {
     await saveDimensionsConfig(config);
+  });
+
+  // Grain cost/benefit estimator (rollup design §8). Probes the most recent
+  // daily month for the candidate grain's cardinality and turns it into
+  // directional size/compression/rebuild bands + per-dim raw-only flags. Cheap
+  // (one scan, ~150–550 ms) so the UI can call it live as dims are toggled.
+  ipcMain.handle('dimensions:estimate-rollup-grain', async (_event, candidate: DimensionsConfig): Promise<RollupGrainEstimate> => {
+    const current = rollupStore.getStats();
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
+    let dirs: string[] = [];
+    try {
+      dirs = (await fs.readdir(rawDir)).filter(d => /^daily-\d{4}-(0[1-9]|1[0-2])$/.test(d)).sort((a, b) => a.localeCompare(b));
+    } catch { /* no data */ }
+    const latest = dirs.at(-1);
+    if (latest === undefined) return emptyRollupEstimate(current);
+
+    const period = latest.replace(/^daily-/, '');
+    const grainColumns = rollupGrainColumns(candidate);
+    const cardCols = grainColumns.filter(c => c !== 'usage_date');
+
+    const costScope = await getCostScope().catch(() => undefined);
+    const availableColumns = await getAvailableColumns('daily');
+    const orgAccountsPath = await getOrgAccountsPath();
+    const accountReverseMap = await getAccountReverseMap();
+    const sql = buildGrainProbeQuery(period, grainColumns, {
+      dataDir: ctx.dataDir, dimensions: candidate, orgAccountsPath, accountReverseMap, costScope, availableColumns,
+    });
+    const rows = await runQuery(sql);
+    const row = rows[0];
+    if (row === undefined) return { ...emptyRollupEstimate(current), probePeriod: period, months: dirs.length };
+
+    const dimCardinalities = cardCols.map((column, i) => ({ column, cardinality: toNum(row[`card_${String(i)}`]) }));
+    return computeRollupEstimate({
+      probePeriod: period,
+      months: dirs.length,
+      probeGrainRows: toNum(row['grain_rows']),
+      probeLineItems: toNum(row['line_items']),
+      current,
+      dimCardinalities,
+    });
   });
 
   ipcMain.handle('dimensions:get-alias-suggestions', async (_event, tagName: string): Promise<AliasSuggestion[]> => {

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -262,12 +262,17 @@ export function registerDimensionsHandlers(app: AppContext): void {
     const row = rows[0];
     if (row === undefined) return { ...emptyRollupEstimate(current), probePeriod: period, months: dirs.length };
 
+    // Actual on-disk size of the raw daily Parquet across the window — the
+    // baseline the UI shows the estimated rollup against.
+    const rawBytes = await sumParquetBytes(fs, path, rawDir, dirs);
+
     const dimCardinalities = cardCols.map((column, i) => ({ column, cardinality: toNum(row[`card_${String(i)}`]) }));
     return computeRollupEstimate({
       probePeriod: period,
       months: dirs.length,
       probeGrainRows: toNum(row['grain_rows']),
       probeLineItems: toNum(row['line_items']),
+      rawBytes,
       current,
       dimCardinalities,
     });
@@ -345,6 +350,28 @@ export function registerDimensionsHandlers(app: AppContext): void {
     ];
     await saveDimensionsConfig({ ...config, tags: updatedTags });
   });
+}
+
+/** Sum the on-disk size of every `*.parquet` across the given daily raw dirs —
+ *  the raw dataset size the rollup estimate is compared against. Best-effort:
+ *  unreadable dirs/files are skipped. */
+async function sumParquetBytes(
+  fs: typeof import('node:fs/promises'),
+  path: typeof import('node:path'),
+  rawDir: string,
+  dirs: readonly string[],
+): Promise<number> {
+  let total = 0;
+  for (const dir of dirs) {
+    const full = path.join(rawDir, dir);
+    let files: string[] = [];
+    try { files = await fs.readdir(full); } catch { continue; }
+    for (const f of files) {
+      if (!f.endsWith('.parquet')) continue;
+      try { total += (await fs.stat(path.join(full, f))).size; } catch { /* skip */ }
+    }
+  }
+  return total;
 }
 
 interface DismissedEntry {

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -90,6 +90,18 @@ export class RollupStore {
   isReady(): boolean { return this.manifest !== null && this.validPeriods.size > 0; }
   getValidPeriods(): ReadonlySet<string> { return this.validPeriods; }
 
+  /** Exact on-disk rollup totals (summed over every built partition) for the
+   *  grain estimator's "current grain" baseline. null when nothing is built. */
+  getStats(): { rows: number; bytes: number; months: number } | null {
+    if (this.manifest === null) return null;
+    const parts = Object.values(this.manifest.partitions);
+    if (parts.length === 0) return null;
+    let rows = 0;
+    let bytes = 0;
+    for (const p of parts) { rows += p.rows; bytes += p.bytes; }
+    return { rows, bytes, months: parts.length };
+  }
+
   /** Serialize a mutation; the callback receives the epoch captured at enqueue
    *  time so it can detect a concurrent invalidate() and abort its commit. */
   private enqueue<T>(fn: (epoch: number) => Promise<T>): Promise<T> {

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -57,6 +57,7 @@ import type {
   SharedPullProgress,
   SharedPullSelection,
   SharedSourceInfo,
+  RollupGrainEstimate,
 } from '@costgoblin/core';
 
 // ---------------------------------------------------------------------------
@@ -227,6 +228,9 @@ const api: CostApi = {
   },
   saveDimensionsConfig(config: DimensionsConfig): Promise<void> {
     return invoke<undefined>('dimensions:save-config', config).then(() => undefined);
+  },
+  estimateRollupGrain(candidate: DimensionsConfig): Promise<RollupGrainEstimate> {
+    return invoke<RollupGrainEstimate>('dimensions:estimate-rollup-grain', candidate);
   },
   getAutoSyncEnabled(): Promise<boolean> {
     return invoke<boolean>('auto-sync:get-enabled');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -45,7 +45,7 @@ import {
   type SharedSourceInfo,
   type RollupGrainEstimate,
 } from '@costgoblin/core/browser';
-import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
+import { DEFAULT_COST_SCOPE, computeRollupEstimate } from '@costgoblin/core/browser';
 
 const costResult: CostResult = {
   rows: [
@@ -282,41 +282,28 @@ export class MockCostApi implements CostApi {
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }
   saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
   estimateRollupGrain(candidate: DimensionsConfig): Promise<RollupGrainEstimate> {
-    // Flag resource_id raw-only so the Dimensions view exercises the badge.
+    // Feed the real estimator a probe-shaped fixture so the mock matches the
+    // shape and thresholds the desktop handler produces. resource_id (when
+    // enabled) is near-unique → flagged; the others stay navigational.
     const enabled = (d: { enabled?: boolean | undefined }): boolean => d.enabled !== false;
     const hasResourceId = candidate.builtIn.some(d => d.field === 'resource_id' && enabled(d));
-    const grainRows = hasResourceId ? 1_840_000 : 92_000;
-    const lineItems = 2_100_000;
-    const months = 12;
-    const bytesPerRow = 16;
-    const rows = grainRows * months;
-    const perPartitionBytes = grainRows * bytesPerRow;
-    const dims: RollupGrainEstimate['dims'] = [
-      { column: 'account_id', cardinality: 14, rawOnly: false },
-      { column: 'service', cardinality: 38, rawOnly: false },
-      { column: 'tag_team', cardinality: 22, rawOnly: false },
-      ...(hasResourceId ? [{ column: 'resource_id', cardinality: 1_820_000, rawOnly: true }] : []),
+    const probeLineItems = 2_100_000;
+    const dimCardinalities = [
+      { column: 'account_id', cardinality: 14 },
+      { column: 'service', cardinality: 38 },
+      { column: 'tag_team', cardinality: 22 },
+      ...(hasResourceId ? [{ column: 'resource_id', cardinality: 1_820_000 }] : []),
     ];
-    return Promise.resolve({
+    const probeGrainRows = hasResourceId ? 1_840_000 : 92_000;
+    return Promise.resolve(computeRollupEstimate({
       probePeriod: '2026-04',
-      months,
-      lineItems,
+      months: 12,
+      probeGrainRows,
+      probeLineItems,
+      rawBytes: 4_900_000_000,
       current: { rows: 1_100_000, bytes: 17_600_000 },
-      candidate: {
-        rows,
-        bytes: rows * bytesPerRow,
-        perPartitionBytes,
-        sizeBand: hasResourceId ? 'large' : 'small',
-        rebuildSeconds: hasResourceId ? 130 : 24,
-        rebuildBand: hasResourceId ? 'slow' : 'fast',
-        growthFactor: rows / 1_100_000,
-      },
-      compressionRate: lineItems / grainRows,
-      rawOnly: hasResourceId
-        ? { recommended: true, reason: 'a monthly partition would be ~28 MB — over the 50 MB raw-only threshold' }
-        : { recommended: false, reason: null },
-      dims,
-    });
+      dimCardinalities,
+    }));
   }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }
   setAutoSyncEnabled(): Promise<void> { return Promise.resolve(); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -43,6 +43,7 @@ import {
   type SharedPullSelection,
   type SharedSourcePreview,
   type SharedSourceInfo,
+  type RollupGrainEstimate,
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE } from '@costgoblin/core/browser';
 
@@ -280,6 +281,43 @@ export class MockCostApi implements CostApi {
   discoverColumnValues(): Promise<{ values: { value: string; cost: number }[]; distinctCount: number; period: string }> { return Promise.resolve({ values: [{ value: 'Usage', cost: 12345 }, { value: 'Tax', cost: 234 }, { value: 'Credit', cost: -100 }], distinctCount: 3, period: '2026-04' }); }
   getDimensionsConfig(): Promise<DimensionsConfig> { return Promise.resolve({ builtIn: [{ name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' }], tags: [{ tagName: 'team', label: 'Team', concept: 'owner' as const }] }); }
   saveDimensionsConfig(): Promise<void> { return Promise.resolve(); }
+  estimateRollupGrain(candidate: DimensionsConfig): Promise<RollupGrainEstimate> {
+    // Flag resource_id raw-only so the Dimensions view exercises the badge.
+    const enabled = (d: { enabled?: boolean | undefined }): boolean => d.enabled !== false;
+    const hasResourceId = candidate.builtIn.some(d => d.field === 'resource_id' && enabled(d));
+    const grainRows = hasResourceId ? 1_840_000 : 92_000;
+    const lineItems = 2_100_000;
+    const months = 12;
+    const bytesPerRow = 16;
+    const rows = grainRows * months;
+    const perPartitionBytes = grainRows * bytesPerRow;
+    const dims: RollupGrainEstimate['dims'] = [
+      { column: 'account_id', cardinality: 14, rawOnly: false },
+      { column: 'service', cardinality: 38, rawOnly: false },
+      { column: 'tag_team', cardinality: 22, rawOnly: false },
+      ...(hasResourceId ? [{ column: 'resource_id', cardinality: 1_820_000, rawOnly: true }] : []),
+    ];
+    return Promise.resolve({
+      probePeriod: '2026-04',
+      months,
+      lineItems,
+      current: { rows: 1_100_000, bytes: 17_600_000 },
+      candidate: {
+        rows,
+        bytes: rows * bytesPerRow,
+        perPartitionBytes,
+        sizeBand: hasResourceId ? 'large' : 'small',
+        rebuildSeconds: hasResourceId ? 130 : 24,
+        rebuildBand: hasResourceId ? 'slow' : 'fast',
+        growthFactor: rows / 1_100_000,
+      },
+      compressionRate: lineItems / grainRows,
+      rawOnly: hasResourceId
+        ? { recommended: true, reason: 'a monthly partition would be ~28 MB — over the 50 MB raw-only threshold' }
+        : { recommended: false, reason: null },
+      dims,
+    });
+  }
   getAutoSyncEnabled(): Promise<boolean> { return Promise.resolve(false); }
   setAutoSyncEnabled(): Promise<void> { return Promise.resolve(); }
   getAutoSyncIntervalMinutes(): Promise<number> { return Promise.resolve(24 * 60); }

--- a/packages/ui/src/__tests__/dimensions-estimate.test.tsx
+++ b/packages/ui/src/__tests__/dimensions-estimate.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { asDimensionId } from '@costgoblin/core/browser';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { DimensionsView } from '../views/dimensions.js';
+
+function renderView() {
+  const api = new MockCostApi();
+  // A config that includes the high-cardinality resource_id built-in so the
+  // estimator (mock) flags it raw-only.
+  vi.spyOn(api, 'getDimensionsConfig').mockResolvedValue({
+    builtIn: [
+      { name: asDimensionId('account'), label: 'Account', field: 'account_id', displayField: 'account_name' },
+      { name: asDimensionId('service'), label: 'AWS Service', field: 'service' },
+      { name: asDimensionId('resource_id'), label: 'Resource', field: 'resource_id' },
+    ],
+    tags: [{ tagName: 'team', label: 'Team', concept: 'owner' }],
+  });
+  const user = userEvent.setup();
+  return {
+    api,
+    user,
+    ...render(
+      <CostApiProvider value={api}>
+        <DimensionsView />
+      </CostApiProvider>,
+    ),
+  };
+}
+
+afterEach(cleanup);
+
+describe('DimensionsView — rollup grain estimate', () => {
+  it('surfaces the rollup impact estimate for the current grain', async () => {
+    renderView();
+    await waitFor(() => { expect(screen.getByText('Rollup impact')).toBeDefined(); });
+    await waitFor(() => { expect(screen.getByText('Est. size')).toBeDefined(); });
+    expect(screen.getByText('Compression')).toBeDefined();
+    expect(screen.getByText('Rebuild')).toBeDefined();
+    expect(screen.getByText(/directional/)).toBeDefined();
+  });
+
+  it('flags resource_id raw-only with a badge and a panel warning', async () => {
+    renderView();
+    await waitFor(() => { expect(screen.getByText(/heavy for the rollup/i)).toBeDefined(); });
+    // The resource pill carries a "raw" badge.
+    expect(screen.getAllByText('raw').length).toBeGreaterThan(0);
+  });
+
+  it('re-estimates and clears the raw-only warning when the dim is toggled off', async () => {
+    const { user } = renderView();
+    await waitFor(() => { expect(screen.getByText(/heavy for the rollup/i)).toBeDefined(); });
+
+    // The SECTION 1 pill is the first button matching the dim label.
+    const resourcePill = screen.getAllByRole('button', { name: /Resource/ })[0];
+    expect(resourcePill).toBeDefined();
+    await user.click(resourcePill as HTMLElement);
+
+    await waitFor(() => { expect(screen.queryByText(/heavy for the rollup/i)).toBeNull(); });
+  });
+});

--- a/packages/ui/src/__tests__/dimensions-estimate.test.tsx
+++ b/packages/ui/src/__tests__/dimensions-estimate.test.tsx
@@ -33,31 +33,32 @@ function renderView() {
 afterEach(cleanup);
 
 describe('DimensionsView — rollup grain estimate', () => {
-  it('surfaces the rollup impact estimate for the current grain', async () => {
+  it('surfaces the rollup impact estimate with a raw-data baseline', async () => {
     renderView();
     await waitFor(() => { expect(screen.getByText('Rollup impact')).toBeDefined(); });
-    await waitFor(() => { expect(screen.getByText('Est. size')).toBeDefined(); });
+    await waitFor(() => { expect(screen.getByText('Raw data')).toBeDefined(); });
+    expect(screen.getByText('Est. rollup')).toBeDefined();
     expect(screen.getByText('Compression')).toBeDefined();
     expect(screen.getByText('Rebuild')).toBeDefined();
     expect(screen.getByText(/directional/)).toBeDefined();
   });
 
-  it('flags resource_id raw-only with a badge and a panel warning', async () => {
+  it('flags resource_id high-cardinality with a count badge and a panel warning', async () => {
     renderView();
-    await waitFor(() => { expect(screen.getByText(/heavy for the rollup/i)).toBeDefined(); });
-    // The resource pill carries a "raw" badge.
-    expect(screen.getAllByText('raw').length).toBeGreaterThan(0);
+    await waitFor(() => { expect(screen.getByText(/Heavy grain/i)).toBeDefined(); });
+    // The resource pill carries a high-cardinality count badge (~1.8M distinct).
+    expect(screen.getAllByText('1.8M').length).toBeGreaterThan(0);
   });
 
-  it('re-estimates and clears the raw-only warning when the dim is toggled off', async () => {
+  it('re-estimates and clears the warning when the dim is toggled off', async () => {
     const { user } = renderView();
-    await waitFor(() => { expect(screen.getByText(/heavy for the rollup/i)).toBeDefined(); });
+    await waitFor(() => { expect(screen.getByText(/Heavy grain/i)).toBeDefined(); });
 
     // The SECTION 1 pill is the first button matching the dim label.
     const resourcePill = screen.getAllByRole('button', { name: /Resource/ })[0];
     expect(resourcePill).toBeDefined();
     await user.click(resourcePill as HTMLElement);
 
-    await waitFor(() => { expect(screen.queryByText(/heavy for the rollup/i)).toBeNull(); });
+    await waitFor(() => { expect(screen.queryByText(/Heavy grain/i)).toBeNull(); });
   });
 });

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1423,13 +1423,13 @@ function AccountTagsContent({ orgData, accountTagKeys, hiddenAccountCols, setHid
   );
 }
 
-function pillClass(enabled: boolean): string {
-  return [
-    'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-    enabled
-      ? 'border-accent/50 bg-accent/10 text-accent hover:bg-accent/20'
-      : 'border-border bg-bg-tertiary/20 text-text-muted hover:border-text-muted hover:text-text-secondary',
-  ].join(' ');
+function pillClass(enabled: boolean, danger = false): string {
+  const state = !enabled
+    ? 'border-border bg-bg-tertiary/20 text-text-muted hover:border-text-muted hover:text-text-secondary'
+    : danger
+      ? 'border-amber-500/50 bg-amber-500/10 text-amber-500 hover:bg-amber-500/20'
+      : 'border-accent/50 bg-accent/10 text-accent hover:bg-accent/20';
+  return ['rounded-full border px-3 py-1 text-xs font-medium transition-colors', state].join(' ');
 }
 
 /** The rollup grain column a built-in/tag dim contributes — mirrors
@@ -1467,17 +1467,28 @@ function formatCount(n: number): string {
   return String(Math.round(n));
 }
 
-/** Small "raw" chip on a pill whose dimension is too high-cardinality for the
- *  rollup — its widgets fall back to raw Parquet. */
-function RawOnlyBadge(): React.JSX.Element {
+/** Chip on a pill whose dimension is high-cardinality enough to drive rollup
+ *  size — shows its distinct-value count so the user can see WHY it's flagged.
+ *  Such dims are best kept raw-only (their widgets fall back to raw Parquet). */
+function RawOnlyBadge({ cardinality }: Readonly<{ cardinality: number | undefined }>): React.JSX.Element {
+  const count = cardinality !== undefined && cardinality > 0 ? formatCount(cardinality) : null;
   return (
     <span
-      title="Very high-cardinality — recommended raw-only. Widgets grouping by it query raw data instead of the rollup."
-      className="ml-1.5 inline-flex items-center gap-0.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0 text-[9px] font-semibold uppercase tracking-wide text-amber-500"
+      title={`High-cardinality${count !== null ? ` (~${count} distinct values)` : ''} — a primary driver of rollup size. Best kept raw-only: widgets grouping by it query raw data instead of the rollup.`}
+      className="ml-1.5 inline-flex items-center gap-0.5 rounded-full border border-amber-500/40 bg-amber-500/15 px-1.5 py-0 text-[9px] font-semibold uppercase tracking-wide text-amber-500"
     >
-      <Database className="h-2.5 w-2.5" />raw
+      <Database className="h-2.5 w-2.5" />{count ?? 'raw'}
     </span>
   );
+}
+
+/** Friendly label for a rollup grain column (for the heaviest-dimension list). */
+function columnLabel(config: DimensionsConfig, column: string): string {
+  const b = config.builtIn.find(d => d.field === column);
+  if (b !== undefined) return b.label;
+  const t = config.tags.find(tg => tagDimColumn(tg) === column);
+  if (t !== undefined) return t.label;
+  return column;
 }
 
 function ImpactStat({ label, value, hint }: Readonly<{ label: string; value: string; hint?: string }>): React.JSX.Element {
@@ -1493,7 +1504,13 @@ function ImpactStat({ label, value, hint }: Readonly<{ label: string; value: str
 /** Cost/benefit summary for the current enabled grain (rollup design §8).
  *  Updates as dims are toggled so the user can weigh the rebuild before it
  *  happens. Numbers are directional (probed from one recent month). */
-function RollupImpactPanel({ estimate, loading }: Readonly<{ estimate: RollupGrainEstimate | null; loading: boolean }>): React.JSX.Element {
+function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: RollupGrainEstimate | null; loading: boolean; config: DimensionsConfig }>): React.JSX.Element {
+  const heaviest = estimate === null
+    ? []
+    : [...estimate.dims].filter(d => d.rawOnly).sort((a, b) => b.cardinality - a.cardinality);
+  const sizeReduction = estimate !== null && estimate.candidate.bytes > 0
+    ? estimate.raw.bytes / estimate.candidate.bytes
+    : 0;
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/40 px-5 py-4">
       <div className="flex items-center justify-between">
@@ -1514,19 +1531,19 @@ function RollupImpactPanel({ estimate, loading }: Readonly<{ estimate: RollupGra
         <>
           <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-4">
             <ImpactStat
-              label="Est. size"
-              value={formatBytes(estimate.candidate.bytes)}
-              hint={`${SIZE_BAND_LABEL[estimate.candidate.sizeBand]}${estimate.candidate.growthFactor !== null ? ` · ${estimate.candidate.growthFactor.toFixed(1)}× current` : ''}`}
+              label="Raw data"
+              value={formatBytes(estimate.raw.bytes)}
+              hint={`${formatCount(estimate.raw.rows)} line items · ${String(estimate.months)} mo`}
             />
             <ImpactStat
-              label="Rollup rows"
-              value={formatCount(estimate.candidate.rows)}
-              hint={`across ${String(estimate.months)} month${estimate.months === 1 ? '' : 's'}`}
+              label="Est. rollup"
+              value={formatBytes(estimate.candidate.bytes)}
+              hint={`${SIZE_BAND_LABEL[estimate.candidate.sizeBand]} · ${formatCount(estimate.candidate.rows)} rows`}
             />
             <ImpactStat
               label="Compression"
-              value={`${estimate.compressionRate >= 1 ? estimate.compressionRate.toFixed(0) : estimate.compressionRate.toFixed(1)}×`}
-              hint="vs raw line items"
+              value={sizeReduction >= 1.05 ? `${sizeReduction.toFixed(1)}×` : '~1×'}
+              hint={`smaller than raw · ${estimate.compressionRate >= 1 ? estimate.compressionRate.toFixed(0) : estimate.compressionRate.toFixed(1)}× fewer rows`}
             />
             <ImpactStat
               label="Rebuild"
@@ -1534,12 +1551,25 @@ function RollupImpactPanel({ estimate, loading }: Readonly<{ estimate: RollupGra
               hint="background re-roll"
             />
           </div>
-          {estimate.rawOnly.recommended && estimate.rawOnly.reason !== null && (
+          {estimate.rawOnly.recommended && (
             <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2">
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
               <p className="text-[11px] leading-snug text-text-secondary">
-                This grain is heavy for the rollup — {estimate.rawOnly.reason}. Consider keeping the flagged
-                <span className="text-amber-500"> raw</span> dimension(s) out of the rollup so dashboards stay fast.
+                {heaviest.length > 0 ? (
+                  <>
+                    Heavy grain — most of the rollup size comes from{' '}
+                    {heaviest.slice(0, 4).map((d, i) => (
+                      <span key={d.column}>
+                        {i > 0 ? ', ' : ''}
+                        <span className="font-medium text-amber-500">{columnLabel(config, d.column)}</span>
+                        {' '}({formatCount(d.cardinality)})
+                      </span>
+                    ))}
+                    . Disabling the heaviest keeps it raw-only so dashboards stay fast.
+                  </>
+                ) : (
+                  <>This grain is heavy for the rollup — {estimate.rawOnly.reason ?? 'it exceeds the size budget'}. Consider a leaner grain so dashboards stay fast.</>
+                )}
               </p>
             </div>
           )}
@@ -1648,6 +1678,7 @@ export function DimensionsView() {
   const estimate = estimateQuery.status === 'success' ? estimateQuery.data : null;
   const estimateLoading = estimateQuery.status === 'loading';
   const rawOnlyColumns = new Set((estimate?.dims ?? []).filter(d => d.rawOnly).map(d => d.column));
+  const cardinalityByColumn = new Map((estimate?.dims ?? []).map(d => [d.column, d.cardinality]));
 
   // Account tag keys from org sync
   const accountTagKeys = orgData === null
@@ -1905,11 +1936,11 @@ export function DimensionsView() {
                     type="button"
                     onClick={locked ? undefined : () => { toggleBuiltInEnabled(idx); }}
                     title={buttonTitle}
-                    className={`${pillClass(isOn)}${locked ? ' cursor-default' : ''}`}
+                    className={`${pillClass(isOn, rawOnly)}${locked ? ' cursor-default' : ''}`}
                   >
                     {locked && <Lock className="inline-block w-3 h-3 mr-1 -mt-0.5" />}
                     {d.label}
-                    {rawOnly && <RawOnlyBadge />}
+                    {rawOnly && <RawOnlyBadge cardinality={cardinalityByColumn.get(builtInGrainColumn(d))} />}
                   </button>
                 );
               })}
@@ -1927,10 +1958,10 @@ export function DimensionsView() {
                     type="button"
                     onClick={() => { toggleTagEnabled(idx); }}
                     title={isOn ? 'Click to disable' : 'Click to enable'}
-                    className={pillClass(isOn)}
+                    className={pillClass(isOn, rawOnly)}
                   >
                     {tag.label}
-                    {rawOnly && <RawOnlyBadge />}
+                    {rawOnly && <RawOnlyBadge cardinality={cardinalityByColumn.get(tagDimColumn(tag))} />}
                   </button>
                 );
               })}
@@ -1946,7 +1977,7 @@ export function DimensionsView() {
 
           {/* Rollup cost/benefit for the current grain — updates as pills are
               toggled so the user can weigh the (background) re-roll first. */}
-          <RollupImpactPanel estimate={estimate} loading={estimateLoading} />
+          <RollupImpactPanel estimate={estimate} loading={estimateLoading} config={config} />
 
           {/* New-tag-dim form appears inline right after the pill rows so the
               user sees where the new pill will land. */}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { ChevronUp, ChevronDown, GripVertical, Lock } from 'lucide-react';
-import type { BuiltInDimension, DimensionsConfig, TagDimension, ConceptType, NormalizationRule } from '@costgoblin/core/browser';
-import { asDimensionId, OU_PATH_SOURCE_KEY } from '@costgoblin/core/browser';
+import { ChevronUp, ChevronDown, GripVertical, Lock, Database, AlertTriangle } from 'lucide-react';
+import type { BuiltInDimension, DimensionsConfig, TagDimension, ConceptType, NormalizationRule, RollupGrainEstimate, RollupSizeBand } from '@costgoblin/core/browser';
+import { asDimensionId, OU_PATH_SOURCE_KEY, tagDimColumn } from '@costgoblin/core/browser';
+import { formatBytes } from '../components/format.js';
 
 const OU_PATH_LABEL = 'OU Path';
 function formatAccountSource(key: string): string {
@@ -1431,6 +1432,123 @@ function pillClass(enabled: boolean): string {
   ].join(' ');
 }
 
+/** The rollup grain column a built-in/tag dim contributes — mirrors
+ *  `rollupGrainColumns` so the UI can match an estimate's per-dim verdict to a
+ *  pill. */
+function builtInGrainColumn(d: BuiltInDimension): string { return d.field; }
+
+/** A digest of the ENABLED grain columns. Drives the estimate refetch: it
+ *  changes when a dim is toggled (the grain changes) but not when a dim is
+ *  reordered or relabelled (those never touch stored bytes). */
+function grainSignature(config: DimensionsConfig): string {
+  const cols: string[] = [];
+  for (const d of config.builtIn) {
+    if (d.enabled === false) continue;
+    cols.push(d.field);
+    if (d.displayField !== undefined && d.displayField.length > 0) cols.push(d.displayField);
+  }
+  for (const t of config.tags) if (t.enabled !== false) cols.push(tagDimColumn(t));
+  return [...new Set(cols)].sort((a, b) => a.localeCompare(b)).join(',');
+}
+
+const SIZE_BAND_LABEL: Record<RollupSizeBand, string> = {
+  tiny: 'tiny', small: 'small', moderate: 'moderate', large: 'large', huge: 'very large',
+};
+
+function formatRebuild(seconds: number): string {
+  if (seconds < 1) return '< 1s';
+  if (seconds < 90) return `~${String(Math.round(seconds))}s`;
+  return `~${String(Math.round(seconds / 60))} min`;
+}
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  return String(Math.round(n));
+}
+
+/** Small "raw" chip on a pill whose dimension is too high-cardinality for the
+ *  rollup — its widgets fall back to raw Parquet. */
+function RawOnlyBadge(): React.JSX.Element {
+  return (
+    <span
+      title="Very high-cardinality — recommended raw-only. Widgets grouping by it query raw data instead of the rollup."
+      className="ml-1.5 inline-flex items-center gap-0.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0 text-[9px] font-semibold uppercase tracking-wide text-amber-500"
+    >
+      <Database className="h-2.5 w-2.5" />raw
+    </span>
+  );
+}
+
+function ImpactStat({ label, value, hint }: Readonly<{ label: string; value: string; hint?: string }>): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] uppercase tracking-wider text-text-muted">{label}</span>
+      <span className="text-sm font-semibold text-text-primary">{value}</span>
+      {hint !== undefined && <span className="text-[10px] text-text-muted">{hint}</span>}
+    </div>
+  );
+}
+
+/** Cost/benefit summary for the current enabled grain (rollup design §8).
+ *  Updates as dims are toggled so the user can weigh the rebuild before it
+ *  happens. Numbers are directional (probed from one recent month). */
+function RollupImpactPanel({ estimate, loading }: Readonly<{ estimate: RollupGrainEstimate | null; loading: boolean }>): React.JSX.Element {
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/40 px-5 py-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Database className="h-4 w-4 text-text-muted" />
+          <h3 className="text-sm font-medium text-text-secondary">Rollup impact</h3>
+        </div>
+        {estimate !== null && estimate.probePeriod.length > 0 && (
+          <span className="text-[10px] text-text-muted">estimated from {estimate.probePeriod} · directional</span>
+        )}
+      </div>
+
+      {loading && estimate === null ? (
+        <p className="mt-3 text-xs text-text-muted">Estimating…</p>
+      ) : estimate === null || estimate.probePeriod.length === 0 ? (
+        <p className="mt-3 text-xs text-text-muted">Sync billing data to estimate the rollup size for this grain.</p>
+      ) : (
+        <>
+          <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <ImpactStat
+              label="Est. size"
+              value={formatBytes(estimate.candidate.bytes)}
+              hint={`${SIZE_BAND_LABEL[estimate.candidate.sizeBand]}${estimate.candidate.growthFactor !== null ? ` · ${estimate.candidate.growthFactor.toFixed(1)}× current` : ''}`}
+            />
+            <ImpactStat
+              label="Rollup rows"
+              value={formatCount(estimate.candidate.rows)}
+              hint={`across ${String(estimate.months)} month${estimate.months === 1 ? '' : 's'}`}
+            />
+            <ImpactStat
+              label="Compression"
+              value={`${estimate.compressionRate >= 1 ? estimate.compressionRate.toFixed(0) : estimate.compressionRate.toFixed(1)}×`}
+              hint="vs raw line items"
+            />
+            <ImpactStat
+              label="Rebuild"
+              value={formatRebuild(estimate.candidate.rebuildSeconds)}
+              hint="background re-roll"
+            />
+          </div>
+          {estimate.rawOnly.recommended && estimate.rawOnly.reason !== null && (
+            <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+              <p className="text-[11px] leading-snug text-text-secondary">
+                This grain is heavy for the rollup — {estimate.rawOnly.reason}. Consider keeping the flagged
+                <span className="text-amber-500"> raw</span> dimension(s) out of the rollup so dashboards stay fast.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 function GripHandle({ attrs }: Readonly<{ attrs: React.HTMLAttributes<HTMLButtonElement> }>): React.JSX.Element {
   return (
     <button
@@ -1517,6 +1635,19 @@ export function DimensionsView() {
     }
   }, [configQuery, api]);
   const orgData = orgQuery.status === 'success' ? orgQuery.data : null;
+
+  // Live rollup cost/benefit estimate for the current enabled grain. Keyed on
+  // the grain signature so it refetches when a dim is toggled (the grain
+  // changes) but not on reorder/relabel. The probe hits DuckDB, so this is
+  // intentionally cheap and fire-and-forget.
+  const estimateSig = config === null ? '' : grainSignature(config);
+  const estimateQuery = useQuery(
+    () => config === null ? Promise.resolve(null) : api.estimateRollupGrain(config),
+    [estimateSig],
+  );
+  const estimate = estimateQuery.status === 'success' ? estimateQuery.data : null;
+  const estimateLoading = estimateQuery.status === 'loading';
+  const rawOnlyColumns = new Set((estimate?.dims ?? []).filter(d => d.rawOnly).map(d => d.column));
 
   // Account tag keys from org sync
   const accountTagKeys = orgData === null
@@ -1764,6 +1895,7 @@ export function DimensionsView() {
                 .map(([idx, d]) => {
                 const locked = LOCKED_DIMENSIONS.has(d.name);
                 const isOn = locked || d.enabled !== false;
+                const rawOnly = isOn && rawOnlyColumns.has(builtInGrainColumn(d));
                 let buttonTitle = 'Click to enable';
                 if (locked) buttonTitle = 'Always enabled — required for cost breakdown';
                 else if (isOn) buttonTitle = 'Click to disable';
@@ -1777,6 +1909,7 @@ export function DimensionsView() {
                   >
                     {locked && <Lock className="inline-block w-3 h-3 mr-1 -mt-0.5" />}
                     {d.label}
+                    {rawOnly && <RawOnlyBadge />}
                   </button>
                 );
               })}
@@ -1787,6 +1920,7 @@ export function DimensionsView() {
             <div className="flex flex-wrap gap-1.5">
               {config.tags.map((tag, idx) => {
                 const isOn = tag.enabled !== false;
+                const rawOnly = isOn && rawOnlyColumns.has(tagDimColumn(tag));
                 return (
                   <button
                     key={tagOrderKey(tag)}
@@ -1796,6 +1930,7 @@ export function DimensionsView() {
                     className={pillClass(isOn)}
                   >
                     {tag.label}
+                    {rawOnly && <RawOnlyBadge />}
                   </button>
                 );
               })}
@@ -1808,6 +1943,10 @@ export function DimensionsView() {
               </button>
             </div>
           </div>
+
+          {/* Rollup cost/benefit for the current grain — updates as pills are
+              toggled so the user can weigh the (background) re-roll first. */}
+          <RollupImpactPanel estimate={estimate} loading={estimateLoading} />
 
           {/* New-tag-dim form appears inline right after the pill rows so the
               user sees where the new pill will land. */}


### PR DESCRIPTION
Implements [#381](https://github.com/etiennechabert/cost-goblin/issues/381) — the rollup grain cost/benefit estimator (rollup design §8, Phase 4).

## What

When a user enables/disables a dashboard dimension, the **Dimensions** view now surfaces the estimated rollup impact so they can weigh the cost/benefit before the (background) re-roll:

- A live **"Rollup impact"** panel under the dimension pills showing estimated **size** (+ band & growth vs the current on-disk rollup), **rollup rows**, **compression** (line-items ÷ rollup rows), and a **rebuild-time** estimate. It refetches as dims are toggled.
- Per-pill **`raw`** badges + a panel warning for dimensions that are too high-cardinality for the rollup. `resource_id` is flagged this way — **data-driven, not a hardcoded list**.

## How

- **core** — `computeRollupEstimate` (pure: directional size/compression/rebuild bands + the raw-only verdict), `isDimRawOnly`, and `buildGrainProbeQuery`: a single recent-month scan returning `COUNT(*)`, `approx_count_distinct(concat_ws(chr(31), <grain cols>))`, and each grain column's cardinality. New `CostApi.estimateRollupGrain(candidate)`.
- **desktop** — `dimensions:estimate-rollup-grain` IPC handler (probes the latest daily month, ~150–550 ms) and `RollupStore.getStats()` for the exact current-rollup baseline from the manifest.
- **ui** — the impact panel + badges, keyed on a grain signature so it only re-estimates when the grain actually changes (not on reorder/relabel).

## Scope & accuracy notes for the reviewer

- **Surface-only**, per the agreed scope: the rollup **grain build is unchanged**. The estimator flags/recommends raw-only; it does not (yet) exclude flagged dims from the grain. Enforcement can be a focused follow-up.
- Estimates are **directional by design** (§8): a single recent-month probe (≈ −10% on stable grains, ≈ +35% on high-cardinality dims), so the UI presents bands, not false precision — the real figure lands after the rebuild.
- The raw-only verdict trips on either an absolute per-partition budget (>50 MB) or a compression floor (a dim whose distinct count exceeds ~50% of the month's line items), so it still fires on small datasets where the byte threshold never would.

## Tests

- Pure unit tests for the estimator math, bands, and thresholds.
- A DuckDB probe test over the synthetic fixtures asserting `resource_id` is flagged raw-only (near-unique per line item) while stable dims are not.
- A UI test for the impact panel, the `resource_id` badge, and re-estimation when the dim is toggled off.

`npm run check` passes across all packages.
