### PR TITLE
fix(ui): stop hover graying-out already-picked calendar days

### DIFF
--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -37,9 +37,12 @@ export function Calendar({
         day_button: cn(
           buttonVariants({ variant: 'ghost' }),
           'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
+          // Keep the subtle ghost hover on unpicked days, but don't let it paint a
+          // gray fill over already-picked days — that fought the range highlight.
+          '[[aria-selected]_&]:hover:bg-transparent [[aria-selected]_&]:hover:text-inherit',
         ),
         selected:
-          'bg-accent text-white rounded-md hover:bg-accent-hover hover:text-white focus:bg-accent-hover focus:text-white',
+          'bg-accent text-white rounded-md',
         range_start:
           'aria-selected:rounded-l-md aria-selected:rounded-r-none',
         range_end:


### PR DESCRIPTION
Follow-up to #390 (single range calendar for custom date selection).

## Problem

After picking a range, hovering an already-selected day looked off: the day buttons use a ghost variant whose `hover:bg-bg-tertiary` painted a gray fill over the day, covering the green endpoints and the range-span highlight.

## Fix

- Gate the ghost hover so it only applies to **unpicked** days. Picked days (whose gridcell carries `aria-selected`) no longer change background/text on hover: `[[aria-selected]_&]:hover:bg-transparent` + `:hover:text-inherit`.
- Dropped the now-redundant `hover:bg-accent-hover / focus:*` styles from the `selected` class.

Net effect: unpicked days keep their subtle gray hover affordance; picked days keep their green/range highlight steady on hover.

One-file change (`packages/ui/src/components/ui/calendar.tsx`). `npm run check` passes (tsc + eslint + 190 UI tests).