### PR TITLE
fix(rollup): probe parquet columns per-period when building rollup partitions

### DIFF
--- a/packages/desktop/src/__tests__/rollup-schema-drift.test.ts
+++ b/packages/desktop/src/__tests__/rollup-schema-drift.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtemp, mkdir, rm, stat } from 'node:fs/promises';
+import { buildRollupPartitionQuery, rollupGrainColumns, type DimensionsConfig, type CostScopeConfig, asDimensionId } from '@costgoblin/core';
+import { RollupStore, type RollupShape, type BuildPartitionSql } from '../main/rollup-store.js';
+import type { RawRow } from '../main/duckdb-client.js';
+
+// Months drift in which optional cost columns they carry: a CUR ships
+// reservation_effective_cost / the SP effective-cost family only from the
+// billing period the user enabled resource IDs. The amortized metric
+// references those columns, so a cold rebuild that builds an OLDER month (which
+// lacks them) with the LATEST month's column set throws a DuckDB Binder Error
+// and that partition never builds. This guards the per-period probe fix.
+
+// Columns every CUR carries. `type` is appended per-column below.
+const BASE_COLS: readonly [string, string][] = [
+  ['line_item_usage_start_date', 'TIMESTAMP'],
+  ['line_item_usage_account_id', 'VARCHAR'],
+  ['line_item_usage_account_name', 'VARCHAR'],
+  ['product_region_code', 'VARCHAR'],
+  ['product_servicecode', 'VARCHAR'],
+  ['product_product_family', 'VARCHAR'],
+  ['line_item_resource_id', 'VARCHAR'],
+  ['line_item_usage_amount', 'DOUBLE'],
+  ['line_item_unblended_cost', 'DOUBLE'],
+  ['line_item_net_unblended_cost', 'DOUBLE'],
+  ['pricing_public_on_demand_cost', 'DOUBLE'],
+  ['line_item_line_item_type', 'VARCHAR'],
+  ['line_item_operation', 'VARCHAR'],
+  ['line_item_usage_type', 'VARCHAR'],
+];
+// Optional RI/SP effective-cost columns — present only once the user enables
+// resource IDs. The amortized metric references these; an older month lacks
+// them entirely (matches real data — 18-col months still keep net_unblended).
+const OPTIONAL_COLS: readonly [string, string][] = [
+  ['reservation_effective_cost', 'DOUBLE'],
+  ['reservation_net_effective_cost', 'DOUBLE'],
+  ['savings_plan_savings_plan_effective_cost', 'DOUBLE'],
+  ['savings_plan_net_savings_plan_effective_cost', 'DOUBLE'],
+];
+
+interface FixtureRow {
+  readonly line_item_usage_start_date: string;
+  readonly line_item_usage_account_id: string;
+  readonly line_item_usage_account_name: string;
+  readonly product_servicecode: string;
+  readonly product_product_family: string;
+  readonly line_item_resource_id: string;
+  readonly line_item_unblended_cost: number;
+  readonly reservation_effective_cost: number;
+  readonly savings_plan_savings_plan_effective_cost: number;
+  readonly line_item_line_item_type: string;
+  readonly line_item_operation: string;
+}
+
+function rowsFor(period: string): readonly FixtureRow[] {
+  const d = `${period}-05`;
+  // One RI-covered, one SP-covered, one plain Usage row.
+  return [
+    { line_item_usage_start_date: `${d} 00:00:00`, line_item_usage_account_id: '111', line_item_usage_account_name: 'acct-a', product_servicecode: 'AmazonEC2', product_product_family: 'Compute', line_item_resource_id: 'i-1', line_item_unblended_cost: 10, reservation_effective_cost: 7, savings_plan_savings_plan_effective_cost: 0, line_item_line_item_type: 'DiscountedUsage', line_item_operation: 'RunInstances' },
+    { line_item_usage_start_date: `${d} 01:00:00`, line_item_usage_account_id: '111', line_item_usage_account_name: 'acct-a', product_servicecode: 'AmazonEC2', product_product_family: 'Compute', line_item_resource_id: 'i-2', line_item_unblended_cost: 20, reservation_effective_cost: 0, savings_plan_savings_plan_effective_cost: 3, line_item_line_item_type: 'SavingsPlanCoveredUsage', line_item_operation: 'RunInstances' },
+    { line_item_usage_start_date: `${d} 02:00:00`, line_item_usage_account_id: '222', line_item_usage_account_name: 'acct-b', product_servicecode: 'AmazonS3', product_product_family: 'Storage', line_item_resource_id: 's-1', line_item_unblended_cost: 5, reservation_effective_cost: 0, savings_plan_savings_plan_effective_cost: 0, line_item_line_item_type: 'Usage', line_item_operation: 'GetObject' },
+  ];
+}
+
+const dimensions: DimensionsConfig = {
+  builtIn: [
+    { name: asDimensionId('account_id'), label: 'Account', field: 'account_id', displayField: 'account_name' },
+    { name: asDimensionId('service'), label: 'Service', field: 'service' },
+  ],
+  tags: [],
+};
+// Amortized is the metric that references the optional RI/SP columns.
+const costScope: CostScopeConfig = { costMetric: 'amortized', costPerspective: 'gross', rules: [] };
+const shape: RollupShape = { signature: 'SIG-DRIFT', grainDimensions: rollupGrainColumns(dimensions), availableColumns: ['account_id', 'account_name', 'service'] };
+const etags = { '2025-10': { f: 'h-old' }, '2026-04': { f: 'h-new' } };
+
+describe('RollupStore cold rebuild over mixed-schema months', () => {
+  let db: Awaited<ReturnType<typeof DuckDBInstance.create>>;
+  let conn: Awaited<ReturnType<typeof db.connect>>;
+  let dataDir: string;
+  let runQuery: (sql: string) => Promise<RawRow[]>;
+
+  // Probe ONE month's columns (mirrors context.ts getColumnsForPeriod).
+  async function probe(period: string): Promise<ReadonlySet<string>> {
+    const glob = `${dataDir}/aws/raw/daily-${period}/*.parquet`;
+    const rows = await runQuery(`DESCRIBE SELECT * FROM read_parquet('${glob}') LIMIT 0`);
+    const cols = new Set<string>();
+    for (const r of rows) { const n = r['column_name']; if (typeof n === 'string') cols.add(n); }
+    return cols;
+  }
+
+  // The fixed wiring: each period's build SQL uses THAT period's columns.
+  const buildPerPeriod: BuildPartitionSql = async (period, outPath) =>
+    buildRollupPartitionQuery(period, 'daily', outPath, { dataDir, dimensions, costScope, availableColumns: await probe(period) });
+
+  // The OLD (buggy) wiring: every period uses the latest month's columns.
+  const buildLatestForAll: BuildPartitionSql = async (period, outPath) =>
+    buildRollupPartitionQuery(period, 'daily', outPath, { dataDir, dimensions, costScope, availableColumns: await probe('2026-04') });
+
+  function sqlValue(col: string, type: string, row: FixtureRow): string {
+    switch (col) {
+      case 'line_item_usage_start_date': return `TIMESTAMP '${row.line_item_usage_start_date}'`;
+      case 'line_item_usage_account_id': return `'${row.line_item_usage_account_id}'`;
+      case 'line_item_usage_account_name': return `'${row.line_item_usage_account_name}'`;
+      case 'product_servicecode': return `'${row.product_servicecode}'`;
+      case 'product_product_family': return `'${row.product_product_family}'`;
+      case 'line_item_resource_id': return `'${row.line_item_resource_id}'`;
+      case 'line_item_unblended_cost': return String(row.line_item_unblended_cost);
+      case 'line_item_line_item_type': return `'${row.line_item_line_item_type}'`;
+      case 'line_item_operation': return `'${row.line_item_operation}'`;
+      case 'reservation_effective_cost': return String(row.reservation_effective_cost);
+      case 'savings_plan_savings_plan_effective_cost': return String(row.savings_plan_savings_plan_effective_cost);
+      // Columns the rollup build doesn't read — fill a type-appropriate default.
+      default: return type === 'TIMESTAMP' ? `TIMESTAMP '${row.line_item_usage_start_date}'` : type === 'VARCHAR' ? `''` : '0';
+    }
+  }
+
+  async function writeMonth(period: string, full: boolean): Promise<void> {
+    const dir = join(dataDir, 'aws', 'raw', `daily-${period}`);
+    await mkdir(dir, { recursive: true });
+    const schema = full ? [...BASE_COLS, ...OPTIONAL_COLS] : [...BASE_COLS];
+    await conn.run(`CREATE OR REPLACE TABLE m (${schema.map(([n, t]) => `${n} ${t}`).join(', ')})`);
+    const colNames = schema.map(([n]) => n).join(', ');
+    const values = rowsFor(period)
+      .map(row => `(${schema.map(([n, t]) => sqlValue(n, t, row)).join(', ')})`)
+      .join(', ');
+    await conn.run(`INSERT INTO m (${colNames}) VALUES ${values}`);
+    await conn.run(`COPY m TO '${join(dir, 'data.parquet')}' (FORMAT PARQUET)`);
+  }
+
+  beforeAll(async () => {
+    db = await DuckDBInstance.create();
+    conn = await db.connect();
+    dataDir = await mkdtemp(join(tmpdir(), 'cg-rollup-drift-'));
+    runQuery = async (sql: string): Promise<RawRow[]> => {
+      const result = await conn.run(sql);
+      const cols = result.columnCount;
+      const names: string[] = [];
+      for (let i = 0; i < cols; i++) names.push(result.columnName(i));
+      const rows: RawRow[] = [];
+      let chunk = await result.fetchChunk();
+      while (chunk !== null && chunk.rowCount > 0) {
+        for (let r = 0; r < chunk.rowCount; r++) {
+          const row: Record<string, unknown> = {};
+          for (let c = 0; c < cols; c++) { const n = names[c]; if (n !== undefined) row[n] = chunk.getColumnVector(c).getItem(r); }
+          rows.push(row);
+        }
+        chunk = await result.fetchChunk();
+      }
+      return rows;
+    };
+    await writeMonth('2025-10', false);
+    await writeMonth('2026-04', true);
+  });
+  afterAll(async () => { await rm(dataDir, { recursive: true, force: true }); });
+
+  it('builds every month, including the older drifted-schema one (no Binder Error)', async () => {
+    const store = new RollupStore({ dataDir, runQuery });
+    // Newest-first, exactly like warmupRollup orders toBuild.
+    await store.maintainPeriods(['2026-04', '2025-10'], buildPerPeriod, etags, shape);
+
+    expect([...store.getValidPeriods()].sort()).toEqual(['2025-10', '2026-04']);
+    await expect(stat(join(dataDir, 'aws', 'rollup', 'daily-2025-10', 'rollup.parquet'))).resolves.toBeDefined();
+    await expect(stat(join(dataDir, 'aws', 'rollup', 'daily-2026-04', 'rollup.parquet'))).resolves.toBeDefined();
+
+    // The drifted month degrades amortized → unblended (it has nothing to
+    // amortize against), so its cost is the sum of unblended: 10 + 20 + 5 = 35.
+    const old = await runQuery(`SELECT SUM(cost) AS c FROM read_parquet('${join(dataDir, 'aws', 'rollup', 'daily-2025-10', 'rollup.parquet').replaceAll('\\', '/')}')`);
+    expect(Number(old[0]?.['c'])).toBeCloseTo(35);
+
+    // The full month uses true amortized: RI effective (7) + SP effective (3) +
+    // Usage unblended (5) = 15.
+    const recent = await runQuery(`SELECT SUM(cost) AS c FROM read_parquet('${join(dataDir, 'aws', 'rollup', 'daily-2026-04', 'rollup.parquet').replaceAll('\\', '/')}')`);
+    expect(Number(recent[0]?.['c'])).toBeCloseTo(15);
+  });
+
+  it('regression guard: the old latest-month-for-all wiring fails to build the drifted month', async () => {
+    const store = new RollupStore({ dataDir, runQuery });
+    await store.maintainPeriods(['2026-04', '2025-10'], buildLatestForAll, etags, shape);
+    // 2026-04 builds; 2025-10's COPY throws a Binder Error and is skipped.
+    expect([...store.getValidPeriods()]).toEqual(['2026-04']);
+  });
+});

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -400,39 +400,61 @@ export function createAppContext(ctx: IpcContext): AppContext {
   // unblended.
   const columnCache = new Map<string, Promise<ReadonlySet<string>>>();
 
+  // DESCRIBE one month's parquet → its column set. Errors degrade to the empty
+  // set (downstream reads that as "no optional columns" and uses the unblended
+  // fallback) rather than blocking the probe.
+  async function probeColumns(tier: string, month: string): Promise<ReadonlySet<string>> {
+    try {
+      const glob = `${ctx.dataDir}/aws/raw/${tier}-${month}/*.parquet`;
+      const rows = await ctx.db.runQuery(`DESCRIBE SELECT * FROM read_parquet('${glob}') LIMIT 0`);
+      const cols = new Set<string>();
+      for (const r of rows) {
+        const name = r['column_name'];
+        if (typeof name === 'string') cols.add(name);
+      }
+      return cols;
+    } catch (err: unknown) {
+      logger.warn(`column-probe: failed — ${err instanceof Error ? err.message : String(err)}`, { tier, month });
+      return new Set<string>();
+    }
+  }
+
   async function getAvailableColumns(tier: 'daily' | 'hourly'): Promise<ReadonlySet<string>> {
     const cached = columnCache.get(tier);
     if (cached !== undefined) return cached;
     const fetch = (async (): Promise<ReadonlySet<string>> => {
-      try {
-        const months = await listLocalMonths(ctx.dataDir, tier);
-        if (months.length === 0) {
-          // No data on disk for this tier — log loudly because the silent
-          // fallback used to surface as misleading "Degraded" warnings in
-          // Cost Scope when capability checks interpreted the empty set as
-          // "all columns missing."
-          logger.warn('column-probe: no months on disk', { tier, dataDir: ctx.dataDir });
-          return new Set<string>();
-        }
-        // Latest month sample is enough — CUR schema is stable across months
-        // within a billing report (AWS bumps schema on version changes, rare
-        // and user-initiated). Recent months also reflect any newly enabled
-        // optional columns whereas older months won't.
-        const month = months.at(-1);
-        const glob = `${ctx.dataDir}/aws/raw/${tier}-${String(month)}/*.parquet`;
-        const rows = await ctx.db.runQuery(`DESCRIBE SELECT * FROM read_parquet('${glob}') LIMIT 0`);
-        const cols = new Set<string>();
-        for (const r of rows) {
-          const name = r['column_name'];
-          if (typeof name === 'string') cols.add(name);
-        }
-        return cols;
-      } catch (err: unknown) {
-        logger.warn(`column-probe: failed — ${err instanceof Error ? err.message : String(err)}`, { tier });
+      const months = await listLocalMonths(ctx.dataDir, tier);
+      if (months.length === 0) {
+        // No data on disk for this tier — log loudly because the silent
+        // fallback used to surface as misleading "Degraded" warnings in
+        // Cost Scope when capability checks interpreted the empty set as
+        // "all columns missing."
+        logger.warn('column-probe: no months on disk', { tier, dataDir: ctx.dataDir });
         return new Set<string>();
       }
+      // Latest month = current capability: newly enabled optional columns
+      // (reservation_effective_cost, the SP/net families) show up here first.
+      // Used for the shape signature and the Cost Scope capability checks. The
+      // rollup BUILD must instead probe per-period — see getColumnsForPeriod.
+      const month = months.at(-1);
+      return probeColumns(tier, String(month));
     })();
     columnCache.set(tier, fetch);
+    return fetch;
+  }
+
+  // Columns present in ONE specific month's parquet. Months drift: a CUR only
+  // carries the optional cost columns from the billing period the user enabled
+  // them, so an older month has fewer columns than the latest. The rollup
+  // builds one month at a time over a single-month read, so it must reference
+  // only that month's columns — otherwise DuckDB throws a Binder Error on the
+  // absent column and the partition never builds. Cached per (tier, period).
+  async function getColumnsForPeriod(tier: 'daily' | 'hourly', period: string): Promise<ReadonlySet<string>> {
+    const key = `${tier}:${period}`;
+    const cached = columnCache.get(key);
+    if (cached !== undefined) return cached;
+    const fetch = probeColumns(tier, period);
+    columnCache.set(key, fetch);
     return fetch;
   }
 
@@ -514,10 +536,16 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const orgPath = await getOrgAccountsPath();
     const accountReverseMap = await getAccountReverseMap();
     const costScope = await getCostScope().catch(() => undefined);
-    const availableColumns = await getAvailableColumns('daily');
-    return (period, outPath) => buildRollupPartitionQuery(period, 'daily', outPath, {
-      dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, accountReverseMap, costScope, availableColumns,
-    });
+    return async (period, outPath) => {
+      // Probe THIS period's columns, not the latest month's: an older month may
+      // lack optional cost columns the latest has, and a single-month build
+      // referencing an absent column throws a Binder Error (Issue: cold rebuild
+      // over mixed-schema months).
+      const availableColumns = await getColumnsForPeriod('daily', period);
+      return buildRollupPartitionQuery(period, 'daily', outPath, {
+        dataDir: ctx.dataDir, dimensions, orgAccountsPath: orgPath, accountReverseMap, costScope, availableColumns,
+      });
+    };
   }
 
   // Warm-load the persisted rollup: validate the manifest against the current

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -12,8 +12,9 @@ import type { RawRow } from './duckdb-client.js';
 
 /** Builds the `COPY (...) TO '<outPath>' (FORMAT PARQUET)` DDL for one period.
  *  Supplied by the caller (context.ts) so the store stays decoupled from the
- *  query builder. */
-export type BuildPartitionSql = (period: string, outPath: string) => string;
+ *  query builder. May be async: the caller probes each period's parquet schema
+ *  before emitting SQL (months drift in which optional cost columns they have). */
+export type BuildPartitionSql = (period: string, outPath: string) => string | Promise<string>;
 
 export interface RollupShape {
   readonly signature: string;
@@ -183,7 +184,7 @@ export class RollupStore {
         try {
           const outPath = this.partitionPath(period);
           await mkdir(this.partitionDir(period), { recursive: true });
-          await this.runQuery(buildSql(period, outPath));
+          await this.runQuery(await buildSql(period, outPath));
           const meta = await this.partitionMeta(outPath, wantHash);
           if (this.epoch !== startEpoch) return; // a drop landed during the build
           manifest = { ...manifest, builtAt: '', partitions: { ...manifest.partitions, [period]: meta } };


### PR DESCRIPTION
## Problem

A full cold rebuild of the daily rollup failed for months whose CUR parquet lacks optional cost columns. `getAvailableColumns('daily')` probed **only the most recent month** and reused that column set for every period it built. Real data has schema drift — months `2025-06..2026-03` have 18 columns (no `reservation_effective_cost` / `savings_plan_savings_plan_effective_cost`); `2026-04..2026-06` have 22. Because the probe sampled the latest month, the `amortized` build SQL referenced `reservation_effective_cost`, so building any pre-2026-04 month threw `Binder Error: column "reservation_effective_cost" not found`. Those months never became rollup-backed (`rollup: build failed for <period> …`), silently falling back to raw.

Latent today because the on-disk rollup cache is valid and never rebuilt — but it bites on any shape-signature invalidation (dimensions / cost-scope edit) or a manual full rebuild, where `warmupRollup` re-derives all months with the latest-month column set.

## Fix

Make the build per-month schema-aware: probe each period's own parquet columns at build time (`getColumnsForPeriod`, cached per `tier:period`) and pass that set into `buildRollupPartitionQuery`. For a month lacking the effective-cost columns, the amortized expression degrades to unblended instead of referencing an absent column. `BuildPartitionSql` may now be async so the build callback can `await` the per-period probe; `getAvailableColumns` (latest-month) is unchanged and still drives the shape signature and capability checks.

## Verification

- `npm run check`: 4 packages typecheck, eslint clean, 744 tests pass. New regression test (`rollup-schema-drift.test.ts`) builds an 18-col and a 22-col month and asserts both build, with a guard proving the old latest-month-for-all wiring fails on the drifted month.
- Drove the **real** Electron main-process startup warmup (`createAppContext` → `warmupBase`) over the real mixed-schema data with `amortized` metric, fresh (absent) rollup dir:
  - **Fixed:** all 13 months build, 0 binder errors, 13 on-disk partitions; the old 18-col month (2025-10) yields a queryable partition (6.7M rows, degraded amortized→unblended).
  - **Reverting one line** to the old behavior reproduced the exact symptom: 10 `rollup: build failed … reservation_effective_cost` errors, only 3 valid periods.

## Follow-up (separate)

The raw multi-period read path (`read_parquet([old, new])`) hits the same drift error for `amortized` queries that can't use the rollup (Explorer, hourly, out-of-grain). Tracked separately — likely a `union_by_name=true` fix with its own perf/test surface.