### PR TITLE
feat(rollup): per-dimension marginal impact in the grain estimator

### DIFF
--- a/packages/core/src/__tests__/rollup-estimator.test.ts
+++ b/packages/core/src/__tests__/rollup-estimator.test.ts
@@ -231,6 +231,19 @@ describe('computeRollupEstimate per-dimension marginal impact', () => {
   });
 });
 
+describe('currentMatchesCandidate', () => {
+  const base = {
+    probePeriod: '2026-04', months: 1, probeGrainRows: 1000, probeLineItems: 10_000,
+    rawBytes: 0, current: { rows: 500, bytes: 8000 }, dimCardinalities: [],
+  } as const;
+  it('defaults to false when the caller omits it', () => {
+    expect(computeRollupEstimate(base).currentMatchesCandidate).toBe(false);
+  });
+  it('passes through when the built rollup matches the grain', () => {
+    expect(computeRollupEstimate({ ...base, currentMatchesCandidate: true }).currentMatchesCandidate).toBe(true);
+  });
+});
+
 describe('emptyRollupEstimate', () => {
   it('carries the current stats but reports no probe', () => {
     const e = emptyRollupEstimate({ rows: 10, bytes: 160 });
@@ -238,6 +251,7 @@ describe('emptyRollupEstimate', () => {
     expect(e.current).toEqual({ rows: 10, bytes: 160 });
     expect(e.raw).toEqual({ rows: 0, bytes: 0 });
     expect(e.rawOnly.recommended).toBe(false);
+    expect(e.currentMatchesCandidate).toBe(false);
     expect(e.dims).toEqual([]);
   });
 });

--- a/packages/core/src/__tests__/rollup-estimator.test.ts
+++ b/packages/core/src/__tests__/rollup-estimator.test.ts
@@ -8,6 +8,10 @@ import {
   classifyRebuildBand,
   RAW_ONLY_PARTITION_BYTES,
   DEFAULT_BYTES_PER_ROW,
+  OUTLIER_MIN_DIMS,
+  OUTLIER_MIN_MULTIPLIER,
+  OUTLIER_MIN_SHARE,
+  OUTLIER_MEDIAN_MULTIPLE,
 } from '../rollup/estimator.js';
 
 const MB = 1024 * 1024;
@@ -70,8 +74,8 @@ describe('computeRollupEstimate', () => {
       rawBytes: 4_900_000_000,
       current: { rows: 1_100_000, bytes: 17_600_000 },
       dimCardinalities: [
-        { column: 'account_id', cardinality: 14 },
-        { column: 'service', cardinality: 38 },
+        { column: 'account_id', cardinality: 14, leaveOneOutGrainRows: 88_000 },
+        { column: 'service', cardinality: 38, leaveOneOutGrainRows: 70_000 },
       ],
     });
     expect(e.candidate.rows).toBe(92_000 * 12);
@@ -93,7 +97,7 @@ describe('computeRollupEstimate', () => {
       probeLineItems: 6_000_000,
       rawBytes: 30_000_000_000,
       current: null,
-      dimCardinalities: [{ column: 'resource_id', cardinality: 5_000_000 }],
+      dimCardinalities: [{ column: 'resource_id', cardinality: 5_000_000, leaveOneOutGrainRows: 50_000 }],
     });
     expect(e.candidate.perPartitionBytes).toBeGreaterThan(RAW_ONLY_PARTITION_BYTES);
     expect(e.rawOnly.recommended).toBe(true);
@@ -111,7 +115,7 @@ describe('computeRollupEstimate', () => {
       current: { rows: 100_000, bytes: 1_600_000 },
       // A low-cardinality dim so neither the byte nor the high-card per-dim rule
       // fires — the recommendation comes purely from the 3× growth.
-      dimCardinalities: [{ column: 'region', cardinality: 200 }],
+      dimCardinalities: [{ column: 'region', cardinality: 200, leaveOneOutGrainRows: 1_500 }],
     });
     expect(e.candidate.perPartitionBytes).toBeLessThan(RAW_ONLY_PARTITION_BYTES);
     expect(e.candidate.growthFactor).toBeCloseTo(3, 1);
@@ -127,6 +131,103 @@ describe('computeRollupEstimate', () => {
     });
     expect(e.months).toBe(1);
     expect(e.candidate.rows).toBe(1000);
+  });
+});
+
+describe('computeRollupEstimate per-dimension marginal impact', () => {
+  const base = {
+    probePeriod: '2026-04', months: 1, probeLineItems: 200_000, rawBytes: 0, current: null,
+  } as const;
+
+  it('exports conservative outlier thresholds', () => {
+    expect(OUTLIER_MIN_DIMS).toBe(2);
+    expect(OUTLIER_MIN_MULTIPLIER).toBe(2);
+    expect(OUTLIER_MIN_SHARE).toBe(0.5);
+    expect(OUTLIER_MEDIAN_MULTIPLE).toBe(4);
+  });
+
+  it('flags no outlier when two dims contribute comparably — and outlier is independent of rawOnly', () => {
+    const e = computeRollupEstimate({
+      ...base, probeGrainRows: 10_000,
+      dimCardinalities: [
+        { column: 'a', cardinality: 50, leaveOneOutGrainRows: 2_000 },
+        { column: 'b', cardinality: 60, leaveOneOutGrainRows: 2_100 },
+      ],
+    });
+    expect(e.dims.every(d => !d.outlier)).toBe(true);
+    // Shares split roughly evenly — neither dwarfs the other.
+    expect(e.dims.map(d => d.impactShare).every(s => s > 0.4 && s < 0.6)).toBe(true);
+    // High multipliers must NOT trip the whole-grain raw-only recommendation.
+    expect(e.rawOnly.recommended).toBe(false);
+  });
+
+  it('flags the single dim that dominates the grain', () => {
+    const e = computeRollupEstimate({
+      ...base, probeGrainRows: 1_840_000,
+      dimCardinalities: [
+        { column: 'resource_id', cardinality: 1_820_000, leaveOneOutGrainRows: 92_000 },
+        { column: 'account_id', cardinality: 14, leaveOneOutGrainRows: 1_800_000 },
+        { column: 'service', cardinality: 38, leaveOneOutGrainRows: 1_780_000 },
+      ],
+    });
+    const resource = e.dims.find(d => d.column === 'resource_id');
+    expect(resource?.outlier).toBe(true);
+    expect(resource?.marginalMultiplier).toBeCloseTo(20, 0);
+    expect(resource?.impactShare).toBeGreaterThan(0.9);
+    expect(e.dims.filter(d => d.outlier)).toHaveLength(1);
+  });
+
+  it('attributes impact by joint grain, not cardinality: a correlated high-cardinality dim reads ~×1', () => {
+    const e = computeRollupEstimate({
+      ...base, probeGrainRows: 500_000,
+      dimCardinalities: [
+        // High cardinality, but implied by `service` → removing it barely shrinks the grain.
+        { column: 'region_detail', cardinality: 8_000, leaveOneOutGrainRows: 495_000 },
+        { column: 'service', cardinality: 40, leaveOneOutGrainRows: 250_000 },
+      ],
+    });
+    const corr = e.dims.find(d => d.column === 'region_detail');
+    const svc = e.dims.find(d => d.column === 'service');
+    expect(corr?.marginalMultiplier).toBeCloseTo(1.01, 1);
+    expect(corr?.outlier).toBe(false);
+    // Lower cardinality yet far higher real impact — the whole point.
+    expect((corr?.cardinality ?? 0)).toBeGreaterThan(svc?.cardinality ?? 0);
+    expect((svc?.marginalMultiplier ?? 0)).toBeGreaterThan(corr?.marginalMultiplier ?? 0);
+  });
+
+  it('clamps HLL noise (loo slightly above the full grain) to ×1 / +0 rows', () => {
+    const e = computeRollupEstimate({
+      ...base, probeGrainRows: 100_000,
+      dimCardinalities: [
+        { column: 'noisy', cardinality: 30, leaveOneOutGrainRows: 101_000 },
+        { column: 'other', cardinality: 40, leaveOneOutGrainRows: 60_000 },
+      ],
+    });
+    const noisy = e.dims.find(d => d.column === 'noisy');
+    expect(noisy?.marginalMultiplier).toBe(1);
+    expect(noisy?.marginalRows).toBe(0);
+    expect(noisy?.impactShare).toBe(0);
+  });
+
+  it('never flags an outlier on a single-dim grain', () => {
+    const e = computeRollupEstimate({
+      ...base, probeGrainRows: 50_000,
+      dimCardinalities: [{ column: 'only', cardinality: 500, leaveOneOutGrainRows: 1_000 }],
+    });
+    expect(e.dims[0]?.marginalMultiplier).toBeCloseTo(50, 0);
+    expect(e.dims[0]?.outlier).toBe(false);
+  });
+
+  it('scales marginal rows by the window months', () => {
+    const e = computeRollupEstimate({
+      ...base, months: 12, probeGrainRows: 100_000,
+      dimCardinalities: [
+        { column: 'big', cardinality: 5_000, leaveOneOutGrainRows: 20_000 },
+        { column: 'small', cardinality: 30, leaveOneOutGrainRows: 90_000 },
+      ],
+    });
+    // (100_000 − 20_000) × 12 months.
+    expect(e.dims.find(d => d.column === 'big')?.marginalRows).toBe(80_000 * 12);
   });
 });
 

--- a/packages/core/src/__tests__/rollup-grain.test.ts
+++ b/packages/core/src/__tests__/rollup-grain.test.ts
@@ -71,6 +71,22 @@ describe('rollupGrainDimensions', () => {
     // Built-ins first, then tags; one entry per enabled dimension.
     expect(dims.map(d => d.column)).toEqual(['account_id', 'service', 'region', 'tag_team', 'tag_environment']);
   });
+
+  it('collapses derived dimensions that share one physical column to a single entry', () => {
+    // Region / Country / Continent are query-time views of the same `region`
+    // column — they must not produce duplicate, identically-attributed rows.
+    const shared: DimensionsConfig = {
+      builtIn: [
+        { name: asDimensionId('region'), label: 'Region', field: 'region' },
+        { name: asDimensionId('region_country'), label: 'Country', field: 'region' },
+        { name: asDimensionId('region_continent'), label: 'Continent', field: 'region' },
+        { name: asDimensionId('service'), label: 'Service', field: 'service' },
+      ],
+      tags: [],
+    };
+    const dims = rollupGrainDimensions(shared);
+    expect(dims.map(d => d.column)).toEqual(['region', 'service']);
+  });
 });
 
 describe('buildRollupPartitionQuery', () => {

--- a/packages/core/src/__tests__/rollup-grain.test.ts
+++ b/packages/core/src/__tests__/rollup-grain.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { rm } from 'node:fs/promises';
 import { buildSource, buildRollupPartitionQuery } from '../query/builder.js';
-import { rollupGrainColumns } from '../rollup/grain.js';
+import { rollupGrainColumns, rollupGrainDimensions } from '../rollup/grain.js';
 import type { DimensionsConfig } from '../types/config.js';
 import type { CostScopeConfig } from '../types/cost-scope.js';
 import { asDimensionId } from '../types/branded.js';
@@ -57,6 +57,21 @@ function scope(rules: CostScopeConfig['rules']): CostScopeConfig {
 function rawSourceJan(): string {
   return buildSource({ dataDir: SYNTHETIC_DIR, tier: 'daily', dimensions, periods: [PERIOD], costMetric: 'unblended' });
 }
+
+describe('rollupGrainDimensions', () => {
+  it('groups a built-in display column under its dimension and drops disabled dims', () => {
+    const dims = rollupGrainDimensions(dimensions);
+    // account_name rides with account_id — it is NOT a standalone dimension.
+    expect(dims.find(d => d.column === 'account_id')?.columns).toEqual(['account_id', 'account_name']);
+    expect(dims.some(d => d.column === 'account_name')).toBe(false);
+    // disabled usage_type is absent; single-column dims carry just themselves.
+    expect(dims.some(d => d.column === 'usage_type')).toBe(false);
+    expect(dims.find(d => d.column === 'service')?.columns).toEqual(['service']);
+    expect(dims.find(d => d.column === 'tag_team')?.columns).toEqual(['tag_team']);
+    // Built-ins first, then tags; one entry per enabled dimension.
+    expect(dims.map(d => d.column)).toEqual(['account_id', 'service', 'region', 'tag_team', 'tag_environment']);
+  });
+});
 
 describe('buildRollupPartitionQuery', () => {
   let db: Awaited<ReturnType<typeof DuckDBInstance.create>>;

--- a/packages/core/src/__tests__/rollup-probe.test.ts
+++ b/packages/core/src/__tests__/rollup-probe.test.ts
@@ -62,19 +62,28 @@ function toNum(v: unknown): number {
   return 0;
 }
 
-/** Run the probe and return line_items, grain_rows, and a column→cardinality
- *  map (mirroring the desktop handler's card_<i> decoding). */
+/** Run the probe and return line_items, grain_rows, a column→cardinality map and
+ *  a column→leave-one-out-grain map (mirroring the desktop handler's card_<i> /
+ *  loo_<i> decoding). */
 async function probe(
   conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>['connect']>>,
   dimensions: DimensionsConfig,
-): Promise<{ lineItems: number; grainRows: number; cards: Map<string, number> }> {
+): Promise<{ lineItems: number; grainRows: number; cards: Map<string, number>; loo: Map<string, number> }> {
   const grain = rollupGrainColumns(dimensions);
   const cardCols = grain.filter(c => c !== 'usage_date');
   const sql = buildGrainProbeQuery(PERIOD, grain, { dataDir: SYNTHETIC_DIR, dimensions, costScope: scope });
   const row = (await queryAll(conn, sql))[0];
   const cards = new Map<string, number>();
-  cardCols.forEach((col, i) => { cards.set(col, toNum(row?.[`card_${String(i)}`])); });
-  return { lineItems: toNum(row?.['line_items']), grainRows: toNum(row?.['grain_rows']), cards };
+  const loo = new Map<string, number>();
+  cardCols.forEach((col, i) => {
+    cards.set(col, toNum(row?.[`card_${String(i)}`]));
+    loo.set(col, toNum(row?.[`loo_${String(i)}`]));
+  });
+  return { lineItems: toNum(row?.['line_items']), grainRows: toNum(row?.['grain_rows']), cards, loo };
+}
+
+function dimInputs(cards: Map<string, number>, loo: Map<string, number>): { column: string; cardinality: number; leaveOneOutGrainRows: number }[] {
+  return [...cards].map(([column, cardinality]) => ({ column, cardinality, leaveOneOutGrainRows: loo.get(column) ?? 0 }));
 }
 
 describe('buildGrainProbeQuery', () => {
@@ -88,7 +97,7 @@ describe('buildGrainProbeQuery', () => {
   afterAll(async () => { /* in-memory db, nothing to clean */ });
 
   it('a stable grain aggregates well below the line-item count', async () => {
-    const { lineItems, grainRows, cards } = await probe(conn, stableGrain);
+    const { lineItems, grainRows, cards, loo } = await probe(conn, stableGrain);
     expect(lineItems).toBeGreaterThan(0);
     expect(grainRows).toBeGreaterThan(0);
     // Pre-aggregation must collapse rows — the stable grain compresses raw.
@@ -96,11 +105,14 @@ describe('buildGrainProbeQuery', () => {
 
     const estimate = computeRollupEstimate({
       probePeriod: PERIOD, months: 1, probeGrainRows: grainRows, probeLineItems: lineItems, rawBytes: 0,
-      current: null, dimCardinalities: [...cards].map(([column, cardinality]) => ({ column, cardinality })),
+      current: null, dimCardinalities: dimInputs(cards, loo),
     });
     expect(estimate.compressionRate).toBeGreaterThan(1);
     expect(estimate.dims.find(d => d.column === 'resource_id')).toBeUndefined();
     expect(estimate.dims.every(d => !d.rawOnly)).toBe(true);
+    // No single navigational dim dominates a balanced grain.
+    expect(estimate.dims.every(d => !d.outlier)).toBe(true);
+    expect(estimate.dims.every(d => d.marginalMultiplier >= 1)).toBe(true);
   });
 
   it('flags resource_id raw-only: it is near-unique per line item', async () => {
@@ -116,11 +128,20 @@ describe('buildGrainProbeQuery', () => {
     const estimate = computeRollupEstimate({
       probePeriod: PERIOD, months: 1, probeGrainRows: withResource.grainRows, probeLineItems: withResource.lineItems, rawBytes: 0,
       current: null,
-      dimCardinalities: [...withResource.cards].map(([column, cardinality]) => ({ column, cardinality })),
+      dimCardinalities: dimInputs(withResource.cards, withResource.loo),
     });
     // The data-driven verdict: resource_id is raw-only, the others are not.
     expect(estimate.dims.find(d => d.column === 'resource_id')?.rawOnly).toBe(true);
     expect(estimate.dims.find(d => d.column === 'service')?.rawOnly).toBe(false);
     expect(estimate.dims.find(d => d.column === 'account_id')?.rawOnly).toBe(false);
+    // The leave-one-out SQL columns flow through to valid per-dim marginals
+    // (multipliers clamped ≥ 1, shares in [0,1] and summing to 1). On this tiny,
+    // dense fixture the other dims already near-uniquely identify each row, so
+    // resource_id's *marginal* multiplier stays modest even though its
+    // *cardinality* flags it raw-only — the cardinality-vs-LOO distinction.
+    const resource = estimate.dims.find(d => d.column === 'resource_id');
+    expect(resource).toBeDefined();
+    expect(estimate.dims.every(d => d.marginalMultiplier >= 1 && d.impactShare >= 0 && d.impactShare <= 1)).toBe(true);
+    expect(estimate.dims.reduce((sum, d) => sum + d.impactShare, 0)).toBeCloseTo(1, 5);
   });
 });

--- a/packages/core/src/__tests__/rollup-probe.test.ts
+++ b/packages/core/src/__tests__/rollup-probe.test.ts
@@ -3,7 +3,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildGrainProbeQuery } from '../query/builder.js';
-import { rollupGrainColumns } from '../rollup/grain.js';
+import { rollupGrainColumns, rollupGrainDimensions } from '../rollup/grain.js';
 import { computeRollupEstimate } from '../rollup/estimator.js';
 import type { DimensionsConfig } from '../types/config.js';
 import type { CostScopeConfig } from '../types/cost-scope.js';
@@ -70,14 +70,14 @@ async function probe(
   dimensions: DimensionsConfig,
 ): Promise<{ lineItems: number; grainRows: number; cards: Map<string, number>; loo: Map<string, number> }> {
   const grain = rollupGrainColumns(dimensions);
-  const cardCols = grain.filter(c => c !== 'usage_date');
+  const grainDims = rollupGrainDimensions(dimensions);
   const sql = buildGrainProbeQuery(PERIOD, grain, { dataDir: SYNTHETIC_DIR, dimensions, costScope: scope });
   const row = (await queryAll(conn, sql))[0];
   const cards = new Map<string, number>();
   const loo = new Map<string, number>();
-  cardCols.forEach((col, i) => {
-    cards.set(col, toNum(row?.[`card_${String(i)}`]));
-    loo.set(col, toNum(row?.[`loo_${String(i)}`]));
+  grainDims.forEach((dim, i) => {
+    cards.set(dim.column, toNum(row?.[`card_${String(i)}`]));
+    loo.set(dim.column, toNum(row?.[`loo_${String(i)}`]));
   });
   return { lineItems: toNum(row?.['line_items']), grainRows: toNum(row?.['grain_rows']), cards, loo };
 }

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1105,14 +1105,18 @@ export function buildRollupPartitionQuery(
 /** Build the cardinality probe behind the grain cost/benefit estimator (rollup
  *  design §8). Over ONE recent month it returns, in a single scan:
  *   - `line_items`  — COUNT(*) (the rollup's raw input for that month),
- *   - `grain_rows`  — `approx_count_distinct` of the candidate grain tuple
- *      (≈ the rollup row count for that month), and
- *   - `card_<i>`    — `approx_count_distinct` of each enabled dimension's primary
+ *   - `grain_rows`  — exact `COUNT(DISTINCT)` of the candidate grain tuple
+ *      (the rollup row count for that month), and
+ *   - `card_<i>`    — exact distinct count of each enabled dimension's primary
  *      column, so the estimator can flag individual raw-only dims (e.g. resource_id), and
  *   - `loo_<i>`     — the grain row count with that whole dimension removed (a
  *      built-in drops both its id and display column), so the estimator can
  *      attribute marginal rollup size per dimension. Indexed by
  *      `rollupGrainDimensions` order (built-ins first, then tags).
+ *
+ *  Counts are EXACT (not HyperLogLog): the per-dimension multiplier is a ratio
+ *  of two distinct-counts, and approx error compounds across the ratio. Exact is
+ *  monotonic (a leave-one-out can only lower the count), so multipliers are ≥ 1.
  *
  *  `grainColumns` come from `rollupGrainColumns` over the candidate dimensions
  *  (usage_date first) and are projected by `buildSource` — the same trusted set
@@ -1163,16 +1167,22 @@ export function buildGrainProbeQuery(
   // the marginal rollup size each dimension drives — a correlation-aware impact,
   // computed in this same single scan. Same trusted grainColumns interpolation
   // as grainConcat above (no user values).
+  //
+  // EXACT COUNT(DISTINCT), not approx_count_distinct: the marginal multiplier is
+  // a ratio of two distinct-counts, and HyperLogLog error (measured 6–13% on
+  // real CUR data) compounds across the ratio, fabricating spurious ×1.1–×1.5
+  // impacts for near-redundant dims. Exact counts are monotonic (loo ≤ grain),
+  // so multipliers are naturally ≥ 1, and cost only a single extra month-scan.
   const grainDims = rollupGrainDimensions(dimensions);
-  const cardSelects = grainDims.map((dim, i) => `CAST(approx_count_distinct(${dim.column}) AS BIGINT) AS card_${String(i)}`);
+  const cardSelects = grainDims.map((dim, i) => `CAST(COUNT(DISTINCT ${dim.column}) AS BIGINT) AS card_${String(i)}`);
   const looSelects = grainDims.map((dim, i) => {
     const remove = new Set(dim.columns);
     const cols = grainColumns.filter(g => !remove.has(g));
-    return `CAST(approx_count_distinct(concat_ws(chr(31), ${cols.join(', ')})) AS BIGINT) AS loo_${String(i)}`;
+    return `CAST(COUNT(DISTINCT concat_ws(chr(31), ${cols.join(', ')})) AS BIGINT) AS loo_${String(i)}`;
   });
   const selects = [
     `CAST(COUNT(*) AS BIGINT) AS line_items`,
-    `CAST(approx_count_distinct(${grainConcat}) AS BIGINT) AS grain_rows`,
+    `CAST(COUNT(DISTINCT ${grainConcat}) AS BIGINT) AS grain_rows`,
     ...cardSelects,
     ...looSelects,
   ];

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1100,7 +1100,9 @@ export function buildRollupPartitionQuery(
  *   - `grain_rows`  — `approx_count_distinct` of the candidate grain tuple
  *      (≈ the rollup row count for that month), and
  *   - `card_<i>`    — `approx_count_distinct` of each non-date grain column,
- *      so the estimator can flag individual raw-only dims (e.g. resource_id).
+ *      so the estimator can flag individual raw-only dims (e.g. resource_id), and
+ *   - `loo_<i>`     — the grain row count with that one dim removed, so the
+ *      estimator can attribute marginal rollup size per dimension.
  *
  *  `grainColumns` come from `rollupGrainColumns` over the candidate dimensions
  *  (usage_date first) and are projected by `buildSource` — the same trusted set
@@ -1145,10 +1147,20 @@ export function buildGrainProbeQuery(
   const grainConcat = `concat_ws(chr(31), ${grainColumns.join(', ')})`;
   const cardCols = grainColumns.filter(c => c !== 'usage_date');
   const cardSelects = cardCols.map((c, i) => `CAST(approx_count_distinct(${c}) AS BIGINT) AS card_${String(i)}`);
+  // Leave-one-out grain row count for each non-date dim: the candidate grain
+  // with only that dim removed (usage_date always kept). The estimator turns
+  // fullGrain ÷ loo_<i> into the marginal rollup size each dim drives — a
+  // correlation-aware impact, computed in this same single scan. Same trusted
+  // grainColumns interpolation as grainConcat above (no user values).
+  const looSelects = cardCols.map((c, i) => {
+    const cols = grainColumns.filter(g => g !== c);
+    return `CAST(approx_count_distinct(concat_ws(chr(31), ${cols.join(', ')})) AS BIGINT) AS loo_${String(i)}`;
+  });
   const selects = [
     `CAST(COUNT(*) AS BIGINT) AS line_items`,
     `CAST(approx_count_distinct(${grainConcat}) AS BIGINT) AS grain_rows`,
     ...cardSelects,
+    ...looSelects,
   ];
   return `SELECT ${selects.join(', ')} FROM ${source} WHERE ${whereConditions.join(' AND ')}`;
 }

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -9,7 +9,7 @@ import { buildAliasSqlCase, normalizeTagValue, resolveAlias } from '../normalize
 import { costExprFor, LIST_METRIC_LINE_ITEM_TYPES } from './cost-metric.js';
 import { QueryBuilder, type ParameterizedQuery } from './parameterized.js';
 import { assertDateString, assertHourString, SecurityError } from './identifier-validator.js';
-import { rollupGrainColumns } from '../rollup/grain.js';
+import { rollupGrainColumns, rollupGrainDimensions } from '../rollup/grain.js';
 
 function assertFiniteNumber(value: number, name: string): void {
   if (!Number.isFinite(value) || value < 0) {
@@ -1099,10 +1099,12 @@ export function buildRollupPartitionQuery(
  *   - `line_items`  — COUNT(*) (the rollup's raw input for that month),
  *   - `grain_rows`  — `approx_count_distinct` of the candidate grain tuple
  *      (≈ the rollup row count for that month), and
- *   - `card_<i>`    — `approx_count_distinct` of each non-date grain column,
- *      so the estimator can flag individual raw-only dims (e.g. resource_id), and
- *   - `loo_<i>`     — the grain row count with that one dim removed, so the
- *      estimator can attribute marginal rollup size per dimension.
+ *   - `card_<i>`    — `approx_count_distinct` of each enabled dimension's primary
+ *      column, so the estimator can flag individual raw-only dims (e.g. resource_id), and
+ *   - `loo_<i>`     — the grain row count with that whole dimension removed (a
+ *      built-in drops both its id and display column), so the estimator can
+ *      attribute marginal rollup size per dimension. Indexed by
+ *      `rollupGrainDimensions` order (built-ins first, then tags).
  *
  *  `grainColumns` come from `rollupGrainColumns` over the candidate dimensions
  *  (usage_date first) and are projected by `buildSource` — the same trusted set
@@ -1145,15 +1147,19 @@ export function buildGrainProbeQuery(
   const whereConditions = [`usage_date >= '${start}'`, `usage_date < '${end}'`, ...exclusionClauses];
 
   const grainConcat = `concat_ws(chr(31), ${grainColumns.join(', ')})`;
-  const cardCols = grainColumns.filter(c => c !== 'usage_date');
-  const cardSelects = cardCols.map((c, i) => `CAST(approx_count_distinct(${c}) AS BIGINT) AS card_${String(i)}`);
-  // Leave-one-out grain row count for each non-date dim: the candidate grain
-  // with only that dim removed (usage_date always kept). The estimator turns
-  // fullGrain ÷ loo_<i> into the marginal rollup size each dim drives — a
-  // correlation-aware impact, computed in this same single scan. Same trusted
-  // grainColumns interpolation as grainConcat above (no user values).
-  const looSelects = cardCols.map((c, i) => {
-    const cols = grainColumns.filter(g => g !== c);
+  // Per-dimension cardinality and leave-one-out grain. card_<i> is the
+  // dimension's own distinct count; loo_<i> is the grain with that whole
+  // dimension removed — a built-in drops both its id and its display column, so
+  // a 1:1 display column (account_name ↔ account_id) isn't split into two
+  // mutually-covering pseudo-dims. The estimator turns fullGrain ÷ loo_<i> into
+  // the marginal rollup size each dimension drives — a correlation-aware impact,
+  // computed in this same single scan. Same trusted grainColumns interpolation
+  // as grainConcat above (no user values).
+  const grainDims = rollupGrainDimensions(dimensions);
+  const cardSelects = grainDims.map((dim, i) => `CAST(approx_count_distinct(${dim.column}) AS BIGINT) AS card_${String(i)}`);
+  const looSelects = grainDims.map((dim, i) => {
+    const remove = new Set(dim.columns);
+    const cols = grainColumns.filter(g => !remove.has(g));
     return `CAST(approx_count_distinct(concat_ws(chr(31), ${cols.join(', ')})) AS BIGINT) AS loo_${String(i)}`;
   });
   const selects = [

--- a/packages/core/src/rollup/estimator.ts
+++ b/packages/core/src/rollup/estimator.ts
@@ -40,6 +40,20 @@ export const HIGH_CARDINALITY_VALUES = 1000;
  *  against (≈ the measured 266 MB / 19.6M rows from the design appendix). */
 export const DEFAULT_BYTES_PER_ROW = 16;
 
+/** Outlier gates for the per-dimension impact list. A single dim is flagged as
+ *  THE dominant grain driver only when it clears all four, so a balanced grain
+ *  flags nothing and at most one dim is ever flagged. Informational only — these
+ *  do NOT feed `rawOnly.recommended` (that stays the whole-grain verdict). */
+export const OUTLIER_MIN_DIMS = 2;
+/** It must at least double the grain on its own. */
+export const OUTLIER_MIN_MULTIPLIER = 2;
+/** It alone must account for ≥ half of total grain inflation Σ(multiplier−1) —
+ *  i.e. more than every other dim combined. */
+export const OUTLIER_MIN_SHARE = 0.5;
+/** …and stand this far above the median peer dim, so it genuinely dwarfs the
+ *  rest rather than merely edging past a field of near-equal contributors. */
+export const OUTLIER_MEDIAN_MULTIPLE = 4;
+
 const REBUILD_BASE_SECONDS_PER_PARTITION = 2;
 const REBUILD_SECONDS_PER_ROW = 0.0000048;
 
@@ -65,6 +79,17 @@ export interface RollupDimEstimate {
   readonly column: string;
   readonly cardinality: number;
   readonly rawOnly: boolean;
+  /** fullGrain ÷ grainWithoutThisDim — how much this dim alone inflates the
+   *  rollup grain (1.0 = redundant given the others). From a leave-one-out
+   *  probe, so it reflects the joint distribution and accounts for correlation,
+   *  unlike raw cardinality. */
+  readonly marginalMultiplier: number;
+  /** Rollup rows this dim adds across the window (fullGrain − grainWithout, scaled by months). */
+  readonly marginalRows: number;
+  /** This dim's share of total grain inflation Σ(multiplier−1) — drives the bar. */
+  readonly impactShare: number;
+  /** True for the single dim that dominates the grain (see OUTLIER_* consts). */
+  readonly outlier: boolean;
 }
 
 export interface RollupGrainEstimate {
@@ -105,7 +130,7 @@ export interface RollupEstimateInput {
   /** Actual on-disk size of the raw daily Parquet across the whole window. */
   readonly rawBytes: number;
   readonly current: RollupCurrentStats | null;
-  readonly dimCardinalities: readonly { readonly column: string; readonly cardinality: number }[];
+  readonly dimCardinalities: readonly { readonly column: string; readonly cardinality: number; readonly leaveOneOutGrainRows: number }[];
 }
 
 export function estimateBytesPerRow(current: RollupCurrentStats | null): number {
@@ -141,6 +166,15 @@ export function classifyRebuildBand(seconds: number): RollupRebuildBand {
   return 'slow';
 }
 
+/** Median of a list of numbers; 0 for an empty list. */
+function median(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+  return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}
+
 export function computeRollupEstimate(input: RollupEstimateInput): RollupGrainEstimate {
   const months = Math.max(1, input.months);
   const bytesPerRow = estimateBytesPerRow(input.current);
@@ -152,10 +186,46 @@ export function computeRollupEstimate(input: RollupEstimateInput): RollupGrainEs
   const compressionRate = perPartitionRows > 0 ? input.probeLineItems / perPartitionRows : 0;
   const growthFactor = input.current !== null && input.current.rows > 0 ? rows / input.current.rows : null;
 
-  const dims = input.dimCardinalities.map(d => ({
-    column: d.column,
-    cardinality: d.cardinality,
-    rawOnly: isDimRawOnly(d.cardinality, input.probeLineItems, bytesPerRow),
+  // Per-dimension marginal impact from the leave-one-out grain counts: how much
+  // each dim alone inflates the rollup grain. Truthful where cardinality lies —
+  // a high-cardinality dim that's implied by another (correlated) drops out at
+  // ≈ ×1 because removing it barely shrinks the joint grain.
+  const marginals = input.dimCardinalities.map(d => {
+    const loo = d.leaveOneOutGrainRows;
+    const multiplier = loo > 0 ? Math.max(1, perPartitionRows / loo) : 1;
+    return {
+      column: d.column,
+      cardinality: d.cardinality,
+      multiplier,
+      inflation: multiplier - 1,
+      marginalRows: Math.max(0, perPartitionRows - loo) * months,
+    };
+  });
+  const totalInflation = marginals.reduce((sum, m) => sum + m.inflation, 0);
+
+  // Only the largest-inflation dim can exceed 50% share, so the dominant-driver
+  // test is applied to it alone — measured against the median of its peers.
+  const ranked = [...marginals].sort((a, b) => b.inflation - a.inflation);
+  const top = ranked[0];
+  const medianPeerInflation = median(ranked.slice(1).map(m => m.inflation));
+  const outlierColumn =
+    top !== undefined &&
+    marginals.length >= OUTLIER_MIN_DIMS &&
+    top.multiplier >= OUTLIER_MIN_MULTIPLIER &&
+    totalInflation > 0 &&
+    top.inflation / totalInflation >= OUTLIER_MIN_SHARE &&
+    (medianPeerInflation <= 0 || top.inflation >= OUTLIER_MEDIAN_MULTIPLE * medianPeerInflation)
+      ? top.column
+      : null;
+
+  const dims = marginals.map(m => ({
+    column: m.column,
+    cardinality: m.cardinality,
+    rawOnly: isDimRawOnly(m.cardinality, input.probeLineItems, bytesPerRow),
+    marginalMultiplier: m.multiplier,
+    marginalRows: m.marginalRows,
+    impactShare: totalInflation > 0 ? m.inflation / totalInflation : 0,
+    outlier: m.column === outlierColumn,
   }));
   const flaggedCount = dims.filter(d => d.rawOnly).length;
 

--- a/packages/core/src/rollup/estimator.ts
+++ b/packages/core/src/rollup/estimator.ts
@@ -104,6 +104,10 @@ export interface RollupGrainEstimate {
   readonly raw: RollupRawStats;
   /** Exact totals summed from the on-disk rollup manifest; null when none built. */
   readonly current: RollupCurrentStats | null;
+  /** True when the built rollup was materialized for THIS exact grain — i.e.
+   *  `current` is the real size of the candidate, not a directional estimate.
+   *  The UI shows actual rollup stats (and hides the rebuild) when set. */
+  readonly currentMatchesCandidate: boolean;
   readonly candidate: {
     readonly rows: number;
     readonly bytes: number;
@@ -130,6 +134,9 @@ export interface RollupEstimateInput {
   /** Actual on-disk size of the raw daily Parquet across the whole window. */
   readonly rawBytes: number;
   readonly current: RollupCurrentStats | null;
+  /** Whether `current` is the built rollup for THIS grain (vs any older grain).
+   *  Defaults to false when omitted (callers that don't track it get an estimate). */
+  readonly currentMatchesCandidate?: boolean;
   readonly dimCardinalities: readonly { readonly column: string; readonly cardinality: number; readonly leaveOneOutGrainRows: number }[];
 }
 
@@ -245,6 +252,7 @@ export function computeRollupEstimate(input: RollupEstimateInput): RollupGrainEs
     lineItems: input.probeLineItems,
     raw: { rows: input.probeLineItems * months, bytes: input.rawBytes },
     current: input.current,
+    currentMatchesCandidate: input.currentMatchesCandidate ?? false,
     candidate: {
       rows,
       bytes,
@@ -268,6 +276,7 @@ export function emptyRollupEstimate(current: RollupCurrentStats | null): RollupG
     lineItems: 0,
     raw: { rows: 0, bytes: 0 },
     current,
+    currentMatchesCandidate: false,
     candidate: {
       rows: 0,
       bytes: 0,

--- a/packages/core/src/rollup/grain.ts
+++ b/packages/core/src/rollup/grain.ts
@@ -30,19 +30,31 @@ export function rollupGrainColumns(dims: DimensionsConfig): string[] {
  *  drops both its id and its display column together, so a 1:1 display column
  *  (e.g. account_name ↔ account_id) is never measured as a redundant
  *  pseudo-dimension. Built-ins first, then tags (same enabled-set semantics as
- *  rollupGrainColumns). */
+ *  rollupGrainColumns).
+ *
+ *  DEDUPED BY PRIMARY COLUMN: several dimensions can map to the SAME physical
+ *  grain column — Region, Country and Continent are all query-time views of the
+ *  one `region` column. They are not independent grain groups (the rollup stores
+ *  the column once), so they collapse to a single entry; otherwise the probe
+ *  would emit identical, mis-attributed duplicate rows. */
 export function rollupGrainDimensions(dims: DimensionsConfig): { column: string; columns: string[] }[] {
   const out: { column: string; columns: string[] }[] = [];
+  const seen = new Set<string>();
+  const add = (column: string, columns: string[]): void => {
+    if (seen.has(column)) return;
+    seen.add(column);
+    out.push({ column, columns });
+  };
   for (const d of dims.builtIn) {
     if (!isEnabled(d)) continue;
     const columns = [d.field];
     if (d.displayField !== undefined && d.displayField.length > 0) columns.push(d.displayField);
-    out.push({ column: d.field, columns });
+    add(d.field, columns);
   }
   for (const t of dims.tags) {
     if (!isEnabled(t)) continue;
     const col = tagDimColumn(t);
-    out.push({ column: col, columns: [col] });
+    add(col, [col]);
   }
   return out;
 }

--- a/packages/core/src/rollup/grain.ts
+++ b/packages/core/src/rollup/grain.ts
@@ -22,3 +22,27 @@ export function rollupGrainColumns(dims: DimensionsConfig): string[] {
   const rest = [...cols].filter(c => c !== 'usage_date').sort((a, b) => a.localeCompare(b));
   return ['usage_date', ...rest];
 }
+
+/** The enabled dimensions as grain groups: each dimension's primary column (a
+ *  built-in's `field`, or a tag's column) paired with EVERY grain column it
+ *  contributes (a built-in also stores its `displayField`). Used by the grain
+ *  probe to attribute marginal rollup size PER DIMENSION — removing a built-in
+ *  drops both its id and its display column together, so a 1:1 display column
+ *  (e.g. account_name ↔ account_id) is never measured as a redundant
+ *  pseudo-dimension. Built-ins first, then tags (same enabled-set semantics as
+ *  rollupGrainColumns). */
+export function rollupGrainDimensions(dims: DimensionsConfig): { column: string; columns: string[] }[] {
+  const out: { column: string; columns: string[] }[] = [];
+  for (const d of dims.builtIn) {
+    if (!isEnabled(d)) continue;
+    const columns = [d.field];
+    if (d.displayField !== undefined && d.displayField.length > 0) columns.push(d.displayField);
+    out.push({ column: d.field, columns });
+  }
+  for (const t of dims.tags) {
+    if (!isEnabled(t)) continue;
+    const col = tagDimColumn(t);
+    out.push({ column: col, columns: [col] });
+  }
+  return out;
+}

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -153,6 +153,9 @@ export interface AppContext {
    *  or line_item_net_*. Cached per-tier for the session; invalidated on
    *  explicit reset via invalidateColumnCache. */
   readonly getAvailableColumns: (tier: 'daily' | 'hourly') => Promise<ReadonlySet<string>>;
+  /** Build-affecting shape signature for a dimensions config — compare against
+   *  rollupStore.getBuiltSignature() to tell if the built rollup matches a grain. */
+  readonly signatureForDimensions: (dims: DimensionsConfig) => Promise<string>;
   readonly queryLog: QueryLog;
   /** Persistent per-period pre-aggregated rollup backing dashboard queries. */
   readonly rollupStore: RollupStore;
@@ -480,15 +483,22 @@ export function createAppContext(ctx: IpcContext): AppContext {
     });
   };
 
-  async function getRollupShape(): Promise<RollupShape> {
+  // Full build-affecting shape signature for an arbitrary dimensions config.
+  // The single source of truth for both the built rollup's signature (via
+  // getRollupShape) and the what-if estimate's "does this grain match what's
+  // built" check — keeping them on one code path so they can never drift (a
+  // drift would silently make the estimate's matched-check always false).
+  // computeShapeSignature ignores aliases/labels/region-enrichment, so the raw
+  // editor `candidate` and the query-enriched dims hash identically for the same
+  // enabled grain.
+  async function signatureForDimensions(dimensions: DimensionsConfig): Promise<string> {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
-    const dimensions = await getQueryDimensions();
     const costScope = await getCostScope().catch(() => undefined);
     const availableColumns = await getAvailableColumns('daily');
     let orgRaw = '';
     try { orgRaw = await fs.readFile(path.join(path.dirname(ctx.dataDir), 'org-accounts.json'), 'utf-8'); } catch { /* no org sync yet */ }
-    const signature = computeShapeSignature({
+    return computeShapeSignature({
       dimensions,
       costMetric: costScope?.costMetric ?? 'unblended',
       costPerspective: costScope?.costPerspective ?? 'gross',
@@ -497,6 +507,12 @@ export function createAppContext(ctx: IpcContext): AppContext {
       orgAccountsDigest: computeOrgAccountsDigest(orgRaw),
       availableColumns: [...availableColumns],
     });
+  }
+
+  async function getRollupShape(): Promise<RollupShape> {
+    const dimensions = await getQueryDimensions();
+    const signature = await signatureForDimensions(dimensions);
+    const availableColumns = await getAvailableColumns('daily');
     return { signature, grainDimensions: rollupGrainColumns(dimensions), availableColumns: [...availableColumns] };
   }
 
@@ -587,6 +603,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     getRegionMap,
     getOrgAccountsPath,
     getAvailableColumns,
+    signatureForDimensions,
     queryLog,
     rollupStore,
     runQuery,

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { applyNormalizationRule, applyStripPatterns, buildGrainProbeQuery, buildSource, computeRollupEstimate, dimensionsConfigToYaml, emptyRollupEstimate, generateAliasSuggestions, isStringRecord, rollupGrainColumns } from '@costgoblin/core';
+import { applyNormalizationRule, applyStripPatterns, buildGrainProbeQuery, buildSource, computeRollupEstimate, dimensionsConfigToYaml, emptyRollupEstimate, generateAliasSuggestions, isStringRecord, rollupGrainColumns, rollupGrainDimensions } from '@costgoblin/core';
 import type { AliasSuggestion, DimensionsConfig, NormalizationRule, RollupGrainEstimate } from '@costgoblin/core';
 import { type AppContext, loadOrgAccountsMap } from './context.js';
 import { toNum, toStr } from './query-utils.js';
@@ -249,7 +249,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
 
     const period = latest.replace(/^daily-/, '');
     const grainColumns = rollupGrainColumns(candidate);
-    const cardCols = grainColumns.filter(c => c !== 'usage_date');
+    const grainDims = rollupGrainDimensions(candidate);
 
     const costScope = await getCostScope().catch(() => undefined);
     const availableColumns = await getAvailableColumns('daily');
@@ -266,8 +266,8 @@ export function registerDimensionsHandlers(app: AppContext): void {
     // baseline the UI shows the estimated rollup against.
     const rawBytes = await sumParquetBytes(fs, path, rawDir, dirs);
 
-    const dimCardinalities = cardCols.map((column, i) => ({
-      column,
+    const dimCardinalities = grainDims.map((dim, i) => ({
+      column: dim.column,
       cardinality: toNum(row[`card_${String(i)}`]),
       leaveOneOutGrainRows: toNum(row[`loo_${String(i)}`]),
     }));

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -77,7 +77,7 @@ function filterUncoveredSuggestions(
 }
 
 export function registerDimensionsHandlers(app: AppContext): void {
-  const { ctx, getConfig, getDimensions, getQueryDimensions, getCostScope, getAvailableColumns, getOrgAccountsPath, getAccountReverseMap, getRegionMap, invalidateDimensions, rollupStore, runQuery } = app;
+  const { ctx, getConfig, getDimensions, getQueryDimensions, getCostScope, getAvailableColumns, getOrgAccountsPath, getAccountReverseMap, getRegionMap, signatureForDimensions, invalidateDimensions, rollupStore, runQuery } = app;
 
   ipcMain.handle('dimensions:discover-tags', async (): Promise<{ tags: { key: string; sampleValues: string[]; rowCount: number; distinctCount: number; coveragePct: number }[]; samplePeriod: string }> => {
     const config = await getConfig();
@@ -271,6 +271,15 @@ export function registerDimensionsHandlers(app: AppContext): void {
       cardinality: toNum(row[`card_${String(i)}`]),
       leaveOneOutGrainRows: toNum(row[`loo_${String(i)}`]),
     }));
+
+    // Is the on-disk rollup actually built for THIS grain? Compare the
+    // candidate's full shape signature to what the partitions were built
+    // against (same signatureForDimensions path getRollupShape uses). When they
+    // match, `current` is the real size of this grain, not an estimate.
+    const builtSignature = rollupStore.getBuiltSignature();
+    const candidateSignature = await signatureForDimensions(candidate);
+    const currentMatchesCandidate = current !== null && builtSignature !== null && builtSignature === candidateSignature;
+
     return computeRollupEstimate({
       probePeriod: period,
       months: dirs.length,
@@ -278,6 +287,7 @@ export function registerDimensionsHandlers(app: AppContext): void {
       probeLineItems: toNum(row['line_items']),
       rawBytes,
       current,
+      currentMatchesCandidate,
       dimCardinalities,
     });
   });

--- a/packages/desktop/src/main/handlers/dimensions.ts
+++ b/packages/desktop/src/main/handlers/dimensions.ts
@@ -266,7 +266,11 @@ export function registerDimensionsHandlers(app: AppContext): void {
     // baseline the UI shows the estimated rollup against.
     const rawBytes = await sumParquetBytes(fs, path, rawDir, dirs);
 
-    const dimCardinalities = cardCols.map((column, i) => ({ column, cardinality: toNum(row[`card_${String(i)}`]) }));
+    const dimCardinalities = cardCols.map((column, i) => ({
+      column,
+      cardinality: toNum(row[`card_${String(i)}`]),
+      leaveOneOutGrainRows: toNum(row[`loo_${String(i)}`]),
+    }));
     return computeRollupEstimate({
       probePeriod: period,
       months: dirs.length,

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -134,6 +134,15 @@ export class RollupStore {
     return { rows, bytes, months: parts.length };
   }
 
+  /** Shape signature the on-disk partitions were actually built against (null
+   *  when nothing is built). Lets callers tell whether a candidate grain matches
+   *  what's already materialized. Keyed off the manifest — stays consistent with
+   *  getStats (both null together) — not the in-memory `shape`, which may hold a
+   *  not-yet-built candidate. */
+  getBuiltSignature(): string | null {
+    return this.manifest === null ? null : this.manifest.shapeSignature;
+  }
+
   /** Serialize a mutation; the callback receives the epoch captured at enqueue
    *  time so it can detect a concurrent invalidate() and abort its commit. */
   private enqueue<T>(fn: (epoch: number) => Promise<T>): Promise<T> {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -551,6 +551,15 @@ function AppShell(): React.JSX.Element {
   // change). Gating on "ever ready" keeps the first cold build — where widgets
   // already show their own loaders — from flashing the "Updating…" badge.
   const reRolling = rollupStatus.state === 'computing' && rollupEverReady;
+  // A stable key that flips when the built rollup changes (computing → ready),
+  // so the Dimensions estimate refetches and its actual/estimated badge stays
+  // correct without a remount. Deliberately ignores `computing` done/total
+  // progress ticks — those would thrash the exact-count probe mid-rebuild.
+  const rollupRevision = rollupStatus.state === 'ready'
+    ? `ready:${String(rollupStatus.periods)}`
+    : rollupStatus.state === 'failed'
+      ? `failed:${String(rollupStatus.periods)}`
+      : rollupStatus.state;
 
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
@@ -835,7 +844,7 @@ function AppShell(): React.JSX.Element {
       case 'cost-scope':
         return <CostScopeView />;
       case 'dimensions':
-        return <DimensionsView />;
+        return <DimensionsView rollupRevision={rollupRevision} />;
       case 'dashboards':
         return <ViewsEditor onConfigPersisted={setViewsConfig} />;
       case 'share':

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -288,13 +288,22 @@ export class MockCostApi implements CostApi {
     const enabled = (d: { enabled?: boolean | undefined }): boolean => d.enabled !== false;
     const hasResourceId = candidate.builtIn.some(d => d.field === 'resource_id' && enabled(d));
     const probeLineItems = 2_100_000;
-    const dimCardinalities = [
-      { column: 'account_id', cardinality: 14 },
-      { column: 'service', cardinality: 38 },
-      { column: 'tag_team', cardinality: 22 },
-      ...(hasResourceId ? [{ column: 'resource_id', cardinality: 1_820_000 }] : []),
-    ];
     const probeGrainRows = hasResourceId ? 1_840_000 : 92_000;
+    // leaveOneOutGrainRows = grain with that dim removed. With resource_id
+    // enabled it dominates (removing it collapses the grain ~20×); the others
+    // are near-redundant (loo ≈ full grain → ≈ ×1).
+    const dimCardinalities = hasResourceId
+      ? [
+          { column: 'account_id', cardinality: 14, leaveOneOutGrainRows: 1_800_000 },
+          { column: 'service', cardinality: 38, leaveOneOutGrainRows: 1_780_000 },
+          { column: 'tag_team', cardinality: 22, leaveOneOutGrainRows: 1_820_000 },
+          { column: 'resource_id', cardinality: 1_820_000, leaveOneOutGrainRows: 92_000 },
+        ]
+      : [
+          { column: 'account_id', cardinality: 14, leaveOneOutGrainRows: 84_000 },
+          { column: 'service', cardinality: 38, leaveOneOutGrainRows: 66_000 },
+          { column: 'tag_team', cardinality: 22, leaveOneOutGrainRows: 88_000 },
+        ];
     return Promise.resolve(computeRollupEstimate({
       probePeriod: '2026-04',
       months: 12,

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -311,6 +311,9 @@ export class MockCostApi implements CostApi {
       probeLineItems,
       rawBytes: 4_900_000_000,
       current: { rows: 1_100_000, bytes: 17_600_000 },
+      // The built rollup (current) represents the navigational grain; toggling
+      // resource_id ON changes the grain → estimate, OFF → matches → actuals.
+      currentMatchesCandidate: !hasResourceId,
       dimCardinalities,
     }));
   }

--- a/packages/ui/src/__tests__/dimensions-estimate.test.tsx
+++ b/packages/ui/src/__tests__/dimensions-estimate.test.tsx
@@ -40,7 +40,7 @@ describe('DimensionsView — rollup grain estimate', () => {
     expect(screen.getByText('Est. rollup')).toBeDefined();
     expect(screen.getByText('Compression')).toBeDefined();
     expect(screen.getByText('Rebuild')).toBeDefined();
-    expect(screen.getByText(/directional/)).toBeDefined();
+    expect(screen.getByText('Estimated')).toBeDefined();
   });
 
   it('flags resource_id as the dominant grain driver in the per-dimension list', async () => {
@@ -74,14 +74,14 @@ describe('DimensionsView — rollup grain estimate', () => {
     // resource_id is enabled in the render config → grain differs from the
     // built rollup → directional estimate.
     await waitFor(() => { expect(screen.getByText('Est. rollup')).toBeDefined(); });
-    expect(screen.getByText(/directional/)).toBeDefined();
+    expect(screen.getByText('Estimated')).toBeDefined();
 
     // Toggle resource_id off → grain matches the built rollup → actual stats.
     const resourcePill = screen.getAllByRole('button', { name: /Resource/ })[0];
     await user.click(resourcePill as HTMLElement);
     await waitFor(() => {
       expect(screen.getByText('Rollup')).toBeDefined();
-      expect(screen.getByText(/actual · current rollup/)).toBeDefined();
+      expect(screen.getByText('Actual')).toBeDefined();
     });
     expect(screen.queryByText('Est. rollup')).toBeNull();
   });

--- a/packages/ui/src/__tests__/dimensions-estimate.test.tsx
+++ b/packages/ui/src/__tests__/dimensions-estimate.test.tsx
@@ -61,8 +61,11 @@ describe('DimensionsView — rollup grain estimate', () => {
     expect(resourcePill).toBeDefined();
     await user.click(resourcePill as HTMLElement);
 
-    await waitFor(() => { expect(screen.queryByText(/multiplies the rollup/i)).toBeNull(); });
-    // The per-dimension list itself remains for the leaner grain.
-    expect(screen.getByText('Per-dimension impact')).toBeDefined();
+    // Wait for the re-estimate to settle (it flashes the loading bar mid-probe):
+    // the outlier warning is gone AND the per-dimension list is back.
+    await waitFor(() => {
+      expect(screen.queryByText(/multiplies the rollup/i)).toBeNull();
+      expect(screen.getByText('Per-dimension impact')).toBeDefined();
+    });
   });
 });

--- a/packages/ui/src/__tests__/dimensions-estimate.test.tsx
+++ b/packages/ui/src/__tests__/dimensions-estimate.test.tsx
@@ -43,22 +43,26 @@ describe('DimensionsView — rollup grain estimate', () => {
     expect(screen.getByText(/directional/)).toBeDefined();
   });
 
-  it('flags resource_id high-cardinality with a count badge and a panel warning', async () => {
+  it('flags resource_id as the dominant grain driver in the per-dimension list', async () => {
     renderView();
-    await waitFor(() => { expect(screen.getByText(/Heavy grain/i)).toBeDefined(); });
-    // The resource pill carries a high-cardinality count badge (~1.8M distinct).
+    await waitFor(() => { expect(screen.getByText('Per-dimension impact')).toBeDefined(); });
+    // The outlier sentence questions the single dominant dimension.
+    await waitFor(() => { expect(screen.getByText(/multiplies the rollup/i)).toBeDefined(); });
+    // The resource pill still carries a high-cardinality count badge (~1.8M distinct).
     expect(screen.getAllByText('1.8M').length).toBeGreaterThan(0);
   });
 
-  it('re-estimates and clears the warning when the dim is toggled off', async () => {
+  it('re-estimates and clears the outlier warning when the dim is toggled off', async () => {
     const { user } = renderView();
-    await waitFor(() => { expect(screen.getByText(/Heavy grain/i)).toBeDefined(); });
+    await waitFor(() => { expect(screen.getByText(/multiplies the rollup/i)).toBeDefined(); });
 
     // The SECTION 1 pill is the first button matching the dim label.
     const resourcePill = screen.getAllByRole('button', { name: /Resource/ })[0];
     expect(resourcePill).toBeDefined();
     await user.click(resourcePill as HTMLElement);
 
-    await waitFor(() => { expect(screen.queryByText(/Heavy grain/i)).toBeNull(); });
+    await waitFor(() => { expect(screen.queryByText(/multiplies the rollup/i)).toBeNull(); });
+    // The per-dimension list itself remains for the leaner grain.
+    expect(screen.getByText('Per-dimension impact')).toBeDefined();
   });
 });

--- a/packages/ui/src/__tests__/dimensions-estimate.test.tsx
+++ b/packages/ui/src/__tests__/dimensions-estimate.test.tsx
@@ -68,4 +68,21 @@ describe('DimensionsView — rollup grain estimate', () => {
       expect(screen.getByText('Per-dimension impact')).toBeDefined();
     });
   });
+
+  it('shows actual rollup stats when the grain matches the built rollup, the estimate otherwise', async () => {
+    const { user } = renderView();
+    // resource_id is enabled in the render config → grain differs from the
+    // built rollup → directional estimate.
+    await waitFor(() => { expect(screen.getByText('Est. rollup')).toBeDefined(); });
+    expect(screen.getByText(/directional/)).toBeDefined();
+
+    // Toggle resource_id off → grain matches the built rollup → actual stats.
+    const resourcePill = screen.getAllByRole('button', { name: /Resource/ })[0];
+    await user.click(resourcePill as HTMLElement);
+    await waitFor(() => {
+      expect(screen.getByText('Rollup')).toBeDefined();
+      expect(screen.getByText(/actual · current rollup/)).toBeDefined();
+    });
+    expect(screen.queryByText('Est. rollup')).toBeNull();
+  });
 });

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1505,9 +1505,10 @@ function ImpactStat({ label, value, hint }: Readonly<{ label: string; value: str
  *  Updates as dims are toggled so the user can weigh the rebuild before it
  *  happens. Numbers are directional (probed from one recent month). */
 function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: RollupGrainEstimate | null; loading: boolean; config: DimensionsConfig }>): React.JSX.Element {
-  const heaviest = estimate === null
+  const rankedDims = estimate === null
     ? []
-    : [...estimate.dims].filter(d => d.rawOnly).sort((a, b) => b.cardinality - a.cardinality);
+    : [...estimate.dims].sort((a, b) => b.marginalMultiplier - a.marginalMultiplier);
+  const outlierDim = rankedDims.find(d => d.outlier);
   const sizeReduction = estimate !== null && estimate.candidate.bytes > 0
     ? estimate.raw.bytes / estimate.candidate.bytes
     : 0;
@@ -1551,26 +1552,46 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
               hint="background re-roll"
             />
           </div>
-          {estimate.rawOnly.recommended && (
-            <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2">
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-              <p className="text-[11px] leading-snug text-text-secondary">
-                {heaviest.length > 0 ? (
-                  <>
-                    Heavy grain — most of the rollup size comes from{' '}
-                    {heaviest.slice(0, 4).map((d, i) => (
-                      <span key={d.column}>
-                        {i > 0 ? ', ' : ''}
-                        <span className="font-medium text-amber-500">{columnLabel(config, d.column)}</span>
-                        {' '}({formatCount(d.cardinality)})
+          {rankedDims.length > 0 && (
+            <div className="mt-4">
+              <span className="text-[10px] uppercase tracking-wider text-text-muted">Per-dimension impact</span>
+              <ul className="mt-2 flex flex-col gap-1.5">
+                {rankedDims.map(d => {
+                  const readout = d.marginalMultiplier >= 1.05
+                    ? `×${d.marginalMultiplier.toFixed(1)}${d.marginalRows > 0 ? ` · +${formatCount(d.marginalRows)}` : ''}`
+                    : '~×1';
+                  return (
+                    <li key={d.column} className="flex items-center gap-2 text-[11px]">
+                      <span className={`flex w-28 shrink-0 items-center gap-1 truncate ${d.outlier ? 'font-medium text-amber-500' : 'text-text-secondary'}`}>
+                        {d.outlier && <AlertTriangle className="h-3 w-3 shrink-0" />}
+                        <span className="truncate">{columnLabel(config, d.column)}</span>
                       </span>
-                    ))}
-                    . Disabling the heaviest keeps it raw-only so dashboards stay fast.
-                  </>
-                ) : (
-                  <>This grain is heavy for the rollup — {estimate.rawOnly.reason ?? 'it exceeds the size budget'}. Consider a leaner grain so dashboards stay fast.</>
-                )}
-              </p>
+                      <span className="h-1.5 flex-1 overflow-hidden rounded-full bg-bg-tertiary">
+                        <span
+                          className={`block h-full rounded-full ${d.outlier ? 'bg-amber-500/70' : 'bg-accent/60'}`}
+                          style={{ width: `${String(Math.round(Math.min(1, d.impactShare) * 100))}%` }}
+                        />
+                      </span>
+                      <span className={`w-24 shrink-0 text-right tabular-nums ${d.outlier ? 'text-amber-500' : 'text-text-muted'}`}>{readout}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+              {outlierDim !== undefined ? (
+                <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+                  <p className="text-[11px] leading-snug text-text-secondary">
+                    <span className="font-medium text-amber-500">{columnLabel(config, outlierDim.column)}</span> alone multiplies the rollup ~×{outlierDim.marginalMultiplier.toFixed(1)} — most of the grain comes from this one dimension. Dimensions work best as filters with a handful of values; the detail table can still show every value when you need it, so keeping this one raw-only keeps dashboards fast.
+                  </p>
+                </div>
+              ) : estimate.rawOnly.recommended ? (
+                <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+                  <p className="text-[11px] leading-snug text-text-secondary">
+                    This grain is heavy for the rollup — {estimate.rawOnly.reason ?? 'it exceeds the size budget'}. Consider a leaner grain so dashboards stay fast.
+                  </p>
+                </div>
+              ) : null}
             </div>
           )}
         </>

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1554,7 +1554,21 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
           <h3 className="text-sm font-medium text-text-secondary">Rollup impact</h3>
         </div>
         {estimate !== null && estimate.probePeriod.length > 0 && (
-          <span className="text-[10px] text-text-muted">{matchedCurrent !== null ? 'actual · current rollup' : `estimated from ${estimate.probePeriod} · directional`}</span>
+          matchedCurrent !== null ? (
+            <span
+              title="These are the real size and row counts of the rollup already built for this grain."
+              className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-accent" />Actual
+            </span>
+          ) : (
+            <span
+              title={`Directional estimate, probed from ${estimate.probePeriod}. Rebuild this grain to get exact numbers.`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-500"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />Estimated
+            </span>
+          )
         )}
       </div>
       <p className="mt-1 text-[11px] leading-snug text-text-muted">

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1523,6 +1523,9 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
           <span className="text-[10px] text-text-muted">estimated from {estimate.probePeriod} · directional</span>
         )}
       </div>
+      <p className="mt-1 text-[11px] leading-snug text-text-muted">
+        The rollup is a compact, pre-aggregated copy of your billing data grouped by these dimensions — dashboards query it instead of the raw line items, so a leaner grain keeps them fast.
+      </p>
 
       {loading && estimate === null ? (
         <p className="mt-3 text-xs text-text-muted">Estimating…</p>

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1701,7 +1701,7 @@ function resolveOrderedRows(config: DimensionsConfig): OrderedRow[] {
   return rows;
 }
 
-export function DimensionsView() {
+export function DimensionsView({ rollupRevision }: Readonly<{ rollupRevision?: string }>): React.JSX.Element {
   const api = useCostApi();
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [editingBuiltInIdx, setEditingBuiltInIdx] = useState<number | null>(null);
@@ -1756,7 +1756,9 @@ export function DimensionsView() {
   const estimateSig = config === null ? '' : grainSignature(config);
   const estimateQuery = useQuery(
     () => config === null ? Promise.resolve(null) : api.estimateRollupGrain(config),
-    [estimateSig],
+    // Refetch when the grain changes OR when the built rollup changes (e.g. a
+    // re-roll finishes) so the actual/estimated badge updates without a remount.
+    [estimateSig, rollupRevision ?? ''],
   );
   const estimate = estimateQuery.status === 'success' ? estimateQuery.data : null;
   const estimateLoading = estimateQuery.status === 'loading';

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1504,6 +1504,29 @@ function ImpactStat({ label, value, hint }: Readonly<{ label: string; value: str
   );
 }
 
+/** Eased progress feedback for the rollup estimate. The probe is an exact
+ *  DuckDB scan (a few seconds; longer when resource_id is on) with no real
+ *  per-query progress to read, so we ease asymptotically toward ~92% — slowing
+ *  as it goes rather than stalling at a hard cap — and let completion unmount
+ *  this (the panel only renders it while a probe is in flight). */
+function EstimateProgress(): React.JSX.Element {
+  const [pct, setPct] = useState(8);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setPct(p => (p >= 92 ? p : p + Math.max(0.6, (92 - p) * 0.1)));
+    }, 150);
+    return () => { clearInterval(id); };
+  }, []);
+  return (
+    <div className="mt-3">
+      <span className="text-xs text-text-muted">Estimating…</span>
+      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-bg-tertiary">
+        <div className="h-full rounded-full bg-accent transition-all duration-200 ease-out" style={{ width: `${String(Math.round(pct))}%` }} />
+      </div>
+    </div>
+  );
+}
+
 /** Cost/benefit summary for the current enabled grain (rollup design §8).
  *  Updates as dims are toggled so the user can weigh the rebuild before it
  *  happens. Numbers are directional (probed from one recent month). */
@@ -1531,7 +1554,7 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
       </p>
 
       {loading && estimate === null ? (
-        <p className="mt-3 text-xs text-text-muted">Estimating…</p>
+        <EstimateProgress />
       ) : estimate === null || estimate.probePeriod.length === 0 ? (
         <p className="mt-3 text-xs text-text-muted">Sync billing data to estimate the rollup size for this grain.</p>
       ) : (

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1535,9 +1535,17 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
     ? []
     : [...estimate.dims].sort((a, b) => b.marginalMultiplier - a.marginalMultiplier);
   const outlierDim = rankedDims.find(d => d.outlier);
-  const sizeReduction = estimate !== null && estimate.candidate.bytes > 0
-    ? estimate.raw.bytes / estimate.candidate.bytes
-    : 0;
+  // When the built rollup already matches this exact grain, show its ACTUAL
+  // size/rows (the same numbers as the header Rollup popover) instead of the
+  // directional estimate, and drop the Rebuild stat (nothing to rebuild).
+  const matchedCurrent = estimate !== null && estimate.currentMatchesCandidate ? estimate.current : null;
+  const rollupBytes = matchedCurrent !== null ? matchedCurrent.bytes : (estimate?.candidate.bytes ?? 0);
+  const sizeReduction = estimate !== null && rollupBytes > 0 ? estimate.raw.bytes / rollupBytes : 0;
+  const rowRatio = estimate === null
+    ? 0
+    : matchedCurrent !== null && matchedCurrent.rows > 0
+      ? estimate.raw.rows / matchedCurrent.rows
+      : estimate.compressionRate;
   return (
     <div className="rounded-xl border border-border bg-bg-secondary/40 px-5 py-4">
       <div className="flex items-center justify-between">
@@ -1546,7 +1554,7 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
           <h3 className="text-sm font-medium text-text-secondary">Rollup impact</h3>
         </div>
         {estimate !== null && estimate.probePeriod.length > 0 && (
-          <span className="text-[10px] text-text-muted">estimated from {estimate.probePeriod} · directional</span>
+          <span className="text-[10px] text-text-muted">{matchedCurrent !== null ? 'actual · current rollup' : `estimated from ${estimate.probePeriod} · directional`}</span>
         )}
       </div>
       <p className="mt-1 text-[11px] leading-snug text-text-muted">
@@ -1559,27 +1567,37 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
         <p className="mt-3 text-xs text-text-muted">Sync billing data to estimate the rollup size for this grain.</p>
       ) : (
         <>
-          <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div className={`mt-3 grid grid-cols-2 gap-4 ${matchedCurrent !== null ? 'sm:grid-cols-3' : 'sm:grid-cols-4'}`}>
             <ImpactStat
               label="Raw data"
               value={formatBytes(estimate.raw.bytes)}
               hint={`${formatCount(estimate.raw.rows)} line items · ${String(estimate.months)} mo`}
             />
-            <ImpactStat
-              label="Est. rollup"
-              value={formatBytes(estimate.candidate.bytes)}
-              hint={`${SIZE_BAND_LABEL[estimate.candidate.sizeBand]} · ${formatCount(estimate.candidate.rows)} rows`}
-            />
+            {matchedCurrent !== null ? (
+              <ImpactStat
+                label="Rollup"
+                value={formatBytes(matchedCurrent.bytes)}
+                hint={`${formatCount(matchedCurrent.rows)} rows`}
+              />
+            ) : (
+              <ImpactStat
+                label="Est. rollup"
+                value={formatBytes(estimate.candidate.bytes)}
+                hint={`${SIZE_BAND_LABEL[estimate.candidate.sizeBand]} · ${formatCount(estimate.candidate.rows)} rows`}
+              />
+            )}
             <ImpactStat
               label="Compression"
               value={sizeReduction >= 1.05 ? `${sizeReduction.toFixed(1)}×` : '~1×'}
-              hint={`smaller than raw · ${estimate.compressionRate >= 1 ? estimate.compressionRate.toFixed(0) : estimate.compressionRate.toFixed(1)}× fewer rows`}
+              hint={`smaller than raw · ${rowRatio >= 1 ? rowRatio.toFixed(0) : rowRatio.toFixed(1)}× fewer rows`}
             />
-            <ImpactStat
-              label="Rebuild"
-              value={formatRebuild(estimate.candidate.rebuildSeconds)}
-              hint="background re-roll"
-            />
+            {matchedCurrent === null && (
+              <ImpactStat
+                label="Rebuild"
+                value={formatRebuild(estimate.candidate.rebuildSeconds)}
+                hint="background re-roll"
+              />
+            )}
           </div>
           {rankedDims.length > 0 && (
             <div className="mt-4">


### PR DESCRIPTION
## Why

The **Rollup impact** panel only showed a whole-grain growth factor (e.g. _"this grain is ~13.1× the current rollup"_) with no way to see **which** dimension drove it. The per-dimension data it did have was raw cardinality — a poor proxy, because the rollup grain is a multiplicative product and dimensions are correlated: a dimension with thousands of distinct values can add almost nothing once another enabled dimension already implies it (Service Category under AWS Service, etc.).

## What

Measure each dimension's **true marginal impact** via leave-one-out, attributing the grain to the dimensions actually responsible.

- **Probe query** (`buildGrainProbeQuery`): in the same single scan, also computes the grain row count with each non-date dim removed (`loo_<i>`). Same trusted-column interpolation as the existing grain concat — no new injection surface.
- **Estimator** (`computeRollupEstimate`): derives per dim `marginalMultiplier = fullGrain ÷ grainWithoutDim`, `marginalRows`, and `impactShare`. Flags **at most one** dominant outlier — it must double the grain on its own, hold >50% of total inflation, *and* stand ≥4× above the median dimension (thresholds are exported, documented consts). HLL noise on the leave-one-out counts is clamped (`max(1, …)` / `max(0, …)`).
- **UI** (`RollupImpactPanel`): replaces the single opaque warning with a sorted per-dimension list (multiplier · added rows · share bar), amber-highlighting the outlier and questioning it (framed around dimensions being filter axes — the detail table still shows every value). A heavy grain with no single culprit still falls back to the growth-factor sentence.

No IPC / `CostApi` signature change, no new files. Outlier detection is informational and does **not** alter the existing raw-only recommendation.

## Accuracy note

On the tiny/dense synthetic fixtures the non-`resource_id` dimensions already near-uniquely identify each row, so leave-one-out multipliers compress toward ~1 and HLL noise is large — the feature is meaningful on real (millions-of-rows) data. The outlier *logic* is therefore tested with controlled literal inputs (`rollup-estimator.test.ts`); the DuckDB probe test (`rollup-probe.test.ts`) asserts only structural soundness of the wired-through marginals.