### PR TITLE
feat(ui): header sync + rollup status indicators

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -378,3 +378,20 @@ export interface UpdateApi {
   onStatusChanged(callback: (status: UpdateStatus) => void): () => void;
   getAppVersion(): Promise<string>;
 }
+
+/** Live state of the on-disk daily rollup. Pushed to the renderer so the header
+ *  can show whether dashboards are currently served from the pre-aggregated
+ *  rollup (`ready`) or transiently from the slower raw path while a re-roll runs
+ *  (`computing`) — e.g. after a dimensions save or a sync. `idle` = no rollup
+ *  built yet (no local data); `failed` = the last build batch hit an error
+ *  (otherwise swallowed to the log). */
+export type RollupStatus =
+  | { readonly state: 'idle' }
+  | { readonly state: 'computing'; readonly done: number; readonly total: number }
+  | { readonly state: 'ready'; readonly periods: number }
+  | { readonly state: 'failed'; readonly message: string; readonly periods: number };
+
+export interface RollupApi {
+  getStatus(): Promise<RollupStatus>;
+  onStatusChanged(callback: (status: RollupStatus) => void): () => void;
+}

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -391,7 +391,18 @@ export type RollupStatus =
   | { readonly state: 'ready'; readonly periods: number }
   | { readonly state: 'failed'; readonly message: string; readonly periods: number };
 
+/** Size KPIs for the built rollup vs the raw daily Parquet it's derived from.
+ *  `rawBytes` is read from the local filesystem (no S3), so it's available even
+ *  without AWS credentials. Null when no rollup is built. */
+export interface RollupStats {
+  readonly months: number;
+  readonly rollupRows: number;
+  readonly rollupBytes: number;
+  readonly rawBytes: number;
+}
+
 export interface RollupApi {
   getStatus(): Promise<RollupStatus>;
+  getStats(): Promise<RollupStats | null>;
   onStatusChanged(callback: (status: RollupStatus) => void): () => void;
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,7 +65,7 @@ export type {
 } from './query.js';
 export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi, RollupStatus, RollupApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi, RollupStatus, RollupApi, RollupStats } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,7 +65,7 @@ export type {
 } from './query.js';
 export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';
 
-export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi } from './api.js';
+export type { Dimension, CostApi, DataInventoryResult, DataTier, PruneResult, AccountMappingStatus, AccountMappingEntry, SavingsPreferences, UIPreferences, PerformanceSettings, PerformanceInfo, AutoSyncStatus, OrgAccount, OrgSyncResult, OrgSyncProgress, UpdateInfo, UpdateLogEntry, UpdateStage, UpdateStatus, UpdateApi, RollupStatus, RollupApi } from './api.js';
 
 export type {
   WidgetSize,

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -530,10 +530,11 @@ export function createAppContext(ctx: IpcContext): AppContext {
       const validation = await rollupStore.loadAndValidate(shape, etags);
       const available = await listLocalMonths(ctx.dataDir, 'daily');
       const toBuild = available.filter(p => !validation.validPeriods.has(p)).sort((a, b) => b.localeCompare(a));
-      if (toBuild.length === 0) return;
+      if (toBuild.length === 0) { rollupStore.markSettled(); return; }
       const buildSql = await buildRollupSqlFor();
       void rollupStore.maintainPeriods(toBuild, buildSql, etags, shape).then(() => { resultCache.clear(); });
     } catch (err: unknown) {
+      rollupStore.markSettled();
       logger.warn(`rollup-warmup: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
@@ -559,6 +560,19 @@ export function createAppContext(ctx: IpcContext): AppContext {
   let warmupInFlight: Promise<void> = Promise.resolve();
   function triggerWarmup(): void { warmupInFlight = warmupRollup().catch(() => undefined); }
 
+  // A dimensions save always drops the rollup (so queries fall back to raw
+  // immediately — correct) but the full re-roll is expensive. The dimensions
+  // view autosaves on every toggle/reorder, so a burst of edits would otherwise
+  // kick one full rebuild each. Coalesce the rebuild: invalidate right away,
+  // debounce the warmup so a burst settles into a single re-roll.
+  const ROLLUP_REROLL_DEBOUNCE_MS = 800;
+  let rerollTimer: ReturnType<typeof setTimeout> | null = null;
+  function scheduleRollupReroll(): void {
+    void rollupStore.invalidate().then(() => { resultCache.clear(); });
+    if (rerollTimer !== null) clearTimeout(rerollTimer);
+    rerollTimer = setTimeout(() => { rerollTimer = null; triggerWarmup(); }, ROLLUP_REROLL_DEBOUNCE_MS);
+  }
+
   return {
     ctx,
     state,
@@ -581,8 +595,8 @@ export function createAppContext(ctx: IpcContext): AppContext {
     invalidateDimensions: () => {
       state.dimensions = null; state.accountMap = null; state.accountReverseMap = null; state.regionMap = null; state.orgAccountsPath = null;
       // A dimensions change can alter the rollup grain/projection → drop the
-      // persisted rollup and rebuild under the new shape-signature.
-      void rollupStore.invalidate().then(() => { resultCache.clear(); triggerWarmup(); });
+      // persisted rollup and rebuild under the new shape-signature (debounced).
+      scheduleRollupReroll();
     },
     invalidateViews: () => { state.views = null; },
     invalidateCostScope: () => {

--- a/packages/desktop/src/main/handlers/rollup.ts
+++ b/packages/desktop/src/main/handlers/rollup.ts
@@ -1,12 +1,25 @@
 import { BrowserWindow, ipcMain } from 'electron';
+import { getLocalDataInventory, type RollupStats } from '@costgoblin/core';
 import type { AppContext } from './context.js';
 
 /** Push rollup compute-state to the renderer. Mirrors the update-status channel
  *  (handlers/update.ts): a pull getter for the initial state on mount, plus a
  *  main→renderer broadcast on every transition so the header indicator tracks
- *  long-running re-rolls without polling. */
+ *  long-running re-rolls without polling. `rollup:get-stats` adds the size KPIs
+ *  shown in the popover — rollup rows/bytes from the manifest plus the raw daily
+ *  on-disk size (local filesystem, so it works without AWS credentials). */
 export function registerRollupHandlers(app: AppContext): void {
   ipcMain.handle('rollup:get-status', () => app.rollupStore.getStatus());
+
+  ipcMain.handle('rollup:get-stats', async (): Promise<RollupStats | null> => {
+    const stats = app.rollupStore.getStats();
+    if (stats === null) return null;
+    let rawBytes = 0;
+    try {
+      rawBytes = (await getLocalDataInventory(app.ctx.dataDir, 'daily')).local.diskBytes;
+    } catch { /* raw size is best-effort — fall back to 0 (compression hidden) */ }
+    return { months: stats.months, rollupRows: stats.rows, rollupBytes: stats.bytes, rawBytes };
+  });
 
   app.rollupStore.onStatusChanged((status) => {
     for (const win of BrowserWindow.getAllWindows()) {

--- a/packages/desktop/src/main/handlers/rollup.ts
+++ b/packages/desktop/src/main/handlers/rollup.ts
@@ -1,0 +1,16 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import type { AppContext } from './context.js';
+
+/** Push rollup compute-state to the renderer. Mirrors the update-status channel
+ *  (handlers/update.ts): a pull getter for the initial state on mount, plus a
+ *  main→renderer broadcast on every transition so the header indicator tracks
+ *  long-running re-rolls without polling. */
+export function registerRollupHandlers(app: AppContext): void {
+  ipcMain.handle('rollup:get-status', () => app.rollupStore.getStatus());
+
+  app.rollupStore.onStatusChanged((status) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('rollup:status-changed', status);
+    }
+  });
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -15,6 +15,7 @@ import { registerDataSharingHandlers } from './handlers/data-sharing.js';
 import { registerExplorerHandlers } from './handlers/explorer.js';
 import { registerDebugHandlers } from './handlers/debug.js';
 import { registerMcpHandlers } from './handlers/mcp-handler.js';
+import { registerRollupHandlers } from './handlers/rollup.js';
 
 export type { AppContext, IpcContext } from './handlers/context.js';
 
@@ -36,6 +37,7 @@ export function registerIpcHandlers(ctx: IpcContext): AppContext {
   registerExplorerHandlers(app);
   registerDebugHandlers(app);
   registerMcpHandlers(app);
+  registerRollupHandlers(app);
 
   app.warmupBase();
 

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -7,8 +7,11 @@ import {
   validateManifest,
   type RollupManifest,
   type RollupPartitionMeta,
+  type RollupStatus,
 } from '@costgoblin/core';
 import type { RawRow } from './duckdb-client.js';
+
+export type RollupStatusListener = (status: RollupStatus) => void;
 
 /** Builds the `COPY (...) TO '<outPath>' (FORMAT PARQUET)` DDL for one period.
  *  Supplied by the caller (context.ts) so the store stays decoupled from the
@@ -63,10 +66,39 @@ export class RollupStore {
   private epoch = 0;
   private queue: Promise<unknown> = Promise.resolve();
 
+  private status: RollupStatus = { state: 'idle' };
+  private readonly statusListeners = new Set<RollupStatusListener>();
+
   constructor(deps: RollupStoreDeps) {
     this.dataDir = deps.dataDir;
     this.runQuery = deps.runQuery;
   }
+
+  /** Subscribe to rollup compute-state transitions. Fires immediately with the
+   *  current status (matching the update-manager convention) so a late
+   *  subscriber doesn't miss the build that's already running. */
+  onStatusChanged(listener: RollupStatusListener): () => void {
+    this.statusListeners.add(listener);
+    listener(this.status);
+    return () => { this.statusListeners.delete(listener); };
+  }
+
+  getStatus(): RollupStatus { return this.status; }
+
+  private setStatus(status: RollupStatus): void {
+    this.status = status;
+    for (const listener of this.statusListeners) listener(status);
+  }
+
+  private settledStatus(): RollupStatus {
+    return this.isReady() ? { state: 'ready', periods: this.validPeriods.size } : { state: 'idle' };
+  }
+
+  /** Emit a terminal status from a path that decided there's nothing to build
+   *  (e.g. warmup after an invalidate found every partition already valid, or no
+   *  local data at all). A no-op while a build is mid-flight — that build owns
+   *  the transition to `ready`/`failed`. */
+  markSettled(): void { this.setStatus(this.settledStatus()); }
 
   private rollupDir(): string { return join(this.dataDir, 'aws', 'rollup'); }
   private manifestPath(): string { return join(this.rollupDir(), 'manifest.json'); }
@@ -185,11 +217,18 @@ export class RollupStore {
         ? this.manifest
         : { schemaVersion: ROLLUP_SCHEMA_VERSION, shapeSignature: shape.signature, builtAt: '', grainDimensions: shape.grainDimensions, availableColumns: shape.availableColumns, partitions: {} };
 
+      const total = periods.length;
+      let done = 0;
+      let failures = 0;
+      this.setStatus({ state: 'computing', done, total });
+
       for (const period of periods) {
-        if (this.epoch !== startEpoch) return; // superseded mid-build
+        if (this.epoch !== startEpoch) return; // superseded mid-build — the newer op owns the status
         const wantHash = computePartitionEtagHash(etagsByPeriod[period]);
         if (opts.force !== true && manifest.partitions[period]?.rawEtagHash === wantHash) {
           this.validPeriods.add(period);
+          done += 1;
+          this.setStatus({ state: 'computing', done, total });
           continue;
         }
         try {
@@ -203,9 +242,18 @@ export class RollupStore {
           this.validPeriods.add(period);
           await this.writeManifestAtomic(manifest);
         } catch (err: unknown) {
+          failures += 1;
           logger.warn(`rollup: build failed for ${period} — ${err instanceof Error ? err.message : String(err)}`);
         }
+        done += 1;
+        this.setStatus({ state: 'computing', done, total });
       }
+
+      this.setStatus(
+        failures > 0
+          ? { state: 'failed', message: `${String(failures)} of ${String(total)} rollup partition${total === 1 ? '' : 's'} failed to build`, periods: this.validPeriods.size }
+          : this.settledStatus(),
+      );
     });
   }
 
@@ -237,6 +285,10 @@ export class RollupStore {
     this.epoch += 1;
     this.manifest = null;
     this.validPeriods = new Set();
+    // Signal "rebuilding" immediately — the caller re-warms right after, and the
+    // ensuing warmup either drives this through to `ready` (via maintainPeriods)
+    // or calls markSettled() when there's nothing to rebuild.
+    this.setStatus({ state: 'computing', done: 0, total: 0 });
     return this.enqueue(async () => {
       await rm(this.rollupDir(), { recursive: true, force: true });
     });

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -414,6 +414,17 @@ contextBridge.exposeInMainWorld('costgoblinUpdate', {
   },
 });
 
+contextBridge.exposeInMainWorld('costgoblinRollup', {
+  getStatus(): Promise<unknown> {
+    return invoke<unknown>('rollup:get-status');
+  },
+  onStatusChanged(callback: (status: unknown) => void): () => void {
+    const handler = (_event: unknown, status: unknown): void => { callback(status); };
+    ipcRenderer.on('rollup:status-changed', handler);
+    return () => { ipcRenderer.removeListener('rollup:status-changed', handler); };
+  },
+});
+
 contextBridge.exposeInMainWorld('costgoblinDebug', {
   isDev(): boolean { return process.env['NODE_ENV'] === 'development'; },
   isE2E(): boolean { return process.env['COSTGOBLIN_E2E'] === '1'; },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -418,6 +418,9 @@ contextBridge.exposeInMainWorld('costgoblinRollup', {
   getStatus(): Promise<unknown> {
     return invoke<unknown>('rollup:get-status');
   },
+  getStats(): Promise<unknown> {
+    return invoke<unknown>('rollup:get-stats');
+  },
   onStatusChanged(callback: (status: unknown) => void): () => void {
     const handler = (_event: unknown, status: unknown): void => { callback(status); };
     ipcRenderer.on('rollup:status-changed', handler);

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -665,27 +665,28 @@ function AppShell(): React.JSX.Element {
       });
   }
 
-  useEffect(() => {
+  const checkMissingPeriods = useCallback(async (): Promise<void> => {
     if (setupCheck.status !== 'ready') return;
-    Promise.all([api.getDataInventory(), api.getConfig()]).then(([inv, config]) => {
+    try {
+      const [inv, config] = await Promise.all([api.getDataInventory(), api.getConfig()]);
       const retentionDays = config.providers[0]?.sync.daily.retentionDays ?? 365;
       const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
       const cutoffPeriod = `${String(cutoff.getFullYear())}-${String(cutoff.getMonth() + 1).padStart(2, '0')}`;
       const missing = inv.periods.filter(p => p.localStatus === 'missing' && p.period >= cutoffPeriod).length;
       setMissingPeriods(missing);
       setSyncError(null);
-    }).catch((err: unknown) => {
-      // Most common cause is expired AWS credentials — surface the
-      // message on the Sync nav indicator. Swallowed silently before,
-      // which left the user on a screen that looked fine while sync
-      // was completely broken.
-      const message = err instanceof Error ? err.message : String(err);
-      setSyncError(message);
-    });
-    // Re-run when the settings tab changes too (not just `view`): leaving the
-    // Data & Sync tab after a download must refresh the gear's missing-periods
-    // badge, which `view` alone no longer captures now that Sync isn't a View.
-  }, [api, view, settingsTab, setupCheck, setSyncError]);
+    } catch (err: unknown) {
+      // Most common cause is expired AWS credentials — surface the message on
+      // the sync indicator. Swallowed silently before, which left the user on a
+      // screen that looked fine while sync was completely broken.
+      setSyncError(err instanceof Error ? err.message : String(err));
+    }
+  }, [api, setupCheck, setSyncError]);
+
+  // Re-check on view / settings-tab change (leaving the Data & Sync tab after a
+  // download must refresh the missing-periods badge) and on demand from the
+  // sync popover's recheck button.
+  useEffect(() => { void checkMissingPeriods(); }, [checkMissingPeriods, view, settingsTab]);
 
   function handleNavClick(id: string) {
     const inSettings = settingsTab !== null;
@@ -1001,6 +1002,7 @@ function AppShell(): React.JSX.Element {
               tiers={syncTiers}
               inSettingsData={settingsTab === 'data-sync'}
               onManageData={() => { enterSettings('data-sync'); }}
+              onRecheck={checkMissingPeriods}
             />
             <RollupStatusButton status={rollupStatus} />
             {(() => {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef, Profiler } from 'react';
 import { CostTrends, MissingTags, Savings, DataManagement, DimensionsView, CostScopeView, ExplorerView, CostApiProvider, useCostApi, SetupWizard, ErrorBoundary, CustomView, OVERVIEW_SEED_VIEW, ViewsEditor, UnsavedChangesProvider, useConfirmLeave, PaletteProvider, CommandPalette, CoinRainLoader, Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose, Button, McpView, SharingActiveBanner, SettingsShell, SETTINGS_TABS, isSettingsTabId } from '@costgoblin/ui';
 import type { NavItem, SettingsTabId } from '@costgoblin/ui';
-import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus } from '@costgoblin/core/browser';
+import type { CostApi, DataSharingStatus, Dimension, FilterMap, SyncStatus, ViewsConfig, ViewSpec, UpdateStatus, RollupStatus } from '@costgoblin/core/browser';
 import { asDimensionId, asTagValue, DEFAULT_LAG_DAYS, tagDimColumn } from '@costgoblin/core/browser';
 import { Download, RefreshCw, TrendingUp, Lightbulb, Tag, Search, Terminal, RotateCw, Settings, ArrowLeft, GitBranch, GitPullRequest } from 'lucide-react';
 import { DebugPanel, useDebugBadge } from './debug-panel.js';
 import { DashboardsDropdown } from './top-menu/dashboards-dropdown.js';
+import { SyncStatusButton, type SyncActivity, type SyncTier } from './top-menu/sync-status-button.js';
+import { RollupStatusButton } from './top-menu/rollup-status-button.js';
 import { GeneralTab } from './settings/general-tab.js';
 import { PerformanceTab } from './settings/performance-tab.js';
 import { ShareTab } from './settings/share-tab.js';
@@ -85,8 +87,6 @@ const ANALYTICAL_NAV: readonly AnalyticalNavItem[] = [
 function hasUpdateIndicator(status: UpdateStatus): boolean {
   return status.state === 'available' || status.state === 'downloading' || status.state === 'downloaded';
 }
-
-type SyncActivity = 'idle' | 'syncing' | 'downloading';
 
 type SetupCheck =
   | { status: 'checking' }
@@ -301,6 +301,12 @@ function countFilesRemaining(statuses: readonly SyncStatus[]): number {
   return remaining;
 }
 
+const SYNC_TIER_LABELS: readonly { readonly id: string; readonly label: string }[] = [
+  { id: 'daily', label: 'Daily' },
+  { id: 'hourly', label: 'Hourly' },
+  { id: 'cost-optimization', label: 'Cost optimization' },
+];
+
 function useSyncPolling(
   api: CostApi,
   setupCheck: SetupCheck,
@@ -309,10 +315,12 @@ function useSyncPolling(
   setSyncError: React.Dispatch<React.SetStateAction<string | null>>;
   syncActivity: SyncActivity;
   syncFilesRemaining: number;
+  syncTiers: readonly SyncTier[];
 } {
   const [syncError, setSyncError] = useState<string | null>(null);
   const [syncActivity, setSyncActivity] = useState<SyncActivity>('idle');
   const [syncFilesRemaining, setSyncFilesRemaining] = useState(0);
+  const [syncTiers, setSyncTiers] = useState<readonly SyncTier[]>([]);
 
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
@@ -326,6 +334,8 @@ function useSyncPolling(
           api.getSyncStatus('cost-optimization'),
         ]);
         if (cancelled) return;
+        const tiers: readonly SyncStatus[] = [daily, hourly, costOpt];
+        setSyncTiers(SYNC_TIER_LABELS.map((t, i) => ({ id: t.id, label: t.label, status: tiers[i] ?? daily })));
         const tuple: SyncStatusTuple = [autoStatus, daily, hourly, costOpt];
         const errorMsg = extractSyncError(tuple);
         if (errorMsg !== null) {
@@ -345,7 +355,7 @@ function useSyncPolling(
     return () => { cancelled = true; clearInterval(timer); };
   }, [api, setupCheck, syncActivity]);
 
-  return { syncError, setSyncError, syncActivity, syncFilesRemaining };
+  return { syncError, setSyncError, syncActivity, syncFilesRemaining, syncTiers };
 }
 
 /** Poll publisher-side sharing status app-wide so the activity banner can show
@@ -477,7 +487,7 @@ function AppShell(): React.JSX.Element {
   const [setupCheck, setSetupCheck] = useState<SetupCheck>({ status: 'checking' });
   const [splashStep, setSplashStep] = useState('Connecting...');
   const [viewsConfig, setViewsConfig] = useState<ViewsConfig | null>(null);
-  const { syncError, setSyncError, syncActivity, syncFilesRemaining } = useSyncPolling(api, setupCheck);
+  const { syncError, setSyncError, syncActivity, syncFilesRemaining, syncTiers } = useSyncPolling(api, setupCheck);
   const { sharingStatus, setSharingStatus } = useDataSharingPolling(api, setupCheck);
   const [stoppingSharing, setStoppingSharing] = useState(false);
   const [debugOpen, setDebugOpen] = useState(false);
@@ -486,6 +496,7 @@ function AppShell(): React.JSX.Element {
   const [reloadConfirmOpen, setReloadConfirmOpen] = useState(false);
   const inFlightCount = useDebugBadge();
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: 'idle' });
+  const [rollupStatus, setRollupStatus] = useState<RollupStatus>({ state: 'idle' });
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
   const [devBranch, setDevBranch] = useState<string | null>(null);
@@ -522,6 +533,13 @@ function AppShell(): React.JSX.Element {
 
   useEffect(() => {
     return globalThis.costgoblinUpdate.onStatusChanged(setUpdateStatus);
+  }, []);
+
+  useEffect(() => {
+    // Pull the current state on mount (a re-roll may already be running before
+    // the renderer subscribes), then track transitions via the push channel.
+    globalThis.costgoblinRollup.getStatus().then(setRollupStatus).catch(() => undefined);
+    return globalThis.costgoblinRollup.onStatusChanged(setRollupStatus);
   }, []);
 
   useEffect(() => {
@@ -975,24 +993,22 @@ function AppShell(): React.JSX.Element {
             >
               <RotateCw size={16} className={clearingCache ? 'animate-spin' : undefined} />
             </button>
+            <SyncStatusButton
+              activity={syncActivity}
+              error={syncError}
+              filesRemaining={syncFilesRemaining}
+              missingPeriods={missingPeriods}
+              tiers={syncTiers}
+              inSettingsData={settingsTab === 'data-sync'}
+              onManageData={() => { enterSettings('data-sync'); }}
+            />
+            <RollupStatusButton status={rollupStatus} />
             {(() => {
-              // The gear is the single Settings entry point. It also carries the
-              // app-wide sync/update status that the standalone Sync button used
-              // to show, with a fixed precedence: error > active > missing > update.
-              const showError = syncError !== null;
-              const showActive = !showError && syncActivity !== 'idle';
-              const showMissing = !showError && syncActivity === 'idle' && missingPeriods > 0 && settingsTab !== 'data-sync';
-              const showUpdate = !showError && !showActive && !showMissing && hasUpdateIndicator(updateStatus);
+              // Sync/missing/error now live on the dedicated sync icon; the gear is
+              // the Settings entry point and carries only the update dot.
+              const showUpdate = hasUpdateIndicator(updateStatus);
               const inSettings = settingsTab !== null;
-              const title = syncError !== null
-                ? `Sync error — ${syncError}`
-                : showActive
-                  ? 'Syncing…'
-                  : showMissing
-                    ? `${String(missingPeriods)} billing period${missingPeriods === 1 ? '' : 's'} not synced`
-                    : showUpdate
-                      ? 'Update available'
-                      : 'Settings';
+              const title = showUpdate ? 'Update available' : 'Settings';
               return (
                 <button
                   type="button"
@@ -1002,26 +1018,12 @@ function AppShell(): React.JSX.Element {
                     inSettings
                       ? 'bg-bg-tertiary text-text-primary'
                       : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
-                    showError ? 'ring-1 ring-negative/60' : '',
-                    showActive ? 'animate-sync-blink' : '',
                   ].join(' ')}
                   aria-label="Settings"
                   aria-expanded={inSettings}
                   title={title}
                 >
                   <Settings size={16} className={inSettings ? 'text-accent' : undefined} />
-                  {showError && (
-                    <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-negative px-1 text-[10px] font-bold text-white">!</span>
-                  )}
-                  {showActive && syncFilesRemaining > 0 && (
-                    <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold text-white">{String(syncFilesRemaining)}</span>
-                  )}
-                  {showActive && syncFilesRemaining === 0 && (
-                    <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-accent animate-pulse" aria-hidden="true" />
-                  )}
-                  {showMissing && (
-                    <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-bold text-bg-primary">{String(missingPeriods)}</span>
-                  )}
                   {showUpdate && (
                     <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-accent" aria-hidden="true" />
                   )}

--- a/packages/desktop/src/renderer/env.d.ts
+++ b/packages/desktop/src/renderer/env.d.ts
@@ -1,4 +1,4 @@
-import type { CostApi, UpdateApi } from '@costgoblin/core/browser';
+import type { CostApi, UpdateApi, RollupApi } from '@costgoblin/core/browser';
 
 declare global {
   interface DebugQueryLogEntry {
@@ -58,12 +58,14 @@ declare global {
   interface Window {
     costgoblin: CostApi;
     costgoblinUpdate: UpdateApi;
+    costgoblinRollup: RollupApi;
     costgoblinDebug: DebugApi;
     costgoblinPerf?: PerfApi;
     __PERF_REACT__?: RenderTiming[];
   }
   var costgoblin: CostApi;
   var costgoblinUpdate: UpdateApi;
+  var costgoblinRollup: RollupApi;
   var costgoblinDebug: DebugApi;
   var costgoblinPerf: PerfApi | undefined;
   var __PERF_REACT__: RenderTiming[] | undefined;

--- a/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { Layers } from 'lucide-react';
+import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
+import type { RollupStatus } from '@costgoblin/core/browser';
+
+interface Props {
+  status: RollupStatus;
+}
+
+function months(n: number): string {
+  return `${String(n)} month${n === 1 ? '' : 's'}`;
+}
+
+function tooltipFor(status: RollupStatus): string {
+  switch (status.state) {
+    case 'computing':
+      return status.total > 0
+        ? `Rebuilding rollup… ${String(status.done)}/${String(status.total)}`
+        : 'Rebuilding rollup…';
+    case 'failed':
+      return `Rollup build failed — ${status.message}`;
+    case 'ready':
+      return `Rollup ready — ${months(status.periods)} pre-aggregated`;
+    case 'idle':
+      return 'Rollup not built — dashboards query raw data';
+  }
+}
+
+/** Header indicator for the on-disk daily rollup. Dashboards silently fall back
+ *  to the slower raw path while a re-roll runs (after a dimensions save or a
+ *  sync); this surfaces that window — and any swallowed build failure — with a
+ *  click-through detail popover. */
+export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const computing = status.state === 'computing';
+  const failed = status.state === 'failed';
+  const pct = status.state === 'computing' && status.total > 0
+    ? Math.round((status.done / status.total) * 100)
+    : 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Rollup status"
+          title={tooltipFor(status)}
+          className={[
+            'relative rounded-md p-1.5 transition-colors',
+            open
+              ? 'bg-bg-tertiary text-text-primary'
+              : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
+          ].join(' ')}
+        >
+          <Layers size={16} className={computing ? 'text-accent' : undefined} />
+          {failed && (
+            <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-negative px-1 text-[10px] font-bold text-white">!</span>
+          )}
+          {computing && (
+            <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-accent animate-pulse" aria-hidden="true" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72">
+        <div className="mb-2 flex items-center gap-2">
+          <Layers size={14} className="text-accent" />
+          <span className="text-sm font-semibold">Rollup</span>
+        </div>
+        {status.state === 'computing' && (
+          <div className="space-y-2">
+            <p className="text-xs text-text-secondary">Rebuilding the pre-aggregated rollup. Dashboards read raw data until it finishes.</p>
+            {status.total > 0 && (
+              <>
+                <div className="h-1.5 overflow-hidden rounded-full bg-bg-tertiary">
+                  <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${String(pct)}%` }} />
+                </div>
+                <p className="text-[11px] tabular-nums text-text-muted">{String(status.done)} / {String(status.total)} months</p>
+              </>
+            )}
+          </div>
+        )}
+        {status.state === 'ready' && (
+          <p className="text-xs text-text-secondary">
+            Dashboards are served from the pre-aggregated rollup — <span className="font-medium tabular-nums text-text-primary">{months(status.periods)}</span> built.
+          </p>
+        )}
+        {status.state === 'idle' && (
+          <p className="text-xs text-text-secondary">No rollup is built yet. Dashboards query the raw data directly.</p>
+        )}
+        {status.state === 'failed' && (
+          <div className="space-y-1">
+            <p className="text-xs text-negative">{status.message}</p>
+            <p className="text-[11px] text-text-muted">Dashboards fall back to raw data. Reload data or re-save dimensions to retry.</p>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Layers } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
-import type { RollupStatus } from '@costgoblin/core/browser';
+import type { RollupStatus, RollupStats } from '@costgoblin/core/browser';
 
 interface Props {
   status: RollupStatus;
@@ -9,6 +9,32 @@ interface Props {
 
 function months(n: number): string {
   return `${String(n)} month${n === 1 ? '' : 's'}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(0)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}
+
+function formatCount(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}K`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function formatRatio(ratio: number): string {
+  return ratio >= 10 ? ratio.toFixed(0) : ratio.toFixed(1);
+}
+
+function KpiRow({ label, value, accent }: Readonly<{ label: string; value: string; accent?: boolean }>): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <span className="text-text-muted">{label}</span>
+      <span className={accent === true ? 'font-medium tabular-nums text-accent' : 'tabular-nums text-text-secondary'}>{value}</span>
+    </div>
+  );
 }
 
 function tooltipFor(status: RollupStatus): string {
@@ -32,6 +58,18 @@ function tooltipFor(status: RollupStatus): string {
  *  click-through detail popover. */
 export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Element {
   const [open, setOpen] = useState(false);
+  const [stats, setStats] = useState<RollupStats | null>(null);
+
+  // Size KPIs are pulled on demand (popover open + ready) rather than pushed —
+  // they only matter when the user looks. Raw size is read server-side from the
+  // local filesystem, so it works without AWS credentials.
+  useEffect(() => {
+    if (!open || status.state !== 'ready') return undefined;
+    let cancelled = false;
+    globalThis.costgoblinRollup.getStats().then((s) => { if (!cancelled) setStats(s); }).catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [open, status.state]);
+
   const computing = status.state === 'computing';
   const failed = status.state === 'failed';
   const pct = status.state === 'computing' && status.total > 0
@@ -80,9 +118,21 @@ export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Eleme
           </div>
         )}
         {status.state === 'ready' && (
-          <p className="text-xs text-text-secondary">
-            Dashboards are served from the pre-aggregated rollup — <span className="font-medium tabular-nums text-text-primary">{months(status.periods)}</span> built.
-          </p>
+          <div className="space-y-2">
+            <p className="text-xs text-text-secondary">Dashboards are served from the pre-aggregated rollup.</p>
+            <div className="divide-y divide-border-subtle text-xs">
+              <KpiRow label="Months built" value={String(status.periods)} />
+              {stats !== null && (
+                <KpiRow label="Rollup size" value={`${formatBytes(stats.rollupBytes)} · ${formatCount(stats.rollupRows)} rows`} />
+              )}
+              {stats !== null && stats.rawBytes > 0 && (
+                <KpiRow label="Raw (daily)" value={formatBytes(stats.rawBytes)} />
+              )}
+              {stats !== null && stats.rawBytes > 0 && stats.rollupBytes > 0 && (
+                <KpiRow label="Compression" value={`${formatRatio(stats.rawBytes / stats.rollupBytes)}× smaller`} accent />
+              )}
+            </div>
+          </div>
         )}
         {status.state === 'idle' && (
           <p className="text-xs text-text-secondary">No rollup is built yet. Dashboards query the raw data directly.</p>

--- a/packages/desktop/src/renderer/top-menu/sync-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/sync-status-button.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CloudDownload } from 'lucide-react';
+import { CloudDownload, RefreshCw } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
 import type { SyncStatus } from '@costgoblin/core/browser';
 
@@ -19,22 +19,26 @@ interface Props {
   tiers: readonly SyncTier[];
   inSettingsData: boolean;
   onManageData: () => void;
+  onRecheck: () => Promise<void>;
 }
 
-function tierState(status: SyncStatus): React.JSX.Element {
+function tierState(status: SyncStatus, synced: boolean): React.JSX.Element {
   switch (status.status) {
     case 'syncing':
       return <span className="tabular-nums text-accent">{String(status.filesDone)}/{String(status.filesTotal)} files</span>;
     case 'completed':
-      return <span className="text-text-muted">up to date</span>;
+      return <span className="text-text-muted">synced</span>;
     case 'failed':
       return <span className="text-negative">failed</span>;
     case 'idle':
-      return <span className="text-text-muted">idle</span>;
+      // `idle` just means "no download running" — the in-memory status resets to
+      // it on every launch. Read it as "synced" when nothing is outstanding so it
+      // doesn't contradict the "All periods synced" footer.
+      return <span className="text-text-muted">{synced ? 'synced' : 'idle'}</span>;
   }
 }
 
-function SyncTierRow({ label, status }: Readonly<{ label: string; status: SyncStatus }>): React.JSX.Element {
+function SyncTierRow({ label, status, synced }: Readonly<{ label: string; status: SyncStatus; synced: boolean }>): React.JSX.Element {
   const bar = status.status === 'syncing'
     ? (() => {
         const fraction = status.bytesTotal > 0
@@ -47,7 +51,7 @@ function SyncTierRow({ label, status }: Readonly<{ label: string; status: SyncSt
     <div className="py-1.5">
       <div className="flex items-center justify-between text-xs">
         <span className="text-text-secondary">{label}</span>
-        {tierState(status)}
+        {tierState(status, synced)}
       </div>
       {bar !== null && (
         <div className="mt-1 h-1 overflow-hidden rounded-full bg-bg-tertiary">
@@ -63,9 +67,17 @@ function SyncTierRow({ label, status }: Readonly<{ label: string; status: SyncSt
  *  and flags un-synced periods — with a per-tier breakdown on click, so the user
  *  doesn't have to open Settings › Data just to see activity. */
 export function SyncStatusButton({
-  activity, error, filesRemaining, missingPeriods, tiers, inSettingsData, onManageData,
+  activity, error, filesRemaining, missingPeriods, tiers, inSettingsData, onManageData, onRecheck,
 }: Readonly<Props>): React.JSX.Element {
   const [open, setOpen] = useState(false);
+  const [rechecking, setRechecking] = useState(false);
+  const synced = missingPeriods === 0;
+
+  function handleRecheck(): void {
+    if (rechecking) return;
+    setRechecking(true);
+    void onRecheck().finally(() => { setRechecking(false); });
+  }
 
   const showError = error !== null;
   const showActive = !showError && activity !== 'idle';
@@ -111,15 +123,27 @@ export function SyncStatusButton({
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-72">
-        <div className="mb-2 flex items-center gap-2">
-          <CloudDownload size={14} className="text-accent" />
-          <span className="text-sm font-semibold">Data sync</span>
+        <div className="mb-2 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <CloudDownload size={14} className="text-accent" />
+            <span className="text-sm font-semibold">Data sync</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleRecheck}
+            disabled={rechecking}
+            className="rounded p-1 text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-50"
+            title="Check for new data"
+            aria-label="Check for new data"
+          >
+            <RefreshCw size={13} className={rechecking ? 'animate-spin' : undefined} />
+          </button>
         </div>
         {showError && (
           <div className="mb-2 rounded-md border border-negative/50 bg-negative-muted px-2.5 py-1.5 text-xs text-negative">{error}</div>
         )}
         <div className="divide-y divide-border-subtle">
-          {tiers.map(t => <SyncTierRow key={t.id} label={t.label} status={t.status} />)}
+          {tiers.map(t => <SyncTierRow key={t.id} label={t.label} status={t.status} synced={synced} />)}
         </div>
         <div className="mt-3 flex items-center justify-between border-t border-border pt-2">
           <span className="text-[11px] text-text-muted">

--- a/packages/desktop/src/renderer/top-menu/sync-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/sync-status-button.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { CloudDownload } from 'lucide-react';
+import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
+import type { SyncStatus } from '@costgoblin/core/browser';
+
+export type SyncActivity = 'idle' | 'syncing' | 'downloading';
+
+export interface SyncTier {
+  readonly id: string;
+  readonly label: string;
+  readonly status: SyncStatus;
+}
+
+interface Props {
+  activity: SyncActivity;
+  error: string | null;
+  filesRemaining: number;
+  missingPeriods: number;
+  tiers: readonly SyncTier[];
+  inSettingsData: boolean;
+  onManageData: () => void;
+}
+
+function tierState(status: SyncStatus): React.JSX.Element {
+  switch (status.status) {
+    case 'syncing':
+      return <span className="tabular-nums text-accent">{String(status.filesDone)}/{String(status.filesTotal)} files</span>;
+    case 'completed':
+      return <span className="text-text-muted">up to date</span>;
+    case 'failed':
+      return <span className="text-negative">failed</span>;
+    case 'idle':
+      return <span className="text-text-muted">idle</span>;
+  }
+}
+
+function SyncTierRow({ label, status }: Readonly<{ label: string; status: SyncStatus }>): React.JSX.Element {
+  const bar = status.status === 'syncing'
+    ? (() => {
+        const fraction = status.bytesTotal > 0
+          ? status.bytesDone / status.bytesTotal
+          : (status.filesTotal > 0 ? status.filesDone / status.filesTotal : 0);
+        return Math.min(100, Math.max(0, Math.round(fraction * 100)));
+      })()
+    : null;
+  return (
+    <div className="py-1.5">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-text-secondary">{label}</span>
+        {tierState(status)}
+      </div>
+      {bar !== null && (
+        <div className="mt-1 h-1 overflow-hidden rounded-full bg-bg-tertiary">
+          <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${String(bar)}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Dedicated data-sync indicator, split out of the Settings gear. Shows whether
+ *  a download is in progress (and how many files remain), surfaces sync errors,
+ *  and flags un-synced periods — with a per-tier breakdown on click, so the user
+ *  doesn't have to open Settings › Data just to see activity. */
+export function SyncStatusButton({
+  activity, error, filesRemaining, missingPeriods, tiers, inSettingsData, onManageData,
+}: Readonly<Props>): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  const showError = error !== null;
+  const showActive = !showError && activity !== 'idle';
+  const showMissing = !showError && activity === 'idle' && missingPeriods > 0 && !inSettingsData;
+
+  const title = showError
+    ? `Sync error — ${error}`
+    : showActive
+      ? 'Syncing…'
+      : showMissing
+        ? `${String(missingPeriods)} billing period${missingPeriods === 1 ? '' : 's'} not synced`
+        : 'Data sync';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Data sync"
+          title={title}
+          className={[
+            'relative rounded-md p-1.5 transition-colors',
+            open
+              ? 'bg-bg-tertiary text-text-primary'
+              : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
+            showError ? 'ring-1 ring-negative/60' : '',
+            showActive ? 'animate-sync-blink' : '',
+          ].join(' ')}
+        >
+          <CloudDownload size={16} />
+          {showError && (
+            <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-negative px-1 text-[10px] font-bold text-white">!</span>
+          )}
+          {showActive && filesRemaining > 0 && (
+            <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold text-white">{String(filesRemaining)}</span>
+          )}
+          {showActive && filesRemaining === 0 && (
+            <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-accent animate-pulse" aria-hidden="true" />
+          )}
+          {showMissing && (
+            <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-bold text-bg-primary">{String(missingPeriods)}</span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72">
+        <div className="mb-2 flex items-center gap-2">
+          <CloudDownload size={14} className="text-accent" />
+          <span className="text-sm font-semibold">Data sync</span>
+        </div>
+        {showError && (
+          <div className="mb-2 rounded-md border border-negative/50 bg-negative-muted px-2.5 py-1.5 text-xs text-negative">{error}</div>
+        )}
+        <div className="divide-y divide-border-subtle">
+          {tiers.map(t => <SyncTierRow key={t.id} label={t.label} status={t.status} />)}
+        </div>
+        <div className="mt-3 flex items-center justify-between border-t border-border pt-2">
+          <span className="text-[11px] text-text-muted">
+            {missingPeriods > 0
+              ? `${String(missingPeriods)} period${missingPeriods === 1 ? '' : 's'} not synced`
+              : 'All periods synced'}
+          </span>
+          <button
+            type="button"
+            onClick={() => { setOpen(false); onManageData(); }}
+            className="text-[11px] font-medium text-accent hover:underline"
+          >
+            Manage data
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1655,6 +1655,7 @@ export function DimensionsView() {
   // resets to status=loading on every dep change, which would otherwise blank
   // the dimensions list for a frame after every reorder/toggle/save.
   const [config, setConfig] = useState<DimensionsConfig | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   useEffect(() => {
     if (configQuery.status !== 'success') return;
     const { config: migrated, changed } = migrateLocked(configQuery.data);
@@ -1791,7 +1792,12 @@ export function DimensionsView() {
   function applyOptimistic(next: DimensionsConfig): void {
     const reconciled = { ...next, order: reconcileOrder(next) };
     setConfig(reconciled);
-    api.saveDimensionsConfig(reconciled).catch(() => undefined);
+    setSaveError(null);
+    api.saveDimensionsConfig(reconciled).catch((err: unknown) => {
+      // The toggle/reorder autosave used to swallow this — a failed persist left
+      // the UI showing a change that never reached disk. Surface it instead.
+      setSaveError(err instanceof Error ? err.message : 'Failed to save dimensions');
+    });
   }
 
   function toggleBuiltInEnabled(idx: number): void {
@@ -1908,6 +1914,19 @@ export function DimensionsView() {
         <h2 className="text-xl font-semibold text-text-primary">Dimensions</h2>
         <p className="text-sm text-text-secondary mt-1">Map tags to cost allocation dimensions</p>
       </div>
+
+      {saveError !== null && (
+        <div className="flex items-start justify-between gap-3 rounded-lg border border-negative/50 bg-negative-muted px-4 py-2.5">
+          <p className="text-sm text-negative">Couldn’t save your change: {saveError}</p>
+          <button
+            type="button"
+            onClick={() => { setSaveError(null); }}
+            className="text-xs font-medium text-negative/80 hover:text-negative"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {/* SECTION 1 — Available dimensions as toggleable pills. Two rows: the
           fixed set of built-ins, then the user-defined tag dims with an


### PR DESCRIPTION
Three header/status improvements from the dimensions↔rollup investigation. All on one branch because #399 and #400 both add buttons to the same header nav, and #400/#401 both touch the rollup lifecycle in `context.ts` — splitting per-issue would interleave within shared files.

## #399 — Dedicated data-sync icon (split from the gear)
The Settings gear used to double as the sync indicator. It's now its own top-right icon (`CloudDownload`) with a click-through popover showing per-tier (daily / hourly / cost-optimization) progress and any sync error. Reuses the existing `useSyncPolling` outputs — **no new main-process work**; the hook just additionally surfaces the per-tier statuses it was already fetching. The gear reverts to settings + the update dot.

## #400 — Global rollup compute-status icon
A new top-right `Layers` icon shows whether dashboards are served from the pre-aggregated rollup (`ready`), transiently from the slower raw path while a re-roll runs (`computing`, with progress), or `failed`.

- `RollupStore` now tracks and emits status transitions (computing → ready/failed) from `maintainPeriods`/`invalidate`.
- New `rollup:status-changed` push channel (modeled on the existing `update:status-changed`) + a `rollup:get-status` getter for the initial state on mount, wired through `handlers/rollup.ts`, the preload bridge (`costgoblinRollup`), and `RollupApi` in core.
- Surfaces build failures that were previously swallowed to `logger.warn`.

## #401 — Robust dimensions saves
- **Debounce the re-roll.** The dimensions view autosaves on every toggle/reorder, and each save dropped the rollup and rebuilt *all* daily partitions. Invalidate still runs immediately (queries fall back to raw right away — correct), but the warmup is now debounced (800ms) so a burst of edits coalesces into a single rebuild.
- **Surface the swallowed error.** The optimistic toggle/reorder autosave used to `.catch(() => undefined)`, so a failed persist left the UI showing a change that never reached disk. It now shows a dismissible error banner in the Dimensions view.

## Verification
`npm run check` passes (tsc ×4 packages, eslint, 761 tests). UI changes verified to type-check and lint; recommend a manual pass in the app watching the rollup icon transition `computing → ready` after a dimensions save, and the sync icon during a download.

Closes #399, #400, #401
