### PR TITLE
feat(ui): per-widget "Updating…" badge during a rollup re-roll

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -497,6 +497,7 @@ function AppShell(): React.JSX.Element {
   const inFlightCount = useDebugBadge();
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: 'idle' });
   const [rollupStatus, setRollupStatus] = useState<RollupStatus>({ state: 'idle' });
+  const [rollupEverReady, setRollupEverReady] = useState(false);
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
   const [devBranch, setDevBranch] = useState<string | null>(null);
@@ -538,9 +539,18 @@ function AppShell(): React.JSX.Element {
   useEffect(() => {
     // Pull the current state on mount (a re-roll may already be running before
     // the renderer subscribes), then track transitions via the push channel.
-    globalThis.costgoblinRollup.getStatus().then(setRollupStatus).catch(() => undefined);
-    return globalThis.costgoblinRollup.onStatusChanged(setRollupStatus);
+    const apply = (status: RollupStatus): void => {
+      setRollupStatus(status);
+      if (status.state === 'ready') setRollupEverReady(true);
+    };
+    globalThis.costgoblinRollup.getStatus().then(apply).catch(() => undefined);
+    return globalThis.costgoblinRollup.onStatusChanged(apply);
   }, []);
+
+  // A re-roll = recomputing an existing rollup (after a sync or dimensions
+  // change). Gating on "ever ready" keeps the first cold build — where widgets
+  // already show their own loaders — from flashing the "Updating…" badge.
+  const reRolling = rollupStatus.state === 'computing' && rollupEverReady;
 
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
@@ -1045,7 +1055,7 @@ function AppShell(): React.JSX.Element {
               const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
               return (
                 <Profiler id={`custom:${view.viewId}`} onRender={onPerfRender}>
-                  <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} />
+                  <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} reRolling={reRolling} />
                 </Profiler>
               );
             })()}

--- a/packages/ui/src/components/updating-badge.tsx
+++ b/packages/ui/src/components/updating-badge.tsx
@@ -1,0 +1,12 @@
+/** Non-blocking "Updating…" badge overlaid on a dashboard widget while the
+ *  rollup partition behind it is being re-rolled (after a sync changed a month,
+ *  or a dimensions change). The figure stays visible — briefly served from raw
+ *  or the prior partition — so this flags that it's being recomputed, not wrong. */
+export function UpdatingBadge(): React.JSX.Element {
+  return (
+    <div className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-full border border-border bg-bg-secondary/90 px-2 py-0.5 text-[10px] font-medium text-text-secondary shadow-sm backdrop-blur-sm">
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" aria-hidden="true" />
+      Updating…
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,7 @@ export { useQuery } from './hooks/use-query.js';
 export { UnsavedChangesProvider, useUnsavedChanges, useConfirmLeave } from './hooks/use-unsaved-changes.js';
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './components/ui/card.js';
+export { UpdatingBadge } from './components/updating-badge.js';
 export { Button, buttonVariants } from './components/ui/button.js';
 export type { ButtonProps } from './components/ui/button.js';
 export { Calendar } from './components/ui/calendar.js';

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -3,6 +3,7 @@ import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser
 import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
+import { UpdatingBadge } from '../components/updating-badge.js';
 import { daysBetween } from '../lib/dates.js';
 import type {
   Dimension,
@@ -52,6 +53,10 @@ interface CustomViewProps {
   readonly spec: ViewSpec;
   readonly headerSubtitle?: string | undefined;
   readonly initialFilter?: FilterMap | undefined;
+  /** True while the rollup behind these widgets is re-rolling — overlays a
+   *  non-blocking "Updating…" badge on each widget so a briefly-stale figure
+   *  reads as recomputing rather than wrong. */
+  readonly reRolling?: boolean | undefined;
 }
 
 function priorityFor(d: Dimension): number {
@@ -96,7 +101,7 @@ function previousRangeFor(dr: DateRange): DateRange {
   };
 }
 
-function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProps) {
+function CustomViewInner({ spec, headerSubtitle, initialFilter, reRolling }: CustomViewProps) {
   const api = useCostApi();
   const lagDays = useLagDays();
   const hourlyConfigured = useHourlyConfigured();
@@ -309,9 +314,10 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter }: CustomViewProp
                     id={w.id}
                     priority={offset + colIdx}
                     minHeight={placeholderMinHeight(w.type)}
-                    className="min-w-0 flex flex-col"
+                    className="relative min-w-0 flex flex-col"
                     style={{ flexBasis: widgetFlexBasis(w.size), flexGrow: 1, flexShrink: 1 }}
                   >
+                    {reRolling === true && <UpdatingBadge />}
                     <Renderer
                       spec={w}
                       dateRange={dateRange}


### PR DESCRIPTION
Implements the deferred serve-while-re-rolling indicator from `docs/rollup-design.md` §5, building on the `rollup:status-changed` channel added in #403.

## What
When a sync changes a month — or a dimensions change invalidates the rollup — the affected partition re-rolls in the background. During that window a dashboard figure can be **briefly stale rather than wrong** (served from the prior partition or the raw fallback). This overlays a small, non-blocking **"Updating…"** badge on each dashboard widget while the re-roll runs.

## How
- `UpdatingBadge` — a tiny pill component (pulsing dot + "Updating…"), overlaid in each widget's top-right.
- `CustomView` gains a `reRolling` prop; the badge renders on every `LazyWidgetSlot` (the shared per-widget wrapper) when it's true. Only mounted/in-view widgets get it.
- The shell (`App.tsx`) computes `reRolling = rollupStatus.state === 'computing' && rollupEverReady`, driven by the existing `rollup:status-changed` subscription. Gating on **ever-ready** means the first cold build — where widgets already show their own loaders — doesn't flash the badge; only a re-roll of an existing rollup does. The badge clears automatically when the rollup returns to `ready`.

## Scope notes
- **v1 is dashboard-wide during a re-roll**, not per-period. A dimensions change re-rolls every partition (so every widget is genuinely affected); a sync re-rolls specific months, where this slightly over-badges widgets whose date range doesn't overlap the changed month. Per-period precision (badge only widgets whose range intersects the re-rolling periods) is a reasonable follow-up — it'd need the status to carry the period set.
- No forced refetch on completion: rollup and raw produce identical aggregates (the invariant #385 audits), so figures are correct throughout; the badge is purely informational.

## Verification
`npm run check` passes (tsc ×4, eslint, 765 tests).

Closes #384
