### PR TITLE
feat(dimensions): unlock usage_type so it can be dropped from the rollup grain

### DIFF
--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -24,8 +24,11 @@ function tagOrderKey(t: { tagName?: string | undefined; accountTagFallback?: str
   return `tag:@${src}:${t.label}`;
 }
 
-// Core dimensions that cannot be disabled — they power the fallback chain and are always needed.
-const LOCKED_DIMENSIONS = new Set([asDimensionId('service'), asDimensionId('service_family'), asDimensionId('usage_type')]);
+// Core dimensions that cannot be disabled — service and service_family anchor
+// the widget fallback chain. usage_type stays a fallback candidate (queried
+// from the raw column regardless of enabled state) but is now toggleable, so a
+// heavy usage_type grain can be dropped from the rollup to keep dashboards fast.
+const LOCKED_DIMENSIONS = new Set([asDimensionId('service'), asDimensionId('service_family')]);
 
 function migrateLocked(cfg: DimensionsConfig): { config: DimensionsConfig; changed: boolean } {
   const needsFix = cfg.builtIn.some(d => LOCKED_DIMENSIONS.has(d.name) && d.enabled === false);


### PR DESCRIPTION
## Why

`usage_type` was force-locked (always enabled, can't be toggled) alongside `service` and `service_family`, because the three form the widget fallback chain (`service → service_family → usage_type`): when Service and Service Category are filtered to a single value, charts fall back to grouping by Usage Type instead of showing a useless single-slice pie.

But fallback candidates are queried **from the raw CUR column regardless of a dimension's enabled state** ([widget.ts](packages/ui/src/widgets/widget.ts) — *"Fallback candidates are built-in CUR columns — always queryable regardless of enabled state"*). So `usage_type` does **not** need to be enabled for the fallback to work — locking it only prevented users from dropping a high-cardinality dimension that frequently dominates the rollup grain.

This pairs with the per-dimension rollup impact panel (#402): that panel often flags Usage Type as the single biggest grain driver and suggests keeping it raw-only — advice you currently can't act on because it's locked.

## What

Remove `usage_type` from `LOCKED_DIMENSIONS` ([dimensions.tsx](packages/ui/src/views/dimensions.tsx)).

- It stays **enabled by default** (the seed config doesn't set `enabled: false`) and remains a fallback candidate — no change for users who leave it on.
- It's now **toggleable**, so a heavy `usage_type` grain can be dropped from the rollup to keep it small and dashboards fast. A widget that falls back to Usage Type still works; that one grouping queries raw instead of the rollup.
- `service` and `service_family` stay locked as the fallback anchors.

## Behavior when a user disables it

The rollup no longer stores `usage_type`, so it's aggregated away (leaner/faster rollup). Widgets that fall back to Usage Type query the raw parquet for that grouping — the standard raw-fallback path — instead of the rollup.