### PR TITLE
feat(ui): rollup popover — per-period rebuild progress

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -387,7 +387,7 @@ export interface UpdateApi {
  *  (otherwise swallowed to the log). */
 export type RollupStatus =
   | { readonly state: 'idle' }
-  | { readonly state: 'computing'; readonly done: number; readonly total: number }
+  | { readonly state: 'computing'; readonly done: number; readonly total: number; readonly periods: readonly string[] }
   | { readonly state: 'ready'; readonly periods: number }
   | { readonly state: 'failed'; readonly message: string; readonly periods: number };
 

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -217,10 +217,13 @@ export class RollupStore {
         ? this.manifest
         : { schemaVersion: ROLLUP_SCHEMA_VERSION, shapeSignature: shape.signature, builtAt: '', grainDimensions: shape.grainDimensions, availableColumns: shape.availableColumns, partitions: {} };
 
+      // Periods are processed in order, so the first `done` of them are
+      // finished and the rest are still pending — the renderer slices on `done`
+      // to show which months are built vs to-do.
       const total = periods.length;
       let done = 0;
       let failures = 0;
-      this.setStatus({ state: 'computing', done, total });
+      this.setStatus({ state: 'computing', done, total, periods });
 
       for (const period of periods) {
         if (this.epoch !== startEpoch) return; // superseded mid-build — the newer op owns the status
@@ -228,7 +231,7 @@ export class RollupStore {
         if (opts.force !== true && manifest.partitions[period]?.rawEtagHash === wantHash) {
           this.validPeriods.add(period);
           done += 1;
-          this.setStatus({ state: 'computing', done, total });
+          this.setStatus({ state: 'computing', done, total, periods });
           continue;
         }
         try {
@@ -246,7 +249,7 @@ export class RollupStore {
           logger.warn(`rollup: build failed for ${period} — ${err instanceof Error ? err.message : String(err)}`);
         }
         done += 1;
-        this.setStatus({ state: 'computing', done, total });
+        this.setStatus({ state: 'computing', done, total, periods });
       }
 
       this.setStatus(
@@ -286,9 +289,10 @@ export class RollupStore {
     this.manifest = null;
     this.validPeriods = new Set();
     // Signal "rebuilding" immediately — the caller re-warms right after, and the
-    // ensuing warmup either drives this through to `ready` (via maintainPeriods)
-    // or calls markSettled() when there's nothing to rebuild.
-    this.setStatus({ state: 'computing', done: 0, total: 0 });
+    // ensuing warmup either drives this through to `ready` (via maintainPeriods,
+    // which fills in the period list) or calls markSettled() when there's
+    // nothing to rebuild.
+    this.setStatus({ state: 'computing', done: 0, total: 0, periods: [] });
     return this.enqueue(async () => {
       await rm(this.rollupDir(), { recursive: true, force: true });
     });

--- a/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
@@ -28,6 +28,21 @@ function formatRatio(ratio: number): string {
   return ratio >= 10 ? ratio.toFixed(0) : ratio.toFixed(1);
 }
 
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatMonth(period: string): string {
+  const [year, month] = period.split('-');
+  const name = MONTH_NAMES[Number(month) - 1] ?? month ?? period;
+  const yy = (year ?? '').slice(2);
+  return yy === '' ? name : `${name} '${yy}`;
+}
+
+function chipClass(isDone: boolean): string {
+  return isDone
+    ? 'rounded border border-accent/30 bg-accent/15 px-1.5 py-0.5 text-[10px] tabular-nums text-accent'
+    : 'rounded border border-border bg-bg-tertiary/40 px-1.5 py-0.5 text-[10px] tabular-nums text-text-muted';
+}
+
 function KpiRow({ label, value, accent }: Readonly<{ label: string; value: string; accent?: boolean }>): React.JSX.Element {
   return (
     <div className="flex items-center justify-between py-1">
@@ -114,6 +129,15 @@ export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Eleme
                 </div>
                 <p className="text-[11px] tabular-nums text-text-muted">{String(status.done)} / {String(status.total)} months</p>
               </>
+            )}
+            {status.periods.length > 0 && (
+              <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto">
+                {status.periods.map((p, i) => (
+                  <span key={p} className={chipClass(i < status.done)} title={i < status.done ? 'Rebuilt' : 'Pending'}>
+                    {formatMonth(p)}
+                  </span>
+                ))}
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
Refines the rollup compute-status popover (from #403 / #400) with a per-period breakdown, requested while testing.

## What
While the rollup is re-rolling, the popover showed only an aggregate `8 / 13 months` count + bar. It now also lists **each month as a chip** — accent/filled once that partition is rebuilt, muted while still pending — so you can see exactly which periods are done and which are to-do.

## How
- `RollupStatus.computing` now carries the ordered `periods` list. Partitions are processed in order, so the renderer slices on `done`: the first `done` are finished, the rest pending — no extra per-period state needed in the store.
- The popover renders the chips (wrapped, scrollable past a few rows) below the existing progress bar.

## Verification
`npm run check` passes (tsc ×4, eslint, 765 tests).

Independent of #405 (the per-widget badge); both touch rollup re-roll visibility but on different surfaces (header popover vs dashboard widgets).

Refs #400