### PR TITLE
chore(fixtures): ignore generated peer state in fixtures config dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__fixtures__/config/.gitignore
+++ b/packages/core/src/__fixtures__/config/.gitignore
@@ -1,0 +1,4 @@
+# Runtime peer device-state written by the desktop peer-store handler when
+# COSTGOBLIN_CONFIG_DIR points here (e2e / homepage-screenshots). Generated,
+# not fixtures — never commit.
+peer-*.json

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## What

Adds a co-located `.gitignore` in `packages/core/src/__fixtures__/config/` with a `peer-*.json` glob so generated peer device-state files are never tracked.

## Why

Running the Electron app or e2e scripts (e.g. `e2e/homepage-screenshots.ts`, which the e2e helpers use) with `COSTGOBLIN_CONFIG_DIR` pointed at the fixtures config dir makes the desktop peer-store handler ([`packages/desktop/src/main/handlers/peer-store.ts`](https://github.com/etiennechabert/cost-goblin/blob/main/packages/desktop/src/main/handlers/peer-store.ts)) write runtime device state into that fixtures directory:

- `peer-identity.json` (this machine's Ed25519 identity — includes a private key)
- `peer-sharing.json` (access secret + label)
- `peer-source.json` (consumer's stored shared source)

These are generated secrets/state, **not** fixtures. They show up as untracked files that a `git add -A` could accidentally sweep into a commit.

## Notes for reviewers

- Used a `peer-*.json` glob rather than two literal filenames — the handler actually writes **three** peer files (`peer-identity`, `peer-sharing`, `peer-source`), and the glob future-proofs any further `peer-*` state.
- No test depends on committed versions of these files — the filenames appear only in `peer-store.ts` as runtime paths; nothing under `packages/**/__tests__` references them.
- Verified the rule with `git check-ignore -v` (matches all three peer paths, leaves the real fixture YAMLs untracked-but-not-ignored) and end-to-end by creating the files and confirming `git status` / `git add -A --dry-run` ignore them.