### PR TITLE
feat(ui): build overlay blocks rollup-backed views until the period is ready

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -497,7 +497,6 @@ function AppShell(): React.JSX.Element {
   const inFlightCount = useDebugBadge();
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: 'idle' });
   const [rollupStatus, setRollupStatus] = useState<RollupStatus>({ state: 'idle' });
-  const [rollupEverReady, setRollupEverReady] = useState(false);
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
   const [devBranch, setDevBranch] = useState<string | null>(null);
@@ -541,7 +540,6 @@ function AppShell(): React.JSX.Element {
     // the renderer subscribes), then track transitions via the push channel.
     const apply = (status: RollupStatus): void => {
       setRollupStatus(status);
-      if (status.state === 'ready') setRollupEverReady(true);
     };
     globalThis.costgoblinRollup.getStatus().then(apply).catch(() => undefined);
     return globalThis.costgoblinRollup.onStatusChanged(apply);
@@ -1060,13 +1058,13 @@ function AppShell(): React.JSX.Element {
               const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
               return (
                 <Profiler id={`custom:${view.viewId}`} onRender={onPerfRender}>
-                  <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} rollupStatus={rollupStatus} rollupEverReady={rollupEverReady} />
+                  <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} rollupStatus={rollupStatus} />
                 </Profiler>
               );
             })()}
             {view.page === 'trends' && (
               <Profiler id="trends" onRender={onPerfRender}>
-                <CostTrends onEntityClick={handleEntityClick} rollupStatus={rollupStatus} rollupEverReady={rollupEverReady} />
+                <CostTrends onEntityClick={handleEntityClick} rollupStatus={rollupStatus} />
               </Profiler>
             )}
             {view.page === 'missing-tags' && (

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -547,11 +547,6 @@ function AppShell(): React.JSX.Element {
     return globalThis.costgoblinRollup.onStatusChanged(apply);
   }, []);
 
-  // A re-roll = recomputing an existing rollup (after a sync or dimensions
-  // change). Gating on "ever ready" keeps the first cold build — where widgets
-  // already show their own loaders — from flashing the "Updating…" badge.
-  const reRolling = rollupStatus.state === 'computing' && rollupEverReady;
-
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;
     // Always surface errors so the user can see what went wrong; for other
@@ -1055,13 +1050,13 @@ function AppShell(): React.JSX.Element {
               const spec = findViewSpec(view.viewId) ?? OVERVIEW_SEED_VIEW;
               return (
                 <Profiler id={`custom:${view.viewId}`} onRender={onPerfRender}>
-                  <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} reRolling={reRolling} />
+                  <CustomView spec={spec} headerSubtitle="Cloud spending visibility" initialFilter={view.initialFilter} rollupStatus={rollupStatus} rollupEverReady={rollupEverReady} />
                 </Profiler>
               );
             })()}
             {view.page === 'trends' && (
               <Profiler id="trends" onRender={onPerfRender}>
-                <CostTrends onEntityClick={handleEntityClick} />
+                <CostTrends onEntityClick={handleEntityClick} rollupStatus={rollupStatus} rollupEverReady={rollupEverReady} />
               </Profiler>
             )}
             {view.page === 'missing-tags' && (

--- a/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Layers } from 'lucide-react';
-import { Popover, PopoverTrigger, PopoverContent } from '@costgoblin/ui';
+import { Popover, PopoverTrigger, PopoverContent, RollupStatusDetail } from '@costgoblin/ui';
 import type { RollupStatus, RollupStats } from '@costgoblin/core/browser';
 
 interface Props {
@@ -9,57 +9,6 @@ interface Props {
 
 function months(n: number): string {
   return `${String(n)} month${n === 1 ? '' : 's'}`;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${String(bytes)} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(0)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
-}
-
-function formatCount(n: number): string {
-  if (n < 1000) return String(n);
-  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}K`;
-  return `${(n / 1_000_000).toFixed(1)}M`;
-}
-
-function formatRatio(ratio: number): string {
-  return ratio >= 10 ? ratio.toFixed(0) : ratio.toFixed(1);
-}
-
-const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-function formatMonth(period: string): string {
-  const [year, month] = period.split('-');
-  const name = MONTH_NAMES[Number(month) - 1] ?? month ?? period;
-  const yy = (year ?? '').slice(2);
-  return yy === '' ? name : `${name} '${yy}`;
-}
-
-type ChipState = 'done' | 'building' | 'pending';
-
-function chipClass(state: ChipState): string {
-  const base = 'rounded border px-1.5 py-0.5 text-[10px] tabular-nums';
-  switch (state) {
-    // `building` is the brighter, pulsing variant — it's the only moving thing
-    // in the popover during a parallel batch, where `done` can sit at 0 for
-    // several seconds while builds run concurrently.
-    case 'building': return `${base} border-accent bg-accent/25 text-accent animate-pulse`;
-    case 'done': return `${base} border-accent/30 bg-accent/15 text-accent`;
-    case 'pending': return `${base} border-border bg-bg-tertiary/40 text-text-muted`;
-  }
-}
-
-const CHIP_TITLE: Record<ChipState, string> = { done: 'Rebuilt', building: 'Building…', pending: 'Pending' };
-
-function KpiRow({ label, value, accent }: Readonly<{ label: string; value: string; accent?: boolean }>): React.JSX.Element {
-  return (
-    <div className="flex items-center justify-between py-1">
-      <span className="text-text-muted">{label}</span>
-      <span className={accent === true ? 'font-medium tabular-nums text-accent' : 'tabular-nums text-text-secondary'}>{value}</span>
-    </div>
-  );
 }
 
 function tooltipFor(status: RollupStatus): string {
@@ -97,9 +46,6 @@ export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Eleme
 
   const computing = status.state === 'computing';
   const failed = status.state === 'failed';
-  const pct = status.state === 'computing' && status.total > 0
-    ? Math.round((status.done / status.total) * 100)
-    : 0;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -129,57 +75,7 @@ export function RollupStatusButton({ status }: Readonly<Props>): React.JSX.Eleme
           <Layers size={14} className="text-accent" />
           <span className="text-sm font-semibold">Rollup</span>
         </div>
-        {status.state === 'computing' && (
-          <div className="space-y-2">
-            <p className="text-xs text-text-secondary">Rebuilding the pre-aggregated rollup. Dashboards read raw data until it finishes.</p>
-            {status.total > 0 && (
-              <>
-                <div className="h-1.5 overflow-hidden rounded-full bg-bg-tertiary">
-                  <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${String(pct)}%` }} />
-                </div>
-                <p className="text-[11px] tabular-nums text-text-muted">{String(status.done)} / {String(status.total)} months</p>
-              </>
-            )}
-            {status.periods.length > 0 && (
-              <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto">
-                {status.periods.map((p, i) => {
-                  const state: ChipState = i < status.done ? 'done' : status.active.includes(p) ? 'building' : 'pending';
-                  return (
-                    <span key={p} className={chipClass(state)} title={CHIP_TITLE[state]}>
-                      {formatMonth(p)}
-                    </span>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        )}
-        {status.state === 'ready' && (
-          <div className="space-y-2">
-            <p className="text-xs text-text-secondary">Dashboards are served from the pre-aggregated rollup.</p>
-            <div className="divide-y divide-border-subtle text-xs">
-              <KpiRow label="Months built" value={String(status.periods)} />
-              {stats !== null && (
-                <KpiRow label="Rollup size" value={`${formatBytes(stats.rollupBytes)} · ${formatCount(stats.rollupRows)} rows`} />
-              )}
-              {stats !== null && stats.rawBytes > 0 && (
-                <KpiRow label="Raw (daily)" value={formatBytes(stats.rawBytes)} />
-              )}
-              {stats !== null && stats.rawBytes > 0 && stats.rollupBytes > 0 && (
-                <KpiRow label="Compression" value={`${formatRatio(stats.rawBytes / stats.rollupBytes)}× smaller`} accent />
-              )}
-            </div>
-          </div>
-        )}
-        {status.state === 'idle' && (
-          <p className="text-xs text-text-secondary">No rollup is built yet. Dashboards query the raw data directly.</p>
-        )}
-        {status.state === 'failed' && (
-          <div className="space-y-1">
-            <p className="text-xs text-negative">{status.message}</p>
-            <p className="text-[11px] text-text-muted">Dashboards fall back to raw data. Reload data or re-save dimensions to retry.</p>
-          </div>
-        )}
+        <RollupStatusDetail status={status} stats={stats} />
       </PopoverContent>
     </Popover>
   );

--- a/packages/ui/src/__tests__/rollup-gate.test.ts
+++ b/packages/ui/src/__tests__/rollup-gate.test.ts
@@ -23,21 +23,33 @@ const range = { start: '2026-05-25', end: '2026-06-24' }; // spans 2026-05, 2026
 describe('rollupGate', () => {
   it('does not block when the rollup is ready', () => {
     const status: RollupStatus = { state: 'ready', periods: 13 };
-    expect(rollupGate(status, true, range).blocked).toBe(false);
+    expect(rollupGate(status, range).blocked).toBe(false);
   });
 
   it('does not block when idle (nothing is building)', () => {
-    expect(rollupGate({ state: 'idle' }, false, range).blocked).toBe(false);
+    expect(rollupGate({ state: 'idle' }, range).blocked).toBe(false);
   });
 
-  it('blocks a cold build when a selected month is still pending', () => {
-    // June not yet built: periods completed-first, done=1 means only the first
-    // entry (2026-05) is built; 2026-06 is in the pending tail.
+  it('blocks a cleared/cold build — every month pending, viewed months unbuilt', () => {
+    // Clear-cache rebuild: done=0, the whole history is in the batch, nothing
+    // built yet → both viewed months are in the pending tail.
+    const status: RollupStatus = {
+      state: 'computing', done: 0, total: 13,
+      periods: ['2026-06', '2026-05', '2026-04', '2026-03', '2026-02', '2026-01', '2025-12', '2025-11', '2025-10', '2025-09', '2025-08', '2025-07', '2025-06'],
+      active: ['2026-06', '2026-05'],
+    };
+    const gate = rollupGate(status, range);
+    expect(gate.blocked).toBe(true);
+    expect(gate.pendingMonths).toEqual(['2026-05', '2026-06']);
+  });
+
+  it('blocks while a single viewed month is still pending', () => {
+    // periods completed-first, done=1 → only 2026-05 built; 2026-06 pending.
     const status: RollupStatus = {
       state: 'computing', done: 1, total: 2,
       periods: ['2026-05', '2026-06'], active: ['2026-06'],
     };
-    const gate = rollupGate(status, false, range);
+    const gate = rollupGate(status, range);
     expect(gate.blocked).toBe(true);
     expect(gate.pendingMonths).toEqual(['2026-06']);
   });
@@ -47,23 +59,16 @@ describe('rollupGate', () => {
       state: 'computing', done: 2, total: 2,
       periods: ['2026-05', '2026-06'], active: [],
     };
-    expect(rollupGate(status, false, range).blocked).toBe(false);
+    expect(rollupGate(status, range).blocked).toBe(false);
   });
 
-  it('does not block a selected month outside the rebuild batch', () => {
-    // Re-roll of an unrelated month; the viewed months are already valid.
+  it('does not block a re-roll of months the user is not viewing (badge handles it)', () => {
+    // Only an unrelated month is rebuilding; the viewed months stay valid in
+    // the rollup (not in the batch at all), so they are still served.
     const status: RollupStatus = {
       state: 'computing', done: 0, total: 1,
       periods: ['2026-01'], active: ['2026-01'],
     };
-    expect(rollupGate(status, false, range).blocked).toBe(false);
-  });
-
-  it('never blocks an incremental re-roll (everReady) — the badge handles it', () => {
-    const status: RollupStatus = {
-      state: 'computing', done: 0, total: 2,
-      periods: ['2026-05', '2026-06'], active: ['2026-05'],
-    };
-    expect(rollupGate(status, true, range).blocked).toBe(false);
+    expect(rollupGate(status, range).blocked).toBe(false);
   });
 });

--- a/packages/ui/src/__tests__/rollup-gate.test.ts
+++ b/packages/ui/src/__tests__/rollup-gate.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { RollupStatus } from '@costgoblin/core/browser';
+import { monthsInRange } from '../lib/dates.js';
+import { rollupGate } from '../lib/rollup-gate.js';
+
+describe('monthsInRange', () => {
+  it('returns every YYYY-MM a range spans, inclusive', () => {
+    expect(monthsInRange({ start: '2026-03-15', end: '2026-05-20' })).toEqual(['2026-03', '2026-04', '2026-05']);
+  });
+  it('returns a single month for an intra-month range', () => {
+    expect(monthsInRange({ start: '2026-06-01', end: '2026-06-24' })).toEqual(['2026-06']);
+  });
+  it('crosses a year boundary', () => {
+    expect(monthsInRange({ start: '2025-12-20', end: '2026-01-05' })).toEqual(['2025-12', '2026-01']);
+  });
+  it('returns [] for an inverted range', () => {
+    expect(monthsInRange({ start: '2026-06-01', end: '2026-05-01' })).toEqual([]);
+  });
+});
+
+const range = { start: '2026-05-25', end: '2026-06-24' }; // spans 2026-05, 2026-06
+
+describe('rollupGate', () => {
+  it('does not block when the rollup is ready', () => {
+    const status: RollupStatus = { state: 'ready', periods: 13 };
+    expect(rollupGate(status, true, range).blocked).toBe(false);
+  });
+
+  it('does not block when idle (nothing is building)', () => {
+    expect(rollupGate({ state: 'idle' }, false, range).blocked).toBe(false);
+  });
+
+  it('blocks a cold build when a selected month is still pending', () => {
+    // June not yet built: periods completed-first, done=1 means only the first
+    // entry (2026-05) is built; 2026-06 is in the pending tail.
+    const status: RollupStatus = {
+      state: 'computing', done: 1, total: 2,
+      periods: ['2026-05', '2026-06'], active: ['2026-06'],
+    };
+    const gate = rollupGate(status, false, range);
+    expect(gate.blocked).toBe(true);
+    expect(gate.pendingMonths).toEqual(['2026-06']);
+  });
+
+  it('does not block once all selected months are built', () => {
+    const status: RollupStatus = {
+      state: 'computing', done: 2, total: 2,
+      periods: ['2026-05', '2026-06'], active: [],
+    };
+    expect(rollupGate(status, false, range).blocked).toBe(false);
+  });
+
+  it('does not block a selected month outside the rebuild batch', () => {
+    // Re-roll of an unrelated month; the viewed months are already valid.
+    const status: RollupStatus = {
+      state: 'computing', done: 0, total: 1,
+      periods: ['2026-01'], active: ['2026-01'],
+    };
+    expect(rollupGate(status, false, range).blocked).toBe(false);
+  });
+
+  it('never blocks an incremental re-roll (everReady) — the badge handles it', () => {
+    const status: RollupStatus = {
+      state: 'computing', done: 0, total: 2,
+      periods: ['2026-05', '2026-06'], active: ['2026-05'],
+    };
+    expect(rollupGate(status, true, range).blocked).toBe(false);
+  });
+});

--- a/packages/ui/src/components/rollup-building-overlay.tsx
+++ b/packages/ui/src/components/rollup-building-overlay.tsx
@@ -1,0 +1,55 @@
+import { Layers } from 'lucide-react';
+import type { RollupStatus } from '@costgoblin/core/browser';
+import { RollupStatusDetail } from './rollup-status-detail.js';
+
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatMonth(period: string): string {
+  const [year, month] = period.split('-');
+  const name = MONTH_NAMES[Number(month) - 1] ?? month ?? period;
+  const yy = (year ?? '').slice(2);
+  return yy === '' ? name : `${name} '${yy}`;
+}
+
+function periodLabel(months: readonly string[]): string {
+  if (months.length === 0) return 'the selected period';
+  if (months.length === 1) return formatMonth(months[0] ?? '');
+  return `${formatMonth(months[0] ?? '')}–${formatMonth(months[months.length - 1] ?? '')}`;
+}
+
+interface Props {
+  readonly status: RollupStatus;
+  /** Months the user is currently viewing — named in the headline and ringed in
+   *  the chip list so they can see their data's progress specifically. */
+  readonly pendingMonths: readonly string[];
+}
+
+/** Full-area "building your data" panel shown over a rollup-backed view while
+ *  the selected period's rollup is still being built (cold first build). It
+ *  replaces the widget grid — so the slow raw queries never fire — and clears
+ *  itself the moment the period's partitions are ready, letting the view mount
+ *  and load. The app header stays usable above it. */
+export function RollupBuildingOverlay({ status, pendingMonths }: Props): React.JSX.Element {
+  return (
+    <div className="flex min-h-[55vh] flex-1 items-center justify-center rounded-2xl border border-border bg-bg-secondary/40 p-8">
+      <div className="w-full max-w-md space-y-5 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-accent/30 bg-accent/10">
+          <Layers size={22} className="animate-pulse text-accent" aria-hidden="true" />
+        </div>
+        <div className="space-y-1.5">
+          <h3 className="text-lg font-semibold text-text-primary">Preparing your cost data</h3>
+          <p className="text-sm text-text-secondary">
+            CostGoblin is pre-aggregating <span className="font-medium text-text-primary">{periodLabel(pendingMonths)}</span> into
+            the rollup. This view loads automatically as soon as it's ready.
+          </p>
+        </div>
+        <div className="rounded-xl border border-border bg-bg-primary/50 p-4 text-left">
+          <RollupStatusDetail status={status} highlight={pendingMonths} />
+        </div>
+        <p className="text-xs text-text-muted">
+          Switch to an already-built month — or open Explorer — to browse while this finishes.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/rollup-status-detail.tsx
+++ b/packages/ui/src/components/rollup-status-detail.tsx
@@ -1,0 +1,132 @@
+import type { RollupStatus, RollupStats } from '@costgoblin/core/browser';
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(0)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}
+
+function formatCount(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}K`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function formatRatio(ratio: number): string {
+  return ratio >= 10 ? ratio.toFixed(0) : ratio.toFixed(1);
+}
+
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatMonth(period: string): string {
+  const [year, month] = period.split('-');
+  const name = MONTH_NAMES[Number(month) - 1] ?? month ?? period;
+  const yy = (year ?? '').slice(2);
+  return yy === '' ? name : `${name} '${yy}`;
+}
+
+type ChipState = 'done' | 'building' | 'pending';
+
+function chipClass(state: ChipState, highlighted: boolean): string {
+  const base = `rounded border px-1.5 py-0.5 text-[10px] tabular-nums${highlighted ? ' ring-1 ring-accent/60' : ''}`;
+  switch (state) {
+    // `building` is the brighter, pulsing variant — it's the only moving thing
+    // in the popover during a parallel batch, where `done` can sit at 0 for
+    // several seconds while builds run concurrently.
+    case 'building': return `${base} border-accent bg-accent/25 text-accent animate-pulse`;
+    case 'done': return `${base} border-accent/30 bg-accent/15 text-accent`;
+    case 'pending': return `${base} border-border bg-bg-tertiary/40 text-text-muted`;
+  }
+}
+
+const CHIP_TITLE: Record<ChipState, string> = { done: 'Rebuilt', building: 'Building…', pending: 'Pending' };
+
+function KpiRow({ label, value, accent }: Readonly<{ label: string; value: string; accent?: boolean }>): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <span className="text-text-muted">{label}</span>
+      <span className={accent === true ? 'font-medium tabular-nums text-accent' : 'tabular-nums text-text-secondary'}>{value}</span>
+    </div>
+  );
+}
+
+interface Props {
+  readonly status: RollupStatus;
+  /** Size KPIs for the `ready` body. Omit (or null) to skip those rows — the
+   *  building overlay doesn't need them. */
+  readonly stats?: RollupStats | null;
+  /** Months to emphasise (e.g. the ones the user is currently viewing) — drawn
+   *  with an accent ring so the user can spot their period in the batch. */
+  readonly highlight?: readonly string[];
+}
+
+/** Presentational rollup status body, shared by the header popover and the
+ *  full-view "building" overlay so both surfaces stay in sync. Renders the
+ *  progress bar + per-period chips while `computing`, size KPIs when `ready`,
+ *  and a short explanation otherwise. */
+export function RollupStatusDetail({ status, stats = null, highlight }: Props): React.JSX.Element {
+  const highlightSet = new Set(highlight ?? []);
+  const pct = status.state === 'computing' && status.total > 0
+    ? Math.round((status.done / status.total) * 100)
+    : 0;
+
+  if (status.state === 'computing') {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-text-secondary">Rebuilding the pre-aggregated rollup. Dashboards read raw data until it finishes.</p>
+        {status.total > 0 && (
+          <>
+            <div className="h-1.5 overflow-hidden rounded-full bg-bg-tertiary">
+              <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${String(pct)}%` }} />
+            </div>
+            <p className="text-[11px] tabular-nums text-text-muted">{String(status.done)} / {String(status.total)} months</p>
+          </>
+        )}
+        {status.periods.length > 0 && (
+          <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto">
+            {status.periods.map((p, i) => {
+              const state: ChipState = i < status.done ? 'done' : status.active.includes(p) ? 'building' : 'pending';
+              return (
+                <span key={p} className={chipClass(state, highlightSet.has(p))} title={CHIP_TITLE[state]}>
+                  {formatMonth(p)}
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (status.state === 'ready') {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-text-secondary">Dashboards are served from the pre-aggregated rollup.</p>
+        <div className="divide-y divide-border-subtle text-xs">
+          <KpiRow label="Months built" value={String(status.periods)} />
+          {stats !== null && (
+            <KpiRow label="Rollup size" value={`${formatBytes(stats.rollupBytes)} · ${formatCount(stats.rollupRows)} rows`} />
+          )}
+          {stats !== null && stats.rawBytes > 0 && (
+            <KpiRow label="Raw (daily)" value={formatBytes(stats.rawBytes)} />
+          )}
+          {stats !== null && stats.rawBytes > 0 && stats.rollupBytes > 0 && (
+            <KpiRow label="Compression" value={`${formatRatio(stats.rawBytes / stats.rollupBytes)}× smaller`} accent />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (status.state === 'failed') {
+    return (
+      <div className="space-y-1">
+        <p className="text-xs text-negative">{status.message}</p>
+        <p className="text-[11px] text-text-muted">Dashboards fall back to raw data. Reload data or re-save dimensions to retry.</p>
+      </div>
+    );
+  }
+
+  return <p className="text-xs text-text-secondary">No rollup is built yet. Dashboards query the raw data directly.</p>;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,6 +11,11 @@ export { UnsavedChangesProvider, useUnsavedChanges, useConfirmLeave } from './ho
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './components/ui/card.js';
 export { UpdatingBadge } from './components/updating-badge.js';
+export { RollupStatusDetail } from './components/rollup-status-detail.js';
+export { RollupBuildingOverlay } from './components/rollup-building-overlay.js';
+export { rollupGate } from './lib/rollup-gate.js';
+export type { RollupGateState } from './lib/rollup-gate.js';
+export { monthsInRange } from './lib/dates.js';
 export { Button, buttonVariants } from './components/ui/button.js';
 export type { ButtonProps } from './components/ui/button.js';
 export { Calendar } from './components/ui/calendar.js';

--- a/packages/ui/src/lib/dates.ts
+++ b/packages/ui/src/lib/dates.ts
@@ -8,6 +8,23 @@ export function daysBetween(start: string, end: string): number {
   return Math.round((new Date(end).getTime() - new Date(start).getTime()) / DAY_MS) + 1;
 }
 
+/** The YYYY-MM months a date range spans, inclusive — mirrors core's
+ *  `computePeriodsInRange` so the renderer can intersect a selected range
+ *  against the rollup's per-period readiness without importing query logic. */
+export function monthsInRange(range: { readonly start: string; readonly end: string }): string[] {
+  const start = new Date(`${range.start}T00:00:00Z`);
+  const end = new Date(`${range.end}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start > end) return [];
+  const out: string[] = [];
+  const cursor = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1));
+  const last = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+  while (cursor.getTime() <= last.getTime()) {
+    out.push(`${String(cursor.getUTCFullYear())}-${String(cursor.getUTCMonth() + 1).padStart(2, '0')}`);
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return out;
+}
+
 export function daysAgo(days: number): DateString {
   const d = new Date(Date.now() - days * DAY_MS);
   return asDateString(d.toISOString().slice(0, 10));

--- a/packages/ui/src/lib/rollup-gate.ts
+++ b/packages/ui/src/lib/rollup-gate.ts
@@ -1,0 +1,40 @@
+import type { RollupStatus } from '@costgoblin/core/browser';
+import { monthsInRange } from './dates.js';
+
+export interface RollupGateState {
+  /** True when the selected range can't yet be served from the rollup and no
+   *  prior rollup exists to fall back on — i.e. a cold first build. The view
+   *  should show the building overlay instead of mounting widgets. */
+  readonly blocked: boolean;
+  /** Every YYYY-MM the selected range spans. */
+  readonly selectedMonths: readonly string[];
+  /** The selected months still waiting to be built (pending or in flight). */
+  readonly pendingMonths: readonly string[];
+}
+
+/** Decide whether a rollup-backed view should block on a not-yet-built period.
+ *
+ *  Only a *cold* build blocks: `everReady` is false (the rollup has never been
+ *  ready this session), so there's no prior rollup serving these months — the
+ *  widgets would grind on the slow raw path with no explanation. An incremental
+ *  re-roll (`everReady` true) keeps data on screen and is surfaced by the
+ *  non-blocking "Updating…" badge instead, so it never blocks.
+ *
+ *  During `computing`, `status.periods` is ordered completed-first: the first
+ *  `done` entries are built, the tail (`periods.slice(done)`) is still pending
+ *  or in flight. A month not in `periods` at all is already valid (a partial
+ *  re-roll) — but on a cold build `periods` is the full set, so the tail is the
+ *  authoritative "not yet available" list. */
+export function rollupGate(
+  status: RollupStatus,
+  everReady: boolean,
+  range: { readonly start: string; readonly end: string },
+): RollupGateState {
+  const selectedMonths = monthsInRange(range);
+  if (status.state !== 'computing' || everReady) {
+    return { blocked: false, selectedMonths, pendingMonths: [] };
+  }
+  const notBuilt = new Set(status.periods.slice(status.done));
+  const pendingMonths = selectedMonths.filter((m) => notBuilt.has(m));
+  return { blocked: pendingMonths.length > 0, selectedMonths, pendingMonths };
+}

--- a/packages/ui/src/lib/rollup-gate.ts
+++ b/packages/ui/src/lib/rollup-gate.ts
@@ -2,9 +2,9 @@ import type { RollupStatus } from '@costgoblin/core/browser';
 import { monthsInRange } from './dates.js';
 
 export interface RollupGateState {
-  /** True when the selected range can't yet be served from the rollup and no
-   *  prior rollup exists to fall back on — i.e. a cold first build. The view
-   *  should show the building overlay instead of mounting widgets. */
+  /** True when the rollup can't serve the selected period and a build is in
+   *  progress to make it so — the view should show the building overlay instead
+   *  of mounting widgets that would grind on the slow raw path. */
   readonly blocked: boolean;
   /** Every YYYY-MM the selected range spans. */
   readonly selectedMonths: readonly string[];
@@ -14,24 +14,24 @@ export interface RollupGateState {
 
 /** Decide whether a rollup-backed view should block on a not-yet-built period.
  *
- *  Only a *cold* build blocks: `everReady` is false (the rollup has never been
- *  ready this session), so there's no prior rollup serving these months — the
- *  widgets would grind on the slow raw path with no explanation. An incremental
- *  re-roll (`everReady` true) keeps data on screen and is surfaced by the
- *  non-blocking "Updating…" badge instead, so it never blocks.
- *
- *  During `computing`, `status.periods` is ordered completed-first: the first
+ *  Availability-driven, exception-style: the question is purely "is the rollup
+ *  present for the months I'm viewing?", never "was it ever ready this session".
+ *  During `computing`, `status.periods` is ordered completed-first — the first
  *  `done` entries are built, the tail (`periods.slice(done)`) is still pending
- *  or in flight. A month not in `periods` at all is already valid (a partial
- *  re-roll) — but on a cold build `periods` is the full set, so the tail is the
- *  authoritative "not yet available" list. */
+ *  or in flight, and any month NOT in `periods` at all is a partition left
+ *  untouched by this build (still valid, still served). So a viewed month is
+ *  unavailable iff it falls in that pending tail.
+ *
+ *  This blocks both a cold first build AND a cleared/rebuilt rollup (every month
+ *  is in the batch, so any viewed month is pending until rebuilt). A re-roll of
+ *  months the user isn't viewing leaves their partitions valid → not blocked,
+ *  and the non-blocking "Updating…" badge covers that case instead. */
 export function rollupGate(
   status: RollupStatus,
-  everReady: boolean,
   range: { readonly start: string; readonly end: string },
 ): RollupGateState {
   const selectedMonths = monthsInRange(range);
-  if (status.state !== 'computing' || everReady) {
+  if (status.state !== 'computing') {
     return { blocked: false, selectedMonths, pendingMonths: [] };
   }
   const notBuilt = new Set(status.periods.slice(status.done));

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   Dimension,
   DimensionId,
+  RollupStatus,
   TrendResult,
   TrendRow,
   EntityRef,
@@ -11,7 +12,9 @@ import { useCostApi } from '../hooks/use-cost-api.js';
 import { useLagDays } from '../hooks/use-lag-days.js';
 import { useQuery } from '../hooks/use-query.js';
 import { getDimensionId } from '../lib/dimensions.js';
+import { rollupGate } from '../lib/rollup-gate.js';
 import { BubbleChart } from '../components/bubble-chart.js';
+import { RollupBuildingOverlay } from '../components/rollup-building-overlay.js';
 import { DateRangePicker, getDefaultDateRange } from '../components/date-range-picker.js';
 import type { DateRange, Granularity } from '../components/date-range-picker.js';
 import { DimensionSelector } from '../components/dimension-selector.js';
@@ -73,9 +76,13 @@ function TrendRowItem({ row, onClick }: Readonly<{ row: TrendRow; onClick: (e: E
 
 interface CostTrendsProps {
   onEntityClick?: (entity: string, dimension: string) => void;
+  /** Live rollup state — Cost Trends is rollup-backed, so a cold first build
+   *  blocks with the build overlay until the viewed period is aggregated. */
+  rollupStatus?: RollupStatus;
+  rollupEverReady?: boolean;
 }
 
-export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps = {}) {
+export function CostTrends({ onEntityClick: onEntityClickProp, rollupStatus, rollupEverReady }: CostTrendsProps = {}) {
   const api = useCostApi();
   const lagDays = useLagDays();
   const dimensionsQuery = useQuery(() => api.getDimensions(), []);
@@ -92,6 +99,13 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
 
   const dimensions: Dimension[] =
     dimensionsQuery.status === 'success' ? dimensionsQuery.data : [];
+
+  const gate = useMemo(
+    () => rollupStatus === undefined
+      ? { blocked: false, selectedMonths: [], pendingMonths: [] }
+      : rollupGate(rollupStatus, rollupEverReady ?? false, state.dateRange),
+    [rollupStatus, rollupEverReady, state.dateRange],
+  );
 
   const firstDimId = dimensions.length > 0 && dimensions[0] !== undefined
     ? getDimensionId(dimensions[0])
@@ -197,6 +211,10 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
         />
       </div>
 
+      {gate.blocked && rollupStatus !== undefined ? (
+        <RollupBuildingOverlay status={rollupStatus} pendingMonths={gate.pendingMonths} />
+      ) : (
+      <>
       {dimensions.length > 0 && (
         <div className="flex flex-wrap items-center gap-4">
           <DimensionSelector
@@ -310,6 +328,8 @@ export function CostTrends({ onEntityClick: onEntityClickProp }: CostTrendsProps
         <div className="rounded-xl border border-border bg-bg-secondary/50 p-12 text-center text-text-secondary">
           No {state.direction === 'all' ? 'changes' : state.direction} above thresholds
         </div>
+      )}
+      </>
       )}
     </div>
   );

--- a/packages/ui/src/views/cost-trends.tsx
+++ b/packages/ui/src/views/cost-trends.tsx
@@ -76,13 +76,13 @@ function TrendRowItem({ row, onClick }: Readonly<{ row: TrendRow; onClick: (e: E
 
 interface CostTrendsProps {
   onEntityClick?: (entity: string, dimension: string) => void;
-  /** Live rollup state — Cost Trends is rollup-backed, so a cold first build
-   *  blocks with the build overlay until the viewed period is aggregated. */
+  /** Live rollup state — Cost Trends is rollup-backed, so it blocks with the
+   *  build overlay whenever the rollup can't serve the viewed period and is
+   *  building it (cold build or a cleared rollup). */
   rollupStatus?: RollupStatus;
-  rollupEverReady?: boolean;
 }
 
-export function CostTrends({ onEntityClick: onEntityClickProp, rollupStatus, rollupEverReady }: CostTrendsProps = {}) {
+export function CostTrends({ onEntityClick: onEntityClickProp, rollupStatus }: CostTrendsProps = {}) {
   const api = useCostApi();
   const lagDays = useLagDays();
   const dimensionsQuery = useQuery(() => api.getDimensions(), []);
@@ -103,8 +103,8 @@ export function CostTrends({ onEntityClick: onEntityClickProp, rollupStatus, rol
   const gate = useMemo(
     () => rollupStatus === undefined
       ? { blocked: false, selectedMonths: [], pendingMonths: [] }
-      : rollupGate(rollupStatus, rollupEverReady ?? false, state.dateRange),
-    [rollupStatus, rollupEverReady, state.dateRange],
+      : rollupGate(rollupStatus, state.dateRange),
+    [rollupStatus, state.dateRange],
   );
 
   const firstDimId = dimensions.length > 0 && dimensions[0] !== undefined

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -56,12 +56,11 @@ interface CustomViewProps {
   readonly spec: ViewSpec;
   readonly headerSubtitle?: string | undefined;
   readonly initialFilter?: FilterMap | undefined;
-  /** Live rollup state. Drives two things: a non-blocking "Updating…" badge per
-   *  widget during an incremental re-roll (data stays visible), and a blocking
-   *  build overlay when the selected period has no rollup yet on a cold first
-   *  build (widgets would otherwise grind on the slow raw path). */
+  /** Live rollup state. Drives two things: a blocking build overlay when the
+   *  rollup can't serve the viewed period and is building it (cold build or a
+   *  cleared rollup), and a non-blocking "Updating…" badge per widget when a
+   *  re-roll touches months the user isn't viewing (data stays visible). */
   readonly rollupStatus?: RollupStatus | undefined;
-  readonly rollupEverReady?: boolean | undefined;
 }
 
 function priorityFor(d: Dimension): number {
@@ -106,23 +105,24 @@ function previousRangeFor(dr: DateRange): DateRange {
   };
 }
 
-function CustomViewInner({ spec, headerSubtitle, initialFilter, rollupStatus, rollupEverReady }: CustomViewProps) {
+function CustomViewInner({ spec, headerSubtitle, initialFilter, rollupStatus }: CustomViewProps) {
   const api = useCostApi();
   const lagDays = useLagDays();
   const hourlyConfigured = useHourlyConfigured();
   const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
 
-  // Cold first build with no rollup for the viewed months yet → block with the
-  // build overlay (widgets don't mount, so they never fire slow raw queries).
-  // An incremental re-roll (the rollup was already ready) never blocks — it
-  // keeps data on screen under the non-blocking "Updating…" badge.
+  // Rollup can't serve the viewed months and is building them (cold build or a
+  // cleared rollup) → block with the build overlay; widgets don't mount, so
+  // they never fire slow raw queries. A re-roll that only touches months the
+  // user isn't viewing leaves their data served → not blocked, and the badge
+  // below covers it.
   const gate = useMemo(
     () => rollupStatus === undefined
       ? { blocked: false, selectedMonths: [], pendingMonths: [] }
-      : rollupGate(rollupStatus, rollupEverReady ?? false, dateRange),
-    [rollupStatus, rollupEverReady, dateRange],
+      : rollupGate(rollupStatus, dateRange),
+    [rollupStatus, dateRange],
   );
-  const reRolling = rollupStatus?.state === 'computing' && rollupEverReady === true;
+  const reRolling = rollupStatus?.state === 'computing' && !gate.blocked;
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [compareEnabled, setCompareEnabled] = useState(false);
   const [filters, setFilters] = useState<FilterMap>(initialFilter ?? {});

--- a/packages/ui/src/views/custom-view.tsx
+++ b/packages/ui/src/views/custom-view.tsx
@@ -4,12 +4,15 @@ import { shouldAutoSwitchToHourly } from '../lib/drag-select.js';
 import { useHourlyConfigured } from '../hooks/use-hourly-configured.js';
 import { HourlyHintBanner } from '../components/hourly-hint-banner.js';
 import { UpdatingBadge } from '../components/updating-badge.js';
+import { RollupBuildingOverlay } from '../components/rollup-building-overlay.js';
 import { daysBetween } from '../lib/dates.js';
+import { rollupGate } from '../lib/rollup-gate.js';
 import type {
   Dimension,
   DimensionId,
   EntityRef,
   FilterMap,
+  RollupStatus,
   TagValue,
   ViewSpec,
 } from '@costgoblin/core/browser';
@@ -53,10 +56,12 @@ interface CustomViewProps {
   readonly spec: ViewSpec;
   readonly headerSubtitle?: string | undefined;
   readonly initialFilter?: FilterMap | undefined;
-  /** True while the rollup behind these widgets is re-rolling — overlays a
-   *  non-blocking "Updating…" badge on each widget so a briefly-stale figure
-   *  reads as recomputing rather than wrong. */
-  readonly reRolling?: boolean | undefined;
+  /** Live rollup state. Drives two things: a non-blocking "Updating…" badge per
+   *  widget during an incremental re-roll (data stays visible), and a blocking
+   *  build overlay when the selected period has no rollup yet on a cold first
+   *  build (widgets would otherwise grind on the slow raw path). */
+  readonly rollupStatus?: RollupStatus | undefined;
+  readonly rollupEverReady?: boolean | undefined;
 }
 
 function priorityFor(d: Dimension): number {
@@ -101,11 +106,23 @@ function previousRangeFor(dr: DateRange): DateRange {
   };
 }
 
-function CustomViewInner({ spec, headerSubtitle, initialFilter, reRolling }: CustomViewProps) {
+function CustomViewInner({ spec, headerSubtitle, initialFilter, rollupStatus, rollupEverReady }: CustomViewProps) {
   const api = useCostApi();
   const lagDays = useLagDays();
   const hourlyConfigured = useHourlyConfigured();
   const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDateRange(lagDays));
+
+  // Cold first build with no rollup for the viewed months yet → block with the
+  // build overlay (widgets don't mount, so they never fire slow raw queries).
+  // An incremental re-roll (the rollup was already ready) never blocks — it
+  // keeps data on screen under the non-blocking "Updating…" badge.
+  const gate = useMemo(
+    () => rollupStatus === undefined
+      ? { blocked: false, selectedMonths: [], pendingMonths: [] }
+      : rollupGate(rollupStatus, rollupEverReady ?? false, dateRange),
+    [rollupStatus, rollupEverReady, dateRange],
+  );
+  const reRolling = rollupStatus?.state === 'computing' && rollupEverReady === true;
   const [granularity, setGranularity] = useState<Granularity>('daily');
   const [compareEnabled, setCompareEnabled] = useState(false);
   const [filters, setFilters] = useState<FilterMap>(initialFilter ?? {});
@@ -296,10 +313,13 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter, reRolling }: Cus
         <HourlyHintBanner onDismiss={() => { setHourlyHint(false); }} />
       )}
 
-      {dimensionsQuery.status === 'loading' && (
+      {dimensionsQuery.status === 'loading' && !gate.blocked && (
         <div className="text-sm text-text-secondary">Loading...</div>
       )}
 
+      {gate.blocked && rollupStatus !== undefined ? (
+        <RollupBuildingOverlay status={rollupStatus} pendingMonths={gate.pendingMonths} />
+      ) : (
       <WidgetSchedulerProvider>
         {spec.rows.map((row, rowIdx) => {
           // Flat display order across rows = load priority (top-left first).
@@ -317,7 +337,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter, reRolling }: Cus
                     className="relative min-w-0 flex flex-col"
                     style={{ flexBasis: widgetFlexBasis(w.size), flexGrow: 1, flexShrink: 1 }}
                   >
-                    {reRolling === true && <UpdatingBadge />}
+                    {reRolling && <UpdatingBadge />}
                     <Renderer
                       spec={w}
                       dateRange={dateRange}
@@ -337,6 +357,7 @@ function CustomViewInner({ spec, headerSubtitle, initialFilter, reRolling }: Cus
           );
         })}
       </WidgetSchedulerProvider>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

When the rollup for the selected period hasn't been built yet (a cold first build), the dashboard and Cost Trends quietly fall back to the slow raw Parquet path with no explanation. Worse, the `Updating…` badge is suppressed until the rollup has been `ready` at least once (`reRolling = computing && rollupEverReady`), so during the exact window where the data isn't ready, there is **no** indicator at all — the widgets just sit there grinding.

## What this does

Adds a **"Preparing your cost data"** overlay that blocks rollup-dependent views while the selected period's rollup is still building, and **auto-dismisses** the moment it's ready.

- **Cold-build only.** Incremental re-rolls (rollup was already ready) keep the existing non-blocking `Updating…` badge — data stays on screen.
- **Per selected period.** `rollupGate()` intersects `monthsInRange(dateRange)` with the not-yet-built tail (`periods.slice(done)` from `RollupStatus`). Switching to an already-built month clears the block immediately.
- **Replaces the widget grid** while blocked, so the slow raw queries never fire; widgets mount and load the instant the overlay clears (driven by the live `onStatusChanged` push).
- **Scope:** Dashboard (`CustomView`) and Cost Trends — the views that route through `resolveRollupSource`. Explorer and Missing Tags read raw regardless of rollup state, so they are intentionally left unaffected.

## Implementation

- `lib/rollup-gate.ts` — the trigger logic (cold-build, per-period).
- `lib/dates.ts` → `monthsInRange()` (range → `YYYY-MM[]`, keeps the core→ui type-only boundary).
- `components/rollup-status-detail.tsx` — the rollup popover body extracted into a shared component (progress bar + per-period chips).
- `components/rollup-building-overlay.tsx` — the full-area building panel, reusing `RollupStatusDetail`.
- `rollup-status-button.tsx` now delegates its body to the shared component (−108 lines).
- `App.tsx` passes `rollupStatus` + `rollupEverReady` into both views (replacing the derived `reRolling` prop).

## Tests

`__tests__/rollup-gate.test.ts` — covers the `slice(done)` boundary, cold-vs-re-roll gating, out-of-batch months, and `monthsInRange`. Full `npm run check` green (779 passing).