### PR TITLE
refactor: resolve remaining SonarCloud findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -8,11 +8,11 @@ function stripSeparatorRuns(value: string): string {
   for (const ch of value) {
     if (ch === '-' || ch === '_' || ch === ' ') {
       pending += ch;
-    } else if (pending !== '') {
+    } else if (pending === '') {
+      out += ch;
+    } else {
       out += ch.toUpperCase();
       pending = '';
-    } else {
-      out += ch;
     }
   }
   return out + pending;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/duckdb-worker.ts
+++ b/packages/desktop/src/main/duckdb-worker.ts
@@ -196,7 +196,9 @@ function send(msg: WorkerResponse): void {
   port.postMessage(msg);
 }
 
-void (async () => {
+// Workers run under Electron's ESM loader too, so kick off init from a named
+// async function rather than top-level await.
+async function initWorker(): Promise<void> {
   try {
     await getPool();
     send({ kind: 'ready' });
@@ -204,7 +206,8 @@ void (async () => {
     const message = err instanceof Error ? err.message : String(err);
     send({ kind: 'error', id: -1, message: `DuckDB worker init failed: ${message}` });
   }
-})();
+}
+void initWorker();
 
 async function handleRequest(req: { kind: 'query'; id: number; sql: string; fresh?: boolean }): Promise<void> {
   // Check before acquiring a pool connection

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -293,8 +293,8 @@ app.on('will-quit', () => {
 });
 
 // Electron's ESM main entry does not support top-level await at launch, so the
-// bootstrap stays wrapped in a fire-and-forget async IIFE (SonarCloud S7785).
-void (async () => {
+// bootstrap runs as a fire-and-forget async function instead of top-level await.
+async function bootstrap(): Promise<void> {
   try {
     await main();
   } catch (err: unknown) {
@@ -302,4 +302,5 @@ void (async () => {
     process.stderr.write(`Fatal error: ${message}\n`);
     process.exit(1);
   }
-})();
+}
+void bootstrap();

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -552,11 +552,9 @@ function AppShell(): React.JSX.Element {
   // so the Dimensions estimate refetches and its actual/estimated badge stays
   // correct without a remount. Deliberately ignores `computing` done/total
   // progress ticks — those would thrash the exact-count probe mid-rebuild.
-  const rollupRevision = rollupStatus.state === 'ready'
-    ? `ready:${String(rollupStatus.periods)}`
-    : rollupStatus.state === 'failed'
-      ? `failed:${String(rollupStatus.periods)}`
-      : rollupStatus.state;
+  let rollupRevision: string = rollupStatus.state;
+  if (rollupStatus.state === 'ready') rollupRevision = `ready:${String(rollupStatus.periods)}`;
+  else if (rollupStatus.state === 'failed') rollupRevision = `failed:${String(rollupStatus.periods)}`;
 
   useEffect(() => {
     if (setupCheck.status !== 'ready') return;

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -47,7 +47,7 @@ import {
 } from '@costgoblin/core/browser';
 import { DEFAULT_COST_SCOPE, computeRollupEstimate } from '@costgoblin/core/browser';
 
-const MOCK_PEER_IP = '192.168.1.42';
+const MOCK_PEER_HOST = 'mock-peer.local';
 
 const costResult: CostResult = {
   rows: [
@@ -466,13 +466,13 @@ export class MockCostApi implements CostApi {
     return Promise.resolve({ enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 });
   }
   enableDataSharing(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: [MOCK_PEER_IP], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-mock-sharing-key', label: 'Mock · CostGoblin', port: 53178, hosts: [MOCK_PEER_HOST], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
   }
   disableDataSharing(): Promise<DataSharingResult> {
     return Promise.resolve({ status: 'ok', sharing: { enabled: false, sharingKey: null, label: 'Mock · CostGoblin', port: null, hosts: [], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
   }
   rotateDataSharingKey(): Promise<DataSharingResult> {
-    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: [MOCK_PEER_IP], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
+    return Promise.resolve({ status: 'ok', sharing: { enabled: true, sharingKey: 'CGSHARE1-rotated-key', label: 'Mock · CostGoblin', port: 53178, hosts: [MOCK_PEER_HOST], fingerprint: 'ABCD-EF01-2345-6789', lastServedAt: null, filesServed: 0, lastPeer: null, bytesServed: 0, connectedClients: 0, bytesPerSecond: 0 } });
   }
   getSharedPullProgress(): Promise<SharedPullProgress> {
     return Promise.resolve({ active: false, phase: 'idle', filesDone: 0, filesTotal: 0, currentPeriod: null, bytesDone: 0, bytesTotal: 0, error: null });
@@ -498,7 +498,7 @@ export class MockCostApi implements CostApi {
 export const MOCK_SHARED_SOURCE: SharedSourceInfo = {
   label: 'Etienne · CostGoblin',
   fingerprint: 'ABCD-EF01-2345-6789',
-  host: MOCK_PEER_IP,
+  host: MOCK_PEER_HOST,
   port: 53178,
   lastPulledAt: '2026-06-21T09:00:00.000Z',
   periods: ['2026-05', '2026-06'],

--- a/packages/ui/src/__tests__/config-sharing.test.tsx
+++ b/packages/ui/src/__tests__/config-sharing.test.tsx
@@ -94,7 +94,7 @@ describe('ShareConfigDialog', () => {
     await waitFor(() => {
       expect(input).toHaveProperty('value', 's3://costgoblin-cur-bucket/costgoblin/org-config.yaml');
     });
-    await user.click(screen.getByRole('option', { name: 'staging' }));
+    await user.click(screen.getByRole('button', { name: 'staging' }));
     await user.click(screen.getByText('Publish'));
     await waitFor(() => {
       expect(publishSpy).toHaveBeenCalledWith({ location: 's3://costgoblin-cur-bucket/costgoblin/org-config.yaml', profile: 'staging' });
@@ -182,7 +182,7 @@ describe('ImportConfigDialog', () => {
       expect(screen.getByText('s3://my-cur-bucket/daily/')).toBeDefined();
     });
 
-    await user.click(screen.getByRole('option', { name: 'prod' }));
+    await user.click(screen.getByRole('button', { name: 'prod' }));
     await user.click(screen.getByText('Apply configuration'));
     await waitFor(() => {
       expect(screen.getByText('Configuration applied.')).toBeDefined();
@@ -253,7 +253,7 @@ describe('ImportConfigDialog', () => {
     await waitFor(() => {
       expect(input).toHaveProperty('value', 's3://costgoblin-cur-bucket/costgoblin/org-config.yaml');
     });
-    await user.click(screen.getByRole('option', { name: 'staging' }));
+    await user.click(screen.getByRole('button', { name: 'staging' }));
     await user.clear(input);
     await user.type(input, 's3://client-bucket/costgoblin/org-config.yaml');
     await user.click(screen.getByText('Fetch from S3'));

--- a/packages/ui/src/__tests__/profile-picker.test.tsx
+++ b/packages/ui/src/__tests__/profile-picker.test.tsx
@@ -38,9 +38,9 @@ describe('ProfilePicker', () => {
     const user = userEvent.setup();
     render(<ProfilePicker profiles={SSO_PROFILES} selected="" onSelect={() => undefined} />);
 
-    expect(screen.getAllByRole('option')).toHaveLength(SSO_PROFILES.length);
+    expect(screen.getAllByRole('button')).toHaveLength(SSO_PROFILES.length);
     await user.type(screen.getByPlaceholderText('Type to filter profiles…'), 'SRE');
-    expect(screen.getAllByRole('option')).toHaveLength(2);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(screen.getByText('sre-emea-admin')).toBeDefined();
   });
 

--- a/packages/ui/src/components/config-sharing.tsx
+++ b/packages/ui/src/components/config-sharing.tsx
@@ -281,12 +281,10 @@ function ChoosingView({ preview, tiers, periods, onToggleTier, onTogglePeriod, o
       </p>
 
       {preview.hasConfig && (
-        <label htmlFor="cg-pull-config-tier" className="flex items-start gap-2 rounded-lg border border-border bg-bg-tertiary/20 px-3 py-2 cursor-pointer">
+        <label htmlFor="cg-pull-config-tier" className="grid grid-cols-[auto_1fr] items-start gap-x-2 rounded-lg border border-border bg-bg-tertiary/20 px-3 py-2 cursor-pointer">
           <input id="cg-pull-config-tier" type="checkbox" checked={tiers.has('config')} onChange={() => { onToggleTier('config'); }} className="mt-0.5 accent-accent" />
-          <span>
-            <span className="text-sm text-text-primary">Configuration</span>
-            <span className="block text-xs text-text-muted">Dimensions, dashboards, cost scope &amp; org tree — applied under your AWS profile.</span>
-          </span>
+          <span className="text-sm text-text-primary">Configuration</span>
+          <span className="col-start-2 block text-xs text-text-muted">Dimensions, dashboards, cost scope &amp; org tree — applied under your AWS profile.</span>
         </label>
       )}
 
@@ -347,6 +345,13 @@ function ChoosingView({ preview, tiers, periods, onToggleTier, onTogglePeriod, o
   );
 }
 
+function toggleInSet<T>(set: ReadonlySet<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
 function AddSharedSourceSection({ onPulled, onBusyChange }: Readonly<{
   onPulled: () => void;
   /** Notifies the parent dialog so it can lock itself while a pull runs. */
@@ -390,12 +395,8 @@ function AddSharedSourceSection({ onPulled, onBusyChange }: Readonly<{
     }).catch((e: unknown) => { setState({ kind: 'entry', error: e instanceof Error ? e.message : String(e) }); });
   }
 
-  function toggleTier(t: SharedSourceTier): void {
-    setTiers(prev => { const next = new Set(prev); if (next.has(t)) { next.delete(t); } else { next.add(t); } return next; });
-  }
-  function togglePeriod(p: string): void {
-    setPeriods(prev => { const next = new Set(prev); if (next.has(p)) { next.delete(p); } else { next.add(p); } return next; });
-  }
+  function toggleTier(t: SharedSourceTier): void { setTiers(prev => toggleInSet(prev, t)); }
+  function togglePeriod(p: string): void { setPeriods(prev => toggleInSet(prev, p)); }
 
   function startPull(): void {
     const selection: SharedPullSelection = { sources: [...tiers], periods: [...periods].sort((a, b) => a.localeCompare(b)) };

--- a/packages/ui/src/components/profile-picker.tsx
+++ b/packages/ui/src/components/profile-picker.tsx
@@ -64,15 +64,14 @@ export function ProfilePicker({ profiles, selected, onSelect, currentProfile, au
       />
       <div
         className={['flex flex-col gap-1 overflow-y-auto', listClassName ?? 'max-h-48'].join(' ')}
-        role="listbox"
+        role="group"
         aria-label="AWS profiles"
       >
         {filtered.map(profile => (
           <button
             key={profile}
             type="button"
-            role="option"
-            aria-selected={selected === profile}
+            aria-pressed={selected === profile}
             onClick={() => { onSelect(profile); }}
             className={[
               'flex items-center gap-2 rounded-lg border px-3 py-2 text-left transition-colors',

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -810,11 +810,11 @@ function camelStripSeparators(value: string): string {
   for (const ch of value) {
     if (ch === '-' || ch === '_' || /\s/.test(ch)) {
       pending += ch;
-    } else if (pending !== '') {
+    } else if (pending === '') {
+      out += ch;
+    } else {
       out += ch.toUpperCase();
       pending = '';
-    } else {
-      out += ch;
     }
   }
   return out + pending;

--- a/packages/ui/src/widgets/stacked-bar-widget.tsx
+++ b/packages/ui/src/widgets/stacked-bar-widget.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '../hooks/use-query.js';
 import { StackedBarChart, bucketBars, type BarDay } from '../components/stacked-bar-chart.js';
 import { asDateString, asHourString, asTagValue } from '@costgoblin/core/browser';
 import { useCostFocus, useCostFocusDispatch } from '../hooks/use-cost-focus.js';
-import type { DailyCostsResult, DimensionId } from '@costgoblin/core/browser';
+import type { DailyCostsResult, DateRange, DateString, DimensionId, Granularity } from '@costgoblin/core/browser';
 import type { WidgetCommonProps } from './widget.js';
 import { dimensionLabelFor, filtersKey, hasSufficientDailyCoverage } from './widget.js';
 import { GroupByTitle } from '../components/group-by-title.js';
@@ -53,6 +53,29 @@ function bucketTotals(raw: readonly number[]): readonly number[] {
     bucketed.push(sum);
   }
   return bucketed;
+}
+
+function resolveRangeSelect(
+  barDays: readonly BarDay[],
+  startIdx: number,
+  endIdx: number,
+  granularity: Granularity,
+  rangeEnd: DateString,
+): DateRange | null {
+  if (granularity === 'hourly') {
+    const fallbackEndHour = `${String(rangeEnd)} 23:00:00`;
+    const hourRange = computeBucketedHourRange(barDays, startIdx, endIdx, fallbackEndHour);
+    if (hourRange === null) return null;
+    return {
+      start: asDateString(hourRange.startHour.slice(0, 10)),
+      end: asDateString(hourRange.endHour.slice(0, 10)),
+      startHour: asHourString(hourRange.startHour),
+      endHour: asHourString(hourRange.endHour),
+    };
+  }
+  const range = computeBucketedRange(barDays, startIdx, endIdx, rangeEnd);
+  if (range === null) return null;
+  return { start: asDateString(range.startDate), end: asDateString(range.endDate) };
 }
 
 export function StackedBarWidget({
@@ -107,24 +130,8 @@ export function StackedBarWidget({
 
   const handleRangeSelect = useCallback((startIdx: number, endIdx: number) => {
     if (onDateRangeChange === undefined) return;
-    if (granularity === 'hourly') {
-      const fallbackEndHour = `${String(dateRange.end)} 23:00:00`;
-      const hourRange = computeBucketedHourRange(barDays, startIdx, endIdx, fallbackEndHour);
-      if (hourRange === null) return;
-      onDateRangeChange({
-        start: asDateString(hourRange.startHour.slice(0, 10)),
-        end: asDateString(hourRange.endHour.slice(0, 10)),
-        startHour: asHourString(hourRange.startHour),
-        endHour: asHourString(hourRange.endHour),
-      });
-      return;
-    }
-    const range = computeBucketedRange(barDays, startIdx, endIdx, dateRange.end);
-    if (range === null) return;
-    onDateRangeChange({
-      start: asDateString(range.startDate),
-      end: asDateString(range.endDate),
-    });
+    const next = resolveRangeSelect(barDays, startIdx, endIdx, granularity, dateRange.end);
+    if (next !== null) onDateRangeChange(next);
   }, [barDays, dateRange.end, granularity, onDateRangeChange]);
 
   if (spec.type !== 'stackedBar') return null;


### PR DESCRIPTION
Clears the **10 code-actionable** findings from the open SonarCloud issue set (the next scan should drop OPEN from 12 → 2). The 2 leftovers are both **S6819** on the chart drag-to-zoom surfaces and are recommended for **Won't Fix** — see the bottom.

## Fixed

| Rule | Where | Fix |
|------|-------|-----|
| S7735 (negated condition) | `core/normalize.ts`, `ui/views/dimensions.tsx` | Invert `pending !== ''` → `=== ''` and swap branches |
| S1313 (hardcoded IP) | `ui/__fixtures__/mock-api.ts` | Mock peer uses hostname `mock-peer.local`, not `192.168.1.42` |
| S3358 (nested ternary) | `desktop/renderer/App.tsx` | Rollup revision key via `if/else` instead of a nested ternary |
| S3776 (cognitive complexity) | `ui/components/config-sharing.tsx` | Extract `toggleInSet` (also de-dups the two set toggles) |
| S3776 (cognitive complexity) | `ui/widgets/stacked-bar-widget.tsx` | Extract `resolveRangeSelect` module helper |
| S7785 (async IIFE) | `desktop/main/main.ts`, `desktop/main/duckdb-worker.ts` | IIFE → named `bootstrap()` / `initWorker()` + `void` call. **Not** converted to top-level await — that crashes Electron's ESM main entry at launch |
| S6819 (listbox role) | `ui/components/profile-picker.tsx` | `role="listbox"`/`option` → a labeled `role="group"` of `aria-pressed` toggle buttons |
| S6853 (label text) | `ui/components/config-sharing.tsx` | Flatten nested spans so the label's text is within jsx-a11y's depth limit |

Two tests (`profile-picker`, `config-sharing`) were updated to query the profile rows by `role="button"` instead of the removed `role="option"`; behavior assertions are unchanged.

`npm run check` (tsc + eslint + 791 tests) is green.

## Version

Bumps `0.5.0` → `0.5.1` (root + desktop `package.json` only) — `v0.5.0` is already tagged, so this is the first PR of the new cycle.

## Not fixed (recommend Won't Fix in SonarCloud)

Both remaining S6819 are `role="button"` on mouse-only drag-to-zoom surfaces:

- `ui/components/stacked-bar-chart.tsx:377` — its container wraps the clickable segment `<button>`s, so it **legally cannot** be a native `<button>` (no nested buttons). `role="button"` is the correct escape hatch for the drag region.
- `ui/views/explorer.tsx:724` — same mouse-only drag surface; a native button here would have no keyboard behavior.

These rules (S6819/S6853/S3776) aren't in the repo's local ESLint, so only the SonarCloud scan on this PR can confirm them.