### PR TITLE
fix(rollup): surface the build-failure reason in the status popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -386,15 +386,18 @@ export interface UpdateApi {
  *  can show whether dashboards are currently served from the pre-aggregated
  *  rollup (`ready`) or transiently from the slower raw path while a re-roll runs
  *  (`computing`) — e.g. after a dimensions save or a sync. `idle` = no rollup
- *  built yet (no local data); `failed` = the last build batch hit an error
- *  (otherwise swallowed to the log). While `computing`, `periods` lists every
- *  month completed-first (the first `done` are built) and `active` is the subset
- *  whose build is in flight right now, so the popover can pulse those chips. */
+ *  built yet (no local data); `failed` = the last build batch hit an error.
+ *  `message` is the count summary ("N of M partitions failed"); `reason` is the
+ *  underlying error (the DuckDB/IO message the build threw) so the user can tell
+ *  *why* it failed without digging through logs. While `computing`, `periods`
+ *  lists every month completed-first (the first `done` are built) and `active` is
+ *  the subset whose build is in flight right now, so the popover can pulse those
+ *  chips. */
 export type RollupStatus =
   | { readonly state: 'idle' }
   | { readonly state: 'computing'; readonly done: number; readonly total: number; readonly periods: readonly string[]; readonly active: readonly string[] }
   | { readonly state: 'ready'; readonly periods: number }
-  | { readonly state: 'failed'; readonly message: string; readonly periods: number };
+  | { readonly state: 'failed'; readonly message: string; readonly reason: string; readonly periods: number };
 
 /** Size KPIs for the built rollup vs the raw daily Parquet it's derived from.
  *  `rawBytes` is read from the local filesystem (no S3), so it's available even

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/__tests__/rollup-store.test.ts
+++ b/packages/desktop/src/__tests__/rollup-store.test.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { mkdtemp, rm, stat, readdir } from 'node:fs/promises';
-import { buildRollupPartitionQuery, rollupGrainColumns, type DimensionsConfig, type CostScopeConfig, asDimensionId } from '@costgoblin/core';
+import { buildRollupPartitionQuery, rollupGrainColumns, type DimensionsConfig, type CostScopeConfig, type RollupStatus, asDimensionId } from '@costgoblin/core';
 import { RollupStore, type RollupShape } from '../main/rollup-store.js';
 import type { RawRow } from '../main/duckdb-client.js';
 
@@ -153,6 +153,23 @@ describe('RollupStore', () => {
     const reloaded = new RollupStore({ dataDir, runQuery });
     const v = await reloaded.loadAndValidate(shape, etags);
     expect(v.validPeriods.size).toBe(0);
+  });
+
+  it('surfaces the underlying error as the failed status reason', async () => {
+    const failDir = await mkdtemp(join(tmpdir(), 'cg-rollup-fail-'));
+    let captured: RollupStatus | undefined;
+    const runBuild = (): Promise<RawRow[]> => Promise.reject(new Error('Binder Error: column "service" not found'));
+    const store = new RollupStore({ dataDir: failDir, runQuery, runBuild });
+    store.onStatusChanged((s) => { captured = s; });
+    await store.maintainPeriods(['2026-01', '2026-02'], buildSql, etags, shape);
+
+    expect(captured?.state).toBe('failed');
+    if (captured?.state === 'failed') {
+      expect(captured.message).toBe('2 of 2 rollup partitions failed to build');
+      // Both periods fail with the same cause → one distinct reason, no "+N".
+      expect(captured.reason).toBe('Binder Error: column "service" not found');
+    }
+    await rm(failDir, { recursive: true, force: true });
   });
 
   it('invalidate() removes the on-disk rollup and resets state', async () => {

--- a/packages/desktop/src/main/rollup-store.ts
+++ b/packages/desktop/src/main/rollup-store.ts
@@ -13,6 +13,19 @@ import type { RawRow } from './duckdb-client.js';
 
 export type RollupStatusListener = (status: RollupStatus) => void;
 
+/** Build the human-readable `reason` for a failed batch from the distinct
+ *  errors its partitions threw. Picks the most common message (the systematic
+ *  root cause behind an all-fail batch), trims it for the popover/IPC payload,
+ *  and notes when other, different errors also occurred. Only called when at
+ *  least one period failed, so the map is never empty. */
+function summarizeErrors(errorCounts: ReadonlyMap<string, number>): string {
+  const sorted = [...errorCounts.entries()].sort((a, b) => b[1] - a[1]);
+  const top = sorted[0]?.[0] ?? 'Unknown error';
+  const trimmed = top.length > 400 ? `${top.slice(0, 400)}…` : top;
+  const others = sorted.length - 1;
+  return others > 0 ? `${trimmed} (+${String(others)} other error${others === 1 ? '' : 's'})` : trimmed;
+}
+
 /** Builds the `COPY (...) TO '<outPath>' (FORMAT PARQUET)` DDL for one period.
  *  Supplied by the caller (context.ts) so the store stays decoupled from the
  *  query builder. May be async: the caller probes each period's parquet schema
@@ -249,6 +262,11 @@ export class RollupStore {
       // so we track completion order explicitly rather than assuming input order.
       const total = periods.length;
       let failures = 0;
+      // Distinct build-error messages → how many periods hit each. A "14 of 14
+      // failed" batch is almost always one systematic cause (bad SQL, missing
+      // column, disk full), so the most common message is the reason worth
+      // surfacing; we keep counts to note when failures are heterogeneous.
+      const errorCounts = new Map<string, number>();
       const completed: string[] = [];
       const completedSet = new Set<string>();
       // `active` = periods whose build is in flight right now. The popover pulses
@@ -313,7 +331,9 @@ export class RollupStore {
             await commit(period, meta);
           } catch (err: unknown) {
             failures += 1;
-            logger.warn(`rollup: build failed for ${period} — ${err instanceof Error ? err.message : String(err)}`);
+            const msg = err instanceof Error ? err.message : String(err);
+            errorCounts.set(msg, (errorCounts.get(msg) ?? 0) + 1);
+            logger.warn(`rollup: build failed for ${period} — ${msg}`);
           }
           // Each finished period (built or failed) leaves the active set and
           // advances progress.
@@ -328,7 +348,7 @@ export class RollupStore {
       if (this.epoch !== startEpoch) return;
       this.setStatus(
         failures > 0
-          ? { state: 'failed', message: `${String(failures)} of ${String(total)} rollup partition${total === 1 ? '' : 's'} failed to build`, periods: this.validPeriods.size }
+          ? { state: 'failed', message: `${String(failures)} of ${String(total)} rollup partition${total === 1 ? '' : 's'} failed to build`, reason: summarizeErrors(errorCounts), periods: this.validPeriods.size }
           : this.settledStatus(),
       );
     });

--- a/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
+++ b/packages/desktop/src/renderer/top-menu/rollup-status-button.tsx
@@ -18,7 +18,7 @@ function tooltipFor(status: RollupStatus): string {
         ? `Rebuilding rollup… ${String(status.done)}/${String(status.total)}`
         : 'Rebuilding rollup…';
     case 'failed':
-      return `Rollup build failed — ${status.message}`;
+      return `Rollup build failed — ${status.message}\n${status.reason}`;
     case 'ready':
       return `Rollup ready — ${months(status.periods)} pre-aggregated`;
     case 'idle':

--- a/packages/ui/src/components/rollup-status-detail.tsx
+++ b/packages/ui/src/components/rollup-status-detail.tsx
@@ -127,8 +127,12 @@ export function RollupStatusDetail({ status, stats = null, highlight }: Props): 
 
   if (status.state === 'failed') {
     return (
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <p className="text-xs text-negative">{status.message}</p>
+        <div className="rounded border border-border bg-bg-tertiary/40 p-1.5">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-text-muted">Error</p>
+          <p className="mt-0.5 max-h-28 overflow-y-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-text-secondary">{status.reason}</p>
+        </div>
         <p className="text-[11px] text-text-muted">Dashboards fall back to raw data. Reload data or re-save dimensions to retry.</p>
       </div>
     );


### PR DESCRIPTION
## Problem

When rollup partitions fail to build, the status popover only showed a count summary — _"14 of 14 rollup partitions failed to build"_ — with no indication of **why**. The actual error was logged via `logger.warn` and swallowed; the user had no accessible way to find it (issue #418).

## Fix

Thread the underlying error message through to the UI:

- **`rollup-store.ts`** — collect each failed period's error message (deduped with counts). An all-fail batch is almost always one systematic cause (bad SQL, missing column, disk full), so a `reason` is built from the most common message, trimmed for the IPC payload, with a `(+N other errors)` note when the failures are heterogeneous.
- **`RollupStatus` type** — the `failed` variant now carries `reason` alongside the `message` summary.
- **`RollupStatusDetail`** — the popover renders the error in a scrollable monospace block under the summary.
- **`RollupStatusButton`** — the hover tooltip now includes the reason for a quick glance.

## Tests

Added a `RollupStore` test that forces a build rejection and asserts the underlying error surfaces as `status.reason`. Full `npm run check` passes (808 tests).

Version bumped 0.5.0 → 0.5.1 (first PR of the cycle past tag `v0.5.0`).

Closes #418