### PR TITLE
fix(sync): surface AWS CLI credential failures with one-click re-auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__tests__/credential-error.test.ts
+++ b/packages/core/src/__tests__/credential-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isCredentialError } from '../sync/s3-client.js';
+import { isCredentialError, isS3SyncDownloadFailure } from '../sync/s3-client.js';
 
 describe('isCredentialError', () => {
   it('detects credential / token provider errors by name', () => {
@@ -20,11 +20,42 @@ describe('isCredentialError', () => {
     expect(isCredentialError(new Error('AWS credentials expired for profile "prod". Run: aws sso login --profile prod'))).toBe(true);
   });
 
+  it('detects aws CLI SSO / credential failures from `aws s3 sync` stderr', () => {
+    // The CLI reports these as stderr text (no SDK error name), folded into
+    // `aws s3 sync failed (exit N): <stderr>` by runAwsS3Sync.
+    expect(isCredentialError(new Error('aws s3 sync failed (exit 1): Error loading SSO Token: Token for solaris does not exist'))).toBe(true);
+    expect(isCredentialError(new Error('aws s3 sync failed (exit 1): Token has expired and refresh failed'))).toBe(true);
+    expect(isCredentialError(new Error('aws s3 sync failed (exit 255): An error occurred (ExpiredToken) when calling GetObject'))).toBe(true);
+    expect(isCredentialError(new Error('aws s3 sync failed (exit 1): InvalidGrantException'))).toBe(true);
+    expect(isCredentialError(new Error('aws s3 sync failed (exit 1): Unable to locate credentials'))).toBe(true);
+  });
+
   it('does not flag unrelated errors or non-errors', () => {
     expect(isCredentialError(new Error('Access Denied: s3:ListBucket'))).toBe(false);
     expect(isCredentialError(new Error('NetworkError: request timed out'))).toBe(false);
+    // An opaque retry-exhaustion download failure is NOT a definite credential
+    // error — it routes through isS3SyncDownloadFailure instead.
+    expect(isCredentialError(new Error('aws s3 sync failed (exit 1): download failed: s3://b/k Max Retries Exceeded'))).toBe(false);
     expect(isCredentialError('a string')).toBe(false);
     expect(isCredentialError(null)).toBe(false);
     expect(isCredentialError(undefined)).toBe(false);
+  });
+});
+
+describe('isS3SyncDownloadFailure', () => {
+  it('detects opaque `aws s3 sync` retry / connection download failures', () => {
+    expect(isS3SyncDownloadFailure(new Error('aws s3 sync failed (exit 1): download failed: s3://b/k Max Retries Exceeded'))).toBe(true);
+    expect(isS3SyncDownloadFailure(new Error('aws s3 sync failed (exit 1): download failed: s3://b/k connection reset'))).toBe(true);
+    expect(isS3SyncDownloadFailure(new Error('aws s3 sync failed (exit 255): Could not connect to the endpoint URL'))).toBe(true);
+  });
+
+  it('is scoped to aws s3 sync failures only', () => {
+    // Not wrapped as an `aws s3 sync failed` error → never matches, even with
+    // retry wording, so SDK / other errors are never misclassified.
+    expect(isS3SyncDownloadFailure(new Error('Max Retries Exceeded'))).toBe(false);
+    // A genuine permission error is not a session / network failure.
+    expect(isS3SyncDownloadFailure(new Error('aws s3 sync failed (exit 1): An error occurred (AccessDenied)'))).toBe(false);
+    expect(isS3SyncDownloadFailure('a string')).toBe(false);
+    expect(isS3SyncDownloadFailure(null)).toBe(false);
   });
 });

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -15,6 +15,7 @@ export {
   createS3Handle,
   parseS3Path,
   isCredentialError,
+  isS3SyncDownloadFailure,
 } from './s3-client.js';
 
 export {

--- a/packages/core/src/sync/s3-client.ts
+++ b/packages/core/src/sync/s3-client.ts
@@ -34,18 +34,48 @@ async function getS3Module(): Promise<typeof import('@aws-sdk/client-s3')> {
   return import('@aws-sdk/client-s3');
 }
 
-/** Whether an error from the AWS SDK indicates missing or expired credentials
- *  (expired SSO token, no resolvable profile) rather than a genuine S3/network
- *  failure. Shared by the desktop sync handlers and the auto-sync scheduler so
- *  credential expiry is detected and surfaced consistently. */
+/** Whether an error indicates missing or expired credentials (expired SSO
+ *  token, no resolvable profile) rather than a genuine S3/network failure.
+ *  Covers both AWS SDK errors (the inventory listing) and the `aws s3 sync`
+ *  CLI's stderr signatures (the download path), so credential expiry is
+ *  surfaced consistently across both. Shared by the desktop sync handlers and
+ *  the auto-sync scheduler. */
 export function isCredentialError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const name = err.name;
   if (name === 'CredentialsProviderError' || name === 'TokenProviderError') return true;
+  const msg = err.message;
   return (
-    err.message.includes('Token is expired') ||
-    err.message.includes('SSO session') ||
-    err.message.includes('credentials')
+    // AWS SDK credential-resolution failures.
+    msg.includes('Token is expired') ||
+    msg.includes('SSO session') ||
+    msg.includes('credentials') ||
+    // `aws s3 sync` CLI credential/SSO failures arrive as stderr text rather
+    // than SDK error names, so the CLI download path classifies them too.
+    msg.includes('Error loading SSO Token') ||
+    msg.includes('Token has expired and refresh failed') ||
+    msg.includes('ExpiredToken') ||
+    msg.includes('InvalidGrantException') ||
+    msg.includes('Unable to locate credentials') ||
+    msg.includes('aws sso login')
+  );
+}
+
+/** An `aws s3 sync` download that failed by exhausting retries or losing the
+ *  connection, with no explicit credential/SSO text in stderr. For an
+ *  SSO-backed bucket this is almost always an expired session, but it can be a
+ *  network/VPN drop — so callers surface a "session may have expired, or check
+ *  your connection" hint with the sign-in action, distinct from a definite
+ *  `isCredentialError`. Scoped to the CLI failure (`aws s3 sync failed`) so it
+ *  never misclassifies SDK or other errors. */
+export function isS3SyncDownloadFailure(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message;
+  if (!msg.includes('aws s3 sync failed')) return false;
+  return (
+    msg.includes('Max Retries Exceeded') ||
+    msg.includes('download failed') ||
+    msg.includes('Could not connect to the endpoint')
   );
 }
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -118,9 +118,12 @@ export function registerAutoSyncHandlers(app: AppContext): void {
           }
           return result;
         } catch (err: unknown) {
-          const error = err instanceof Error ? err : new Error(String(err));
+          // Surface credential expiry / opaque `aws s3 sync` download failures as
+          // the actionable "run aws sso login" message so the toolbar offers
+          // one-click re-auth instead of a raw CLI error (mirrors getInventory).
+          const error = toUserFriendlyError(err, provider.credentials.profile);
           state.syncStatuses[syncId] = { status: 'failed', error, lastSync: null };
-          throw err;
+          throw error;
         }
       },
       getLocalPeriods: async (tier: string) => {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -25,6 +25,7 @@ import {
   logger,
   isStringRecord,
   isCredentialError,
+  isS3SyncDownloadFailure,
 } from '@costgoblin/core';
 import { buildAccountReverseMap } from './query-utils.js';
 import type {
@@ -733,6 +734,9 @@ export { isCredentialError };
 export function toUserFriendlyError(err: unknown, profile: string): Error {
   if (isCredentialError(err)) {
     return new Error(`AWS credentials expired for profile "${profile}". Run: aws sso login --profile ${profile}`);
+  }
+  if (isS3SyncDownloadFailure(err)) {
+    return new Error(`Download from S3 failed — your AWS session may have expired. Run: aws sso login --profile ${profile} and retry. If it persists, check your network/VPN connection.`);
   }
   return err instanceof Error ? err : new Error(String(err));
 }

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -423,7 +423,7 @@ function handleSyncError(
     state.syncStatuses[syncId] = { status: 'idle', lastSync: null };
     return raw;
   }
-  const error = isCredentialError(err) ? toUserFriendlyError(err, profile) : raw;
+  const error = toUserFriendlyError(err, profile);
   logger.error(`Selective sync '${syncId}' failed: ${error.message}`);
   state.syncStatuses[syncId] = { status: 'failed', error, lastSync: null };
   return error;


### PR DESCRIPTION
## Summary

When an SSO session expires, the **inventory** path (AWS SDK) already detects it and shows the "Sign in to AWS" action — but the **download** path shells out to `aws s3 sync`, whose stderr (`Max Retries Exceeded`, `Error loading SSO Token`, …) never matched `isCredentialError`. So a stale session surfaced a raw CLI error in the toolbar with no way to re-auth, forcing a manual `aws sso login` in a terminal.

## Changes

- **`isCredentialError`** — also match the AWS CLI's SSO/credential stderr signatures (`Error loading SSO Token`, `Token has expired and refresh failed`, `ExpiredToken`, `InvalidGrantException`, `Unable to locate credentials`, `aws sso login`), not just SDK error shapes.
- **`isS3SyncDownloadFailure`** (new) — classify opaque `aws s3 sync` retry/connection failures (`Max Retries Exceeded` / `download failed` / `Could not connect to the endpoint`). These are almost always an expired SSO session for an SSO-backed bucket, but can be network — so they're surfaced as an honest *"your session may have expired — run `aws sso login`, or check your network/VPN"* message that still offers the sign-in action. Scoped to `aws s3 sync failed` so SDK/other errors are never misclassified.
- Route **both** the manual (`handleSyncError`) and **auto-sync** download failures through `toUserFriendlyError`, so the toolbar offers the existing one-click re-auth (`data:sso-login`, which auto-re-syncs on success) instead of a raw CLI error. The auto-sync path is what produced the launch-time banner.

No UI change needed — the toolbar's `ssoLoginProfile()` already renders the sign-in button when the error message contains `aws sso login --profile <profile>`.

## Verification

- `npm run check` — tsc + ESLint + Vitest: **815 passed, 5 skipped** (3 new classifier tests in `credential-error.test.ts`).
- Confirmed the cross-package string contract: the UI's `ssoLoginProfile()` parser extracts the profile from the new download-failure message (so the button renders), and still returns `null` for the raw pre-fix CLI error.

Bumps version 0.5.2 → 0.5.3.
