### PR TITLE
fix(sso): spinner feedback + 30s click lock on Open SSO Login button

### DIFF
--- a/packages/ui/src/__tests__/sso-login-button.test.tsx
+++ b/packages/ui/src/__tests__/sso-login-button.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, cleanup, act } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CostApiProvider } from '../hooks/use-cost-api.js';
+import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { SsoLoginButton } from '../components/sso-login-button.js';
+
+class SsoApi extends MockCostApi {
+  calls = 0;
+  result: Promise<void> = Promise.resolve();
+  override ssoLogin(): Promise<void> {
+    this.calls += 1;
+    return this.result;
+  }
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function setup(api: SsoApi) {
+  render(
+    <CostApiProvider value={api}>
+      <SsoLoginButton profile="prod" />
+    </CostApiProvider>,
+  );
+  return { button: screen.getByRole('button') };
+}
+
+describe('SsoLoginButton', () => {
+  it('shows progress feedback, locks the button, and swallows repeat clicks until the lock expires', async () => {
+    vi.useFakeTimers();
+    let startLogin!: () => void;
+    const api = new SsoApi();
+    api.result = new Promise<void>((resolve) => { startLogin = resolve; });
+    const { button } = setup(api);
+
+    expect(button.textContent).toContain('Open SSO Login');
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+
+    await act(async () => { button.click(); await Promise.resolve(); });
+    expect(api.calls).toBe(1);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.textContent).toContain('Opening SSO Login');
+
+    // Impatient repeat clicks during the multi-second open must not spawn more SSO tabs.
+    await act(async () => { button.click(); button.click(); await Promise.resolve(); });
+    expect(api.calls).toBe(1);
+
+    // Browser is now opening (promise resolved) — button stays locked.
+    await act(async () => { startLogin(); await Promise.resolve(); });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+
+    // Lock expires after 30s → usable again.
+    act(() => { vi.advanceTimersByTime(30_000); });
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(button.textContent).toContain('Open SSO Login');
+  });
+
+  it('unlocks immediately when the login fails to start', async () => {
+    const api = new SsoApi();
+    api.result = Promise.reject(new Error('AWS_CLI_NOT_FOUND'));
+    const { button } = setup(api);
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    // CLI missing → button is replaced by the install hint, not left spinning.
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText(/Install the AWS CLI/i)).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/sso-login-button.tsx
+++ b/packages/ui/src/components/sso-login-button.tsx
@@ -1,13 +1,44 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useCostApi } from '../hooks/use-cost-api.js';
 
 const AWS_CLI_INSTALL_URL = 'https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html';
 
 const DEFAULT_HINT = 'A browser window will open. Refresh this page after logging in.';
 
+// Launching `aws sso login` can take several seconds before the browser opens.
+// Lock the button for this long after a click so impatient repeat-clicks don't
+// spawn multiple SSO tabs.
+const LOCK_MS = 30_000;
+
 export function SsoLoginButton({ profile, hint = DEFAULT_HINT }: Readonly<{ profile: string; hint?: string }>) {
   const api = useCostApi();
   const [cliMissing, setCliMissing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const lockTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (lockTimer.current !== null) clearTimeout(lockTimer.current);
+  }, []);
+
+  const handleClick = () => {
+    if (busy) return;
+    setBusy(true);
+    lockTimer.current = setTimeout(() => {
+      lockTimer.current = null;
+      setBusy(false);
+    }, LOCK_MS);
+    api.ssoLogin(profile).catch((err: unknown) => {
+      // The login didn't start — unlock immediately so the user can retry.
+      if (lockTimer.current !== null) {
+        clearTimeout(lockTimer.current);
+        lockTimer.current = null;
+      }
+      setBusy(false);
+      if (err instanceof Error && err.message.includes('AWS_CLI_NOT_FOUND')) {
+        setCliMissing(true);
+      }
+    });
+  };
 
   if (cliMissing) {
     return (
@@ -25,16 +56,12 @@ export function SsoLoginButton({ profile, hint = DEFAULT_HINT }: Readonly<{ prof
     <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
       <button
         type="button"
-        onClick={() => {
-          api.ssoLogin(profile).catch((err: unknown) => {
-            if (err instanceof Error && err.message.includes('AWS_CLI_NOT_FOUND')) {
-              setCliMissing(true);
-            }
-          });
-        }}
-        className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover transition-colors"
+        onClick={handleClick}
+        disabled={busy}
+        className="inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-accent"
       >
-        Open SSO Login
+        {busy && <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-white/40 border-t-white" aria-hidden="true" />}
+        {busy ? 'Opening SSO Login…' : 'Open SSO Login'}
       </button>
       <span className="text-xs text-text-secondary">{hint}</span>
     </div>


### PR DESCRIPTION
## Problem

Clicking **Open SSO Login** in the Data sync popover takes ~5s before the browser window appears (cold-starting `aws sso login`). During that gap the button gives no feedback, so an impatient user clicks it again — and each click spawns another SSO browser tab.

## Change

`SsoLoginButton`:

- **Spinner + progress label** — on click the button shows a small spinner and switches its label to *"Opening SSO Login…"*, so the multi-second launch no longer looks like a dead click.
- **30s click lock** — the button is `disabled` (greyed, `cursor-not-allowed`) for 30s after a click. Both a `busy` guard and the native `disabled` attribute block re-entry, so repeat-clicks can't open multiple SSO tabs.
- **Fails fast** — if the login can't start (e.g. `AWS_CLI_NOT_FOUND`), the lock is cleared immediately so the user can retry / see the "Install the AWS CLI" hint instead of waiting out the lock.
- The lock is anchored to the click time (not promise resolution), bounding the disabled window to 30s regardless of how long the CLI takes to spawn. Timer is cleaned up on unmount.

## Tests

New `sso-login-button.test.tsx` covers: spinner + disabled on click, repeat clicks not triggering a second `ssoLogin` call, the lock releasing after 30s (fake timers), and immediate unlock-to-install-hint on CLI-missing failure.

`npm run check` is green (tsc × 4 packages, eslint, 888 tests).