### PR TITLE
fix(packaging): ship @sentry/electron in the asar (fixes startup crash)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -19,6 +19,7 @@
         "@aws-sdk/client-s3": "^3.1073.0",
         "@aws-sdk/client-ssm": "^3.1073.0",
         "@duckdb/node-api": "^1.5.4-r.1",
+        "@sentry/electron": "^7.14.0",
         "@smithy/shared-ini-file-loader": "^4.6.1",
         "electron-updater": "^6.8.9",
         "yaml": "^2.9.0"
@@ -13140,7 +13141,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1073.0",
         "@aws-sdk/client-s3": "^3.1073.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,
@@ -31,6 +31,7 @@
     "@aws-sdk/client-s3": "^3.1073.0",
     "@aws-sdk/client-ssm": "^3.1073.0",
     "@duckdb/node-api": "^1.5.4-r.1",
+    "@sentry/electron": "^7.14.0",
     "@smithy/shared-ini-file-loader": "^4.6.1",
     "electron-updater": "^6.8.9",
     "yaml": "^2.9.0"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

The packaged app crashes on launch (post-update to 0.5.3) with:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@sentry/electron' imported from
/Applications/CostGoblin.app/Contents/Resources/app.asar/packages/desktop/out/main/main.js
\`\`\`

## Root cause

PR #422 (opt-in Sentry telemetry) added `@sentry/electron` to `packages/desktop/package.json` but **not** to the **root** `package.json`.

electron-builder packs from the repo root and bundles **only the root package's production dependency closure** — its module collector runs `npm list --omit dev` from the root, and the `@costgoblin/desktop` workspace is not a root dependency, so its deps are never traversed. The `files: node_modules/**/*` glob only filters *within* that collected set; it cannot add a module outside it.

Vite lib-mode externalizes every desktop dependency, leaving a bare `import '@sentry/electron'` in `out/main/main.js`. With the package pruned from the asar, that import resolves to nothing → `ERR_MODULE_NOT_FOUND` at launch.

This is exactly why the other 7 main-process runtime deps (`@aws-sdk/*`, `@duckdb/node-api`, `@smithy/*`, `electron-updater`, `yaml`) are already duplicated into root `dependencies` — it's load-bearing. `@sentry/electron` was the lone omission. **Dev mode was unaffected** because nothing is packed there, so the gap only surfaced in a released build.

## Fix

- Add `@sentry/electron` to root `package.json` `dependencies` (now all 8 externalized main-process deps are present); `npm install` hoists it to root `node_modules` and records it as a root dependency in the lockfile, so electron-builder packs it.
- Bump to `0.5.4` (first PR of a new release cycle — latest tag is `v0.5.3`).

No source-code change — purely a packaging-manifest fix.

## Note on recovery

Existing 0.5.3 installs cannot self-heal: the crash is at main-process module load, before electron-updater runs. Users must manually install 0.5.4 once the `v0.5.4` release is built.