### PR TITLE
ci(release): upload DuckDB native debug files to Sentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,18 +90,27 @@ jobs:
           npx --yes @sentry/cli@^2 sourcemaps inject packages/desktop/out
           npx --yes @sentry/cli@^2 sourcemaps upload --release "$REL" packages/desktop/out
 
-      # Native crashes inside DuckDB (libduckdb.dylib / duckdb.node) land in
-      # Crashpad minidumps. Unlike Electron's own frames, Sentry has no symbols
-      # for third-party modules, so without these debug files it reports
-      # "A required debug information file was missing" and the native frames
-      # stay unresolved (COSTGOBLIN-4). The prebuilt binaries carry no DWARF but
-      # do ship a symbol table + unwind info — enough for function-level frames.
-      # Each matrix runner uploads the natives npm installed for its own platform;
-      # Sentry dedupes by debug ID. Debug files are project-global (matched by
-      # debug ID, not tied to a build), so no --release. Soft-fail like the
-      # source maps — never block a release.
+      # Native crashes inside DuckDB (the duckdb.node addon + the libduckdb
+      # engine) land in Crashpad minidumps. Sentry has no symbols for
+      # third-party native modules, so without their debug files it reports
+      # "A required debug information file was missing" and native frames stay
+      # unresolved (COSTGOBLIN-4). The prebuilt binaries carry no DWARF but ship
+      # a symbol table + unwind info — enough for function-level frames.
+      #
+      # We ship BOTH x64 and arm64 for every OS (electron-builder.yml), but each
+      # GitHub runner is single-arch, so `npm ci` installs only the @duckdb
+      # binding matching the runner's own os/cpu — uploading node_modules/@duckdb
+      # would silently miss every other arch. Instead fetch all eight
+      # @duckdb/node-bindings-<os>-<arch> tarballs (`npm pack` ignores the os/cpu
+      # install gate) at the version this build resolved and upload them
+      # together. Debug files are project-global (matched by debug ID, not tied
+      # to a build), so this runs once on Linux and needs no --release.
+      # sentry-cli uploads whatever is usable and skips the rest: macOS + Linux
+      # (every arch, incl. musl) symbolicate; Windows' duckdb.dll is stripped
+      # with no PDB shipped, so only its duckdb.node addon resolves. Soft-fail
+      # like the source maps — never block a release.
       - name: Upload native debug files to Sentry
-        if: vars.SENTRY_ORG != ''
+        if: matrix.platform == 'linux' && vars.SENTRY_ORG != ''
         continue-on-error: true
         shell: bash
         env:
@@ -111,7 +120,15 @@ jobs:
           SENTRY_URL: ${{ vars.SENTRY_URL || 'https://de.sentry.io' }}
         run: |
           set -euo pipefail
-          npx --yes @sentry/cli@^2 debug-files upload node_modules/@duckdb
+          dest="$RUNNER_TEMP/duckdb-dif"
+          mkdir -p "$dest"
+          # All eight per-arch packages are node-bindings' optionalDependencies
+          # and share its version — derive both so a DuckDB bump needs no edit.
+          specs=$(node -p "Object.entries(require('@duckdb/node-bindings/package.json').optionalDependencies||{}).map(([k,v])=>k+'@'+v).join(' ')")
+          ( cd "$dest"
+            for spec in $specs; do npm pack "$spec"; done
+            for tgz in *.tgz; do d="${tgz%.tgz}"; mkdir -p "$d"; tar -xzf "$tgz" -C "$d"; done )
+          npx --yes @sentry/cli@^2 debug-files upload "$dest"
 
       - name: Build installers
         run: npx --no-install electron-builder --${{ matrix.platform }} --publish always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,9 @@ jobs:
       # Inject debug IDs into the built JS (so shipped bundles match the maps)
       # and upload source maps, so renderer/main stack traces are readable in
       # Sentry. Runs before packaging so electron-builder ships the injected JS.
-      # Native Electron frames are symbolicated server-side by Sentry, so no
-      # dSYM upload is needed. Skipped entirely when Sentry isn't configured.
+      # Electron/Chromium's own native frames are symbolicated by Sentry's symbol
+      # server; third-party native modules are handled by the next step.
+      # Skipped entirely when Sentry isn't configured.
       - name: Upload source maps to Sentry
         if: vars.SENTRY_ORG != ''
         # Source maps are an observability nicety, not a release artifact — a
@@ -88,6 +89,29 @@ jobs:
           REL="costgoblin@${GITHUB_REF#refs/tags/v}"
           npx --yes @sentry/cli@^2 sourcemaps inject packages/desktop/out
           npx --yes @sentry/cli@^2 sourcemaps upload --release "$REL" packages/desktop/out
+
+      # Native crashes inside DuckDB (libduckdb.dylib / duckdb.node) land in
+      # Crashpad minidumps. Unlike Electron's own frames, Sentry has no symbols
+      # for third-party modules, so without these debug files it reports
+      # "A required debug information file was missing" and the native frames
+      # stay unresolved (COSTGOBLIN-4). The prebuilt binaries carry no DWARF but
+      # do ship a symbol table + unwind info — enough for function-level frames.
+      # Each matrix runner uploads the natives npm installed for its own platform;
+      # Sentry dedupes by debug ID. Debug files are project-global (matched by
+      # debug ID, not tied to a build), so no --release. Soft-fail like the
+      # source maps — never block a release.
+      - name: Upload native debug files to Sentry
+        if: vars.SENTRY_ORG != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_URL: ${{ vars.SENTRY_URL || 'https://de.sentry.io' }}
+        run: |
+          set -euo pipefail
+          npx --yes @sentry/cli@^2 debug-files upload node_modules/@duckdb
 
       - name: Build installers
         run: npx --no-install electron-builder --${{ matrix.platform }} --publish always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

Sentry's **COSTGOBLIN-4** is a native crash (Crashpad minidump) inside DuckDB that can't be symbolicated. The event's *Event Processing Errors* show:

> A required debug information file was missing

for two binaries in `@duckdb/node-bindings-darwin-arm64` (`duckdb.node` and `libduckdb.dylib`) — their Mach-O UUIDs match the binaries exactly.

## Root cause

The release workflow uploaded **JS source maps** but never **native debug files**. The old comment claimed no dSYM upload was needed because "native Electron frames are symbolicated server-side" — true for Electron/Chromium's own binaries (Sentry's symbol server has them), but **not** for a third-party native module like DuckDB.

## Fix

Add an **Upload native debug files to Sentry** step to `release.yml` (after the source-map upload). It fetches **all eight** `@duckdb/node-bindings-<os>-<arch>` tarballs via `npm pack` (which ignores the os/cpu install gate) at the resolved version, extracts them, and uploads in one shot:

```
specs=$(node -p "...optionalDependencies...")   # all 8, version-derived
for spec in $specs; do npm pack "$spec"; done    # cross-arch download
npx @sentry/cli@^2 debug-files upload "$dest"
```

- Runs **once on the Linux runner** — debug files are project-global (matched by debug ID, not tied to a release), so per-runner uploads aren't needed.
- Mirrors the source-map step: gated on `vars.SENTRY_ORG`, `continue-on-error: true` so it can never block a release.

The DuckDB prebuilts carry no DWARF (no line numbers) but ship a **symbol table + unwind info** → function-level frames + a correct stack.

### Why download all arches (not just the runner's)

Each GitHub runner is single-arch, so `npm ci` installs only the runner's own `@duckdb` binding — but electron-builder ships **both** x64 and arm64 for every OS. Uploading `node_modules/@duckdb` would silently miss every secondary arch. Fetching all eight tarballs closes that gap.

Validated against `sentry-cli debug-files check` (14 of 16 binaries usable):

| Platform | Coverage |
|---|---|
| macOS x64 + arm64 | ✅ addon + engine |
| Linux x64 / arm64 / musl | ✅ addon + engine |
| Windows x64 + arm64 | ⚠️ addon only — `duckdb.dll` is stripped, no PDB shipped |

## Notes

- **Future releases only.** The currently-shipped build won't retroactively symbolicate; a one-time manual `debug-files upload` (with the Sentry auth token) against this version's binaries resolves the existing COSTGOBLIN-4.
- A separate, pre-existing **packaging** concern was spotted during review: because electron-builder packages `node_modules` as-is (`npmRebuild: false`) and each runner only `npm ci`s its host arch, the dual-arch *installers* may ship a wrong-arch DuckDB binary. That's out of scope here and tracked separately.
- Version bumped `0.5.4` → `0.5.5` (first PR of the cycle; `v0.5.4` is the latest tag).