### PR TITLE
fix(packaging): ship correct-arch DuckDB binding in every installer

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,11 @@
 appId: com.costgoblin.app
 productName: CostGoblin
+# Makes node_modules/@duckdb arch-correct before packing each arch. The release
+# matrix builds both x64 and arm64 on a single-arch runner, where npm only
+# installs the host-arch DuckDB binding; this swaps in the right one per arch so
+# secondary-arch installers don't crash on launch. Relies on sequential per-arch
+# packing — do NOT set concurrency.jobs >= 2 (it would race the shared node_modules).
+beforePack: ./scripts/before-pack.cjs
 directories:
   buildResources: build
   output: dist

--- a/scripts/before-pack.cjs
+++ b/scripts/before-pack.cjs
@@ -1,0 +1,121 @@
+// electron-builder beforePack hook: make node_modules/@duckdb arch-correct per target arch.
+//
+// Why: the release matrix builds BOTH x64 and arm64 installers for every OS on a
+// single-arch runner. `npm ci` only installs the host-arch, os/cpu-gated
+// `@duckdb/node-bindings-<os>-<arch>` package, and electron-builder copies
+// node_modules as-is without filtering by target arch. So without this hook the
+// secondary-arch installer ships the wrong-arch duckdb.node and crashes on launch
+// (the loader resolves the binding by runtime process.arch and require()s a
+// package dir that isn't there).
+//
+// What: electron-builder packs arches sequentially (concurrency.jobs=1, the
+// default — do NOT raise it) and re-reads node_modules from disk for each arch.
+// This hook runs once per (platform, arch) before the file copy and rewrites
+// node_modules/@duckdb so it contains exactly the binding(s) the target arch
+// needs. Missing bindings are fetched from the exact tarball pinned in
+// package-lock.json (integrity-verified). npmRebuild stays false — these are
+// prebuilt binaries, nothing is compiled.
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const crypto = require("node:crypto");
+const { execFileSync } = require("node:child_process");
+const { Arch } = require("builder-util");
+
+const OS_TOKEN = { darwin: "darwin", mas: "darwin", win32: "win32", linux: "linux" };
+
+// Binding packages a given (os, arch) needs. Linux ships both the glibc and the
+// musl variant; the loader picks at runtime via detect-libc.
+function wantedBindings(osToken, archName) {
+  if (osToken === "linux") {
+    return [`node-bindings-linux-${archName}`, `node-bindings-linux-${archName}-musl`];
+  }
+  return [`node-bindings-${osToken}-${archName}`];
+}
+
+function log(msg) {
+  process.stdout.write(`  • [duckdb-binding] ${msg}\n`);
+}
+
+function readLockEntry(appDir, bindingName) {
+  const lock = JSON.parse(fs.readFileSync(path.join(appDir, "package-lock.json"), "utf8"));
+  const entry = lock.packages?.[`node_modules/@duckdb/${bindingName}`];
+  if (!entry?.resolved || !entry.integrity) {
+    throw new Error(`package-lock.json has no resolved/integrity for @duckdb/${bindingName}`);
+  }
+  return entry;
+}
+
+async function downloadAndExtract(appDir, bindingName, destDir) {
+  const { resolved, integrity } = readLockEntry(appDir, bindingName);
+  log(`fetching @duckdb/${bindingName} from ${resolved}`);
+  const res = await fetch(resolved);
+  if (!res.ok) {
+    throw new Error(`failed to download @duckdb/${bindingName}: HTTP ${res.status}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+
+  const [algo, expected] = integrity.split("-");
+  const actual = crypto.createHash(algo).update(buf).digest("base64");
+  if (actual !== expected) {
+    throw new Error(`integrity mismatch for @duckdb/${bindingName}: expected ${algo}-${expected}, got ${algo}-${actual}`);
+  }
+
+  const tgz = path.join(os.tmpdir(), `duckdb-${bindingName}-${process.pid}.tgz`);
+  fs.writeFileSync(tgz, buf);
+  fs.mkdirSync(destDir, { recursive: true });
+  // `tar` is a real executable on every CI runner (incl. Windows bsdtar) — safe
+  // for execFileSync (unlike the npm.cmd shim). --strip-components drops package/.
+  execFileSync("tar", ["-xzf", tgz, "-C", destDir, "--strip-components=1"], { stdio: "inherit" });
+  fs.rmSync(tgz, { force: true });
+}
+
+// Cache (per build process) of extracted binding dirs, so a binding removed for
+// one arch and needed for its own arch is restored without re-downloading.
+async function ensureInCache(appDir, cacheRoot, duckdbDir, bindingName) {
+  const cacheDir = path.join(cacheRoot, bindingName);
+  if (fs.existsSync(path.join(cacheDir, "package.json"))) {
+    return cacheDir;
+  }
+  const installed = path.join(duckdbDir, bindingName);
+  if (fs.existsSync(path.join(installed, "package.json"))) {
+    fs.cpSync(installed, cacheDir, { recursive: true });
+    return cacheDir;
+  }
+  await downloadAndExtract(appDir, bindingName, cacheDir);
+  return cacheDir;
+}
+
+exports.default = async function beforePack(context) {
+  const osToken = OS_TOKEN[context.electronPlatformName];
+  if (!osToken) return;
+  const archName = Arch[context.arch];
+  if (archName !== "x64" && archName !== "arm64") return;
+
+  const appDir = context.packager.info.appDir;
+  const duckdbDir = path.join(appDir, "node_modules", "@duckdb");
+  if (!fs.existsSync(duckdbDir)) return;
+
+  const wanted = new Set(wantedBindings(osToken, archName));
+  const cacheRoot = path.join(os.tmpdir(), `costgoblin-duckdb-bindings-${process.pid}`);
+
+  log(`packing ${context.electronPlatformName}/${archName}: ensuring bindings ${[...wanted].join(", ")}`);
+
+  // Remove bindings not wanted for this arch (preserving them in cache first, so
+  // the host-arch binding the runner installed can be restored for its own arch).
+  for (const entry of fs.readdirSync(duckdbDir)) {
+    if (entry.startsWith("node-bindings-") && !wanted.has(entry)) {
+      await ensureInCache(appDir, cacheRoot, duckdbDir, entry);
+      fs.rmSync(path.join(duckdbDir, entry), { recursive: true, force: true });
+    }
+  }
+
+  // Materialize each wanted binding (from cache, or download if absent).
+  for (const name of wanted) {
+    const dest = path.join(duckdbDir, name);
+    if (fs.existsSync(path.join(dest, "package.json"))) continue;
+    const src = await ensureInCache(appDir, cacheRoot, duckdbDir, name);
+    fs.cpSync(src, dest, { recursive: true });
+  }
+};

--- a/scripts/before-pack.cjs
+++ b/scripts/before-pack.cjs
@@ -38,6 +38,13 @@ function log(msg) {
   process.stdout.write(`  • [duckdb-binding] ${msg}\n`);
 }
 
+// A binding dir is usable only if it actually holds the native addon — the file
+// the loader requires and the whole point of the swap. Gate on it (not a sibling
+// like package.json) so a half-populated dir is never treated as good.
+function hasBinding(dir) {
+  return fs.existsSync(path.join(dir, "duckdb.node"));
+}
+
 function readLockEntry(appDir, bindingName) {
   const lock = JSON.parse(fs.readFileSync(path.join(appDir, "package-lock.json"), "utf8"));
   const entry = lock.packages?.[`node_modules/@duckdb/${bindingName}`];
@@ -75,11 +82,11 @@ async function downloadAndExtract(appDir, bindingName, destDir) {
 // one arch and needed for its own arch is restored without re-downloading.
 async function ensureInCache(appDir, cacheRoot, duckdbDir, bindingName) {
   const cacheDir = path.join(cacheRoot, bindingName);
-  if (fs.existsSync(path.join(cacheDir, "package.json"))) {
+  if (hasBinding(cacheDir)) {
     return cacheDir;
   }
   const installed = path.join(duckdbDir, bindingName);
-  if (fs.existsSync(path.join(installed, "package.json"))) {
+  if (hasBinding(installed)) {
     fs.cpSync(installed, cacheDir, { recursive: true });
     return cacheDir;
   }
@@ -114,7 +121,7 @@ exports.default = async function beforePack(context) {
   // Materialize each wanted binding (from cache, or download if absent).
   for (const name of wanted) {
     const dest = path.join(duckdbDir, name);
-    if (fs.existsSync(path.join(dest, "package.json"))) continue;
+    if (hasBinding(dest)) continue;
     const src = await ensureInCache(appDir, cacheRoot, duckdbDir, name);
     fs.cpSync(src, dest, { recursive: true });
   }


### PR DESCRIPTION
## Problem

Every release ships **both** x64 and arm64 installers for each OS, but each is built on a **single-arch** GitHub runner (`macos-latest`=arm64, `windows-latest`=x64, `ubuntu-latest`=x64). `npm ci` installs only the host-arch, `os`/`cpu`-gated `@duckdb/node-bindings-<os>-<arch>` package, and electron-builder copies `node_modules` as-is **without filtering by target arch**. So every *secondary-arch* installer shipped the **wrong-arch** `duckdb.node` and crashes on launch — the loader (`@duckdb/node-bindings/duckdb.js`) resolves the binding by runtime `process.arch` and `require()`s a package directory that isn't in the bundle.

Confirmed by inspecting the published **v0.5.4** artifacts:

| Installer (secondary arch) | Built on | Shipped binding | Loader needs | Result |
|---|---|---|---|---|
| Intel-Mac dmg/zip (x64) | arm64 runner | `darwin-arm64` only | `darwin-x64` | ❌ crash |
| arm64 Linux deb/AppImage | x64 runner | `linux-x64` + `-x64-musl` | `linux-arm64` | ❌ crash |
| arm64 Windows (NSIS `app-arm64`) | x64 runner | `win32-x64` only | `win32-arm64` | ❌ crash |

The universal `libduckdb.dylib` on macOS doesn't rescue Intel Macs — the loader needs the `darwin-x64` *package dir* with an x64 `duckdb.node`, which is entirely absent. Native-arch builds (arm64 Mac, x64 Windows, x64 Linux) were already correct.

## Fix

A `beforePack` electron-builder hook (`scripts/before-pack.cjs`) that makes `node_modules/@duckdb` arch-correct **before packing each arch**:

- Removes any `node-bindings-*` package not wanted for the target arch (preserving it in a per-process cache first, so the host binding the runner installed can be restored for its own arch without re-downloading).
- Materializes each wanted binding (Linux gets both glibc + musl variants), fetching from the **exact tarball pinned in `package-lock.json`** and verifying its `sha512` integrity.

This relies on confirmed electron-builder v26 behaviour: it packs arches **sequentially** (`concurrency.jobs=1`, the default), **re-reads `node_modules` from disk per arch** (no memoization), and does **no** cpu/os arch filtering of its own. `npmRebuild` stays `false` — these are prebuilt binaries, nothing is compiled.

No changes to `release.yml` are needed; the hook runs automatically inside `electron-builder`.

## Verification

Built `dir` targets for all three platforms × both arches locally and checked the packaged binary (`file` on `duckdb.node`):

- darwin **x64** → Mach-O **x86_64**; darwin **arm64** → Mach-O **arm64**
- linux **x64** → ELF **x86-64** (glibc + musl); linux **arm64** → ELF **ARM aarch64** (glibc + musl)
- win32 **x64** → PE32+ **x86-64**; win32 **arm64** → PE32+ **Aarch64**

Each installer now contains **exactly** its matching binding (no wrong-arch binary, no 8-binding bloat). Also confirmed the asar header references the swapped-in binding (marked `unpack`), so the loader's `require` resolves correctly. `npm run check` passes (883 tests).

Unrelated to the Sentry-telemetry PR (#434).