### PR TITLE
fix(rollup): hash grain keys in estimator probe to stop OOM crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1106,7 +1106,7 @@ export function buildRollupPartitionQuery(
 /** Build the cardinality probe behind the grain cost/benefit estimator (rollup
  *  design §8). Over ONE recent month it returns, in a single scan:
  *   - `line_items`  — COUNT(*) (the rollup's raw input for that month),
- *   - `grain_rows`  — exact `COUNT(DISTINCT)` of the candidate grain tuple
+ *   - `grain_rows`  — distinct count of the candidate grain tuple
  *      (the rollup row count for that month), and
  *   - `card_<i>`    — exact distinct count of each enabled dimension's primary
  *      column, so the estimator can flag individual raw-only dims (e.g. resource_id), and
@@ -1115,9 +1115,13 @@ export function buildRollupPartitionQuery(
  *      attribute marginal rollup size per dimension. Indexed by
  *      `rollupGrainDimensions` order (built-ins first, then tags).
  *
- *  Counts are EXACT (not HyperLogLog): the per-dimension multiplier is a ratio
- *  of two distinct-counts, and approx error compounds across the ratio. Exact is
- *  monotonic (a leave-one-out can only lower the count), so multipliers are ≥ 1.
+ *  `grain_rows`/`loo_<i>` count distinct 64-bit HASHES of the grain tuple, not
+ *  the concatenated strings — exact-to-the-collision (collisions ~0 in practice;
+ *  see the body) but with 8-byte keys instead of materializing millions of long
+ *  strings, which is what kept the probe from OOM-ing. NOT HyperLogLog: the
+ *  per-dimension multiplier is a ratio of two distinct-counts and approx error
+ *  compounds across the ratio. A leave-one-out can only lower the count, so
+ *  multipliers are ≥ 1 (also clamped in the estimator).
  *
  *  `grainColumns` come from `rollupGrainColumns` over the candidate dimensions
  *  (usage_date first) and are projected by `buildSource` — the same trusted set
@@ -1159,31 +1163,40 @@ export function buildGrainProbeQuery(
   assertDateString(end);
   const whereConditions = [`usage_date >= '${start}'`, `usage_date < '${end}'`, ...exclusionClauses];
 
-  const grainConcat = `concat_ws(chr(31), ${grainColumns.join(', ')})`;
+  // Distinct grain rows. We count distinct 64-bit HASHES of the grain tuple, not
+  // the concatenated strings themselves: COUNT(DISTINCT) over a string key
+  // materializes the full key (~80+ bytes) for every distinct value in an
+  // in-memory hash set that does NOT spill, and the grain is near-unique when a
+  // high-cardinality dim (resource_id) is enabled — millions of long keys.
+  // Hashing to a UBIGINT keeps the count exact-to-the-collision while storing
+  // 8-byte keys, cutting peak probe memory ~8× (measured ~16 GB → ~2 GB on a
+  // 7.8M line-item month). COUNT(DISTINCT hash(x)) ≤ COUNT(DISTINCT x): a
+  // collision can only merge two tuples, never split one, so the count is a
+  // tight lower bound that is monotone with the true grain. Collisions are
+  // negligible — a handful per ~7M distinct keys (~1e-6), far below the 6–13%
+  // HyperLogLog error that ruled out approx_count_distinct here (that error
+  // compounds across the loo ÷ grain ratio, fabricating spurious ×1.1–×1.5
+  // impacts for near-redundant dims).
+  const grainHash = `hash(concat_ws(chr(31), ${grainColumns.join(', ')}))`;
   // Per-dimension cardinality and leave-one-out grain. card_<i> is the
-  // dimension's own distinct count; loo_<i> is the grain with that whole
-  // dimension removed — a built-in drops both its id and its display column, so
-  // a 1:1 display column (account_name ↔ account_id) isn't split into two
-  // mutually-covering pseudo-dims. The estimator turns fullGrain ÷ loo_<i> into
-  // the marginal rollup size each dimension drives — a correlation-aware impact,
-  // computed in this same single scan. Same trusted grainColumns interpolation
-  // as grainConcat above (no user values).
-  //
-  // EXACT COUNT(DISTINCT), not approx_count_distinct: the marginal multiplier is
-  // a ratio of two distinct-counts, and HyperLogLog error (measured 6–13% on
-  // real CUR data) compounds across the ratio, fabricating spurious ×1.1–×1.5
-  // impacts for near-redundant dims. Exact counts are monotonic (loo ≤ grain),
-  // so multipliers are naturally ≥ 1, and cost only a single extra month-scan.
+  // dimension's own distinct count (single column — cheap, kept exact); loo_<i>
+  // is the grain with that whole dimension removed — a built-in drops both its id
+  // and its display column, so a 1:1 display column (account_name ↔ account_id)
+  // isn't split into two mutually-covering pseudo-dims. The estimator turns
+  // fullGrain ÷ loo_<i> into the marginal rollup size each dimension drives — a
+  // correlation-aware impact, computed in this same single scan. Same trusted
+  // grainColumns interpolation as grainHash above (no user values); loo uses the
+  // identical hash trick so all N+1 distinct sets stay 8-byte-keyed.
   const grainDims = rollupGrainDimensions(dimensions);
   const cardSelects = grainDims.map((dim, i) => `CAST(COUNT(DISTINCT ${dim.column}) AS BIGINT) AS card_${String(i)}`);
   const looSelects = grainDims.map((dim, i) => {
     const remove = new Set(dim.columns);
     const cols = grainColumns.filter(g => !remove.has(g));
-    return `CAST(COUNT(DISTINCT concat_ws(chr(31), ${cols.join(', ')})) AS BIGINT) AS loo_${String(i)}`;
+    return `CAST(COUNT(DISTINCT hash(concat_ws(chr(31), ${cols.join(', ')}))) AS BIGINT) AS loo_${String(i)}`;
   });
   const selects = [
     `CAST(COUNT(*) AS BIGINT) AS line_items`,
-    `CAST(COUNT(DISTINCT ${grainConcat}) AS BIGINT) AS grain_rows`,
+    `CAST(COUNT(DISTINCT ${grainHash}) AS BIGINT) AS grain_rows`,
     ...cardSelects,
     ...looSelects,
   ];

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -1118,10 +1118,14 @@ export function buildRollupPartitionQuery(
  *  `grain_rows`/`loo_<i>` count distinct 64-bit HASHES of the grain tuple, not
  *  the concatenated strings — exact-to-the-collision (collisions ~0 in practice;
  *  see the body) but with 8-byte keys instead of materializing millions of long
- *  strings, which is what kept the probe from OOM-ing. NOT HyperLogLog: the
- *  per-dimension multiplier is a ratio of two distinct-counts and approx error
- *  compounds across the ratio. A leave-one-out can only lower the count, so
- *  multipliers are ≥ 1 (also clamped in the estimator).
+ *  strings. That is a per-key constant-factor cut (~8× peak memory on measured
+ *  data), NOT a structural bound: the scan still builds `N+1` distinct sets at
+ *  once (full grain + one per enabled dimension), so peak still grows with the
+ *  number of enabled dimensions. It moved the live estimate well clear of the
+ *  OOM cliff for normal configs; a pathologically wide grain could still be
+ *  heavy. NOT HyperLogLog: the per-dimension multiplier is a ratio of two
+ *  distinct-counts and approx error compounds across the ratio. A leave-one-out
+ *  can only lower the count, so multipliers are ≥ 1 (also clamped in the estimator).
  *
  *  `grainColumns` come from `rollupGrainColumns` over the candidate dimensions
  *  (usage_date first) and are projected by `buildSource` — the same trusted set
@@ -1177,26 +1181,27 @@ export function buildGrainProbeQuery(
   // HyperLogLog error that ruled out approx_count_distinct here (that error
   // compounds across the loo ÷ grain ratio, fabricating spurious ×1.1–×1.5
   // impacts for near-redundant dims).
-  const grainHash = `hash(concat_ws(chr(31), ${grainColumns.join(', ')}))`;
+  // 64-bit hash of a grain tuple — the 8-byte distinct key (see above). `cols`
+  // are trusted grain columns (no user values), same interpolation as the rest.
+  const grainHashExpr = (cols: readonly string[]): string => `hash(concat_ws(chr(31), ${cols.join(', ')}))`;
   // Per-dimension cardinality and leave-one-out grain. card_<i> is the
   // dimension's own distinct count (single column — cheap, kept exact); loo_<i>
   // is the grain with that whole dimension removed — a built-in drops both its id
   // and its display column, so a 1:1 display column (account_name ↔ account_id)
   // isn't split into two mutually-covering pseudo-dims. The estimator turns
   // fullGrain ÷ loo_<i> into the marginal rollup size each dimension drives — a
-  // correlation-aware impact, computed in this same single scan. Same trusted
-  // grainColumns interpolation as grainHash above (no user values); loo uses the
+  // correlation-aware impact, computed in this same single scan. loo uses the
   // identical hash trick so all N+1 distinct sets stay 8-byte-keyed.
   const grainDims = rollupGrainDimensions(dimensions);
   const cardSelects = grainDims.map((dim, i) => `CAST(COUNT(DISTINCT ${dim.column}) AS BIGINT) AS card_${String(i)}`);
   const looSelects = grainDims.map((dim, i) => {
     const remove = new Set(dim.columns);
     const cols = grainColumns.filter(g => !remove.has(g));
-    return `CAST(COUNT(DISTINCT hash(concat_ws(chr(31), ${cols.join(', ')}))) AS BIGINT) AS loo_${String(i)}`;
+    return `CAST(COUNT(DISTINCT ${grainHashExpr(cols)}) AS BIGINT) AS loo_${String(i)}`;
   });
   const selects = [
     `CAST(COUNT(*) AS BIGINT) AS line_items`,
-    `CAST(COUNT(DISTINCT ${grainHash}) AS BIGINT) AS grain_rows`,
+    `CAST(COUNT(DISTINCT ${grainHashExpr(grainColumns)}) AS BIGINT) AS grain_rows`,
     ...cardSelects,
     ...looSelects,
   ];

--- a/packages/core/src/rollup/estimator.ts
+++ b/packages/core/src/rollup/estimator.ts
@@ -127,7 +127,9 @@ export interface RollupGrainEstimate {
 export interface RollupEstimateInput {
   readonly probePeriod: string;
   readonly months: number;
-  /** approx_count_distinct over the candidate grain tuple in the probe month. */
+  /** Distinct count of the candidate grain tuple in the probe month (counted
+   *  over 64-bit hashes of the tuple — exact-to-the-collision; see
+   *  `buildGrainProbeQuery`). */
   readonly probeGrainRows: number;
   /** COUNT(*) in the probe month. */
   readonly probeLineItems: number;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/ui/src/hooks/use-debounced-value.ts
+++ b/packages/ui/src/hooks/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+/** Trailing-edge debounce of a value. Returns the input only after it has held
+ *  steady for `ms`, so a burst of changes collapses into a single settled value. */
+export function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => { setDebounced(value); }, ms);
+    return () => { clearTimeout(id); };
+  }, [value, ms]);
+  return debounced;
+}

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -44,6 +44,7 @@ function migrateLocked(cfg: DimensionsConfig): { config: DimensionsConfig; chang
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useUnsavedChanges } from '../hooks/use-unsaved-changes.js';
 import { useQuery } from '../hooks/use-query.js';
+import { useDebouncedValue } from '../hooks/use-debounced-value.js';
 import { CoinRainLoader } from '../components/coin-rain-loader.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
 import { AliasSuggestions } from '../components/alias-suggestions.js';
@@ -1474,17 +1475,6 @@ function grainSignature(config: DimensionsConfig): string {
   return [...new Set(cols)].sort((a, b) => a.localeCompare(b)).join(',');
 }
 
-/** Trailing-edge debounce of a value. Returns the input only after it has held
- *  steady for `ms`, so a burst of changes collapses into a single settled value. */
-function useDebouncedValue<T>(value: T, ms: number): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => { setDebounced(value); }, ms);
-    return () => { clearTimeout(id); };
-  }, [value, ms]);
-  return debounced;
-}
-
 const SIZE_BAND_LABEL: Record<RollupSizeBand, string> = {
   tiny: 'tiny', small: 'small', moderate: 'moderate', large: 'large', huge: 'very large',
 };
@@ -1693,11 +1683,18 @@ function RollupImpactPanel({ estimate, loading, stale, config }: Readonly<{ esti
   const rollupBytes = matchedCurrent === null ? (estimate?.candidate.bytes ?? 0) : matchedCurrent.bytes;
   const sizeReduction = estimate !== null && rollupBytes > 0 ? estimate.raw.bytes / rollupBytes : 0;
   const rowRatio = computeRowRatio(estimate, matchedCurrent);
+  // When the probe has run and found no data on disk (probePeriod === ''), show
+  // the sync hint even while stale/loading — toggling a dim on an un-synced
+  // install must not flash the "Estimating…" spinner over the real "no data" state.
+  const noData = estimate !== null && estimate.probePeriod.length === 0;
+  const syncHint = <p className="mt-3 text-xs text-text-muted">Sync billing data to estimate the rollup size for this grain.</p>;
   let body: React.JSX.Element;
-  if (stale || (loading && estimate === null)) {
+  if (noData) {
+    body = syncHint;
+  } else if (stale || (loading && estimate === null)) {
     body = <EstimateProgress />;
-  } else if (estimate === null || estimate.probePeriod.length === 0) {
-    body = <p className="mt-3 text-xs text-text-muted">Sync billing data to estimate the rollup size for this grain.</p>;
+  } else if (estimate === null) {
+    body = syncHint;
   } else {
     body = (
       <ImpactDetails
@@ -1855,8 +1852,10 @@ export function DimensionsView({ rollupRevision }: Readonly<{ rollupRevision?: s
   const estimateLoading = estimateQuery.status === 'loading';
   // The grain changed but the (debounced) probe hasn't refired yet — the shown
   // estimate is for the previous grain. Surface the "Estimating…" cue instantly
-  // (as it did before the debounce) so the panel never silently shows stale
-  // numbers during the 350 ms settle window.
+  // (as it did before the debounce) for the 350 ms settle window so the panel
+  // doesn't sit on the previous grain's numbers without a hint. (useQuery flips
+  // to its own loading state one passive-effect tick after the window closes, so
+  // a single handoff frame can still paint the prior estimate — acceptable.)
   const estimateStale = estimateSig !== debouncedEstimateSig;
   const rawOnlyColumns = new Set((estimate?.dims ?? []).filter(d => d.rawOnly).map(d => d.column));
   const cardinalityByColumn = new Map((estimate?.dims ?? []).map(d => [d.column, d.cardinality]));

--- a/packages/ui/src/views/dimensions.tsx
+++ b/packages/ui/src/views/dimensions.tsx
@@ -1474,6 +1474,17 @@ function grainSignature(config: DimensionsConfig): string {
   return [...new Set(cols)].sort((a, b) => a.localeCompare(b)).join(',');
 }
 
+/** Trailing-edge debounce of a value. Returns the input only after it has held
+ *  steady for `ms`, so a burst of changes collapses into a single settled value. */
+function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => { setDebounced(value); }, ms);
+    return () => { clearTimeout(id); };
+  }, [value, ms]);
+  return debounced;
+}
+
 const SIZE_BAND_LABEL: Record<RollupSizeBand, string> = {
   tiny: 'tiny', small: 'small', moderate: 'moderate', large: 'large', huge: 'very large',
 };
@@ -1670,7 +1681,7 @@ function ImpactDetails({ estimate, matchedCurrent, sizeReduction, rowRatio, rank
 /** Cost/benefit summary for the current enabled grain (rollup design §8).
  *  Updates as dims are toggled so the user can weigh the rebuild before it
  *  happens. Numbers are directional (probed from one recent month). */
-function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: RollupGrainEstimate | null; loading: boolean; config: DimensionsConfig }>): React.JSX.Element {
+function RollupImpactPanel({ estimate, loading, stale, config }: Readonly<{ estimate: RollupGrainEstimate | null; loading: boolean; stale: boolean; config: DimensionsConfig }>): React.JSX.Element {
   const rankedDims = estimate === null
     ? []
     : [...estimate.dims].sort((a, b) => b.marginalMultiplier - a.marginalMultiplier);
@@ -1683,7 +1694,7 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
   const sizeReduction = estimate !== null && rollupBytes > 0 ? estimate.raw.bytes / rollupBytes : 0;
   const rowRatio = computeRowRatio(estimate, matchedCurrent);
   let body: React.JSX.Element;
-  if (loading && estimate === null) {
+  if (stale || (loading && estimate === null)) {
     body = <EstimateProgress />;
   } else if (estimate === null || estimate.probePeriod.length === 0) {
     body = <p className="mt-3 text-xs text-text-muted">Sync billing data to estimate the rollup size for this grain.</p>;
@@ -1707,7 +1718,7 @@ function RollupImpactPanel({ estimate, loading, config }: Readonly<{ estimate: R
           <Database className="h-4 w-4 text-text-muted" />
           <h3 className="text-sm font-medium text-text-secondary">Rollup impact</h3>
         </div>
-        {estimate !== null && estimate.probePeriod.length > 0 && (
+        {!stale && estimate !== null && estimate.probePeriod.length > 0 && (
           matchedCurrent === null ? (
             <span
               title={`Directional estimate, probed from ${estimate.probePeriod}. Rebuild this grain to get exact numbers.`}
@@ -1826,15 +1837,27 @@ export function DimensionsView({ rollupRevision }: Readonly<{ rollupRevision?: s
   // the grain signature so it refetches when a dim is toggled (the grain
   // changes) but not on reorder/relabel. The probe hits DuckDB, so this is
   // intentionally cheap and fire-and-forget.
+  // Debounce the grain signature before probing: each dim toggle changes the
+  // grain, and the probe is a heavy DuckDB scan (multi-second, multi-GB on real
+  // data). Without this, dragging through several toggles fires a probe per
+  // intermediate grain, stacking heavy queries against the worker pool. Wait for
+  // the grain to settle (350 ms) so only the final grain is probed.
   const estimateSig = config === null ? '' : grainSignature(config);
+  const debouncedEstimateSig = useDebouncedValue(estimateSig, 350);
   const estimateQuery = useQuery(
     () => config === null ? Promise.resolve(null) : api.estimateRollupGrain(config),
-    // Refetch when the grain changes OR when the built rollup changes (e.g. a
-    // re-roll finishes) so the actual/estimated badge updates without a remount.
-    [estimateSig, rollupRevision ?? ''],
+    // Refetch when the (settled) grain changes OR when the built rollup changes
+    // (e.g. a re-roll finishes) so the actual/estimated badge updates without a
+    // remount.
+    [debouncedEstimateSig, rollupRevision ?? ''],
   );
   const estimate = estimateQuery.status === 'success' ? estimateQuery.data : null;
   const estimateLoading = estimateQuery.status === 'loading';
+  // The grain changed but the (debounced) probe hasn't refired yet — the shown
+  // estimate is for the previous grain. Surface the "Estimating…" cue instantly
+  // (as it did before the debounce) so the panel never silently shows stale
+  // numbers during the 350 ms settle window.
+  const estimateStale = estimateSig !== debouncedEstimateSig;
   const rawOnlyColumns = new Set((estimate?.dims ?? []).filter(d => d.rawOnly).map(d => d.column));
   const cardinalityByColumn = new Map((estimate?.dims ?? []).map(d => [d.column, d.cardinality]));
 
@@ -2153,7 +2176,7 @@ export function DimensionsView({ rollupRevision }: Readonly<{ rollupRevision?: s
 
           {/* Rollup cost/benefit for the current grain — updates as pills are
               toggled so the user can weigh the (background) re-roll first. */}
-          <RollupImpactPanel estimate={estimate} loading={estimateLoading} config={config} />
+          <RollupImpactPanel estimate={estimate} loading={estimateLoading} stale={estimateStale} config={config} />
 
           {/* New-tag-dim form appears inline right after the pill rows so the
               user sees where the new pill will land. */}


### PR DESCRIPTION
## Problem

The **Rollup impact** estimator (the "Estimating…" panel on the Dimensions settings page) crashes the app via memory exhaustion. Both Sentry crashes (#437, #438) bottom out in `partition_alloc::PartitionRoot::OutOfMemory → PartitionOutOfMemoryMappingFailure` — Chromium's allocator failing an `mmap` and deliberately terminating the process. Reproduced on real data: the probe spikes to **~16–19 GB RSS** for a single month.

## Root cause

`buildGrainProbeQuery` runs, in **one query**, `1 full-grain + N leave-one-out` **exact `COUNT(DISTINCT concat_ws(...))`** aggregates over the grain tuple. On real billing data the grain is near-unique — `resource_id` has ~286k distinct values, so a 7.8M-line-item month yields ~6.96M distinct grain rows (~1.12× compression). Each of the ~10–12 aggregates materializes an in-memory hash set of **millions of ~80-byte concatenated strings simultaneously**, and these distinct aggregates do **not** spill (confirmed: throws OOM under `memory_limit`, 0 bytes spilled). DuckDB runs in a worker thread inside the Electron main process, so the allocation spike kills the whole app.

Introduced by #402, which switched `approx_count_distinct` → exact **and** added the N leave-one-out aggregates.

## Fix

Count distinct **64-bit `hash()`** of each grain tuple instead of the raw concatenated string — `COUNT(DISTINCT hash(concat_ws(...)))`. 8-byte keys instead of materializing long strings; `COUNT(DISTINCT hash(x)) ≤ COUNT(DISTINCT x)`, so it's a tight, monotone lower bound. Collisions are negligible (a handful per ~7M keys), far below the 6–13% HyperLogLog error that ruled out `approx_count_distinct` for this ratio-based estimator. Per-dimension `card_<i>` stays exact (single-column, cheap).

Measured end-to-end with the real dimensions config (all dims enabled, including `resource_id` → 12 hashed aggregates):

| | Peak RSS | Time | grain_rows |
|---|---|---|---|
| Before (exact string concat) | **~19 GB** | 7.3 s | exact |
| After (hashed) | **2.6 GB** | 4.7 s | exact-to-collision |

Naive `USING SAMPLE … × scale` was rejected — distinct counts don't scale linearly (10% sample gave `region` cardinality 170 vs true 17), which would corrupt the low-cardinality marginals #402 exists to get right.

### Defense-in-depth

- Debounce the live estimate 350 ms so dragging through several dim toggles coalesces into one probe instead of stacking heavy queries against the worker pool.
- Surface the "Estimating…" cue during the settle window so the panel doesn't sit on the previous grain's numbers without a hint.

## Trade-offs & limitations

- **Precision: counts are now exact-to-the-collision, not perfectly exact.** `grain_rows`/`loo_<i>` count distinct 64-bit hashes, so colliding tuples are undercounted — always **≤** the true count. Measured **29 fewer on a 6.96M-row grain (0.0004%)**. The per-dimension cardinalities the UI displays (`card_<i>`) stay **exact** (single-column distinct, unchanged). The marginal multiplier is a ratio `grain_rows / loo_<i>` where both terms undercount by ~1e-6 and the errors cancel, so the ratio error is ~1e-6 — unlike HLL's 6–13% *percentage* error it does **not** compound across the ratio, and it sits ~5 orders of magnitude below the estimate's own directional banding (−10%…+35%).
- **Memory is reduced ~8×, not bounded.** Hashing is a per-key constant-factor cut, not a structural fix: the scan still builds `N+1` simultaneous distinct sets, so peak still grows with the number of distinct grain rows **and** the number of enabled dimensions. A much larger account or a pathologically wide grain config could still be heavy. A hard bound would need a spillable `GROUP BY` form or sequential per-aggregate probing (heavier/slower) — deferred, since this clears the OOM cliff for normal configs.
- **Estimate latency: +350 ms.** The debounce delays the probe until the grain settles. A single handoff frame at the end of that window can still briefly paint the previous grain's numbers (the query hook's loading state lags one passive-effect tick) — cosmetic, not a data error.

## Verification

- `npm run check` green — tsc + eslint + 883 tests (incl. the grain-probe DuckDB test).
- End-to-end real-data measurement of the generated SQL (19 GB → 2.6 GB, same results).
- Adversarial multi-agent review of the diff: no correctness/security/behavioral defects; only doc-comment accuracy and the debounce UX cue, both addressed here.

Fixes #437, #438
