### PR TITLE
ci(release): use macos-15-intel runner for the Intel Mac x64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13          # Intel (x64)
+          - os: macos-15-intel    # Intel (x64)
             platform: mac
             arch: x64
           - os: macos-14          # Apple Silicon (arm64)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

The v0.5.6 release run is stuck: the `build (macos-13, mac, x64)` job has sat in `queued` indefinitely (`runner_id: 0`, no runner ever assigned) while the other five arch jobs completed.

GitHub **retired the `macos-13` (Intel Ventura) runner image** — deprecation began 2025-09-22 and the image was fully unsupported by 2025-12-08 ([changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), [runner-images #13046](https://github.com/actions/runner-images/issues/13046)). The per-`(os, arch)` matrix introduced in #440 pinned `runs-on: macos-13` for the Intel Mac build, so that job now waits forever for a runner that no longer exists.

Because the `publish` job is `needs: build` (runs only after all six build jobs succeed), the dead Mac x64 job **blocks the entire release** — no draft, no merged update manifests, nothing published.

## Fix

- Swap `macos-13` → **`macos-15-intel`**, GitHub's current Intel x86_64 runner. It still reports `process.arch === 'x64'`, so the existing host-arch DuckDB binding assertion (`node-bindings-darwin-x64`) and the `--x64` target narrowing keep working unchanged.
- Bump `0.5.6` → **`0.5.7`** (root + `packages/desktop`). v0.5.6 was tagged but never published — it died on this exact bug — so the release is re-cut as v0.5.7. This also keeps the `version bumped past latest release` CI check green (package.json must sit exactly one release ahead of the latest tag `v0.5.6`).

## Follow-up to actually ship

1. Merge this.
2. Cancel the stuck v0.5.6 run.
3. Tag **v0.5.7** to trigger a clean release.

## Note

Intel macOS runners disappear entirely when `macos-15` retires (~Fall 2027). At that point the Intel-Mac x64 installer will need cross-compilation or to be dropped.