### PR TITLE
fix(site): arch-aware downloads + Windows arm64 on the homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2665,6 +2665,10 @@ Format:   <span class="code-file">Parquet</span>
     applyHero();                       // labels now; href once the fetch resolves
     refineArch(os).then(applyHero);    // re-apply if UA-CH refines the arch
 
+    // Until the release fetch resolves, point every grid button at the releases
+    // page so an early click (e.g. via the Safari picker) is never a no-op '#'.
+    document.querySelectorAll('[data-asset]').forEach(el => { el.href = RELEASES_FALLBACK; });
+
     // Fetch latest release from GitHub API
     fetch('https://api.github.com/repos/etiennechabert/cost-goblin/releases/latest')
       .then(r => { if (!r.ok) throw new Error('release fetch failed'); return r.json(); })
@@ -2702,9 +2706,11 @@ Format:   <span class="code-file">Parquet</span>
         applyHero();
       })
       .catch(() => {
-        // Fallback: link to releases page
-        document.getElementById('hero-download').href = RELEASES_FALLBACK;
+        // Release fetch failed: keep every grid button on the releases page and let
+        // applyHero set the hero consistently (incl. the Safari "choose" picker),
+        // so the hero label and its href never disagree.
         document.querySelectorAll('[data-asset]').forEach(el => { el.href = RELEASES_FALLBACK; });
+        applyHero();
       });
 
     // Highlight detected platform card

--- a/docs/index.html
+++ b/docs/index.html
@@ -2131,10 +2131,11 @@
           <svg class="platform-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
           <h4>Windows</h4>
           <div class="platform-links">
-            <a class="dl-btn primary" data-asset="win-exe" href="#">
+            <a class="dl-btn primary" data-asset="win-x64-exe" href="#">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-              64-bit Installer (.exe)
+              x64 Installer (.exe)
             </a>
+            <a class="dl-btn" data-asset="win-arm64-exe" href="#">Arm64 Installer (.exe)</a>
           </div>
         </div>
 
@@ -2570,30 +2571,79 @@ Format:   <span class="code-file">Parquet</span>
       return 'mac';
     }
 
+    // --- CPU architecture detection (best-effort) ---
+    // macOS: Safari masks Apple Silicon in the UA, so the WebGL renderer string
+    // ("Apple GPU"/"Apple M…") is the reliable hardware signal. Win/Linux are
+    // refined async via UA Client Hints below. Falls back to the dominant arch.
+    function detectArch(targetOs) {
+      if (targetOs === 'mac') {
+        try {
+          const gl = document.createElement('canvas').getContext('webgl');
+          const dbg = gl && gl.getExtension('WEBGL_debug_renderer_info');
+          const renderer = dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) : '';
+          if (/apple/i.test(renderer)) return 'arm64';
+          if (renderer) return 'x64';
+        } catch (e) { /* ignore */ }
+        return 'arm64';
+      }
+      return 'x64';
+    }
+
+    // Chromium exposes the true arch via UA Client Hints — this is what catches
+    // Windows/Linux arm64. Absent in Safari/Firefox; mac already handled above.
+    async function refineArch(targetOs) {
+      if (targetOs === 'mac') return;
+      const uaData = navigator.userAgentData;
+      if (!uaData || !uaData.getHighEntropyValues) return;
+      try {
+        const hev = await uaData.getHighEntropyValues(['architecture']);
+        if (hev.architecture === 'arm') arch = 'arm64';
+        else if (hev.architecture === 'x86') arch = 'x64';
+      } catch (e) { /* ignore */ }
+    }
+
     const os = detectOS();
+    let arch = detectArch(os);
+    let urlMap = null;
 
     const HERO_LABELS = {
-      mac: { label: 'Download for macOS', platform: 'macOS Apple Silicon' },
-      win: { label: 'Download for Windows', platform: 'Windows 64-bit' },
-      linux: { label: 'Download for Linux', platform: 'Linux amd64' },
+      mac:   { label: 'Download for macOS',   platform: { arm64: 'macOS Apple Silicon', x64: 'macOS Intel' } },
+      win:   { label: 'Download for Windows', platform: { arm64: 'Windows Arm64',       x64: 'Windows x64' } },
+      linux: { label: 'Download for Linux',   platform: { arm64: 'Linux arm64',         x64: 'Linux amd64' } },
     };
-
-    // Set hero labels immediately (links populated after API fetch)
-    document.getElementById('hero-download-label').textContent = HERO_LABELS[os].label;
-    document.getElementById('hero-platform-label').textContent = HERO_LABELS[os].platform;
 
     // Asset matchers: data-asset → predicate on filename
     const ASSET_MATCHERS = {
       'mac-arm64-dmg':       (n) => n.endsWith('.dmg') && n.includes('arm64'),
       'mac-intel-dmg':       (n) => n.endsWith('.dmg') && !n.includes('arm64'),
-      'win-exe':             (n) => n.endsWith('.exe') && !n.endsWith('.blockmap'),
+      'win-x64-exe':         (n) => n.endsWith('.exe') && n.includes('x64'),
+      'win-arm64-exe':       (n) => n.endsWith('.exe') && n.includes('arm64'),
       'linux-amd64-deb':     (n) => n.endsWith('.deb') && n.includes('amd64'),
       'linux-arm64-deb':     (n) => n.endsWith('.deb') && n.includes('arm64'),
       'linux-x64-appimage':  (n) => n.endsWith('.AppImage') && !n.includes('arm64'),
       'linux-arm64-appimage':(n) => n.endsWith('.AppImage') && n.includes('arm64'),
     };
 
-    const HERO_ASSET = { mac: 'mac-arm64-dmg', win: 'win-exe', linux: 'linux-amd64-deb' };
+    const HERO_ASSET = {
+      mac:   { arm64: 'mac-arm64-dmg',   x64: 'mac-intel-dmg' },
+      win:   { arm64: 'win-arm64-exe',   x64: 'win-x64-exe' },
+      linux: { arm64: 'linux-arm64-deb', x64: 'linux-amd64-deb' },
+    };
+
+    // Apply the hero button's label + (once the API fetch resolves) its URL for
+    // the detected os/arch, falling back to x64 if the arm64 asset is absent.
+    function applyHero() {
+      const labels = HERO_LABELS[os];
+      document.getElementById('hero-download-label').textContent = labels.label;
+      document.getElementById('hero-platform-label').textContent = labels.platform[arch];
+      if (urlMap) {
+        const heroUrl = urlMap[HERO_ASSET[os][arch]] || urlMap[HERO_ASSET[os].x64];
+        if (heroUrl) document.getElementById('hero-download').href = heroUrl;
+      }
+    }
+
+    applyHero();                       // labels now; href once the fetch resolves
+    refineArch(os).then(applyHero);    // re-apply if UA-CH refines the arch
 
     // Fetch latest release from GitHub API
     fetch('https://api.github.com/repos/etiennechabert/cost-goblin/releases/latest')
@@ -2603,7 +2653,6 @@ Format:   <span class="code-file">Parquet</span>
         const assets = release.assets || [];
 
         // Update version labels
-
         var metaEl = document.getElementById('version-meta');
         var dlEl = document.getElementById('version-download');
         metaEl.textContent = ' · ' + version;
@@ -2615,21 +2664,22 @@ Format:   <span class="code-file">Parquet</span>
         document.getElementById('releases-link').href = release.html_url;
 
         // Build asset URL map
-        const urlMap = {};
+        urlMap = {};
         for (const [key, matcher] of Object.entries(ASSET_MATCHERS)) {
           const asset = assets.find(a => matcher(a.name));
           if (asset) urlMap[key] = asset.browser_download_url;
         }
 
-        // Update all download links
+        // Wire up every download link; hide buttons with no matching asset so
+        // users never click a dead link (e.g. an arch a release hasn't shipped).
         document.querySelectorAll('[data-asset]').forEach(el => {
           const url = urlMap[el.dataset.asset];
-          if (url) el.href = url;
+          if (url) { el.href = url; el.style.display = ''; }
+          else { el.style.display = 'none'; }
         });
 
         // Update hero download button
-        const heroUrl = urlMap[HERO_ASSET[os]];
-        if (heroUrl) document.getElementById('hero-download').href = heroUrl;
+        applyHero();
       })
       .catch(() => {
         // Fallback: link to releases page

--- a/docs/index.html
+++ b/docs/index.html
@@ -2572,11 +2572,12 @@ Format:   <span class="code-file">Parquet</span>
     }
 
     // --- CPU architecture detection (best-effort) ---
-    // macOS: the WebGL renderer ("Apple GPU"/"Apple M…") is the reliable hardware
-    // signal since Safari masks Apple Silicon in the UA. When WebGL is blocked we
-    // default to x64 — it runs on every Mac (native on Intel, Rosetta on Apple
-    // Silicon), whereas an arm64 build won't launch on Intel at all. Win/Linux
-    // are refined async via UA Client Hints below.
+    // macOS: Chrome/Edge expose a detailed WebGL renderer ("ANGLE (Apple, … Apple
+    // M1 …)" vs "…Intel…") that reliably identifies the chip. Safari masks it to a
+    // bare "Apple GPU" on EVERY Mac (Intel included) and has no UA Client Hints,
+    // so the arch is genuinely undetectable there — return null and let the user
+    // pick rather than risk handing an Intel Mac an arm64 build that won't launch.
+    // Win/Linux are refined async via UA Client Hints below.
     function detectArch(targetOs) {
       if (targetOs === 'mac') {
         try {
@@ -2585,9 +2586,11 @@ Format:   <span class="code-file">Parquet</span>
           const dbg = gl && gl.getExtension('WEBGL_debug_renderer_info');
           const renderer = (dbg && gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) || '';
           if (gl) gl.getExtension('WEBGL_lose_context')?.loseContext();
-          if (/apple/i.test(renderer)) return 'arm64';
-          if (renderer) return 'x64';
+          if (renderer && renderer !== 'Apple GPU') {
+            return /apple/i.test(renderer) ? 'arm64' : 'x64';
+          }
         } catch (e) { /* ignore */ }
+        return null;   // undetectable (Safari masks the renderer / WebGL blocked)
       }
       return 'x64';
     }
@@ -2641,13 +2644,21 @@ Format:   <span class="code-file">Parquet</span>
     // CTA is never a dead end.
     function applyHero() {
       const labels = HERO_LABELS[os];
+      // arch === null → undetectable Mac (Safari): don't guess, send to the picker.
+      if (arch === null) {
+        document.getElementById('hero-download-label').textContent = 'Choose your Mac download';
+        document.getElementById('hero-platform-label').textContent = 'Apple Silicon or Intel';
+        document.getElementById('hero-download').href = '#download';
+        return;
+      }
       document.getElementById('hero-download-label').textContent = labels.label;
       let shownArch = arch;
+      let heroUrl = RELEASES_FALLBACK;   // valid target even before the fetch resolves
       if (urlMap) {
-        let heroUrl = urlMap[HERO_ASSET[os][arch]];
-        if (!heroUrl) { shownArch = 'x64'; heroUrl = urlMap[HERO_ASSET[os].x64]; }
-        document.getElementById('hero-download').href = heroUrl || RELEASES_FALLBACK;
+        heroUrl = urlMap[HERO_ASSET[os][arch]];
+        if (!heroUrl) { shownArch = 'x64'; heroUrl = urlMap[HERO_ASSET[os].x64] || RELEASES_FALLBACK; }
       }
+      document.getElementById('hero-download').href = heroUrl;
       document.getElementById('hero-platform-label').textContent = labels.platform[shownArch];
     }
 
@@ -2656,7 +2667,7 @@ Format:   <span class="code-file">Parquet</span>
 
     // Fetch latest release from GitHub API
     fetch('https://api.github.com/repos/etiennechabert/cost-goblin/releases/latest')
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error('release fetch failed'); return r.json(); })
       .then(release => {
         const version = release.tag_name; // e.g. "v0.2.2"
         const assets = release.assets || [];

--- a/docs/index.html
+++ b/docs/index.html
@@ -2572,19 +2572,22 @@ Format:   <span class="code-file">Parquet</span>
     }
 
     // --- CPU architecture detection (best-effort) ---
-    // macOS: Safari masks Apple Silicon in the UA, so the WebGL renderer string
-    // ("Apple GPU"/"Apple M…") is the reliable hardware signal. Win/Linux are
-    // refined async via UA Client Hints below. Falls back to the dominant arch.
+    // macOS: the WebGL renderer ("Apple GPU"/"Apple M…") is the reliable hardware
+    // signal since Safari masks Apple Silicon in the UA. When WebGL is blocked we
+    // default to x64 — it runs on every Mac (native on Intel, Rosetta on Apple
+    // Silicon), whereas an arm64 build won't launch on Intel at all. Win/Linux
+    // are refined async via UA Client Hints below.
     function detectArch(targetOs) {
       if (targetOs === 'mac') {
         try {
-          const gl = document.createElement('canvas').getContext('webgl');
+          const canvas = document.createElement('canvas');
+          const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
           const dbg = gl && gl.getExtension('WEBGL_debug_renderer_info');
-          const renderer = dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) : '';
+          const renderer = (dbg && gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) || '';
+          if (gl) gl.getExtension('WEBGL_lose_context')?.loseContext();
           if (/apple/i.test(renderer)) return 'arm64';
           if (renderer) return 'x64';
         } catch (e) { /* ignore */ }
-        return 'arm64';
       }
       return 'x64';
     }
@@ -2616,7 +2619,7 @@ Format:   <span class="code-file">Parquet</span>
     const ASSET_MATCHERS = {
       'mac-arm64-dmg':       (n) => n.endsWith('.dmg') && n.includes('arm64'),
       'mac-intel-dmg':       (n) => n.endsWith('.dmg') && !n.includes('arm64'),
-      'win-x64-exe':         (n) => n.endsWith('.exe') && n.includes('x64'),
+      'win-x64-exe':         (n) => n.endsWith('.exe') && !n.includes('arm64'),
       'win-arm64-exe':       (n) => n.endsWith('.exe') && n.includes('arm64'),
       'linux-amd64-deb':     (n) => n.endsWith('.deb') && n.includes('amd64'),
       'linux-arm64-deb':     (n) => n.endsWith('.deb') && n.includes('arm64'),
@@ -2630,16 +2633,22 @@ Format:   <span class="code-file">Parquet</span>
       linux: { arm64: 'linux-arm64-deb', x64: 'linux-amd64-deb' },
     };
 
-    // Apply the hero button's label + (once the API fetch resolves) its URL for
-    // the detected os/arch, falling back to x64 if the arm64 asset is absent.
+    const RELEASES_FALLBACK = 'https://github.com/etiennechabert/cost-goblin/releases/latest';
+
+    // Apply the hero button's label + (once the API fetch resolves) its URL.
+    // Keep the label in sync with the arch actually served: fall back to x64 when
+    // the detected arch isn't published, then to the releases page so the primary
+    // CTA is never a dead end.
     function applyHero() {
       const labels = HERO_LABELS[os];
       document.getElementById('hero-download-label').textContent = labels.label;
-      document.getElementById('hero-platform-label').textContent = labels.platform[arch];
+      let shownArch = arch;
       if (urlMap) {
-        const heroUrl = urlMap[HERO_ASSET[os][arch]] || urlMap[HERO_ASSET[os].x64];
-        if (heroUrl) document.getElementById('hero-download').href = heroUrl;
+        let heroUrl = urlMap[HERO_ASSET[os][arch]];
+        if (!heroUrl) { shownArch = 'x64'; heroUrl = urlMap[HERO_ASSET[os].x64]; }
+        document.getElementById('hero-download').href = heroUrl || RELEASES_FALLBACK;
       }
+      document.getElementById('hero-platform-label').textContent = labels.platform[shownArch];
     }
 
     applyHero();                       // labels now; href once the fetch resolves
@@ -2683,9 +2692,8 @@ Format:   <span class="code-file">Parquet</span>
       })
       .catch(() => {
         // Fallback: link to releases page
-        const fallback = 'https://github.com/etiennechabert/cost-goblin/releases/latest';
-        document.getElementById('hero-download').href = fallback;
-        document.querySelectorAll('[data-asset]').forEach(el => { el.href = fallback; });
+        document.getElementById('hero-download').href = RELEASES_FALLBACK;
+        document.querySelectorAll('[data-asset]').forEach(el => { el.href = RELEASES_FALLBACK; });
       });
 
     // Highlight detected platform card


### PR DESCRIPTION
## Why

The marketing site (`docs/index.html`) detected the user's **OS** but never their **CPU architecture**, and the download logic hadn't kept up with the new 6-variant build matrix. Two concrete problems now that arm64 Windows ships:

- The single `win-exe` matcher `(n) => n.endsWith('.exe') && !n.endsWith('.blockmap')` matched **both** `…-x64.exe` and `…-arm64.exe`. `assets.find()` returns whichever GitHub lists first, so a Windows user could be handed the wrong-arch installer non-deterministically — and there was **no arm64 Windows button** in the download grid at all.
- The hero button blindly assumed the dominant arch per OS (Apple Silicon mac / x64 win / amd64 linux), so e.g. an Intel Mac user got an arm64 `.dmg` from the big button.

## What

- **Architecture detection.** `detectArch()` reads the WebGL renderer to distinguish Apple Silicon (`"Apple GPU"` → arm64) from Intel on macOS — necessary because Safari masks this in the UA. `refineArch()` then uses UA Client Hints (`getHighEntropyValues(['architecture'])`) on Chromium to catch **Windows / Linux arm64**. Sensible per-OS defaults otherwise.
- **Windows arm64.** Split `win-exe` into `win-x64-exe` / `win-arm64-exe` (matching the `-x64` / `-arm64` tokens electron-builder writes via `artifactName`), and added a dedicated **Arm64 Installer** button.
- **Hero button is now arch-aware** (`HERO_ASSET[os][arch]`) with an x64 fallback when the arm64 asset isn't in the release, plus arch-specific labels ("macOS Apple Silicon" vs "macOS Intel", "Windows x64" vs "Windows Arm64", …).
- **Dead-link guard.** Buttons whose asset isn't present in the current release are hidden rather than pointing at `#`.

URL resolution is still dynamic (GitHub `releases/latest` API), so nothing is hardcoded to a version.

## Verification

Loaded the page in a real browser against the live API: macOS hero → `…-arm64.dmg`, Intel button → no-token `.dmg`, all Linux buttons resolve. The current published release (v0.5.5) has no Windows assets yet, so both Windows buttons correctly hide and will appear automatically once the in-progress Windows builds publish.

The auto-updater (`electron-updater` 6.8.9) was also reviewed and already serves the correct arch per platform (mac via `filterFilesForArch`, win via the arch token, linux via per-arch manifest names) — no changes needed there.

> Note: `docs/index.html` is a standalone static file outside the `packages/*` TypeScript scope, so `npm run check` (tsc/eslint/vitest) doesn't cover it.