### PR TITLE
fix(sync): prune stale CUR part files left behind by aws s3 sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__tests__/selective-sync.test.ts
+++ b/packages/core/src/__tests__/selective-sync.test.ts
@@ -325,6 +325,86 @@ describe('syncSelectedFiles', () => {
     expect(mockWriteFile).toHaveBeenCalledWith(expectedEtagFile, expect.stringContaining('new-hash'));
   });
 
+  describe('stale-file pruning', () => {
+    it('deletes local parquet no longer in the current manifest', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      // Staging dir holds the two current parts plus a leftover from a prior export.
+      mockReaddir.mockResolvedValue(['file1.parquet', 'file2.parquet', 'stale-old-part.parquet']);
+
+      const files = [
+        file('cur/data/BILLING_PERIOD=2026-03/file1.parquet', 'h1'),
+        file('cur/data/BILLING_PERIOD=2026-03/file2.parquet', 'h2'),
+      ];
+      const dataDir = join('/tmp', 'prune-test');
+      const dest = join(dataDir, 'aws', 'raw', 'daily-2026-03');
+
+      await syncSelectedFiles({
+        bucketPath: 's3://test-bucket/cur/data/',
+        profile: 'test-profile',
+        dataDir,
+        expectedDataType: 'daily',
+        files,
+      });
+
+      expect(mockRm).toHaveBeenCalledWith(join(dest, 'stale-old-part.parquet'), { force: true });
+      expect(mockRm).not.toHaveBeenCalledWith(join(dest, 'file1.parquet'), expect.anything());
+      expect(mockRm).not.toHaveBeenCalledWith(join(dest, 'file2.parquet'), expect.anything());
+    });
+
+    it('keeps every file when the directory matches the manifest', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['file1.parquet', 'file2.parquet']);
+
+      await syncSelectedFiles({
+        bucketPath: 's3://test-bucket/cur/data/',
+        profile: 'test-profile',
+        dataDir: '/tmp/prune-clean',
+        expectedDataType: 'daily',
+        files: [
+          file('cur/data/BILLING_PERIOD=2026-03/file1.parquet'),
+          file('cur/data/BILLING_PERIOD=2026-03/file2.parquet'),
+        ],
+      });
+
+      expect(mockRm).not.toHaveBeenCalled();
+    });
+
+    it('leaves non-parquet files (e.g. in-flight download temp files) untouched', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['file1.parquet', 'file1.parquet.aB3x9', 'notes.txt', 'stale.parquet']);
+
+      const dest = join('/tmp/prune-temp', 'aws', 'raw', 'daily-2026-03');
+      await syncSelectedFiles({
+        bucketPath: 's3://test-bucket/cur/data/',
+        profile: 'test-profile',
+        dataDir: '/tmp/prune-temp',
+        expectedDataType: 'daily',
+        files: [file('cur/data/BILLING_PERIOD=2026-03/file1.parquet')],
+      });
+
+      expect(mockRm).toHaveBeenCalledWith(join(dest, 'stale.parquet'), { force: true });
+      expect(mockRm).not.toHaveBeenCalledWith(join(dest, 'file1.parquet.aB3x9'), expect.anything());
+      expect(mockRm).not.toHaveBeenCalledWith(join(dest, 'notes.txt'), expect.anything());
+    });
+
+    it('does not prune when the period sync fails', async () => {
+      mockSpawn.mockReturnValue(createFailedSpawn(1, 'Access Denied'));
+      mockReaddir.mockResolvedValue(['stale.parquet']);
+
+      await expect(
+        syncSelectedFiles({
+          bucketPath: 's3://test-bucket/cur/data/',
+          profile: 'test-profile',
+          dataDir: '/tmp/prune-fail',
+          expectedDataType: 'daily',
+          files: [file('cur/data/BILLING_PERIOD=2026-03/file1.parquet')],
+        })
+      ).rejects.toThrow('Access Denied');
+
+      expect(mockRm).not.toHaveBeenCalled();
+    });
+  });
+
   it('handles empty file list', async () => {
     const result = await syncSelectedFiles({
       bucketPath: 's3://bucket/cur/',

--- a/packages/core/src/__tests__/selective-sync.test.ts
+++ b/packages/core/src/__tests__/selective-sync.test.ts
@@ -387,6 +387,26 @@ describe('syncSelectedFiles', () => {
       expect(mockRm).not.toHaveBeenCalledWith(join(dest, 'notes.txt'), expect.anything());
     });
 
+    it('treats a deletion failure as best-effort and still completes the sync', async () => {
+      mockSpawn.mockImplementation(() => createSuccessfulSpawn());
+      mockReaddir.mockResolvedValue(['file1.parquet', 'stale.parquet']);
+      // The stale file is locked / permission-denied — rm rejects.
+      mockRm.mockRejectedValue(new Error('EPERM: operation not permitted'));
+
+      const dataDir = '/tmp/prune-besteffort';
+      const result = await syncSelectedFiles({
+        bucketPath: 's3://test-bucket/cur/data/',
+        profile: 'test-profile',
+        dataDir,
+        expectedDataType: 'daily',
+        files: [file('cur/data/BILLING_PERIOD=2026-03/file1.parquet')],
+      });
+
+      // Download succeeded and etags were still persisted despite the prune error.
+      expect(result.filesDownloaded).toBe(1);
+      expect(mockWriteFile).toHaveBeenCalledWith(join(dataDir, 'sync-etags.json'), expect.any(String));
+    });
+
     it('does not prune when the period sync fails', async () => {
       mockSpawn.mockReturnValue(createFailedSpawn(1, 'Access Denied'));
       mockReaddir.mockResolvedValue(['stale.parquet']);

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
-import { mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, rm, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 let cachedAwsPath: string | null = null;
 function findAwsCli(): string {
@@ -145,6 +145,43 @@ async function saveEtags(
   await writeFile(etagPath, JSON.stringify(savedEtags, null, 2));
 }
 
+/**
+ * Reconciles a freshly-synced directory against the current S3 manifest by
+ * deleting any local `.parquet` whose name is no longer in it.
+ *
+ * `aws s3 sync` runs without `--delete`, so it only adds/updates files — it
+ * never removes a local part file that vanished from S3. AWS restates a CUR
+ * billing period repeatedly through the month and can change the part-file
+ * assembly between exports; without this prune, an old export's parts linger
+ * next to the new ones and every row they hold is double-counted at query time
+ * (e.g. a $3,000 Shield subscription showing as $6,000 across 2 line items).
+ *
+ * `manifestFiles` MUST be the complete current file set for the directory's
+ * period — every caller passes whole-period manifests (auto-sync and the
+ * data-management views both `flatMap(p => p.files)`), the same invariant
+ * `saveEtags` relies on when it overwrites a period's etags wholesale.
+ */
+async function pruneStaleFiles(destDir: string, manifestFiles: readonly ManifestFileEntry[]): Promise<number> {
+  const expected = new Set(manifestFiles.map(f => basename(f.key)));
+  let entries: string[];
+  try {
+    entries = await readdir(destDir);
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const name of entries) {
+    if (name.endsWith('.parquet') && !expected.has(name)) {
+      await rm(join(destDir, name), { force: true });
+      removed++;
+    }
+  }
+  if (removed > 0) {
+    logger.info(`Pruned ${String(removed)} stale file(s) not in current manifest from ${destDir}`);
+  }
+  return removed;
+}
+
 function groupFilesByDate(periodFiles: readonly ManifestFileEntry[]): Map<string, ManifestFileEntry[]> {
   const dateGroups = new Map<string, ManifestFileEntry[]>();
   for (const file of periodFiles) {
@@ -219,6 +256,7 @@ async function syncDateGroup(opts: SyncDateGroupOptions): Promise<number> {
   await mkdir(destDir, { recursive: true });
 
   await runAwsS3Sync({ source: s3Source, dest: destDir, profile, signal, onLine });
+  await pruneStaleFiles(destDir, dateFiles);
 
   return dateFiles.length;
 }
@@ -345,6 +383,7 @@ export async function syncSelectedFiles(options: SelectiveSyncOptions): Promise<
 
     totalFilesDownloaded += periodFiles.length;
 
+    await pruneStaleFiles(stagingDir, periodFiles);
     await saveEtags(dataDir, tier, period, periodFiles);
   }
 

--- a/packages/core/src/sync/selective-sync.ts
+++ b/packages/core/src/sync/selective-sync.ts
@@ -146,34 +146,32 @@ async function saveEtags(
 }
 
 /**
- * Reconciles a freshly-synced directory against the current S3 manifest by
- * deleting any local `.parquet` whose name is no longer in it.
- *
- * `aws s3 sync` runs without `--delete`, so it only adds/updates files — it
- * never removes a local part file that vanished from S3. AWS restates a CUR
- * billing period repeatedly through the month and can change the part-file
- * assembly between exports; without this prune, an old export's parts linger
- * next to the new ones and every row they hold is double-counted at query time
- * (e.g. a $3,000 Shield subscription showing as $6,000 across 2 line items).
- *
- * `manifestFiles` MUST be the complete current file set for the directory's
- * period — every caller passes whole-period manifests (auto-sync and the
- * data-management views both `flatMap(p => p.files)`), the same invariant
- * `saveEtags` relies on when it overwrites a period's etags wholesale.
+ * Deletes any local `.parquet` not in the current manifest. `aws s3 sync` runs
+ * without `--delete`, so a previous CUR export's part files linger when AWS
+ * re-chunks a period — and get double-counted at query time. `manifestFiles`
+ * must be the period's complete file set (callers flatMap whole-period
+ * manifests). Best-effort: a failed deletion never fails a successful sync.
  */
 async function pruneStaleFiles(destDir: string, manifestFiles: readonly ManifestFileEntry[]): Promise<number> {
+  // An empty manifest must never be read as "delete everything in the dir".
+  if (manifestFiles.length === 0) return 0;
   const expected = new Set(manifestFiles.map(f => basename(f.key)));
   let entries: string[];
   try {
     entries = await readdir(destDir);
   } catch {
-    return 0;
+    return 0; // dir vanished or was never created — nothing to prune
   }
   let removed = 0;
   for (const name of entries) {
-    if (name.endsWith('.parquet') && !expected.has(name)) {
+    if (!name.endsWith('.parquet') || expected.has(name)) continue;
+    try {
       await rm(join(destDir, name), { force: true });
       removed++;
+    } catch (err) {
+      // A locked / permission-denied stale file must not fail a sync whose
+      // download already succeeded (mirrors the legacy-dir cleanup below).
+      logger.warn(`Failed to prune stale file ${name} from ${destDir}`, { err });
     }
   }
   if (removed > 0) {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

A single AWS Shield Advanced subscription line ($3,000) was being reported as **$6,000** with "Line Items 2" in the explorer. Tracing it against the local store, the raw parquet genuinely held **two byte-for-byte identical copies** of the one $3,000 hourly row, sitting in two different part files of the same period dir (`daily-2026-06/…-00002` and `…-00007`). The query was faithfully summing what was on disk — the duplication was upstream, in the synced files.

## Root cause

`runAwsS3Sync` runs `aws s3 sync <prefix> <dest>` with **no `--delete`**, and the period directory (`aws/raw/{tier}-{period}/`) is never cleared. `aws s3 sync` without `--delete` only *adds/updates* keys — it never removes a local file that disappeared from S3.

AWS restates a CUR billing period repeatedly through the month and can change the part-file assembly between exports. When that happens, stale part files from a previous export linger next to the new ones, and every row they hold is double-counted at query time. (A contaminated part was even carrying data through 2026-07/2027 inside a `daily-2026-06` dir — a clear remnant of a different export generation.)

The "is this period synced?" check (`getPeriodStatus`) only verifies that every *expected* remote file is present and hash-matched — it never walks the local dir to find *extra* files. And `diffManifests()`, which already computes the `toDelete` set, had **no callers**.

## Fix

After each period's `aws s3 sync` succeeds, reconcile the directory against the current manifest: delete any local `.parquet` whose name is no longer in it. Applied to both the daily/hourly period path and the cost-optimization date path.

- Runs only after the sync resolves (a failed/aborted sync prunes nothing).
- Relies on callers passing the complete per-period manifest — the same invariant `saveEtags` already assumes; verified across `auto-sync` and the data-management views (both `flatMap(p => p.files)`).
- Non-`.parquet` files (e.g. in-flight `aws s3 cp` temp downloads) are left untouched.

## Verification

`npm run check` green (tsc ×4, eslint, 887 tests). Four new tests in `selective-sync.test.ts` cover: stale part deleted, clean dir untouched, non-parquet/temp files preserved, and no prune on a failed sync.