### PR TITLE
feat(telemetry): emit Sentry performance traces (query + sync + pageload)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -5,7 +5,7 @@ export type {
   TelemetryEventKind,
   TelemetryOutboxEntry,
 } from './telemetry/types.js';
-export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE, isTelemetryEnabled } from './telemetry/types.js';
+export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE_DEV, TELEMETRY_TRACES_SAMPLE_RATE_PROD, resolveTracesSampleRate, isTelemetryEnabled } from './telemetry/types.js';
 export * from './normalize/index.js';
 export * from './models/index.js';
 export { QUERY_CANCELLED_MESSAGE } from './query/cancellation.js';

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -5,7 +5,7 @@ export type {
   TelemetryEventKind,
   TelemetryOutboxEntry,
 } from './telemetry/types.js';
-export { TELEMETRY_DEFAULTS, isTelemetryEnabled } from './telemetry/types.js';
+export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE, isTelemetryEnabled } from './telemetry/types.js';
 export * from './normalize/index.js';
 export * from './models/index.js';
 export { QUERY_CANCELLED_MESSAGE } from './query/cancellation.js';

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -5,7 +5,7 @@ export type {
   TelemetryEventKind,
   TelemetryOutboxEntry,
 } from './telemetry/types.js';
-export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE_DEV, TELEMETRY_TRACES_SAMPLE_RATE_PROD, resolveTracesSampleRate, isTelemetryEnabled } from './telemetry/types.js';
+export { TELEMETRY_DEFAULTS, isTelemetryEnabled } from './telemetry/types.js';
 export * from './normalize/index.js';
 export * from './models/index.js';
 export { QUERY_CANCELLED_MESSAGE } from './query/cancellation.js';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -4,6 +4,6 @@ export type {
   TelemetryEventKind,
   TelemetryOutboxEntry,
 } from './types.js';
-export { TELEMETRY_DEFAULTS, isTelemetryEnabled, parseTelemetryPreferences } from './types.js';
+export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE, isTelemetryEnabled, parseTelemetryPreferences } from './types.js';
 export { redactSensitiveString, isSensitiveKey, redactValueDeep, redactNumeric } from './scrub.js';
 export { summarizeEventForOutbox } from './summary.js';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -4,6 +4,6 @@ export type {
   TelemetryEventKind,
   TelemetryOutboxEntry,
 } from './types.js';
-export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE, isTelemetryEnabled, parseTelemetryPreferences } from './types.js';
+export { TELEMETRY_DEFAULTS, TELEMETRY_TRACES_SAMPLE_RATE_DEV, TELEMETRY_TRACES_SAMPLE_RATE_PROD, resolveTracesSampleRate, isTelemetryEnabled, parseTelemetryPreferences } from './types.js';
 export { redactSensitiveString, isSensitiveKey, redactValueDeep, redactNumeric } from './scrub.js';
 export { summarizeEventForOutbox } from './summary.js';

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -34,8 +34,9 @@ export const TELEMETRY_DEFAULTS: TelemetryPreferences = {
  * samples a fraction — enough volume for p95/p99 latency trends across releases
  * while staying well under Sentry's quota; local dev (only ever emits when a DSN
  * is set) samples everything so a developer sees every trace they generate. The
- * sampling decision is made independently in each process (main + renderer), so
- * both resolve it from here — one source of truth so the two can't drift.
+ * main process resolves this ONCE (from `app.isPackaged`) and surfaces it on
+ * {@link TelemetryStatus.tracesSampleRate}, so the renderer samples at the same
+ * rate — one decision, no cross-process drift.
  */
 export const TELEMETRY_TRACES_SAMPLE_RATE_DEV = 1.0;
 export const TELEMETRY_TRACES_SAMPLE_RATE_PROD = 0.1;
@@ -78,6 +79,11 @@ export interface TelemetryStatus {
    *  here until the app restarts — distinct from {@link preferences}, the desired
    *  state. The settings "● Active" badge keys off this, not the saved pref. */
   readonly armed: TelemetryPreferences;
+  /** The Sentry `tracesSampleRate` this build uses for performance tracing,
+   *  resolved once in the main process (dev samples more than prod). Surfaced so
+   *  the renderer samples at the SAME rate as the main process — one decision, no
+   *  cross-process drift. See {@link resolveTracesSampleRate}. */
+  readonly tracesSampleRate: number;
 }
 
 export type TelemetryEventKind = 'error' | 'transaction' | 'session' | 'crash' | 'other';

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -29,6 +29,14 @@ export const TELEMETRY_DEFAULTS: TelemetryPreferences = {
   analytics: false,
 };
 
+/**
+ * Sentry `tracesSampleRate` when the performance channel is on. The sampling
+ * decision is made independently in each process (main + renderer), so both
+ * inits must use this same value — keep it here as the single source of truth so
+ * the two can't drift.
+ */
+export const TELEMETRY_TRACES_SAMPLE_RATE = 0.1;
+
 /** True when at least one channel is on — i.e. the SDK should be initialised. */
 export function isTelemetryEnabled(prefs: TelemetryPreferences): boolean {
   return prefs.errorReports || prefs.nativeCrashReports || prefs.performance || prefs.analytics;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -30,12 +30,19 @@ export const TELEMETRY_DEFAULTS: TelemetryPreferences = {
 };
 
 /**
- * Sentry `tracesSampleRate` when the performance channel is on. The sampling
- * decision is made independently in each process (main + renderer), so both
- * inits must use this same value — keep it here as the single source of truth so
- * the two can't drift.
+ * Sentry `tracesSampleRate` when the performance channel is on. Production
+ * samples a fraction — enough volume for p95/p99 latency trends across releases
+ * while staying well under Sentry's quota; local dev (only ever emits when a DSN
+ * is set) samples everything so a developer sees every trace they generate. The
+ * sampling decision is made independently in each process (main + renderer), so
+ * both resolve it from here — one source of truth so the two can't drift.
  */
-export const TELEMETRY_TRACES_SAMPLE_RATE = 0.1;
+export const TELEMETRY_TRACES_SAMPLE_RATE_DEV = 1.0;
+export const TELEMETRY_TRACES_SAMPLE_RATE_PROD = 0.1;
+
+export function resolveTracesSampleRate(isDev: boolean): number {
+  return isDev ? TELEMETRY_TRACES_SAMPLE_RATE_DEV : TELEMETRY_TRACES_SAMPLE_RATE_PROD;
+}
 
 /** True when at least one channel is on — i.e. the SDK should be initialised. */
 export function isTelemetryEnabled(prefs: TelemetryPreferences): boolean {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -4,6 +4,7 @@ import { QueryLog } from '../query-log.js';
 import { awaitWithTimeout } from '../async-timeout.js';
 import { computeDefaultPoolSize } from '../duckdb-tuning.js';
 import { RollupStore, type BuildPartitionSql, type RollupShape } from '../rollup-store.js';
+import { traceSpan, SPAN_OP } from '../telemetry/tracing.js';
 import {
   asDimensionId,
   applyNormalizationRule,
@@ -494,7 +495,10 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const cached = resultCache.get(sql);
     if (cached !== undefined) return Promise.resolve(cached);
     return dedup(sql, async () => {
-      const result = await wrappedRunQuery(sql);
+      const result = await traceSpan(
+        { name: 'duckdb.query', op: SPAN_OP.dbQuery, attributes: { 'db.system': 'duckdb' } },
+        () => wrappedRunQuery(sql),
+      );
       if (result.length > 0) resultCache.set(sql, result);
       return result;
     });
@@ -510,7 +514,10 @@ export function createAppContext(ctx: IpcContext): AppContext {
       return Promise.resolve(cached);
     }
     return dedup(key, async () => {
-      const result = await wrappedRunPreparedQuery(sql, params, materialized);
+      const result = await traceSpan(
+        { name: 'duckdb.query', op: SPAN_OP.dbQuery, attributes: { 'db.system': 'duckdb', 'db.prepared': true } },
+        () => wrappedRunPreparedQuery(sql, params, materialized),
+      );
       if (result.length > 0) resultCache.set(key, result);
       return result;
     });

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -4,7 +4,7 @@ import { QueryLog } from '../query-log.js';
 import { awaitWithTimeout } from '../async-timeout.js';
 import { computeDefaultPoolSize } from '../duckdb-tuning.js';
 import { RollupStore, type BuildPartitionSql, type RollupShape } from '../rollup-store.js';
-import { traceSpan, SPAN_OP } from '../telemetry/tracing.js';
+import { traceSpan, SPAN_OP, type SpanOptions } from '../telemetry/tracing.js';
 import {
   asDimensionId,
   applyNormalizationRule,
@@ -465,6 +465,12 @@ export function createAppContext(ctx: IpcContext): AppContext {
     return fetch;
   }
 
+  // Static span options, hoisted out of the per-call closures so a query/build
+  // with tracing OFF (the common case) allocates nothing on the hot path.
+  const QUERY_SPAN: SpanOptions = { name: 'duckdb.query', op: SPAN_OP.dbQuery, attributes: { 'db.system': 'duckdb' } };
+  const PREPARED_QUERY_SPAN: SpanOptions = { name: 'duckdb.query', op: SPAN_OP.dbQuery, attributes: { 'db.system': 'duckdb', 'db.prepared': true } };
+  const ROLLUP_BUILD_SPAN: SpanOptions = { name: 'rollup.build', op: SPAN_OP.rollupBuild };
+
   const queryLog = new QueryLog();
   const rollupStore = new RollupStore({
     dataDir: ctx.dataDir,
@@ -472,7 +478,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     // Partition builds run on a fresh, disposable connection (flat per-build
     // time) and fan out across the DuckDB pool so a full-history rebuild is
     // ~pool-size faster than the old sequential pass.
-    runBuild: (sql) => ctx.db.runBuildQuery(sql),
+    runBuild: (sql) => traceSpan(ROLLUP_BUILD_SPAN, () => ctx.db.runBuildQuery(sql)),
     buildConcurrency: computeDefaultPoolSize(),
   });
   const resultCache = new LRUCache<string, RawRow[]>(50);
@@ -495,10 +501,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
     const cached = resultCache.get(sql);
     if (cached !== undefined) return Promise.resolve(cached);
     return dedup(sql, async () => {
-      const result = await traceSpan(
-        { name: 'duckdb.query', op: SPAN_OP.dbQuery, attributes: { 'db.system': 'duckdb' } },
-        () => wrappedRunQuery(sql),
-      );
+      const result = await traceSpan(QUERY_SPAN, () => wrappedRunQuery(sql));
       if (result.length > 0) resultCache.set(sql, result);
       return result;
     });
@@ -514,10 +517,7 @@ export function createAppContext(ctx: IpcContext): AppContext {
       return Promise.resolve(cached);
     }
     return dedup(key, async () => {
-      const result = await traceSpan(
-        { name: 'duckdb.query', op: SPAN_OP.dbQuery, attributes: { 'db.system': 'duckdb', 'db.prepared': true } },
-        () => wrappedRunPreparedQuery(sql, params, materialized),
-      );
+      const result = await traceSpan(PREPARED_QUERY_SPAN, () => wrappedRunPreparedQuery(sql, params, materialized));
       if (result.length > 0) resultCache.set(key, result);
       return result;
     });
@@ -612,7 +612,10 @@ export function createAppContext(ctx: IpcContext): AppContext {
       const etags = await getEtagsByPeriod();
       if (!rollupStore.isReady()) await rollupStore.loadAndValidate(shape, etags);
       const buildSql = await buildRollupSqlFor();
-      await rollupStore.maintainPeriods(periods, buildSql, etags, shape, { force: true });
+      await traceSpan(
+        { name: 'rollup.maintain', op: SPAN_OP.rollupMaintain, forceTransaction: true, attributes: { 'rollup.periods': periods.length } },
+        () => rollupStore.maintainPeriods(periods, buildSql, etags, shape, { force: true }),
+      );
       resultCache.clear();
     } catch (err: unknown) {
       logger.warn(`rollup-maintain: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/desktop/src/main/handlers/context.ts
+++ b/packages/desktop/src/main/handlers/context.ts
@@ -603,7 +603,13 @@ export function createAppContext(ctx: IpcContext): AppContext {
       const toBuild = available.filter(p => !validation.validPeriods.has(p)).sort((a, b) => b.localeCompare(a));
       if (toBuild.length === 0) { rollupStore.markSettled(); return; }
       const buildSql = await buildRollupSqlFor();
-      void rollupStore.maintainPeriods(toBuild, buildSql, etags, shape).then(() => { resultCache.clear(); });
+      // Wrap the fire-and-forget rebuild in a transaction (the span is tied to the
+      // promise, so it stays open until the background builds settle), mirroring
+      // rollup.maintain — the rollup.build child spans nest under it.
+      void traceSpan(
+        { name: 'rollup.warmup', op: SPAN_OP.rollupWarmup, forceTransaction: true, attributes: { 'rollup.periods': toBuild.length } },
+        () => rollupStore.maintainPeriods(toBuild, buildSql, etags, shape),
+      ).then(() => { resultCache.clear(); });
     } catch (err: unknown) {
       rollupStore.markSettled();
       logger.warn(`rollup-warmup: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -32,6 +32,7 @@ import {
   toUserFriendlyError,
 } from './context.js';
 import { triggerAutoSyncNow } from '../auto-sync.js';
+import { traceSpan, SPAN_OP } from '../telemetry/tracing.js';
 
 type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
 
@@ -257,7 +258,20 @@ export function registerSyncHandlers(app: AppContext): void {
     const tier = resolveDataType(syncId);
 
     try {
-      const result = await runSync(ctx, provider.credentials.profile, bucketPath, tier, fileEntries, syncId, state);
+      const result = await traceSpan(
+        {
+          name: 'sync.s3',
+          op: SPAN_OP.sync,
+          forceTransaction: true,
+          attributes: { 'sync.tier': tier, 'sync.files_requested': fileEntries.length },
+        },
+        async (span) => {
+          const r = await runSync(ctx, provider.credentials.profile, bucketPath, tier, fileEntries, syncId, state);
+          span?.setAttribute('sync.files_downloaded', r.filesDownloaded);
+          span?.setAttribute('sync.rows_processed', r.rowsProcessed);
+          return r;
+        },
+      );
       syncWorkerIds.delete(syncId);
 
       const now = new Date();

--- a/packages/desktop/src/main/telemetry/controller.ts
+++ b/packages/desktop/src/main/telemetry/controller.ts
@@ -11,6 +11,7 @@ import {
   QUERY_CANCELLED_MESSAGE,
   summarizeEventForOutbox,
   TELEMETRY_DEFAULTS,
+  TELEMETRY_TRACES_SAMPLE_RATE,
 } from '@costgoblin/core';
 import type { TelemetryPreferences, TelemetryStatus } from '@costgoblin/core';
 import { redactEventInPlace } from './scrub-event.js';
@@ -84,6 +85,15 @@ class TelemetryController {
     };
   }
 
+  /** True when performance tracing is actually armed this session — the gate the
+   *  span helpers ({@link ./tracing}) consult before creating any Sentry span.
+   *  Mirrors {@link armedChannels}'s performance value (SDK active, armed at boot,
+   *  still wanted); when false the helpers are pure pass-throughs that create no
+   *  SDK objects, so the hot query path pays nothing for non-opted-in users. */
+  isTracingActive(): boolean {
+    return this.armedChannels().performance;
+  }
+
   async getOutbox(): ReturnType<TelemetryOutbox['list']> {
     return this.outbox === null ? [] : this.outbox.list();
   }
@@ -142,7 +152,7 @@ class TelemetryController {
         integrations: (defaults) =>
           this.prefs.nativeCrashReports ? defaults : defaults.filter((i) => i.name !== 'SentryMinidump'),
         // Tracing only when the performance channel is on.
-        tracesSampleRate: this.prefs.performance ? 0.1 : 0,
+        tracesSampleRate: this.prefs.performance ? TELEMETRY_TRACES_SAMPLE_RATE : 0,
         // Never let the SDK attach IP/user/cookies — our scrub is the backstop,
         // but default-off is the first line of defence.
         sendDefaultPii: false,

--- a/packages/desktop/src/main/telemetry/controller.ts
+++ b/packages/desktop/src/main/telemetry/controller.ts
@@ -9,9 +9,9 @@ import {
   isTelemetryEnabled,
   logger,
   QUERY_CANCELLED_MESSAGE,
+  resolveTracesSampleRate,
   summarizeEventForOutbox,
   TELEMETRY_DEFAULTS,
-  TELEMETRY_TRACES_SAMPLE_RATE,
 } from '@costgoblin/core';
 import type { TelemetryPreferences, TelemetryStatus } from '@costgoblin/core';
 import { redactEventInPlace } from './scrub-event.js';
@@ -87,11 +87,12 @@ class TelemetryController {
 
   /** True when performance tracing is actually armed this session — the gate the
    *  span helpers ({@link ./tracing}) consult before creating any Sentry span.
-   *  Mirrors {@link armedChannels}'s performance value (SDK active, armed at boot,
-   *  still wanted); when false the helpers are pure pass-throughs that create no
-   *  SDK objects, so the hot query path pays nothing for non-opted-in users. */
+   *  Equivalent to {@link armedChannels}'s performance value (SDK active, armed at
+   *  boot, still wanted) but inlined: this runs on the hot query path, so it must
+   *  not allocate the way armedChannels() does. When false the helpers are pure
+   *  pass-throughs that create no SDK objects, so opted-out users pay nothing. */
   isTracingActive(): boolean {
-    return this.armedChannels().performance;
+    return this.active && this.initSnapshot !== null && this.initSnapshot.performance && this.prefs.performance;
   }
 
   async getOutbox(): ReturnType<TelemetryOutbox['list']> {
@@ -151,8 +152,9 @@ class TelemetryController {
         // arms the native crash handler. Scrubbed JS error capture flows either way.
         integrations: (defaults) =>
           this.prefs.nativeCrashReports ? defaults : defaults.filter((i) => i.name !== 'SentryMinidump'),
-        // Tracing only when the performance channel is on.
-        tracesSampleRate: this.prefs.performance ? TELEMETRY_TRACES_SAMPLE_RATE : 0,
+        // Tracing only when the performance channel is on. Dev (unpackaged, with
+        // a DSN set) samples everything; packaged releases sample at the prod rate.
+        tracesSampleRate: this.prefs.performance ? resolveTracesSampleRate(!app.isPackaged) : 0,
         // Never let the SDK attach IP/user/cookies — our scrub is the backstop,
         // but default-off is the first line of defence.
         sendDefaultPii: false,

--- a/packages/desktop/src/main/telemetry/controller.ts
+++ b/packages/desktop/src/main/telemetry/controller.ts
@@ -68,7 +68,16 @@ class TelemetryController {
       active: this.active,
       preferences: this.prefs,
       armed: this.armedChannels(),
+      tracesSampleRate: this.tracesSampleRate(),
     };
+  }
+
+  /** The Sentry `tracesSampleRate` this build uses for performance tracing — dev
+   *  (unpackaged) samples everything, packaged releases sample the prod fraction.
+   *  Resolved once here from `app.isPackaged` and surfaced via {@link getStatus}
+   *  so the renderer samples at the same rate (no cross-process drift). */
+  private tracesSampleRate(): number {
+    return resolveTracesSampleRate(!app.isPackaged);
   }
 
   /** What each channel is *actually* doing this session (vs. the desired state in
@@ -154,7 +163,7 @@ class TelemetryController {
           this.prefs.nativeCrashReports ? defaults : defaults.filter((i) => i.name !== 'SentryMinidump'),
         // Tracing only when the performance channel is on. Dev (unpackaged, with
         // a DSN set) samples everything; packaged releases sample at the prod rate.
-        tracesSampleRate: this.prefs.performance ? resolveTracesSampleRate(!app.isPackaged) : 0,
+        tracesSampleRate: this.prefs.performance ? this.tracesSampleRate() : 0,
         // Never let the SDK attach IP/user/cookies — our scrub is the backstop,
         // but default-off is the first line of defence.
         sendDefaultPii: false,

--- a/packages/desktop/src/main/telemetry/tracing.ts
+++ b/packages/desktop/src/main/telemetry/tracing.ts
@@ -10,11 +10,18 @@ import { telemetry } from './controller.js';
 export const SPAN_OP = {
   /** One DuckDB query round-trip (main → worker → main). */
   dbQuery: 'db.query',
+  /** One rollup partition build (a single period, on a fresh connection). */
+  rollupBuild: 'rollup.build',
+  /** A post-sync rollup re-roll over the periods a sync changed. */
+  rollupMaintain: 'rollup.maintain',
   /** One S3 selective-sync run (download + ingest of a set of periods). */
   sync: 'sync.s3',
 } as const;
 
-type StartSpanOptions = Parameters<typeof Sentry.startSpan>[0];
+/** Options accepted by {@link traceSpan} — Sentry's `startSpan` options. Exported
+ *  so call sites can hoist static span options to module constants (no per-call
+ *  allocation on the hot path) without importing the Sentry SDK themselves. */
+export type SpanOptions = Parameters<typeof Sentry.startSpan>[0];
 
 /**
  * Run `fn` inside a Sentry span when performance tracing is armed; otherwise call
@@ -27,7 +34,7 @@ type StartSpanOptions = Parameters<typeof Sentry.startSpan>[0];
  * when tracing is off) so callers can attach result attributes — row counts,
  * byte totals — after the work completes.
  */
-export function traceSpan<T>(options: StartSpanOptions, fn: (span: Span | undefined) => T): T {
+export function traceSpan<T>(options: SpanOptions, fn: (span: Span | undefined) => T): T {
   if (!telemetry.isTracingActive()) return fn(undefined);
   return Sentry.startSpan(options, (span) => fn(span));
 }

--- a/packages/desktop/src/main/telemetry/tracing.ts
+++ b/packages/desktop/src/main/telemetry/tracing.ts
@@ -12,6 +12,8 @@ export const SPAN_OP = {
   dbQuery: 'db.query',
   /** One rollup partition build (a single period, on a fresh connection). */
   rollupBuild: 'rollup.build',
+  /** The startup warm-load rebuild of missing/stale partitions. */
+  rollupWarmup: 'rollup.warmup',
   /** A post-sync rollup re-roll over the periods a sync changed. */
   rollupMaintain: 'rollup.maintain',
   /** One S3 selective-sync run (download + ingest of a set of periods). */

--- a/packages/desktop/src/main/telemetry/tracing.ts
+++ b/packages/desktop/src/main/telemetry/tracing.ts
@@ -1,0 +1,33 @@
+import * as Sentry from '@sentry/electron/main';
+import type { Span } from '@sentry/electron/main';
+import { telemetry } from './controller.js';
+
+/**
+ * Low-cardinality Sentry span `op` strings for the main-process operations we
+ * instrument. Centralised so every emit site — and any future dashboard or
+ * alert keyed off these ops — stays in lockstep.
+ */
+export const SPAN_OP = {
+  /** One DuckDB query round-trip (main → worker → main). */
+  dbQuery: 'db.query',
+  /** One S3 selective-sync run (download + ingest of a set of periods). */
+  sync: 'sync.s3',
+} as const;
+
+type StartSpanOptions = Parameters<typeof Sentry.startSpan>[0];
+
+/**
+ * Run `fn` inside a Sentry span when performance tracing is armed; otherwise call
+ * it directly — a pure pass-through that constructs no SDK objects, so the hot
+ * query path costs nothing for the (near-total) majority who never opt in.
+ *
+ * The span finishes automatically once `fn`'s result settles (a returned promise
+ * is awaited by the SDK). With no active parent it becomes its own transaction;
+ * inside another span it nests. `fn` receives the live `Span` (or `undefined`
+ * when tracing is off) so callers can attach result attributes — row counts,
+ * byte totals — after the work completes.
+ */
+export function traceSpan<T>(options: StartSpanOptions, fn: (span: Span | undefined) => T): T {
+  if (!telemetry.isTracingActive()) return fn(undefined);
+  return Sentry.startSpan(options, (span) => fn(span));
+}

--- a/packages/desktop/src/renderer/telemetry/renderer-telemetry.ts
+++ b/packages/desktop/src/renderer/telemetry/renderer-telemetry.ts
@@ -1,4 +1,4 @@
-import { TELEMETRY_TRACES_SAMPLE_RATE } from '@costgoblin/core/browser';
+import { resolveTracesSampleRate } from '@costgoblin/core/browser';
 import type { TelemetryStatus } from '@costgoblin/core/browser';
 
 let initialized = false;
@@ -33,7 +33,10 @@ export async function syncRendererTelemetry(status: TelemetryStatus): Promise<vo
     const Sentry = await import('@sentry/electron/renderer');
     Sentry.init({
       ...(wantTracing
-        ? { tracesSampleRate: TELEMETRY_TRACES_SAMPLE_RATE, integrations: [Sentry.browserTracingIntegration()] }
+        ? {
+            tracesSampleRate: resolveTracesSampleRate(globalThis.costgoblinDebug.isDev()),
+            integrations: [Sentry.browserTracingIntegration()],
+          }
         : {}),
     });
   } catch {

--- a/packages/desktop/src/renderer/telemetry/renderer-telemetry.ts
+++ b/packages/desktop/src/renderer/telemetry/renderer-telemetry.ts
@@ -1,4 +1,3 @@
-import { resolveTracesSampleRate } from '@costgoblin/core/browser';
 import type { TelemetryStatus } from '@costgoblin/core/browser';
 
 let initialized = false;
@@ -16,8 +15,8 @@ let initialized = false;
  * at boot, so we key off `armed.performance` — the channel state the main
  * process actually init'd with — to avoid emitting transactions the main gate
  * would only drop. The browser-tracing integration auto-creates pageload +
- * navigation transactions; their sampling is decided here in the renderer, so
- * the rate must be set on this init too (the same value the main process uses).
+ * navigation transactions; the sample rate comes from `status.tracesSampleRate`
+ * (resolved once in the main process) so both processes sample identically.
  *
  * Idempotent (one init per session) and fail-safe: a bundling/SDK failure is
  * swallowed so it can never break the UI. The sole caller runs once on mount, so
@@ -33,10 +32,7 @@ export async function syncRendererTelemetry(status: TelemetryStatus): Promise<vo
     const Sentry = await import('@sentry/electron/renderer');
     Sentry.init({
       ...(wantTracing
-        ? {
-            tracesSampleRate: resolveTracesSampleRate(globalThis.costgoblinDebug.isDev()),
-            integrations: [Sentry.browserTracingIntegration()],
-          }
+        ? { tracesSampleRate: status.tracesSampleRate, integrations: [Sentry.browserTracingIntegration()] }
         : {}),
     });
   } catch {

--- a/packages/desktop/src/renderer/telemetry/renderer-telemetry.ts
+++ b/packages/desktop/src/renderer/telemetry/renderer-telemetry.ts
@@ -1,14 +1,23 @@
+import { TELEMETRY_TRACES_SAMPLE_RATE } from '@costgoblin/core/browser';
 import type { TelemetryStatus } from '@costgoblin/core/browser';
 
 let initialized = false;
 
 /**
- * Lazily initialise the renderer-side Sentry SDK once the user has opted into
- * crash reports and the main-process reporter is active. Renderer events are
- * forwarded over IPC to the main process, where the `beforeSend` scrub and the
- * channel gate apply — so the renderer never holds a DSN and never sends
- * anything on its own; turning the channel back off makes the main process drop
- * whatever the renderer forwards.
+ * Lazily initialise the renderer-side Sentry SDK once the user has armed crash
+ * reports or performance tracing and the main-process reporter is active.
+ * Renderer events are forwarded over IPC to the main process, where the
+ * `beforeSend` / `beforeSendTransaction` scrub and the channel gate apply — so
+ * the renderer never holds a DSN and never sends anything on its own; turning a
+ * channel back off makes the main process drop whatever the renderer forwards.
+ *
+ * Gating: `errorReports` applies live (its gate is re-checked per event in the
+ * main process), so we key off the desired preference. Performance tracing arms
+ * at boot, so we key off `armed.performance` — the channel state the main
+ * process actually init'd with — to avoid emitting transactions the main gate
+ * would only drop. The browser-tracing integration auto-creates pageload +
+ * navigation transactions; their sampling is decided here in the renderer, so
+ * the rate must be set on this init too (the same value the main process uses).
  *
  * Idempotent (one init per session) and fail-safe: a bundling/SDK failure is
  * swallowed so it can never break the UI. The sole caller runs once on mount, so
@@ -16,11 +25,17 @@ let initialized = false;
  * `initialized = false` reset only helps if a future caller retries.
  */
 export async function syncRendererTelemetry(status: TelemetryStatus): Promise<void> {
-  if (initialized || !status.active || !status.preferences.errorReports) return;
+  const wantErrors = status.preferences.errorReports;
+  const wantTracing = status.armed.performance;
+  if (initialized || !status.active || (!wantErrors && !wantTracing)) return;
   initialized = true;
   try {
     const Sentry = await import('@sentry/electron/renderer');
-    Sentry.init({});
+    Sentry.init({
+      ...(wantTracing
+        ? { tracesSampleRate: TELEMETRY_TRACES_SAMPLE_RATE, integrations: [Sentry.browserTracingIntegration()] }
+        : {}),
+    });
   } catch {
     initialized = false;
   }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -495,7 +495,7 @@ export class MockCostApi implements CostApi {
   }
   getTelemetryPreferences(): Promise<TelemetryPreferences> { return Promise.resolve({ errorReports: false, nativeCrashReports: false, performance: false, analytics: false }); }
   setTelemetryPreferences(): Promise<void> { return Promise.resolve(); }
-  getTelemetryStatus(): Promise<TelemetryStatus> { return Promise.resolve({ dsnConfigured: false, active: false, preferences: { errorReports: false, nativeCrashReports: false, performance: false, analytics: false }, armed: { errorReports: false, nativeCrashReports: false, performance: false, analytics: false } }); }
+  getTelemetryStatus(): Promise<TelemetryStatus> { return Promise.resolve({ dsnConfigured: false, active: false, preferences: { errorReports: false, nativeCrashReports: false, performance: false, analytics: false }, armed: { errorReports: false, nativeCrashReports: false, performance: false, analytics: false }, tracesSampleRate: 0 }); }
   getTelemetryOutbox(): Promise<readonly TelemetryOutboxEntry[]> { return Promise.resolve([]); }
   exportConfigBundle(): Promise<ExportConfigBundleResult> {
     return Promise.resolve({ status: 'saved', path: '/mock/costgoblin-config-2026-06-11.yaml' });


### PR DESCRIPTION
## Summary

Sentry performance tracing was **wired but inert** — the sample rate, channel gate, transaction scrub, and audit-outbox "Trace" label all existed, but nothing ever *started* a span. So Sentry's Performance view stayed empty even with the channel on and a DSN configured. This PR adds the missing span producers.

## What's added

- **`traceSpan` helper** (`telemetry/tracing.ts`) — runs work inside a Sentry span when performance tracing is armed, and is a zero-cost pass-through (creates no SDK objects) for the ~all users who never opt in.
- **`db.query` spans** around the central `runQuery` / `runPreparedQuery` choke point in `context.ts` (cache hits skipped).
- **`sync.s3` transaction** around the S3 selective sync, tagged with tier / files requested / files downloaded / rows processed.
- **`browserTracingIntegration`** in the renderer for pageload + navigation transactions. The renderer SDK now also inits when `performance` is armed (previously error-reports only); transactions forward over IPC to the main client where the same `beforeSendTransaction` scrub + gate apply.
- **Shared `TELEMETRY_TRACES_SAMPLE_RATE` (0.1)** in core, so the main and renderer sampling decisions can't drift.

Gated on the `performance` preference (off by default) plus a configured DSN — no behavior change for users who haven't opted in.

## Note on the SDK version

`@sentry/electron@^7.14.0` is the Electron *wrapper* version; it is independently versioned and built on **Sentry v10** (`@sentry/core/node/browser@10.60.0`). The code therefore uses the v10 OTEL `startSpan` / `browserTracingIntegration` API, not the legacy v7 hub API.

## Verification

Ran the packaged app against fixture data with a dummy DSN and `performance` enabled, then inspected the local audit outbox (every event handed to the transport is mirrored there post-scrub):

- **24 transactions emitted** — 23 `duckdb.query` + 1 pageload.
- The pageload transaction name came through as `/Users/[user]/…`, confirming the PII scrub also redacts transaction data.

`npm run check` passes (tsc + eslint + 883 tests).