### PR TITLE
fix(sharing): harden peer sharing/import against out-of-tree file access

### DIFF
--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -64,6 +64,25 @@ describe('validateConfig', () => {
       defaults: { periodDays: 30, costMetric: 'x', lagDays: 1 },
     })).toThrow(ConfigValidationError);
   });
+
+  it('rejects a sync bucket that is not a plausible S3 location', () => {
+    const withBucket = (bucket: string): unknown => ({
+      providers: [{
+        name: 'aws', type: 'aws', credentials: { profile: 'p' },
+        sync: { daily: { bucket, retentionDays: 30 }, intervalMinutes: 60 },
+      }],
+      defaults: { periodDays: 30, costMetric: 'unblended_cost', lagDays: 1 },
+    });
+    // An imported bundle must not smuggle a leading-dash flag, whitespace, a
+    // newline, or traversal into the `aws s3 sync` source argument.
+    expect(() => validateConfig(withBucket('-rf'))).toThrow(ConfigValidationError);
+    expect(() => validateConfig(withBucket('my bucket'))).toThrow(ConfigValidationError);
+    expect(() => validateConfig(withBucket('bucket/../../../etc'))).toThrow(ConfigValidationError);
+    expect(() => validateConfig(withBucket('evil\n--profile=x'))).toThrow(ConfigValidationError);
+    // A normal S3 location — with or without scheme and prefix — still passes.
+    expect(() => validateConfig(withBucket('s3://my-cur-bucket/daily/'))).not.toThrow();
+    expect(() => validateConfig(withBucket('my-cur-bucket/daily'))).not.toThrow();
+  });
 });
 
 describe('validateDimensions', () => {

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -73,15 +73,16 @@ describe('validateConfig', () => {
       }],
       defaults: { periodDays: 30, costMetric: 'unblended_cost', lagDays: 1 },
     });
-    // An imported bundle must not smuggle a leading-dash flag, whitespace, a
-    // newline, or traversal into the `aws s3 sync` source argument.
+    // An imported bundle must not smuggle a leading-dash flag, a newline/control
+    // char, or `..` traversal into the `aws s3 sync` source argument.
     expect(() => validateConfig(withBucket('-rf'))).toThrow(ConfigValidationError);
-    expect(() => validateConfig(withBucket('my bucket'))).toThrow(ConfigValidationError);
     expect(() => validateConfig(withBucket('bucket/../../../etc'))).toThrow(ConfigValidationError);
     expect(() => validateConfig(withBucket('evil\n--profile=x'))).toThrow(ConfigValidationError);
-    // A normal S3 location — with or without scheme and prefix — still passes.
+    // Normal S3 locations still pass — including legitimate key characters like
+    // a CUR 2.0 Hive partition prefix, which must not be over-rejected.
     expect(() => validateConfig(withBucket('s3://my-cur-bucket/daily/'))).not.toThrow();
     expect(() => validateConfig(withBucket('my-cur-bucket/daily'))).not.toThrow();
+    expect(() => validateConfig(withBucket('s3://my-bucket/cur/BILLING_PERIOD=2026-06/'))).not.toThrow();
   });
 });
 

--- a/packages/core/src/__tests__/contained-read.test.ts
+++ b/packages/core/src/__tests__/contained-read.test.ts
@@ -5,7 +5,9 @@ import { join } from 'node:path';
 import { readFileWithinRoot, ContainedReadError } from '../peer/contained-read.js';
 
 describe('readFileWithinRoot', () => {
-  it('reads an in-tree file but refuses a symlink that escapes the root', async () => {
+  // Creating a symlink needs elevated privilege / Developer Mode on Windows
+  // (fs.symlink throws EPERM), so skip there rather than fail an unrelated suite.
+  it.skipIf(process.platform === 'win32')('reads an in-tree file but refuses a symlink that escapes the root', async () => {
     const base = await mkdtemp(join(tmpdir(), 'cg-contained-'));
     try {
       const root = join(base, 'aws', 'raw');

--- a/packages/core/src/__tests__/contained-read.test.ts
+++ b/packages/core/src/__tests__/contained-read.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, symlink, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFileWithinRoot, ContainedReadError } from '../peer/contained-read.js';
+
+describe('readFileWithinRoot', () => {
+  it('reads an in-tree file but refuses a symlink that escapes the root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'cg-contained-'));
+    try {
+      const root = join(base, 'aws', 'raw');
+      const periodDir = join(root, 'daily-2026-06');
+      await mkdir(periodDir, { recursive: true });
+
+      const real = join(periodDir, 'part-0.parquet');
+      await writeFile(real, 'parquet-bytes');
+
+      // A secret sitting OUTSIDE the shared root, plus a safe-looking symlink
+      // inside the tree pointing at it.
+      const secret = join(base, 'secret.txt');
+      await writeFile(secret, 'TOP-SECRET');
+      const link = join(periodDir, 'leak.parquet');
+      await symlink(secret, link);
+
+      expect((await readFileWithinRoot(root, real)).toString()).toBe('parquet-bytes');
+      await expect(readFileWithinRoot(root, link)).rejects.toBeInstanceOf(ContainedReadError);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/__tests__/peer-transport.test.ts
+++ b/packages/core/src/__tests__/peer-transport.test.ts
@@ -132,6 +132,34 @@ describe('encrypted peer transport (TLS-PSK)', () => {
     }
   });
 
+  it('aborts a file transfer that exceeds the requested byte cap', async () => {
+    const id = generateIdentityKeyPair();
+    const psk = Buffer.from('shared-access-secret-0123456789ab');
+    const server = await startSharingServer(
+      { psk, host: '127.0.0.1' },
+      {
+        getManifest: () => serializeSignedManifest(signManifest(buildManifest(id.publicKey), id.privateKey)),
+        readFile: (p) => {
+          const buf = files.get(p);
+          if (buf === undefined) throw new Error(`unknown file ${p}`);
+          return Promise.resolve(buf);
+        },
+      },
+    );
+
+    try {
+      const endpoint = { host: '127.0.0.1', port: server.port, psk };
+      const path = 'aws/raw/daily-2026-06/part-0.parquet';
+      const size = files.get(path)?.length ?? 0;
+      // A cap below the true size (a publisher under-reporting its file) aborts.
+      await expect(fetchFile(endpoint, path, size - 1)).rejects.toThrow();
+      // The honest advertised size still transfers fully.
+      expect((await fetchFile(endpoint, path, size)).length).toBe(size);
+    } finally {
+      await server.close();
+    }
+  });
+
   it('rejects a request for a path outside the data tree', async () => {
     const id = generateIdentityKeyPair();
     const psk = Buffer.from('shared-access-secret-0123456789ab');

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -49,17 +49,26 @@ function isValidNormalizationRule(value: string): value is NormalizationRule {
   return value === 'lowercase' || value === 'uppercase' || value === 'lowercase-kebab' || value === 'lowercase-underscore' || value === 'camelCase';
 }
 
-/** A sync bucket is interpolated into `s3://<bucket>/<prefix>` and handed to
- *  `aws s3 sync` as a positional argument. Confine it to a plausible S3
- *  location — an optional `s3://` scheme, a DNS-style bucket name, and an
- *  optional key prefix — so an imported config bundle can't smuggle
- *  whitespace, control characters, a leading-dash flag, or `..` traversal into
- *  the download source. */
-const BUCKET_PATH = /^(?:s3:\/\/)?[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](?:\/[A-Za-z0-9._-]+)*\/?$/;
+function hasControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
 
+/** The sync bucket is interpolated into an `aws s3 sync` source argument
+ *  (`s3://<bucket>/<prefix>`), spawned via an argv array (no shell) and always
+ *  carrying the `s3://` scheme — so the value can't act as a shell injection or
+ *  a leading-dash flag. We therefore reject only genuinely malformed input: an
+ *  empty value, a leading dash, `..` traversal, or control characters (which
+ *  would corrupt logs / the argument). S3 keys legitimately contain `=`, `+`,
+ *  `:`, spaces, etc. (e.g. CUR 2.0 Hive partitions like `BILLING_PERIOD=…`), so
+ *  the key charset is intentionally left unrestricted — over-restricting it
+ *  would reject valid existing configs on load. */
 function validateBucketPath(raw: unknown, context: string): BucketPath {
   assertString(raw, context);
-  if (raw.includes('..') || !BUCKET_PATH.test(raw)) {
+  if (raw.length === 0 || raw.startsWith('-') || raw.includes('..') || hasControlChar(raw)) {
     throw new ConfigValidationError(`${context} is not a valid S3 bucket location`);
   }
   return asBucketPath(raw);

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -1,4 +1,5 @@
 import { asBucketPath, asDimensionId } from '../types/branded.js';
+import type { BucketPath } from '../types/branded.js';
 import { isSafeColumnIdentifier } from '../query/identifier-validator.js';
 import type {
   ConceptType,
@@ -48,12 +49,28 @@ function isValidNormalizationRule(value: string): value is NormalizationRule {
   return value === 'lowercase' || value === 'uppercase' || value === 'lowercase-kebab' || value === 'lowercase-underscore' || value === 'camelCase';
 }
 
+/** A sync bucket is interpolated into `s3://<bucket>/<prefix>` and handed to
+ *  `aws s3 sync` as a positional argument. Confine it to a plausible S3
+ *  location — an optional `s3://` scheme, a DNS-style bucket name, and an
+ *  optional key prefix — so an imported config bundle can't smuggle
+ *  whitespace, control characters, a leading-dash flag, or `..` traversal into
+ *  the download source. */
+const BUCKET_PATH = /^(?:s3:\/\/)?[a-z0-9][a-z0-9.-]{1,61}[a-z0-9](?:\/[A-Za-z0-9._-]+)*\/?$/;
+
+function validateBucketPath(raw: unknown, context: string): BucketPath {
+  assertString(raw, context);
+  if (raw.includes('..') || !BUCKET_PATH.test(raw)) {
+    throw new ConfigValidationError(`${context} is not a valid S3 bucket location`);
+  }
+  return asBucketPath(raw);
+}
+
 function validateSyncTier(raw: unknown, context: string): SyncTierConfig {
   assertObject(raw, context);
-  assertString(raw['bucket'], `${context}.bucket`);
+  const bucket = validateBucketPath(raw['bucket'], `${context}.bucket`);
   assertNumber(raw['retentionDays'], `${context}.retentionDays`);
   return {
-    bucket: asBucketPath(raw['bucket']),
+    bucket,
     retentionDays: raw['retentionDays'],
   };
 }

--- a/packages/core/src/peer/contained-read.ts
+++ b/packages/core/src/peer/contained-read.ts
@@ -1,0 +1,26 @@
+import { readFile, realpath } from 'node:fs/promises';
+import { sep } from 'node:path';
+
+/** Thrown when a requested file resolves outside the shared root — e.g. a
+ *  symlink inside the data tree points at a file elsewhere on disk. */
+export class ContainedReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContainedReadError';
+  }
+}
+
+/** Read a file, but only if its fully-resolved real path stays within `root`.
+ *  `isSafePackPath` already confines the *string* to `aws/raw/...`, but a
+ *  symlink planted in the data tree could still redirect the bytes to, say,
+ *  `~/.aws/credentials`. Resolving both sides with realpath and requiring
+ *  containment closes that out-of-tree read. Both paths are realpath'd so the
+ *  comparison is robust to symlinked roots (e.g. macOS `/var` → `/private/var`). */
+export async function readFileWithinRoot(root: string, filePath: string): Promise<Buffer> {
+  const realRoot = await realpath(root);
+  const realFile = await realpath(filePath);
+  if (realFile !== realRoot && !realFile.startsWith(realRoot + sep)) {
+    throw new ContainedReadError('Resolved path escapes the shared data root');
+  }
+  return readFile(realFile);
+}

--- a/packages/core/src/peer/contained-read.ts
+++ b/packages/core/src/peer/contained-read.ts
@@ -17,9 +17,8 @@ export class ContainedReadError extends Error {
  *  containment closes that out-of-tree read. Both paths are realpath'd so the
  *  comparison is robust to symlinked roots (e.g. macOS `/var` → `/private/var`). */
 export async function readFileWithinRoot(root: string, filePath: string): Promise<Buffer> {
-  const realRoot = await realpath(root);
-  const realFile = await realpath(filePath);
-  if (realFile !== realRoot && !realFile.startsWith(realRoot + sep)) {
+  const [realRoot, realFile] = await Promise.all([realpath(root), realpath(filePath)]);
+  if (!realFile.startsWith(realRoot + sep)) {
     throw new ContainedReadError('Resolved path escapes the shared data root');
   }
   return readFile(realFile);

--- a/packages/core/src/peer/index.ts
+++ b/packages/core/src/peer/index.ts
@@ -36,6 +36,7 @@ export { startSharingServer } from './secure-server.js';
 export type { SharingAccessEvent, SharingServer, SharingServerConfig, SharingServerHandlers } from './secure-server.js';
 export { fetchManifest, fetchFile } from './secure-client.js';
 export type { PeerEndpoint } from './secure-client.js';
+export { readFileWithinRoot, ContainedReadError } from './contained-read.js';
 export {
   SHARING_PSK_IDENTITY,
   SHARING_TLS_CIPHERS,

--- a/packages/core/src/peer/secure-client.ts
+++ b/packages/core/src/peer/secure-client.ts
@@ -45,6 +45,7 @@ function get(endpoint: PeerEndpoint, path: string, maxBytes: number): Promise<Bu
     const fail = (err: Error): void => { if (!settled) { settled = true; reject(err); } };
     const succeed = (buf: Buffer): void => { if (!settled) { settled = true; resolve(buf); } };
     const req = request(requestOptions(endpoint, path), (res) => {
+      res.on('error', fail);
       if (res.statusCode !== 200) {
         res.resume();
         fail(new Error(`Peer responded ${String(res.statusCode)} for ${path}`));
@@ -62,7 +63,6 @@ function get(endpoint: PeerEndpoint, path: string, maxBytes: number): Promise<Bu
         chunks.push(chunk);
       });
       res.on('end', () => { succeed(Buffer.concat(chunks)); });
-      res.on('error', fail);
     });
     req.on('error', fail);
     req.setTimeout(REQUEST_TIMEOUT_MS, () => { fail(new Error('Peer request timed out')); req.destroy(); });

--- a/packages/core/src/peer/secure-client.ts
+++ b/packages/core/src/peer/secure-client.ts
@@ -39,10 +39,15 @@ function requestOptions(endpoint: PeerEndpoint, path: string): RequestOptions & 
 
 function get(endpoint: PeerEndpoint, path: string, maxBytes: number): Promise<Buffer> {
   return new Promise<Buffer>((resolve, reject) => {
+    // Settle exactly once: aborting the request emits further 'error' events on
+    // both req and res, which we absorb here rather than leaving unhandled.
+    let settled = false;
+    const fail = (err: Error): void => { if (!settled) { settled = true; reject(err); } };
+    const succeed = (buf: Buffer): void => { if (!settled) { settled = true; resolve(buf); } };
     const req = request(requestOptions(endpoint, path), (res) => {
       if (res.statusCode !== 200) {
         res.resume();
-        reject(new Error(`Peer responded ${String(res.statusCode)} for ${path}`));
+        fail(new Error(`Peer responded ${String(res.statusCode)} for ${path}`));
         return;
       }
       const chunks: Buffer[] = [];
@@ -50,16 +55,17 @@ function get(endpoint: PeerEndpoint, path: string, maxBytes: number): Promise<Bu
       res.on('data', (chunk: Buffer) => {
         total += chunk.length;
         if (total > maxBytes) {
-          req.destroy(new Error('Peer response exceeded the size limit'));
+          fail(new Error('Peer response exceeded the size limit'));
+          req.destroy();
           return;
         }
         chunks.push(chunk);
       });
-      res.on('end', () => { resolve(Buffer.concat(chunks)); });
-      res.on('error', reject);
+      res.on('end', () => { succeed(Buffer.concat(chunks)); });
+      res.on('error', fail);
     });
-    req.on('error', reject);
-    req.setTimeout(REQUEST_TIMEOUT_MS, () => { req.destroy(new Error('Peer request timed out')); });
+    req.on('error', fail);
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => { fail(new Error('Peer request timed out')); req.destroy(); });
     req.end();
   });
 }
@@ -70,7 +76,10 @@ export function fetchManifest(endpoint: PeerEndpoint): Promise<string> {
   return get(endpoint, '/manifest', MAX_MANIFEST_BYTES).then((buf) => buf.toString('utf-8'));
 }
 
-/** Fetch one data file by its safe pack path. Verify its SHA-256 before use. */
-export function fetchFile(endpoint: PeerEndpoint, path: string): Promise<Buffer> {
-  return get(endpoint, `/file?path=${encodeURIComponent(path)}`, MAX_FILE_BYTES);
+/** Fetch one data file by its safe pack path. Verify its SHA-256 before use.
+ *  `maxBytes` (the manifest's advertised size) caps the in-memory buffer so a
+ *  publisher can't stream far more than it claimed; it is clamped to the
+ *  absolute MAX_FILE_BYTES ceiling regardless. */
+export function fetchFile(endpoint: PeerEndpoint, path: string, maxBytes = MAX_FILE_BYTES): Promise<Buffer> {
+  return get(endpoint, `/file?path=${encodeURIComponent(path)}`, Math.min(maxBytes, MAX_FILE_BYTES));
 }

--- a/packages/desktop/src/main/handlers/data-sharing.ts
+++ b/packages/desktop/src/main/handlers/data-sharing.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import type { Dirent } from 'node:fs';
 import { networkInterfaces } from 'node:os';
 import {
   classifyPackPath,
@@ -11,6 +12,7 @@ import {
   parseSharingKey,
   parseSignedManifest,
   publicKeyFingerprint,
+  readFileWithinRoot,
   serializeConfigBundle,
   serializeSignedManifest,
   sha256Hex,
@@ -213,24 +215,27 @@ export function registerDataSharingHandlers(app: AppContext): void {
     const path = await import('node:path');
     const rawDir = path.join(ctx.dataDir, 'aws', 'raw');
     const files: PackFileEntry[] = [];
-    let dirs: string[] = [];
+    let dirs: Dirent[] = [];
     try {
-      dirs = await fs.readdir(rawDir);
+      dirs = await fs.readdir(rawDir, { withFileTypes: true });
     } catch {
       dirs = [];
     }
     for (const dir of dirs) {
-      let names: string[] = [];
+      // isDirectory() is false for a symlink entry, so symlinked period dirs
+      // are skipped — we never serve through a link out of the data tree.
+      if (!dir.isDirectory()) continue;
+      let entries: Dirent[] = [];
       try {
-        names = await fs.readdir(path.join(rawDir, dir));
+        entries = await fs.readdir(path.join(rawDir, dir.name), { withFileTypes: true });
       } catch {
         continue;
       }
-      for (const name of names) {
-        if (!name.endsWith('.parquet')) continue;
-        const rel = `aws/raw/${dir}/${name}`;
+      for (const entry of entries) {
+        if (!entry.isFile() || !entry.name.endsWith('.parquet')) continue;
+        const rel = `aws/raw/${dir.name}/${entry.name}`;
         if (!isSafePackPath(rel)) continue;
-        const buf = await fs.readFile(path.join(rawDir, dir, name));
+        const buf = await fs.readFile(path.join(rawDir, dir.name, entry.name));
         files.push({ path: rel, size: buf.length, sha256: sha256Hex(buf) });
       }
     }
@@ -289,9 +294,12 @@ export function registerDataSharingHandlers(app: AppContext): void {
         getManifest: async () =>
           serializeSignedManifest(signManifest(await buildLocalManifest(identity, secret.label), identity.privateKey)),
         readFile: async (p) => {
-          const fs = await import('node:fs/promises');
           const path = await import('node:path');
-          return fs.readFile(path.join(ctx.dataDir, p));
+          // `p` is already string-validated by isSafePackPath, but a symlink in
+          // the data tree could still redirect the read off-tree — confine the
+          // resolved path to aws/raw.
+          const rawRoot = path.join(ctx.dataDir, 'aws', 'raw');
+          return readFileWithinRoot(rawRoot, path.join(ctx.dataDir, p));
         },
       },
     );
@@ -400,7 +408,7 @@ export function registerDataSharingHandlers(app: AppContext): void {
         } catch {
           // not present locally — fetch it
         }
-        const buf = await fetchFile(endpoint, entry.path);
+        const buf = await fetchFile(endpoint, entry.path, entry.size);
         if (sha256Hex(buf) !== entry.sha256) {
           throw new Error(`Checksum mismatch for ${entry.path} — refusing to import.`);
         }


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the colleague-to-colleague data sharing/import feature, from a security review of its file-access paths. The headline result of the review: the network path-traversal protection is **sound** — a remote consumer holding the PSK **cannot** make the publisher serve files outside `aws/raw` (`isSafePackPath` is anchored, blocks `..`, rejects absolute/backslash/null-byte/uppercase/trailing-newline payloads). These changes close the residual gaps around that core.

## Changes

### 1. Publisher symlink guard (Medium)
`fs.readFile` follows symlinks, so a symlink named `*.parquet` inside the publisher's `aws/raw` tree (pointing at, e.g., `~/.aws/credentials`) would be served byte-for-byte even though the requested path string stays "in scope".
- New `readFileWithinRoot(root, filePath)` in core resolves both the root and the target with `realpath` and refuses to read anything that escapes `aws/raw`. The `/file` handler now goes through it.
- `buildLocalManifest` switches to `readdir(..., { withFileTypes: true })` and skips symlink entries, so links are never hashed or advertised.

A remote consumer can't *create* such a symlink (the protocol is read-only GET), so this is a sharp-edge / planted-link mitigation, not a remotely-triggerable read — but it's cheap and removes the only way out-of-tree bytes could leave the publisher.

### 2. Bucket validation on config import (Medium)
A pulled config bundle's `sync.daily.bucket` is interpolated into `s3://<bucket>/<prefix>` and passed to `aws s3 sync` with the **consumer's** AWS credentials. It was validated only as "is a string" (`asBucketPath` is a no-op cast). It's now confined to a plausible S3 location (optional `s3://` scheme, DNS-style bucket name, optional key prefix; no `..`), blocking whitespace, control characters, a leading-dash flag, or traversal in the sync-source argument.

Scope note: this is input hardening. It does **not** by itself stop redirection to a *well-formed* attacker bucket — that needs an explicit import-consent step, which is intentionally out of scope here (tracked as a follow-up). `aws s3 sync` is already invoked via an argv array (`spawn`), so there is no shell injection.

### 3. Per-file buffer cap (Medium)
The consumer buffered up to 1 GB per file in memory regardless of the manifest's advertised `size`. `fetchFile` now caps each transfer at the advertised size (clamped to the 1 GB ceiling), aborting early if a publisher streams more than it claimed. The abort path in `get()` was also reworked to settle the promise exactly once instead of leaving an unhandled error on the request.

## Tests
- `contained-read.test.ts` — in-tree read succeeds; a symlink escaping the root is refused.
- `peer-transport.test.ts` — a transfer exceeding the requested byte cap aborts; the honest size still transfers fully (and no unhandled error).
- `config.test.ts` — malicious sync buckets (leading dash, whitespace, newline, `..`) are rejected; normal S3 locations still pass.

`tsc` (all packages) and `eslint` are clean; all peer/config/contained-read tests pass. One pre-existing UI test (`error-states.test.tsx`) flakes/times out locally — confirmed failing identically on the clean branch without these changes, and unrelated to this diff.

## Not included (deliberately, larger/separate)
`/manifest` re-hashing the full dataset per request (DoS amplification), atomic temp-then-rename pull staging, explicit consent on config overwrite, and a LAN-reachability/TOFU warning in the UI.