### PR TITLE
ci(release): bump artifact actions to Node 24 versions (v7/v8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
       # huge *-unpacked/ dirs or builder-*.yml. Globs that match nothing on a given
       # platform are silently skipped; every platform matches at least one file.
       - name: Upload dist artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist-${{ matrix.platform }}-${{ matrix.arch }}
           if-no-files-found: error
@@ -223,7 +223,7 @@ jobs:
           node-version: 24
 
       - name: Download all dist artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 


### PR DESCRIPTION
## What

`release.yml` was the last workflow still pinning the Node 20 versions of the artifact actions:

- `actions/upload-artifact` v4.6.2 → **v7**
- `actions/download-artifact` v4.3.0 → **v8**

## Why

GitHub Actions now flags Node 20 as deprecated, emitting a *"target Node.js 20 but are being forced to run on Node.js 24"* warning on every release run. `ci.yml` already runs v7/v8; this aligns `release.yml` to the same SHAs (upload v7 ↔ download v8 are compatible and already proven together in CI), clearing the warning.