### PR TITLE
feat(data-mgmt): live sync/S3 activity log panel on Data & Sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -55,6 +55,7 @@ import type {
   MissingTagsResult,
   SavingsResult,
   SyncStatus,
+  SyncLogLine,
   TrendQueryParams,
   TrendResult,
 } from './query.js';
@@ -160,6 +161,14 @@ export interface CostApi {
   querySavings(): Promise<SavingsResult>;
   queryEntityDetail(params: EntityDetailParams): Promise<EntityDetailResult>;
   getSyncStatus(syncId?: string): Promise<SyncStatus>;
+  /** Current backlog of the live sync/S3 activity log (main-process ring
+   *  buffer, ephemeral — cleared on app restart). */
+  getSyncLog(): Promise<readonly SyncLogLine[]>;
+  /** Subscribe to new sync/S3 log lines as they're appended. Returns an
+   *  unsubscribe fn. Pushed via IPC, so no polling. */
+  subscribeSyncLog(listener: (line: SyncLogLine) => void): () => void;
+  /** Empty the sync/S3 activity log ring buffer. */
+  clearSyncLog(): Promise<void>;
   getConfig(): Promise<CostGoblinConfig>;
   getDimensions(): Promise<Dimension[]>;
   getOrgTree(): Promise<OrgNode[]>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -56,6 +56,7 @@ import type {
   SavingsResult,
   SyncStatus,
   SyncLogLine,
+  SyncLogLevel,
   TrendQueryParams,
   TrendResult,
 } from './query.js';
@@ -167,6 +168,10 @@ export interface CostApi {
   /** Subscribe to new sync/S3 log lines as they're appended. Returns an
    *  unsubscribe fn. Pushed via IPC, so no polling. */
   subscribeSyncLog(listener: (line: SyncLogLine) => void): () => void;
+  /** Append a renderer-originated line to the sync/S3 activity log — used by
+   *  on-demand actions (manual Sync/Prune) to narrate the S3 check, which
+   *  otherwise runs silently when there's nothing to download. */
+  appendSyncLog(level: SyncLogLevel, message: string): Promise<void>;
   /** Empty the sync/S3 activity log ring buffer. */
   clearSyncLog(): Promise<void>;
   getConfig(): Promise<CostGoblinConfig>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -62,6 +62,8 @@ export type {
   SavingsRecommendation,
   SavingsResult,
   SyncStatus,
+  SyncLogLevel,
+  SyncLogLine,
   QueryState,
 } from './query.js';
 export { DEFAULT_PLACEHOLDER_PATTERNS } from './query.js';

--- a/packages/core/src/types/query.ts
+++ b/packages/core/src/types/query.ts
@@ -252,6 +252,19 @@ export type SyncStatus =
   | { readonly status: 'completed'; readonly lastSync: Date; readonly filesDownloaded: number }
   | { readonly status: 'failed'; readonly error: Error; readonly lastSync: Date | null };
 
+export type SyncLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/** One line in the live, ephemeral sync/S3 activity log surfaced on the
+ *  Data & Sync screen. `seq` is a monotonic id assigned by the main-process
+ *  ring buffer — it gives the renderer stable React keys and lets it dedup the
+ *  initial backlog against pushed lines. `ts` is epoch ms. */
+export interface SyncLogLine {
+  readonly seq: number;
+  readonly ts: number;
+  readonly level: SyncLogLevel;
+  readonly message: string;
+}
+
 export type QueryState<T> =
   | { readonly status: 'idle' }
   | { readonly status: 'loading' }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/auto-sync.ts
+++ b/packages/desktop/src/main/auto-sync.ts
@@ -1,8 +1,12 @@
 import { logger, parseJsonObject, configuredTierRetentions, periodsOutsideRetention, retentionCutoffPeriod, isCredentialError } from '@costgoblin/core';
-import type { AutoSyncStatus } from '@costgoblin/core';
+import type { AutoSyncStatus, SyncLogLevel } from '@costgoblin/core';
 import { updatePrefsFile } from './handlers/prefs-file.js';
 
 export interface AutoSyncDeps {
+  /** Optional sink for the Data & Sync activity log. The actual downloads
+   *  stream through the sync worker already; this surfaces the local-only
+   *  breadcrumbs (checking / nothing-to-sync / prune) that never hit it. */
+  onLog?: (level: SyncLogLevel, message: string) => void;
   getPrefsPath: () => Promise<string>;
   getConfig: () => Promise<{ providers: { sync: {
     daily: { retentionDays?: number | undefined };
@@ -97,6 +101,14 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Log a scheduler breadcrumb: keep the existing stdout line (always info, as
+// before) and additionally feed the Data & Sync activity log at the given
+// level so failures stand out there.
+function note(deps: AutoSyncDeps, level: SyncLogLevel, message: string): void {
+  logger.info(message);
+  deps.onLog?.(level, message);
+}
+
 async function syncTier(
   deps: AutoSyncDeps,
   tier: { name: string; retention: number },
@@ -110,11 +122,11 @@ async function syncTier(
     // error status so the toolbar flags that background sync is blocked. Other
     // (transient) inventory failures stay a silent skip as before.
     if (isCredentialError(err)) {
-      logger.info(`Auto-sync: ${tier.name} inventory failed (credentials) — ${errorMessage(err)}`);
+      note(deps, 'warn', `Auto-sync: ${tier.name} inventory failed (credentials) — ${errorMessage(err)}`);
       status = { state: 'error', message: errorMessage(err), lastRun: new Date().toISOString() };
       return 'error';
     }
-    logger.info(`Auto-sync: failed to get ${tier.name} inventory — ${errorMessage(err)}`);
+    note(deps, 'warn', `Auto-sync: failed to get ${tier.name} inventory — ${errorMessage(err)}`);
     return 'skip';
   }
 
@@ -122,20 +134,20 @@ async function syncTier(
     .filter(p => (p.localStatus === 'missing' || p.localStatus === 'stale') && p.period >= cutoff);
 
   if (missing.length === 0) {
-    logger.info(`Auto-sync: ${tier.name} — nothing to sync`);
+    note(deps, 'info', `Auto-sync: ${tier.name} — nothing to sync`);
     return 'skip';
   }
 
   const files = missing.flatMap(p => [...p.files]);
-  logger.info(`Auto-sync: ${tier.name} — syncing ${String(missing.length)} periods (${String(files.length)} files)`);
+  note(deps, 'info', `Auto-sync: ${tier.name} — syncing ${String(missing.length)} periods (${String(files.length)} files)`);
   status = { state: 'syncing', tier: tier.name, filesDone: 0, filesTotal: files.length };
 
   try {
     const result = await deps.syncPeriods(files, tier.name);
-    logger.info(`Auto-sync: ${tier.name} — synced ${String(result.filesDownloaded)} files`);
+    note(deps, 'info', `Auto-sync: ${tier.name} — synced ${String(result.filesDownloaded)} files`);
     return 'ok';
   } catch (err: unknown) {
-    logger.info(`Auto-sync: ${tier.name} — sync failed: ${errorMessage(err)}`);
+    note(deps, 'warn', `Auto-sync: ${tier.name} — sync failed: ${errorMessage(err)}`);
     status = { state: 'error', message: errorMessage(err), lastRun: new Date().toISOString() };
     return 'error';
   }
@@ -153,16 +165,16 @@ async function prunePass(
     try {
       local = await deps.getLocalPeriods(tier);
     } catch (err: unknown) {
-      logger.info(`Auto-prune: failed to read ${tier} local data — ${errorMessage(err)}`);
+      note(deps, 'warn', `Auto-prune: failed to read ${tier} local data — ${errorMessage(err)}`);
       continue;
     }
     const expired = periodsOutsideRetention(local, retentionDays);
     if (expired.length === 0) continue;
-    logger.info(`Auto-prune: ${tier} — removing ${String(expired.length)} period(s) outside ${String(retentionDays)}d retention: ${expired.join(', ')}`);
+    note(deps, 'info', `Auto-prune: ${tier} — removing ${String(expired.length)} period(s) outside ${String(retentionDays)}d retention: ${expired.join(', ')}`);
     try {
       await deps.deletePeriods(expired, tier);
     } catch (err: unknown) {
-      logger.info(`Auto-prune: ${tier} — delete failed: ${errorMessage(err)}`);
+      note(deps, 'warn', `Auto-prune: ${tier} — delete failed: ${errorMessage(err)}`);
     }
   }
 }
@@ -182,7 +194,7 @@ async function runOnce(deps: AutoSyncDeps): Promise<void> {
     }
 
     status = { state: 'checking' };
-    logger.info('Auto-sync: checking');
+    note(deps, 'info', 'Auto-sync: checking');
 
     const config = await deps.getConfig();
     const provider = config.providers[0];

--- a/packages/desktop/src/main/handlers/auto-sync.ts
+++ b/packages/desktop/src/main/handlers/auto-sync.ts
@@ -15,6 +15,7 @@ import {
 import { deleteLocalPeriodFiles, cascadeRollupForDeletedMonth, changedRollupMonths } from './sync.js';
 import { type AppContext, prefsPath, toUserFriendlyError } from './context.js';
 import type { SyncClient } from '../sync-client.js';
+import { recordSyncLog } from '../sync-log.js';
 
 type Tier = 'daily' | 'hourly' | 'cost-optimization';
 
@@ -36,6 +37,7 @@ export function registerAutoSyncHandlers(app: AppContext): void {
 
   function buildAutoSyncDeps(syncClient: SyncClient) {
     return {
+      onLog: recordSyncLog,
       getPrefsPath: autoSyncPrefsPath,
       getConfig: async () => {
         const config = await getConfig();

--- a/packages/desktop/src/main/handlers/sync-log.ts
+++ b/packages/desktop/src/main/handlers/sync-log.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain } from 'electron';
-import { snapshotSyncLog, clearSyncLog, onSyncLogAppend } from '../sync-log.js';
+import type { SyncLogLevel } from '@costgoblin/core';
+import { snapshotSyncLog, clearSyncLog, onSyncLogAppend, recordSyncLog } from '../sync-log.js';
 
 /** Surface the live sync/S3 activity log to the renderer. Mirrors the
  *  rollup-status channel (handlers/rollup.ts): a pull getter for the backlog on
@@ -8,6 +9,13 @@ import { snapshotSyncLog, clearSyncLog, onSyncLogAppend } from '../sync-log.js';
 export function registerSyncLogHandlers(): void {
   ipcMain.handle('sync-log:get', () => snapshotSyncLog());
   ipcMain.handle('sync-log:clear', () => { clearSyncLog(); });
+
+  // Renderer-originated lines (on-demand Sync/Prune narrating the S3 check).
+  ipcMain.handle('sync-log:record', (_event, level: unknown, message: unknown) => {
+    if (typeof message !== 'string') return;
+    const lvl: SyncLogLevel = level === 'debug' || level === 'warn' || level === 'error' ? level : 'info';
+    recordSyncLog(lvl, message);
+  });
 
   onSyncLogAppend((line) => {
     for (const win of BrowserWindow.getAllWindows()) {

--- a/packages/desktop/src/main/handlers/sync-log.ts
+++ b/packages/desktop/src/main/handlers/sync-log.ts
@@ -1,0 +1,17 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import { snapshotSyncLog, clearSyncLog, onSyncLogAppend } from '../sync-log.js';
+
+/** Surface the live sync/S3 activity log to the renderer. Mirrors the
+ *  rollup-status channel (handlers/rollup.ts): a pull getter for the backlog on
+ *  mount, plus a main→renderer broadcast on every appended line so the Data &
+ *  Sync panel tails it without polling. */
+export function registerSyncLogHandlers(): void {
+  ipcMain.handle('sync-log:get', () => snapshotSyncLog());
+  ipcMain.handle('sync-log:clear', () => { clearSyncLog(); });
+
+  onSyncLogAppend((line) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('sync-log:append', line);
+    }
+  });
+}

--- a/packages/desktop/src/main/handlers/sync.ts
+++ b/packages/desktop/src/main/handlers/sync.ts
@@ -32,6 +32,7 @@ import {
   toUserFriendlyError,
 } from './context.js';
 import { triggerAutoSyncNow } from '../auto-sync.js';
+import { recordSyncLog } from '../sync-log.js';
 
 type ExpectedDataType = 'daily' | 'hourly' | 'cost-optimization';
 
@@ -137,6 +138,7 @@ export async function deleteLocalPeriodFiles(
   const removedAny = await removeMatchingDirs(rawDir, prefix, period, fs, path);
   if (removedAny) {
     logger.info(`Deleted local data (${tier}): ${prefix}-${period}*`);
+    recordSyncLog('info', `Deleted local data (${tier}): ${prefix}-${period}`);
   }
 
   await pruneEtagFile(path.join(dataDir, getEtagFileName(tier)), period, fs);
@@ -240,6 +242,7 @@ export function registerSyncHandlers(app: AppContext): void {
     }
     if (deleted.length > 0) {
       logger.info(`Prune: removed ${String(deleted.length)} period(s) outside retention`);
+      recordSyncLog('info', `Prune: removed ${String(deleted.length)} period(s) outside retention`);
     }
     return { deleted };
   });
@@ -255,6 +258,7 @@ export function registerSyncHandlers(app: AppContext): void {
     state.syncStatuses[syncId] = { status: 'syncing', phase: 'downloading', progress: 0, filesTotal: fileEntries.length, filesDone: 0, bytesTotal: 0, bytesDone: 0, message: '' };
 
     const tier = resolveDataType(syncId);
+    recordSyncLog('info', `Sync started: ${tier} (${String(fileEntries.length)} file(s))`);
 
     try {
       const result = await runSync(ctx, provider.credentials.profile, bucketPath, tier, fileEntries, syncId, state);
@@ -292,6 +296,7 @@ export function registerSyncHandlers(app: AppContext): void {
     if (workerId !== undefined) {
       ctx.syncClient.cancelSync(workerId);
       logger.info(`Sync '${syncId}' cancelled by user`);
+      recordSyncLog('warn', `Sync '${syncId}' cancelled by user`);
     }
   });
 
@@ -427,6 +432,7 @@ function handleSyncError(
   }
   const error = toUserFriendlyError(err, profile);
   logger.error(`Selective sync '${syncId}' failed: ${error.message}`);
+  recordSyncLog('error', `Sync '${syncId}' failed: ${error.message}`);
   state.syncStatuses[syncId] = { status: 'failed', error, lastSync: null };
   return error;
 }

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -18,6 +18,7 @@ import { registerMcpHandlers } from './handlers/mcp-handler.js';
 import { registerRollupHandlers } from './handlers/rollup.js';
 import { registerBaselinesHandlers } from './handlers/baselines.js';
 import { registerTelemetryHandlers } from './handlers/telemetry.js';
+import { registerSyncLogHandlers } from './handlers/sync-log.js';
 
 export type { AppContext, IpcContext } from './handlers/context.js';
 
@@ -42,6 +43,7 @@ export function registerIpcHandlers(ctx: IpcContext): AppContext {
   registerRollupHandlers(app);
   registerBaselinesHandlers(app);
   registerTelemetryHandlers(app);
+  registerSyncLogHandlers();
 
   app.warmupBase();
 

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -15,6 +15,7 @@ import type { DuckDBClient } from './duckdb-client.js';
 import { resolveMemoryGB, resolveRollupConcurrency, resolveThreads } from './duckdb-tuning.js';
 import { createSyncClient } from './sync-client.js';
 import type { SyncClient } from './sync-client.js';
+import { recordSyncLog } from './sync-log.js';
 import { registerIpcHandlers } from './ipc.js';
 import { startMcpServer, stopMcpServer } from './mcp.js';
 import { initAutoUpdater, checkForUpdates } from './update-manager.js';
@@ -287,7 +288,7 @@ async function main(): Promise<void> {
   logger.info('DuckDB worker ready');
 
   const syncWorkerPath = join(__dirname, '..', 'worker', 'sync-worker.cjs');
-  const syncClient = await createSyncClient(syncWorkerPath);
+  const syncClient = await createSyncClient(syncWorkerPath, recordSyncLog);
   logger.info('Sync worker ready');
 
   installCSP();

--- a/packages/desktop/src/main/sync-client.ts
+++ b/packages/desktop/src/main/sync-client.ts
@@ -1,6 +1,9 @@
 import { logger } from '@costgoblin/core';
-import type { ManifestFileEntry, SyncProgress } from '@costgoblin/core';
+import type { ManifestFileEntry, SyncProgress, SyncLogLevel } from '@costgoblin/core';
 import { initWorkerLifecycle } from './worker-lifecycle.js';
+
+/** A log line forwarded from the sync worker thread. */
+export type SyncLogSink = (level: SyncLogLevel, message: string, ts: number) => void;
 
 export interface SyncOptions {
   readonly bucketPath: string;
@@ -26,7 +29,8 @@ type WorkerResponse =
   | { kind: 'ready' }
   | { kind: 'progress'; id: number; phase: 'downloading' | 'repartitioning' | 'done'; filesDone: number; filesTotal: number; bytesDone?: number; bytesTotal?: number; message?: string }
   | { kind: 'complete'; id: number; filesDownloaded: number; rowsProcessed: number }
-  | { kind: 'error'; id: number; message: string };
+  | { kind: 'error'; id: number; message: string }
+  | { kind: 'log'; level: SyncLogLevel; message: string; ts: number };
 
 function hasProps(msg: unknown): msg is Record<string, unknown> {
   return typeof msg === 'object' && msg !== null;
@@ -35,6 +39,9 @@ function hasProps(msg: unknown): msg is Record<string, unknown> {
 function isWorkerResponse(msg: unknown): msg is WorkerResponse {
   if (!hasProps(msg)) return false;
   if (msg['kind'] === 'ready') return true;
+  if (msg['kind'] === 'log') {
+    return typeof msg['message'] === 'string' && typeof msg['ts'] === 'number' && typeof msg['level'] === 'string';
+  }
   if ((msg['kind'] === 'progress' || msg['kind'] === 'complete' || msg['kind'] === 'error') && typeof msg['id'] === 'number') {
     if (msg['kind'] === 'progress') {
       return (
@@ -57,7 +64,7 @@ interface PendingSync {
   onProgress?: ((progress: SyncProgress) => void) | undefined;
 }
 
-export async function createSyncClient(workerPath: string): Promise<SyncClient> {
+export async function createSyncClient(workerPath: string, onLog?: SyncLogSink): Promise<SyncClient> {
   const lifecycle = await initWorkerLifecycle<PendingSync>(
     workerPath,
     (msg) => isWorkerResponse(msg) && msg.kind === 'ready',
@@ -72,6 +79,12 @@ export async function createSyncClient(workerPath: string): Promise<SyncClient> 
   worker.on('message', (msg: unknown) => {
     if (!isWorkerResponse(msg)) return;
     if (msg.kind === 'ready') return;
+    if (msg.kind === 'log') {
+      // Log lines aren't tied to a request id — they stream for the whole
+      // worker lifetime and feed the sync activity log.
+      onLog?.(msg.level, msg.message, msg.ts);
+      return;
+    }
 
     const entry = pending.get(msg.id);
     if (entry === undefined) return;

--- a/packages/desktop/src/main/sync-log.ts
+++ b/packages/desktop/src/main/sync-log.ts
@@ -1,0 +1,40 @@
+import type { SyncLogLine, SyncLogLevel } from '@costgoblin/core';
+
+// Live, ephemeral sync/S3 activity log. A bounded ring buffer in the main
+// process, fed by the sync worker's forwarded log lines (the `[aws] …`
+// transfer detail) plus the main-process orchestration breadcrumbs (auto-sync,
+// prune). The Data & Sync screen reads the backlog on mount and subscribes for
+// pushed appends — mirrors the update-manager log buffer, just larger because a
+// sync is verbose. Not persisted: cleared on restart.
+
+const LIMIT = 1000;
+
+const buffer: SyncLogLine[] = [];
+let seq = 0;
+
+type Listener = (line: SyncLogLine) => void;
+const listeners = new Set<Listener>();
+
+export function recordSyncLog(level: SyncLogLevel, message: string, ts: number = Date.now()): void {
+  const line: SyncLogLine = { seq: seq++, ts, level, message };
+  buffer.push(line);
+  if (buffer.length > LIMIT) {
+    buffer.splice(0, buffer.length - LIMIT);
+  }
+  for (const listener of listeners) {
+    listener(line);
+  }
+}
+
+export function snapshotSyncLog(): readonly SyncLogLine[] {
+  return buffer.slice();
+}
+
+export function clearSyncLog(): void {
+  buffer.length = 0;
+}
+
+export function onSyncLogAppend(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}

--- a/packages/desktop/src/main/sync-worker.ts
+++ b/packages/desktop/src/main/sync-worker.ts
@@ -1,6 +1,6 @@
 import { parentPort } from 'node:worker_threads';
-import { syncSelectedFiles } from '@costgoblin/core';
-import type { SelectiveSyncOptions, ManifestFileEntry, SyncProgress } from '@costgoblin/core';
+import { syncSelectedFiles, logger } from '@costgoblin/core';
+import type { SelectiveSyncOptions, ManifestFileEntry, SyncProgress, SyncLogLevel } from '@costgoblin/core';
 
 if (parentPort === null) {
   throw new Error('sync-worker.ts must be run as a Node.js Worker thread');
@@ -54,7 +54,18 @@ interface ErrorResponse {
   readonly message: string;
 }
 
-type WorkerResponse = ReadyResponse | ProgressResponse | CompleteResponse | ErrorResponse;
+// Worker logs go to a logger with no handlers in this thread (the stdout handler
+// is installed only in main), so they'd otherwise be discarded. Forward every
+// entry to main — the worker runs nothing but the sync, so all of it is
+// sync/S3 activity for the Data & Sync log panel.
+interface LogResponse {
+  readonly kind: 'log';
+  readonly level: SyncLogLevel;
+  readonly message: string;
+  readonly ts: number;
+}
+
+type WorkerResponse = ReadyResponse | ProgressResponse | CompleteResponse | ErrorResponse | LogResponse;
 
 // ---------------------------------------------------------------------------
 // Type guards
@@ -96,6 +107,13 @@ const cancelledIds = new Set<number>();
 function send(msg: WorkerResponse): void {
   port.postMessage(msg);
 }
+
+// Forward this thread's logs (the `[aws] …` transfer lines, "Processing
+// period", "Sync complete", prune warnings) to main so the Data & Sync panel
+// can tail them. minLevel is 'info' by default, so debug noise is dropped.
+logger.addHandler((entry) => {
+  send({ kind: 'log', level: entry.level, message: entry.message, ts: Date.parse(entry.timestamp) });
+});
 
 // ---------------------------------------------------------------------------
 // Sync request handler

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -147,6 +147,9 @@ const api: CostApi = {
     ipcRenderer.on('sync-log:append', handler);
     return () => { ipcRenderer.removeListener('sync-log:append', handler); };
   },
+  appendSyncLog(level: SyncLogLine['level'], message: string): Promise<void> {
+    return invoke<undefined>('sync-log:record', level, message).then(() => undefined);
+  },
   clearSyncLog(): Promise<void> {
     return invoke<undefined>('sync-log:clear').then(() => undefined);
   },

--- a/packages/desktop/src/preload/preload.ts
+++ b/packages/desktop/src/preload/preload.ts
@@ -20,6 +20,7 @@ import type {
   EntityDetailParams,
   EntityDetailResult,
   SyncStatus,
+  SyncLogLine,
   SavingsResult,
   DataInventoryResult,
   DataTier,
@@ -137,6 +138,17 @@ const api: CostApi = {
   },
   getSyncStatus(syncId?: string): Promise<SyncStatus> {
     return invoke<SyncStatus>('sync:status', syncId);
+  },
+  getSyncLog(): Promise<readonly SyncLogLine[]> {
+    return invoke<readonly SyncLogLine[]>('sync-log:get');
+  },
+  subscribeSyncLog(listener: (line: SyncLogLine) => void): () => void {
+    const handler = (_event: unknown, line: SyncLogLine): void => { listener(line); };
+    ipcRenderer.on('sync-log:append', handler);
+    return () => { ipcRenderer.removeListener('sync-log:append', handler); };
+  },
+  clearSyncLog(): Promise<void> {
+    return invoke<undefined>('sync-log:clear').then(() => undefined);
   },
   getConfig(): Promise<CostGoblinConfig> {
     return invoke<CostGoblinConfig>('config:get');

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -264,6 +264,7 @@ export class MockCostApi implements CostApi {
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
   getSyncLog(): Promise<readonly SyncLogLine[]> { return Promise.resolve([]); }
   subscribeSyncLog(): () => void { return () => undefined; }
+  appendSyncLog(): Promise<void> { return Promise.resolve(); }
   clearSyncLog(): Promise<void> { return Promise.resolve(); }
   getConfig(): Promise<CostGoblinConfig> { return Promise.resolve(config); }
   getDimensions(): Promise<Dimension[]> { return Promise.resolve(mockDimensions); }

--- a/packages/ui/src/__fixtures__/mock-api.ts
+++ b/packages/ui/src/__fixtures__/mock-api.ts
@@ -17,6 +17,7 @@ import {
   type PruneResult,
   type SavingsResult,
   type SyncStatus,
+  type SyncLogLine,
   type TrendResult,
   type CostGoblinConfig,
   type DimensionsConfig,
@@ -261,6 +262,9 @@ export class MockCostApi implements CostApi {
   }
   queryEntityDetail(): Promise<EntityDetailResult> { return Promise.resolve(entityDetailResult); }
   getSyncStatus(): Promise<SyncStatus> { return Promise.resolve(syncStatus); }
+  getSyncLog(): Promise<readonly SyncLogLine[]> { return Promise.resolve([]); }
+  subscribeSyncLog(): () => void { return () => undefined; }
+  clearSyncLog(): Promise<void> { return Promise.resolve(); }
   getConfig(): Promise<CostGoblinConfig> { return Promise.resolve(config); }
   getDimensions(): Promise<Dimension[]> { return Promise.resolve(mockDimensions); }
   getOrgTree(): Promise<OrgNode[]> { return Promise.resolve(orgTree); }

--- a/packages/ui/src/__tests__/data-management.test.tsx
+++ b/packages/ui/src/__tests__/data-management.test.tsx
@@ -94,10 +94,17 @@ describe('DataManagement', () => {
     });
   });
 
-  it('prune button is disabled when no local data is outside retention', async () => {
-    renderDataManagement();
+  it('prune button is clickable even when nothing is outside retention', async () => {
+    // Prune is an on-demand action: always clickable so the user can re-check
+    // and remove anything outside retention. With nothing expired it opens the
+    // confirmation rather than being inert.
+    const { user } = renderDataManagement();
     const pruneBtn = await screen.findByRole('button', { name: /^Prune$/ });
-    expect(pruneBtn).toHaveProperty('disabled', true);
+    expect(pruneBtn).toHaveProperty('disabled', false);
+    await user.click(pruneBtn);
+    await waitFor(() => {
+      expect(screen.getByText('Prune old data')).toBeDefined();
+    });
   });
 
   it('prune button shows confirmation when data is outside retention', async () => {
@@ -140,10 +147,21 @@ describe('DataManagement', () => {
     });
   });
 
-  it('sync button is disabled when all tiers are up to date', async () => {
-    renderDataManagement();
+  it('sync button is clickable even when all tiers are up to date', async () => {
+    // Sync is on-demand: always clickable (except mid-sync) so a click re-checks
+    // S3 and pulls anything new, rather than being hard-disabled off a possibly
+    // stale snapshot.
+    const api = new MockCostApi();
+    const spy = vi.spyOn(api, 'getDataInventory');
+    const { user } = renderDataManagement(api);
     const syncBtn = await screen.findByRole('button', { name: /^Sync$/ });
-    expect(syncBtn).toHaveProperty('disabled', true);
+    expect(syncBtn).toHaveProperty('disabled', false);
+    const callsBefore = spy.mock.calls.length;
+    await user.click(syncBtn);
+    // The click re-checks the configured tier(s) against S3.
+    await waitFor(() => {
+      expect(spy.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
   });
 
   it('sync button shows count and syncs missing/stale periods on demand', async () => {

--- a/packages/ui/src/views/data-management-logs.tsx
+++ b/packages/ui/src/views/data-management-logs.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { SyncLogLine, SyncLogLevel } from '@costgoblin/core/browser';
+import { useCostApi } from '../hooks/use-cost-api.js';
+
+const MAX_LINES = 1000;
+
+type LevelFilter = 'all' | 'warn' | 'error';
+
+function levelClass(level: SyncLogLevel): string {
+  switch (level) {
+    case 'error': return 'text-negative';
+    case 'warn': return 'text-warning';
+    case 'debug': return 'text-text-muted';
+    default: return 'text-text-secondary';
+  }
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, { hour12: false });
+}
+
+/** Expandable terminal-style tail of the live sync/S3 activity log. Reads the
+ *  main-process ring-buffer backlog on mount and subscribes for pushed appends
+ *  (no polling). Collapsible via the same chevron-disclosure pattern as the org
+ *  / region sections. `active` drives the live dot while a sync is in flight. */
+export function SyncLogPanel({ active = false }: { active?: boolean }) {
+  const api = useCostApi();
+  const [expanded, setExpanded] = useState(false);
+  const [lines, setLines] = useState<readonly SyncLogLine[]>([]);
+  const [filter, setFilter] = useState<LevelFilter>('all');
+  const [copied, setCopied] = useState(false);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const atBottomRef = useRef(true);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+  }, []);
+
+  const addLines = useCallback((incoming: readonly SyncLogLine[]) => {
+    if (incoming.length === 0) return;
+    setLines(prev => {
+      const last = prev.at(-1);
+      const lastSeq = last === undefined ? -1 : last.seq;
+      let next: SyncLogLine[];
+      if (incoming.every(l => l.seq > lastSeq)) {
+        // Steady state: pushed lines arrive in monotonic seq order, so a plain
+        // append keeps everything sorted with no dedup/re-sort work.
+        next = [...prev, ...incoming];
+      } else {
+        // One-time mount race (backlog vs an early push overlap on seq): dedup
+        // by seq and re-sort. seq is monotonic, so sorting restores order.
+        const bySeq = new Map<number, SyncLogLine>();
+        for (const l of prev) bySeq.set(l.seq, l);
+        for (const l of incoming) bySeq.set(l.seq, l);
+        next = [...bySeq.values()].sort((a, b) => a.seq - b.seq);
+      }
+      return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
+    });
+  }, []);
+
+  useEffect(() => {
+    // Subscribe before fetching the backlog so no line emitted in between is
+    // lost (dedup reconciles any overlap).
+    const unsubscribe = api.subscribeSyncLog(line => { addLines([line]); });
+    api.getSyncLog().then(backlog => { addLines(backlog); }).catch(() => undefined);
+    return unsubscribe;
+  }, [api, addLines]);
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return lines;
+    if (filter === 'error') return lines.filter(l => l.level === 'error');
+    return lines.filter(l => l.level === 'warn' || l.level === 'error');
+  }, [lines, filter]);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const el = scrollRef.current;
+    if (el !== null && atBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [filtered, expanded]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+  };
+
+  const handleCopy = () => {
+    const text = filtered.map(l => `${formatTime(l.ts)} ${l.message}`).join('\n');
+    void navigator.clipboard.writeText(text)
+      .then(() => {
+        setCopied(true);
+        if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+        copyTimerRef.current = setTimeout(() => { setCopied(false); }, 1500);
+      })
+      .catch(() => undefined);
+  };
+
+  const handleClear = () => {
+    void api.clearSyncLog().catch(() => undefined);
+    setLines([]);
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-bg-secondary/50 overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3">
+        <button
+          type="button"
+          onClick={() => { setExpanded(v => !v); }}
+          className="flex items-center gap-2 flex-1 text-left hover:bg-bg-tertiary/30 transition-colors rounded -mx-1 px-1"
+        >
+          <div className={`h-2 w-2 rounded-full ${active ? 'bg-accent animate-pulse' : 'bg-text-muted/40'}`} />
+          <span className="text-sm font-medium text-text-primary">Activity log</span>
+          {lines.length > 0 && <span className="text-text-muted text-xs">({String(lines.length)})</span>}
+          <span className="text-text-muted ml-auto text-xs">{expanded ? '▾' : '▸'}</span>
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-border">
+          <div className="flex items-center gap-2 px-4 py-2 text-xs">
+            <div className="flex items-center gap-1">
+              {(['all', 'warn', 'error'] as const).map(f => (
+                <button
+                  key={f}
+                  type="button"
+                  onClick={() => { setFilter(f); }}
+                  className={`rounded px-2 py-0.5 transition-colors ${filter === f ? 'bg-bg-tertiary text-text-primary' : 'text-text-muted hover:text-text-secondary'}`}
+                >
+                  {f === 'all' ? 'All' : f === 'warn' ? 'Warnings' : 'Errors'}
+                </button>
+              ))}
+            </div>
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleCopy}
+                disabled={filtered.length === 0}
+                className="rounded px-2 py-0.5 text-text-muted hover:text-text-secondary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+              <button
+                type="button"
+                onClick={handleClear}
+                disabled={lines.length === 0}
+                className="rounded px-2 py-0.5 text-text-muted hover:text-text-secondary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="max-h-64 overflow-y-auto bg-bg-primary/40 px-4 py-2 font-mono text-[10px] leading-relaxed"
+          >
+            {filtered.length === 0 ? (
+              <p className="text-text-muted py-2">No sync activity yet — logs stream here while data syncs from S3.</p>
+            ) : (
+              filtered.map(l => (
+                <div key={l.seq} className="whitespace-pre-wrap break-all">
+                  <span className="text-text-muted">{formatTime(l.ts)}</span>{' '}
+                  <span className={levelClass(l.level)}>{l.message}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -294,17 +294,24 @@ export function DataManagement() {
 
   function handlePrune() {
     setShowPrune(false);
+    void api.appendSyncLog('info', 'Manual prune — checking local data against retention…');
     api.pruneNow().then((result) => {
       setPruneNotice(
         result.deleted.length === 0
           ? 'Nothing to prune — all local data is within retention.'
           : `Pruned ${String(result.deleted.length)} period(s) outside retention.`,
       );
+      // The data:prune handler logs the removals when there are any; narrate the
+      // no-op case here so the click always leaves a trace in the activity log.
+      if (result.deleted.length === 0) {
+        void api.appendSyncLog('info', 'Prune — nothing outside the retention window');
+      }
       setDailyRefreshKey(k => k + 1);
       setHourlyRefreshKey(k => k + 1);
       setCostOptRefreshKey(k => k + 1);
       setTimeout(() => { setPruneNotice(null); }, 6000);
     }).catch((err: unknown) => {
+      void api.appendSyncLog('error', `Prune failed — ${err instanceof Error ? err.message : String(err)}`);
       setPruneNotice(`Prune failed: ${err instanceof Error ? err.message : String(err)}`);
     });
   }
@@ -314,6 +321,7 @@ export function DataManagement() {
   // `aws s3 sync` processes don't contend; the 2s status poller above drives each
   // tier card's progress while a sync is in flight.
   async function handleSyncAll() {
+    void api.appendSyncLog('info', 'Manual sync — checking S3 for new or updated data…');
     const tiers: {
       id: DataTier;
       cutoff: string;
@@ -333,11 +341,16 @@ export function DataManagement() {
       let fresh: DataInventoryResult;
       try {
         fresh = await api.getDataInventory(tier.id);
-      } catch {
-        continue; // S3 unreachable / creds expired — skip (mirrors auto-sync)
+      } catch (err: unknown) {
+        // S3 unreachable / creds expired — surface it instead of skipping silently.
+        void api.appendSyncLog('warn', `${tier.id}: S3 check failed — ${err instanceof Error ? err.message : String(err)}`);
+        continue;
       }
       const files = syncableWithinCutoff(fresh, tier.cutoff).flatMap(p => [...p.files]);
-      if (files.length === 0) continue;
+      if (files.length === 0) {
+        void api.appendSyncLog('info', `${tier.id}: up to date`);
+        continue;
+      }
       tier.setState({ status: 'downloading', filesDone: 0, filesTotal: files.length, bytesDone: 0, bytesTotal: 0, message: '' });
       try {
         const result = await api.syncPeriods(files, tier.id);

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -8,6 +8,7 @@ import { SetupWizard } from './setup-wizard.js';
 import { OrgAccountsSection } from './data-management-org.js';
 import { SsmParameterSection } from './data-management-ssm.js';
 import { TierPanel, type SyncState } from './data-management-tier.js';
+import { SyncLogPanel } from './data-management-logs.js';
 import { SsoLoginButton } from '../components/sso-login-button.js';
 import { SchedulerControls } from '../components/scheduler-controls.js';
 
@@ -634,6 +635,8 @@ export function DataManagement() {
           />
         </div>
       )}
+
+      <SyncLogPanel active={anySyncing} />
 
       {showDeleteAll && (
         <ConfirmModal

--- a/packages/ui/src/views/data-management.tsx
+++ b/packages/ui/src/views/data-management.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import type { DataInventoryResult, CostGoblinConfig, SyncStatus } from '@costgoblin/core/browser';
+import type { DataInventoryResult, DataTier, CostGoblinConfig, SyncStatus } from '@costgoblin/core/browser';
 import { useCostApi } from '../hooks/use-cost-api.js';
 import { useQuery } from '../hooks/use-query.js';
 import { ConfirmModal } from '../components/confirm-modal.js';
@@ -315,18 +315,28 @@ export function DataManagement() {
   // tier card's progress while a sync is in flight.
   async function handleSyncAll() {
     const tiers: {
-      id: string;
-      inventory: DataInventoryResult | null;
+      id: DataTier;
       cutoff: string;
+      configured: boolean;
       setState: (s: SyncState) => void;
       bump: () => void;
     }[] = [
-      { id: 'daily', inventory, cutoff: dailyCutoffPeriod, setState: setDailySyncState, bump: () => { setDailyRefreshKey(k => k + 1); } },
-      { id: 'hourly', inventory: hourlyInventory, cutoff: hourlyCutoffPeriod, setState: setHourlySyncState, bump: () => { setHourlyRefreshKey(k => k + 1); } },
-      { id: 'cost-optimization', inventory: costOptInventory, cutoff: costOptCutoffPeriod, setState: setCostOptSyncState, bump: () => { setCostOptRefreshKey(k => k + 1); } },
+      { id: 'daily', cutoff: dailyCutoffPeriod, configured: dailyBucket !== null, setState: setDailySyncState, bump: () => { setDailyRefreshKey(k => k + 1); } },
+      { id: 'hourly', cutoff: hourlyCutoffPeriod, configured: hourlyBucket !== null, setState: setHourlySyncState, bump: () => { setHourlyRefreshKey(k => k + 1); } },
+      { id: 'cost-optimization', cutoff: costOptCutoffPeriod, configured: costOptBucket !== null, setState: setCostOptSyncState, bump: () => { setCostOptRefreshKey(k => k + 1); } },
     ];
     for (const tier of tiers) {
-      const files = syncableWithinCutoff(tier.inventory, tier.cutoff).flatMap(p => [...p.files]);
+      if (!tier.configured) continue;
+      // Re-check S3 now rather than trusting the inventory snapshot the disabled
+      // state was derived from — a manual Sync should always reflect what's
+      // actually on S3 and pull anything missing or out of date.
+      let fresh: DataInventoryResult;
+      try {
+        fresh = await api.getDataInventory(tier.id);
+      } catch {
+        continue; // S3 unreachable / creds expired — skip (mirrors auto-sync)
+      }
+      const files = syncableWithinCutoff(fresh, tier.cutoff).flatMap(p => [...p.files]);
       if (files.length === 0) continue;
       tier.setState({ status: 'downloading', filesDone: 0, filesTotal: files.length, bytesDone: 0, bytesTotal: 0, message: '' });
       try {
@@ -485,8 +495,8 @@ export function DataManagement() {
           <button
             type="button"
             onClick={() => { handleSyncAll().catch(() => undefined); }}
-            disabled={syncableTotal === 0 || anySyncing}
-            title={syncableTotal === 0 ? 'All tiers are up to date' : `Sync ${String(syncableTotal)} period(s) that are missing or out of date`}
+            disabled={anySyncing}
+            title={anySyncing ? 'Sync in progress…' : syncableTotal === 0 ? 'Re-check S3 and download any new or updated data' : `Sync ${String(syncableTotal)} period(s) that are missing or out of date`}
             className="rounded-md border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {syncableTotal === 0 ? 'Sync' : `Sync (${String(syncableTotal)})`}
@@ -494,8 +504,7 @@ export function DataManagement() {
           <button
             type="button"
             onClick={() => { setShowPrune(true); }}
-            disabled={prunableTotal === 0}
-            title={prunableTotal === 0 ? 'No local data is outside the retention window' : `Delete ${String(prunableTotal)} period(s) outside the retention window`}
+            title={prunableTotal === 0 ? 'Re-check local data and remove anything outside the retention window' : `Delete ${String(prunableTotal)} period(s) outside the retention window`}
             className="rounded-md border border-border bg-bg-tertiary/50 px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {prunableTotal === 0 ? 'Prune' : `Prune (${String(prunableTotal)})`}
@@ -652,7 +661,9 @@ export function DataManagement() {
       {showPrune && (
         <ConfirmModal
           title="Prune old data"
-          message={`Remove ${String(prunableTotal)} local period(s) that fall outside each tier's retention window? This data can be re-downloaded from S3 anytime.`}
+          message={prunableTotal === 0
+            ? "Re-check local data and remove anything that falls outside each tier's retention window? This data can be re-downloaded from S3 anytime."
+            : `Remove ${String(prunableTotal)} local period(s) that fall outside each tier's retention window? This data can be re-downloaded from S3 anytime.`}
           confirmLabel="Prune"
           destructive
           onConfirm={handlePrune}


### PR DESCRIPTION
## What

Adds an expandable **Activity log** panel at the bottom of the Data & Sync screen that tails what's happening with S3 in real time — so a sync is no longer a black box.

## Why

`aws s3 sync` output was already captured line-by-line in `selective-sync.ts`, but it ran in the **sync worker thread** whose logger has no handlers installed — so those lines were silently discarded (invisible even in dev). This surfaces them.

## How

- **Worker → main:** `sync-worker.ts` installs a `logger.addHandler` that forwards every line to main over `postMessage` (the worker only runs the sync, so all of it is sync/S3 activity). `sync-client.ts` routes the new `log` messages to an `onLog` sink.
- **Ring buffer:** new `sync-log.ts` — a bounded (1000-line) ephemeral buffer in main, mirroring the `update-manager` pattern. Also fed by manual-sync start/cancel/fail + deletions and auto-sync/prune breadcrumbs.
- **Push to renderer:** `handlers/sync-log.ts` exposes `sync-log:get` (backlog) and broadcasts `sync-log:append` (live tail) — reusing the exact rollup/update push pattern, no polling.
- **UI:** `data-management-logs.tsx` — collapsible chevron panel (matches the org/region sections), live pulsing dot while syncing, monospace auto-scrolling tail, level filter (All / Warnings / Errors), Copy, Clear.
- Routed through the **`CostApi` interface** (`getSyncLog` / `subscribeSyncLog` / `clearSyncLog`) with no-op mock impls, so the UI stays testable.

Ephemeral — the buffer clears on app restart.

## Verification

`npm run check` green (tsc + eslint + 934 tests). A max-effort multi-agent review pass was applied: redundant wrapper removed, the renderer's per-line merge fast-pathed for monotonic seq, and the copy-feedback timer cleaned up on unmount.

Version bumped to 0.6.2.