### PR TITLE
docs(setup): precise AWS console path for creating the CUR 2.0 export

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ On first launch, the setup wizard guides you through connecting to your AWS CUR 
 
 ### Setting Up a CUR Report
 
-CostGoblin reads **CUR 2.0 via AWS Data Exports** (not legacy CUR). Create one in the [AWS Billing Console → Data Exports](https://docs.aws.amazon.com/cur/latest/userguide/what-is-data-exports.html).
+CostGoblin reads **CUR 2.0 via AWS Data Exports** (not legacy CUR). To create one:
+
+1. In the AWS console, open **Billing and Cost Management**.
+2. In the left navigation, choose **Data Exports** ([direct console link](https://us-east-1.console.aws.amazon.com/costmanagement/home#/bcm-data-exports)).
+3. Click **Create export** and select **CUR 2.0** as the data table, with the settings below.
+
+> ⚠️ Don't create the report from the legacy **Cost & Usage Reports** page — that produces legacy CUR: `.csv.gz` files next to a `*-Manifest.json`, which CostGoblin can't read. A correct CUR 2.0 export delivers Parquet files under `data/` and `metadata/` folders. If you see the former in your bucket, delete that report and recreate it in [Data Exports](https://docs.aws.amazon.com/cur/latest/userguide/what-is-data-exports.html).
 
 **Export settings:**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2208,7 +2208,8 @@
             <span class="step-num">2</span>
             <h4>Create the CUR exports</h4>
           </div>
-          <p>In the AWS Billing Console &rarr; <strong>Data Exports</strong>, create two exports. Select <strong>Cost and usage report (CUR)</strong> as the data table and configure each one as follows:</p>
+          <p>From <strong>Billing and Cost Management</strong>, open <a href="https://us-east-1.console.aws.amazon.com/costmanagement/home#/bcm-data-exports" target="_blank" rel="noopener"><strong>Data Exports</strong></a> in the left navigation, then click <strong>Create export</strong>. Select <strong>CUR 2.0</strong> as the data table and create two exports, configured as follows:</p>
+          <div class="step-note">Use <strong>Data Exports</strong>, not the legacy <strong>Cost &amp; Usage Reports</strong> page &mdash; legacy reports deliver <em>.csv.gz</em> files with a <em>Manifest.json</em>, which CostGoblin can't read. A correct CUR 2.0 export lands as Parquet under <em>data/</em> and <em>metadata/</em> folders.</div>
           <div class="code-block">
 <span class="code-comment">Data table content settings</span>
 <span class="code-comment">─────────────────────────────────────</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,8 +26,8 @@
       --border: #1a1f1a;
       --border-glow: #10b981;
       --text: #e2e8e2;
-      --text-dim: #6b7b6b;
-      --text-muted: #3a4a3a;
+      --text-dim: #8fa08f;
+      --text-muted: #758575;
       --emerald: #10b981;
       --emerald-dim: #065f46;
       --emerald-glow: rgba(16, 185, 129, 0.15);

--- a/docs/index.html
+++ b/docs/index.html
@@ -2196,8 +2196,8 @@
           <p>Pick a dedicated bucket (or prefix) for all CostGoblin data. We recommend this structure so each export lands in its own namespace:</p>
           <div class="code-block">
 <span class="code-dir">s3://your-company-billing/</span>
-├── <span class="code-dir">cur_daily/</span>         <span class="code-comment"># Daily Cost &amp; Usage Report</span>
-├── <span class="code-dir">cur_hourly/</span>        <span class="code-comment"># Hourly Cost &amp; Usage Report</span>
+├── <span class="code-dir">cur_daily/</span>         <span class="code-comment"># Daily Cost &amp; Usage Report — required</span>
+├── <span class="code-dir">cur_hourly/</span>        <span class="code-comment"># Hourly Cost &amp; Usage Report — optional</span>
 └── <span class="code-dir">cost_optimization/</span> <span class="code-comment"># Cost Optimization Hub export</span>
           </div>
           <div class="step-note">Use any bucket name. The three prefixes are what matters.</div>
@@ -2208,12 +2208,12 @@
             <span class="step-num">2</span>
             <h4>Create the CUR exports</h4>
           </div>
-          <p>From <strong>Billing and Cost Management</strong>, open <a href="https://us-east-1.console.aws.amazon.com/costmanagement/home#/bcm-data-exports" target="_blank" rel="noopener"><strong>Data Exports</strong></a> in the left navigation, then click <strong>Create export</strong>. Select <strong>CUR 2.0</strong> as the data table and create two exports, configured as follows:</p>
+          <p>From <strong>Billing and Cost Management</strong>, open <a href="https://us-east-1.console.aws.amazon.com/costmanagement/home#/bcm-data-exports" target="_blank" rel="noopener"><strong>Data Exports</strong></a> in the left navigation, then click <strong>Create export</strong>. Select <strong>CUR 2.0</strong> as the data table. Only the <strong>daily</strong> export is required. You can optionally create a second, <strong>hourly</strong> export &mdash; helpful to understand how costs distribute within a day (intraday drill-down and incident analysis). Configure each as follows:</p>
           <div class="step-note">Use <strong>Data Exports</strong>, not the legacy <strong>Cost &amp; Usage Reports</strong> page &mdash; legacy reports deliver <em>.csv.gz</em> files with a <em>Manifest.json</em>, which CostGoblin can't read. A correct CUR 2.0 export lands as Parquet under <em>data/</em> and <em>metadata/</em> folders.</div>
           <div class="code-block">
 <span class="code-comment">Data table content settings</span>
 <span class="code-comment">─────────────────────────────────────</span>
-Time granularity:    <span class="code-file">Daily</span>  <span class="code-comment">(or Hourly for the second export)</span>
+Time granularity:    <span class="code-file">Daily</span>  <span class="code-comment">(or Hourly for the optional second export)</span>
 
 Additional export content:
  <span class="code-file">&#x2713;</span> Include resource IDs                             <span class="code-comment">on by default</span>
@@ -2229,7 +2229,7 @@ Data export overwriting: <span class="code-file">Overwrite existing data export 
 <span class="code-comment">Data export storage settings</span>
 <span class="code-comment">─────────────────────────────────────</span>
 S3 bucket:       <span class="code-dir">your-company-billing</span>
-S3 path prefix:  <span class="code-dir">cur_daily</span>  <span class="code-comment">(or cur_hourly for the second export)</span>
+S3 path prefix:  <span class="code-dir">cur_daily</span>  <span class="code-comment">(or cur_hourly for the optional hourly export)</span>
           </div>
           <p>Under <strong>Column selection</strong>, enable these and disable the rest to keep file sizes small:</p>
           <div class="code-block">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -59,14 +59,14 @@ function WelcomeStep({ onNext, onImport }: Readonly<{ onNext: () => void; onImpo
         </p>
       </div>
       <p className="text-text-muted text-xs">
-        {"Don't have a CUR yet? "}
+        {"Don't have a CUR yet? Create a CUR 2.0 export in "}
         <a
-          href="https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html"
+          href="https://us-east-1.console.aws.amazon.com/costmanagement/home#/bcm-data-exports"
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent underline underline-offset-2 hover:text-accent-hover"
         >
-          Learn how to create a CUR v2 report
+          Billing and Cost Management &rarr; Data Exports
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Summary

Fixes #316 — the setup documentation didn't precisely describe *where* in the AWS console a CUR 2.0 export is created, and the setup wizard even linked to the **legacy CUR** creation guide. Following the legacy path produces `.csv.gz` files with a `Manifest.json` (exactly the S3 hierarchy shown in the issue), which CostGoblin cannot read.

## Changes

- **README** — "Setting Up a CUR Report" now gives the exact console path: **Billing and Cost Management** → **Data Exports** ([direct console link](https://us-east-1.console.aws.amazon.com/costmanagement/home#/bcm-data-exports)) → **Create export** → **CUR 2.0** data table. Added a warning describing how a wrong (legacy) report looks in S3 (`.csv.gz` + `Manifest.json`) vs. a correct one (`data/` + `metadata/` Parquet folders).
- **docs site (`docs/index.html`)** — step 2 of the get-started walkthrough uses the same precise navigation with the direct console link, plus a note steering users away from the legacy Cost & Usage Reports page.
- **Setup wizard** — the "Don't have a CUR yet?" link no longer points at the legacy CUR guide (`cur-create.html`); it now opens the console Data Exports page directly.
- **Version bump** `0.6.3` → `0.6.4` (first PR of the new release cycle; root + desktop `package.json` only).

## Verification

- `npm run check` passes (tsc + eslint + 933 tests) — also enforced by the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
