### PR TITLE
fix(normalize): empty alias list generated invalid SQL IN (), breaking the dimension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -114,6 +114,14 @@ describe('validateDimensions', () => {
       tags: [],
     })).toThrow(ConfigValidationError);
   });
+
+  it('drops alias entries with empty lists', () => {
+    const dims = validateDimensions({
+      builtIn: [],
+      tags: [{ tagName: 'x', label: 'X', aliases: { production: [], development: ['dev'] } }],
+    });
+    expect(dims.tags[0]?.aliases).toEqual({ development: ['dev'] });
+  });
 });
 
 describe('validateOrgTree', () => {

--- a/packages/core/src/__tests__/normalize-sql.test.ts
+++ b/packages/core/src/__tests__/normalize-sql.test.ts
@@ -72,4 +72,17 @@ describe('normalize SQL ↔ JS parity', () => {
     const sqlExpr = buildAliasSqlCase('NULL', { normalize: 'camelCase' });
     expect(await evalScalar(conn, sqlExpr)).toBeNull();
   });
+
+  // Regression: an empty alias list used to emit `WHEN field IN () THEN ...`,
+  // a DuckDB parse error that broke every query on the dimension.
+  it('empty alias lists still produce parseable SQL', async () => {
+    const empty = buildAliasSqlCase(`'prod'`, { aliases: { production: [] } });
+    expect(await evalScalar(conn, empty)).toBe('prod');
+
+    const mixed = buildAliasSqlCase(`'STG'`, {
+      normalize: 'lowercase',
+      aliases: { production: [], staging: ['stg'] },
+    });
+    expect(await evalScalar(conn, mixed)).toBe('staging');
+  });
 });

--- a/packages/core/src/__tests__/normalize.test.ts
+++ b/packages/core/src/__tests__/normalize.test.ts
@@ -111,4 +111,26 @@ describe('buildAliasSqlCase', () => {
     expect(result).toContain("'prd'");
     expect(result).toContain("'production'");
   });
+
+  it('returns plain field when every alias list is empty', () => {
+    const dim: TagDimension = {
+      tagName: 'x',
+      label: 'X',
+      aliases: { production: [] },
+    };
+    expect(buildAliasSqlCase('tag_x', dim)).toBe('tag_x');
+  });
+
+  it('skips empty alias lists so no invalid IN () is emitted', () => {
+    const dim: TagDimension = {
+      tagName: 'x',
+      label: 'X',
+      aliases: { production: [], development: ['dev'] },
+    };
+    const result = buildAliasSqlCase('tag_x', dim);
+    expect(result).not.toContain('IN ()');
+    expect(result).not.toContain("'production'");
+    expect(result).toContain("'dev'");
+    expect(result).toContain("'development'");
+  });
 });

--- a/packages/core/src/config/validator.ts
+++ b/packages/core/src/config/validator.ts
@@ -153,6 +153,11 @@ function validateAliases(value: unknown, ctx: string): Record<string, string[]> 
   const result: Record<string, string[]> = {};
   for (const [key, arr] of Object.entries(value)) {
     assertArray(arr, `${ctx}.aliases.${key}`);
+    // Drop empty entries rather than reject: they're semantic no-ops the UI
+    // editor already discards on save, but hand-edited YAML and shared
+    // bundles can contain them — and downstream SQL generation must never
+    // see an alias entry with no values (invalid `IN ()`).
+    if (arr.length === 0) continue;
     result[key] = arr.map((v, j) => {
       assertString(v, `${ctx}.aliases.${key}[${String(j)}]`);
       return v;

--- a/packages/core/src/normalize/normalize.ts
+++ b/packages/core/src/normalize/normalize.ts
@@ -191,10 +191,15 @@ function buildAliasCases(
   fieldExpr: string,
   aliases: Readonly<Record<string, readonly string[]>>,
 ): string[] {
-  return Object.entries(aliases).map(([canonical, aliasList]) => {
-    const allValues = aliasList.map(a => `'${a.replaceAll("'", "''")}'`).join(', ');
-    return `WHEN ${fieldExpr} IN (${allValues}) THEN '${canonical.replaceAll("'", "''")}'`;
-  });
+  // Empty alias lists are semantic no-ops (resolveAlias only maps
+  // canonical→canonical for them) but would emit `IN ()` — a DuckDB parse
+  // error that breaks every query touching the dimension.
+  return Object.entries(aliases)
+    .filter(([, aliasList]) => aliasList.length > 0)
+    .map(([canonical, aliasList]) => {
+      const allValues = aliasList.map(a => `'${a.replaceAll("'", "''")}'`).join(', ');
+      return `WHEN ${fieldExpr} IN (${allValues}) THEN '${canonical.replaceAll("'", "''")}'`;
+    });
 }
 
 export function buildAliasSqlCase(

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {


### PR DESCRIPTION
Fixes #453

## Problem

`buildAliasCases` mapped every alias entry unconditionally, so an entry with an empty list (`aliases: { prod: [] }`) produced `WHEN field IN () THEN 'prod'` — a DuckDB parse error. The broken CASE gets baked into the dimension's field expression by `tryResolveField`, so **every query touching that dimension failed** with a SQL syntax error. `validateAliases` accepted empty arrays, and configs arrive from hand-edited YAML and shared bundles, so the input was reachable.

## Fix

Two layers, per the issue's suggestion:

- **`buildAliasCases`** (`packages/core/src/normalize/normalize.ts`) — filter out entries with empty alias lists before emitting `WHEN ... IN (...)`. They're semantic no-ops: `resolveAlias` only maps canonical→canonical for them, which is what the CASE's `ELSE` fall-through already does. This also protects alias maps that don't flow through the validator (e.g. region-enrichment merges).
- **`validateAliases`** (`packages/core/src/config/validator.ts`) — drop empty entries at load time rather than reject. The UI editor's `textToAliases` already discards them on save; rejecting would make a whole hand-edited config or imported bundle fail to load over a harmless no-op.

## Tests (written first, verified red → green)

- `normalize.test.ts` — all-empty aliases return the plain field expression; mixed empty + non-empty entries emit no `IN ()` and keep the real rule
- `normalize-sql.test.ts` — regression test against **real DuckDB**: SQL generated from empty/mixed alias configs parses and evaluates correctly (this is the exact parse-error path from the issue)
- `config.test.ts` — validator drops empty-list entries, keeps non-empty ones

## Version

`0.6.3 → 0.6.4` (both `package.json` files; first PR after the `v0.6.3` release).

`npm run check` passes: tsc (4 packages) + eslint + 937 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)