### PR TITLE
fix(onboarding): add window drag regions to header-less screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.6.3",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.6.3",
+      "version": "0.5.5",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -13096,7 +13096,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.6.3",
+      "version": "0.5.5",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1075.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "costgoblin",
-  "version": "0.5.5",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "costgoblin",
-      "version": "0.5.5",
+      "version": "0.6.3",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/core",
@@ -13096,7 +13096,7 @@
     },
     "packages/desktop": {
       "name": "@costgoblin/desktop",
-      "version": "0.5.5",
+      "version": "0.6.3",
       "dependencies": {
         "@aws-sdk/client-organizations": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1075.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -442,8 +442,8 @@ function SplashScreen({ step }: Readonly<{ step: string }>): React.JSX.Element {
 
   return (
     <div
-      className="min-h-screen flex flex-col items-center justify-center"
-      style={{ background: '#0a0a0a', WebkitAppRegion: 'drag' } as React.CSSProperties}
+      className="min-h-screen flex flex-col items-center justify-center [-webkit-app-region:drag]"
+      style={{ background: '#0a0a0a' }}
     >
       <div className="relative h-48 w-48 mb-6">
         {order.map((src, i) => (

--- a/packages/desktop/src/renderer/setup-telemetry-step.tsx
+++ b/packages/desktop/src/renderer/setup-telemetry-step.tsx
@@ -99,9 +99,12 @@ export function SetupTelemetryStep({ onDone }: Readonly<{ onDone: () => void }>)
     api.setTelemetryPreferences(next).then(onDone, onDone);
   }
 
+  // Like the setup wizard, this step renders without the app header (the
+  // window's only macOS drag region) — the backdrop takes over as the drag
+  // area and the card opts back out to stay clickable. (#317)
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg-primary p-4">
-      <div className="w-full max-w-lg rounded-xl border border-border bg-bg-secondary p-8">
+    <div className="flex min-h-screen items-center justify-center bg-bg-primary p-4 [-webkit-app-region:drag]">
+      <div className="w-full max-w-lg rounded-xl border border-border bg-bg-secondary p-8 [-webkit-app-region:no-drag]">
         <div className="mb-6 flex justify-center">
           <img src="goblin.png" alt="CostGoblin" className="h-16 w-auto" />
         </div>

--- a/packages/ui/src/__tests__/config-sharing.test.tsx
+++ b/packages/ui/src/__tests__/config-sharing.test.tsx
@@ -170,6 +170,16 @@ describe('ShareConfigDialog', () => {
 });
 
 describe('ImportConfigDialog', () => {
+  // The dialog can open above a window drag region (e.g. the standalone setup
+  // wizard's backdrop, issue #317); without an explicit no-drag opt-out, clicks
+  // on it would drag the window instead of reaching the modal.
+  it('opts the modal out of window drag regions', () => {
+    const api = new MockCostApi();
+    const { container } = renderWithApi(api, <ImportConfigDialog onClose={() => undefined} onApplied={() => undefined} />);
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.className).toContain('[-webkit-app-region:no-drag]');
+  });
+
   it('previews a bundle, applies it with the chosen profile, then reports done', async () => {
     const api = new MockCostApi();
     const applySpy = vi.spyOn(api, 'applyConfigBundle');

--- a/packages/ui/src/__tests__/error-states.test.tsx
+++ b/packages/ui/src/__tests__/error-states.test.tsx
@@ -3,6 +3,7 @@ import { userEvent } from '@testing-library/user-event';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { CostApiProvider } from '../hooks/use-cost-api.js';
 import { MockCostApi } from '../__fixtures__/mock-api.js';
+import { ErrorBoundary } from '../components/error-boundary.js';
 import { DataManagement } from '../views/data-management.js';
 import { SetupWizard } from '../views/setup-wizard.js';
 import { ViewsEditor } from '../views/views-editor.js';
@@ -236,5 +237,29 @@ describe('ViewsEditor error states', () => {
     await waitFor(() => {
       expect(screen.getByText('Config file corrupted')).toBeDefined();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error Boundary — crash fallback
+// ---------------------------------------------------------------------------
+
+function Boom(): never {
+  throw new Error('kaboom');
+}
+
+describe('ErrorBoundary fallback', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  // The fallback replaces the whole tree, including the app header that hosts
+  // the macOS window drag region — so it needs its own, or a crashed window
+  // can't be moved (same trap as issue #317).
+  it('fallback screen is a window drag region and the card opts out', () => {
+    // React logs the caught error via console.error; keep the test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { container } = render(<ErrorBoundary><Boom /></ErrorBoundary>);
+    expect(screen.getByText('Something went wrong')).toBeDefined();
+    expect(container.firstElementChild?.className).toContain('[-webkit-app-region:drag]');
+    expect(container.querySelector('[class*="[-webkit-app-region:no-drag]"]')).not.toBeNull();
   });
 });

--- a/packages/ui/src/__tests__/setup-wizard.test.tsx
+++ b/packages/ui/src/__tests__/setup-wizard.test.tsx
@@ -165,3 +165,21 @@ describe('SetupWizard', () => {
     expect(screen.queryByLabelText('Back to welcome')).toBeNull();
   });
 });
+
+// The desktop window has no native title bar (titleBarStyle: hiddenInset), and
+// standalone onboarding renders without the app header that normally hosts the
+// macOS drag region — so the wizard backdrop must itself be draggable or the
+// window can't be moved at all during setup (issue #317).
+describe('SetupWizard window drag region', () => {
+  it('standalone wizard backdrop is a drag region and the card opts out', () => {
+    const { container } = renderWizard();
+    expect(container.firstElementChild?.className).toContain('[-webkit-app-region:drag]');
+    expect(container.querySelector('[class*="[-webkit-app-region:no-drag]"]')).not.toBeNull();
+  });
+
+  it('embedded source mode (Data Management modal) is not a drag region', async () => {
+    const { container } = renderWizard({ source: 'daily', profile: 'default' });
+    await waitFor(() => { expect(screen.getByText('my-cur-bucket')).toBeDefined(); });
+    expect(container.firstElementChild?.className).not.toContain('[-webkit-app-region:drag]');
+  });
+});

--- a/packages/ui/src/components/config-sharing.tsx
+++ b/packages/ui/src/components/config-sharing.tsx
@@ -101,7 +101,10 @@ function SharingModal({ title, onClose, children, dismissable = true }: Readonly
   }, [onClose, dismissable]);
 
   return (
-    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
+    // no-drag: the modal can open above a window drag region (the standalone
+    // setup wizard's backdrop, or the app header) — without the opt-out,
+    // clicks there would drag the window instead of reaching the modal. (#317)
+    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none [-webkit-app-region:no-drag]" aria-modal="true">
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         {...(dismissable ? { onClick: onClose } : {})}

--- a/packages/ui/src/components/error-boundary.tsx
+++ b/packages/ui/src/components/error-boundary.tsx
@@ -22,8 +22,11 @@ export class ErrorBoundary extends Component<Props, State> {
   render(): ReactNode {
     if (this.state.error !== null) {
       return (
-        <div className="min-h-screen bg-bg-primary flex items-center justify-center p-8">
-          <div className="max-w-lg w-full rounded-xl border border-negative/50 bg-negative-muted p-6">
+        // This fallback replaces the whole tree, including the app header that
+        // hosts the macOS window drag region — the backdrop takes over as the
+        // drag area so a crashed window can still be moved (see #317).
+        <div className="min-h-screen bg-bg-primary flex items-center justify-center p-8 [-webkit-app-region:drag]">
+          <div className="max-w-lg w-full rounded-xl border border-negative/50 bg-negative-muted p-6 [-webkit-app-region:no-drag]">
             <h2 className="text-lg font-semibold text-negative">Something went wrong</h2>
             <p className="mt-2 text-sm text-text-secondary leading-relaxed">
               {this.state.error.message}

--- a/packages/ui/src/views/setup-wizard.tsx
+++ b/packages/ui/src/views/setup-wizard.tsx
@@ -654,9 +654,14 @@ export function SetupWizard({ onComplete, source: initialSource, profile: initia
     }
   }
 
+  // Standalone onboarding renders without the app header — the window's only
+  // macOS drag region (titleBarStyle: hiddenInset means no native title bar) —
+  // so the backdrop doubles as one and the card opts back out to stay
+  // clickable. Skipped in source mode, where the wizard sits in a modal over
+  // the normal app chrome. (#317)
   return (
-    <div className="min-h-screen bg-bg-primary flex items-center justify-center p-4">
-      <Card className="relative w-full max-w-lg border-border bg-bg-secondary">
+    <div className={`min-h-screen bg-bg-primary flex items-center justify-center p-4${isSourceMode ? '' : ' [-webkit-app-region:drag]'}`}>
+      <Card className="relative w-full max-w-lg border-border bg-bg-secondary [-webkit-app-region:no-drag]">
         {!isSourceMode && wizard.step !== 'welcome' && (
           <button
             type="button"


### PR DESCRIPTION
Fixes #317

## Problem

The desktop window uses `titleBarStyle: 'hiddenInset'` — there is no native title bar, so the window is only movable through elements carrying `-webkit-app-region: drag`. The main app header has one, but three full-screen states render **without** that header and had no drag region of their own, leaving the window impossible to move on macOS:

- **`SetupWizard`** (standalone first-run onboarding) — the exact state the reporter was stuck in
- **`SetupTelemetryStep`** (final onboarding step)
- **`ErrorBoundary` crash fallback** (replaces the whole tree, header included)

## Fix

Follow the pattern the splash screen already uses: the screen's full backdrop becomes a drag region, and the centered interactive card opts back out with `no-drag` so it stays clickable.

- `SetupWizard` applies the drag backdrop only in standalone mode — in source mode it renders as a modal inside Data Management, where the app header already provides the drag region.
- `SharingModal` (used by the Import-from-a-teammate dialog, which can open above the wizard's drag backdrop) opts out wholesale, so backdrop-click-to-close and its controls keep working.

## Tests

New RTL assertions (written red-first): standalone wizard backdrop is a drag region with a no-drag card, source-mode wizard is not, the ErrorBoundary fallback is, and `ImportConfigDialog` opts out. Full `npm run check` passes (typecheck ×4 packages, eslint, 937 tests).

Also bumps the version to 0.6.4 (first PR after the v0.6.3 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)