### PR TITLE
fix(security): reject unknown dimension ids in filter-values handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costgoblin",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Desktop app for cloud cost visibility",
   "main": "packages/desktop/out/main/main.js",
   "private": true,

--- a/packages/core/src/__tests__/resolve-field.test.ts
+++ b/packages/core/src/__tests__/resolve-field.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { resolveField, tryResolveField } from '../query/builder.js';
+import { SecurityError } from '../query/identifier-validator.js';
+import type { DimensionsConfig } from '../types/config.js';
+import { asDimensionId } from '../types/branded.js';
+
+const testDimensions: DimensionsConfig = {
+  builtIn: [
+    {
+      name: asDimensionId('account'),
+      label: 'Account',
+      field: 'account_id',
+      displayField: 'account_name',
+    },
+    {
+      name: asDimensionId('service'),
+      label: 'Service',
+      field: 'service',
+      aliases: { EC2: ['Amazon Elastic Compute Cloud'] },
+    },
+  ],
+  tags: [
+    {
+      tagName: 'team',
+      label: 'Team',
+      normalize: 'lowercase-kebab',
+    },
+    {
+      tagName: 'cost-center',
+      label: 'Cost Center',
+    },
+  ],
+};
+
+describe('resolveField', () => {
+  it('resolves a built-in dimension by name to its field', () => {
+    const resolved = resolveField(asDimensionId('account'), testDimensions);
+    expect(resolved.rawField).toBe('account_id');
+    expect(resolved.fieldExpr).toBe('account_id');
+    expect(resolved.dim).toBe(testDimensions.builtIn[0]);
+  });
+
+  it('applies aliases to a built-in dimension via a CASE expression', () => {
+    const resolved = resolveField(asDimensionId('service'), testDimensions);
+    expect(resolved.rawField).toBe('service');
+    expect(resolved.fieldExpr).toContain('CASE');
+    expect(resolved.fieldExpr).toContain('EC2');
+  });
+
+  it('resolves a tag dimension by its tag column id', () => {
+    const resolved = resolveField(asDimensionId('tag_cost_center'), testDimensions);
+    expect(resolved.rawField).toBe('tag_cost_center');
+    expect(resolved.fieldExpr).toBe('tag_cost_center');
+  });
+
+  it('applies normalization to a tag dimension', () => {
+    const resolved = resolveField(asDimensionId('tag_team'), testDimensions);
+    expect(resolved.rawField).toBe('tag_team');
+    expect(resolved.fieldExpr).not.toBe('tag_team');
+  });
+
+  it('throws SecurityError for an unknown dimension id', () => {
+    expect(() => resolveField(asDimensionId('nonexistent'), testDimensions)).toThrow(SecurityError);
+  });
+
+  it('does not fall through to a built-in FIELD name that is not a dimension NAME', () => {
+    // 'account_id' is the account dim's field, but its name is 'account' —
+    // passing the raw column must be rejected, not interpolated.
+    expect(() => resolveField(asDimensionId('account_id'), testDimensions)).toThrow(SecurityError);
+  });
+
+  it('throws SecurityError for a SQL injection payload', () => {
+    const payload = "(SELECT content FROM read_text('/home/user/.aws/credentials'))";
+    expect(() => resolveField(asDimensionId(payload), testDimensions)).toThrow(SecurityError);
+  });
+});
+
+describe('tryResolveField', () => {
+  it('returns null for an unknown dimension id instead of throwing', () => {
+    expect(tryResolveField(asDimensionId('nonexistent'), testDimensions)).toBeNull();
+  });
+
+  it('returns the same resolution as resolveField for known ids', () => {
+    const viaTry = tryResolveField(asDimensionId('account'), testDimensions);
+    const viaStrict = resolveField(asDimensionId('account'), testDimensions);
+    expect(viaTry).toEqual(viaStrict);
+  });
+});

--- a/packages/core/src/query/builder.ts
+++ b/packages/core/src/query/builder.ts
@@ -59,7 +59,7 @@ export function computePeriodsInRange(dateRange: { readonly start: string; reado
   return periods;
 }
 
-interface ResolvedDimension {
+export interface ResolvedDimension {
   readonly fieldExpr: string;
   readonly rawField: string;
   /** The backing dim, when the id resolves to a known built-in or tag.
@@ -69,7 +69,12 @@ interface ResolvedDimension {
   readonly dim: BuiltInDimension | TagDimension | null;
 }
 
-function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension | null {
+/** Resolve a dimension id to its SQL field expression, or null when the id
+ *  matches neither a built-in nor a tag dimension. This (and its throwing
+ *  wrapper `resolveField`) is the ONLY sanctioned way to turn a
+ *  renderer/config-supplied dimension id into SQL — an unresolved id must
+ *  never be interpolated as-is. */
+export function tryResolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension | null {
   const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
   if (builtIn !== undefined) {
     // Built-ins now support normalize + aliases just like tags; apply them at
@@ -99,7 +104,9 @@ function normalizeRuleValue(value: string, dim: BuiltInDimension | TagDimension 
   return resolveAlias(normalized, dim.aliases);
 }
 
-function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
+/** Like `tryResolveField`, but throws `SecurityError` for unknown ids —
+ *  use this whenever the resolved expression is interpolated into SQL. */
+export function resolveField(dimensionId: DimensionId, dimensions: DimensionsConfig): ResolvedDimension {
   const resolved = tryResolveField(dimensionId, dimensions);
   if (resolved !== null) return resolved;
   throw new SecurityError(

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -14,8 +14,10 @@ export {
   buildGrainProbeQuery,
   buildRuleMatchExpr,
   computePeriodsInRange,
+  resolveField,
+  tryResolveField,
 } from './builder.js';
-export type { QueryContextOptions, BuildSourceOptions, BaselineDiscoveryParams } from './builder.js';
+export type { QueryContextOptions, BuildSourceOptions, BaselineDiscoveryParams, ResolvedDimension } from './builder.js';
 
 export { costExprFor } from './cost-metric.js';
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costgoblin/desktop",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/desktop/src/main/handlers/explorer.ts
+++ b/packages/desktop/src/main/handlers/explorer.ts
@@ -6,13 +6,13 @@ import {
   assertHourString,
   buildSource,
   buildRuleMatchExpr,
-  buildAliasSqlCase,
   computePeriodsInRange,
   DEFAULT_LAG_DAYS,
   isStringRecord,
   logger,
   listLocalMonths,
   parseJsonObject,
+  resolveField,
   tagDimColumn,
 } from '@costgoblin/core';
 import type {
@@ -705,12 +705,9 @@ export function registerExplorerHandlers(app: AppContext): void {
     const qc = await prepareQueryContext(app, { ...params, filters: withoutSelf });
     if (qc.empty) return [];
 
-    const builtIn = qc.dimensions.builtIn.find(d => d.name === dimId);
-    const tag = qc.dimensions.tags.find(d => tagDimColumn(d) === dimId);
-    const field = builtIn === undefined ? dimId : builtIn.field;
-    let fieldExpr = field;
-    if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
-    else if (tag !== undefined) fieldExpr = buildAliasSqlCase(tagDimColumn(tag), tag);
+    // Throws SecurityError for ids that match neither a built-in nor a tag
+    // dimension — a renderer-supplied id must never reach the SQL verbatim.
+    const { fieldExpr } = resolveField(asDimensionId(dimId), qc.dimensions);
 
     const sql = `
       SELECT ${fieldExpr} AS val,

--- a/packages/desktop/src/main/handlers/query-filters.ts
+++ b/packages/desktop/src/main/handlers/query-filters.ts
@@ -1,10 +1,10 @@
 import { ipcMain } from 'electron';
 import {
+  asDimensionId,
   buildSource,
-  buildAliasSqlCase,
   buildRuleMatchExpr,
   computePeriodsInRange,
-  tagDimColumn,
+  resolveField,
   QueryBuilder,
 } from '@costgoblin/core';
 import type { AppContext } from './context.js';
@@ -15,19 +15,6 @@ import {
   toStr,
 } from './query-utils.js';
 import { originStore } from '../query-log.js';
-
-function resolveFieldExpr(
-  dimensionId: string,
-  dimensions: import('@costgoblin/core').DimensionsConfig,
-): { field: string; fieldExpr: string } {
-  const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
-  const tag = dimensions.tags.find(d => tagDimColumn(d) === dimensionId);
-  const field = builtIn === undefined ? dimensionId : builtIn.field;
-  let fieldExpr = field;
-  if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
-  else if (tag !== undefined) fieldExpr = buildAliasSqlCase(field, tag);
-  return { field, fieldExpr };
-}
 
 /** Build a SQL IN-list using parameterized placeholders. */
 function buildSqlList(values: readonly string[], qb: QueryBuilder): string {
@@ -70,16 +57,16 @@ function buildFilterWhereClauses(
   const clauses: string[] = [];
   for (const [key, values] of Object.entries(filterEntries)) {
     if (values.length === 0) continue;
-    const { field: ff, fieldExpr: ffExpr } = resolveFieldExpr(key, dimensions);
+    const { rawField, fieldExpr } = resolveField(asDimensionId(key), dimensions);
 
-    if (ff === 'account_id') {
+    if (rawField === 'account_id') {
       const { allIds, usedReverse } = resolveAccountIds(values, accountReverseMap);
       if (usedReverse) {
-        clauses.push(`${ff} IN (${buildSqlList([...allIds], qb)})`);
+        clauses.push(`${rawField} IN (${buildSqlList([...allIds], qb)})`);
         continue;
       }
     }
-    const clause = buildValueClause(ffExpr, values, qb);
+    const clause = buildValueClause(fieldExpr, values, qb);
     if (clause.length > 0) clauses.push(clause);
   }
   return clauses;
@@ -128,7 +115,9 @@ export function registerFilterHandlers(app: AppContext): void {
       : await getCostScope().catch(() => undefined);
 
     const qb = new QueryBuilder();
-    const { fieldExpr } = resolveFieldExpr(dimensionId, dimensions);
+    // Throws SecurityError for ids that match neither a built-in nor a tag
+    // dimension — a renderer-supplied id must never reach the SQL verbatim.
+    const { fieldExpr } = resolveField(asDimensionId(dimensionId), dimensions);
 
     const matSource = dateRange === undefined
       ? undefined

--- a/packages/mcp/src/tools/get-filter-values.ts
+++ b/packages/mcp/src/tools/get-filter-values.ts
@@ -1,9 +1,9 @@
 import {
-  buildAliasSqlCase,
+  asDimensionId,
   buildSource,
   computePeriodsInRange,
   QueryBuilder,
-  tagDimColumn,
+  resolveField,
   logger,
 } from '@costgoblin/core';
 import type { McpContext } from '../context.js';
@@ -48,12 +48,10 @@ export async function getFilterValues(
   const orgPath = await ctx.getOrgAccountsPath();
   const availableColumns = await ctx.getAvailableColumns('daily');
 
-  const builtIn = dimensions.builtIn.find(d => d.name === dimensionId);
-  const tag = dimensions.tags.find(d => tagDimColumn(d) === dimensionId);
-  const field = builtIn !== undefined ? builtIn.field : dimensionId;
-  let fieldExpr = field;
-  if (builtIn !== undefined) fieldExpr = buildAliasSqlCase(field, builtIn);
-  else if (tag !== undefined) fieldExpr = buildAliasSqlCase(field, tag);
+  // lookupDimension above already rejected unknown ids with a friendly error;
+  // resolveField still throws SecurityError as defense in depth so the id can
+  // never reach the SQL verbatim.
+  const { fieldExpr } = resolveField(asDimensionId(dimensionId), dimensions);
 
   const qb = new QueryBuilder();
   const startParam = qb.addParam(dateRange.start);


### PR DESCRIPTION
Fixes #456 (P0, security).

## Problem

Both filter-value handlers (`query:filter-values` in `query-filters.ts` and `explorer:filter-values` in `explorer.ts`) resolved a renderer-supplied dimension id against the dimensions config and, when it matched **neither a built-in nor a tag dimension, interpolated the raw string into the SQL** (`SELECT ${fieldExpr} AS val ... FROM ...`). A compromised or misbehaving renderer could pass e.g. `(SELECT content FROM read_text('~/.aws/credentials'))` as the dimension id and read arbitrary local files through DuckDB — bypassing the `validateColumnName`/`resolveField` machinery the rest of the query pipeline uses.

The same fallback shape existed a third time in the MCP `get_filter_values` tool, though there it was unreachable because `lookupDimension` rejects unknown ids first.

## Fix

- **core**: export `resolveField` / `tryResolveField` (and the `ResolvedDimension` type) from `packages/core/src/query/builder.ts` — the canonical resolution used by all dashboard queries, which throws `SecurityError` for ids that resolve to neither a built-in nor a tag dimension. Doc comments now state this is the only sanctioned way to turn a dimension id into SQL.
- **desktop**: `query-filters.ts` drops its local `resolveFieldExpr` (used both for the requested dimension and for filter keys) and `explorer.ts` drops its inline copy; both now call core's `resolveField`, so unknown ids throw before any SQL is built.
- **mcp**: `get-filter-values.ts` switches its inline copy to `resolveField` as defense in depth behind the existing `lookupDimension` gate.

No legitimate caller is affected: the UI only ever passes ids sourced from `getDimensions()` (built-in names + tag columns, including disabled dims, which remain in the config and still resolve), and unknown filter keys already threw at dashboard-query time via the same core path.

## Tests

New `packages/core/src/__tests__/resolve-field.test.ts`: built-in/tag/alias/normalize resolution shapes, unknown id → `SecurityError`, raw field name that isn't a dim name (`account_id`) → `SecurityError`, and the issue's `read_text` injection payload → `SecurityError`.

Also bumps the version to 0.6.4 (first PR after the v0.6.3 tag, per the release rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)