### PR TITLE
fix(ui): opt full-screen overlays out of the window drag region

### DIFF
--- a/packages/ui/src/__tests__/command-palette.test.tsx
+++ b/packages/ui/src/__tests__/command-palette.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandPalette } from '../components/command-palette.js';
+
+afterEach(cleanup);
+
+const items = [{ id: 'overview', label: 'Overview' }];
+
+describe('CommandPalette', () => {
+  it('opts the overlay and content out of window drag regions', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette items={items} onNavigate={vi.fn()} />);
+    await user.keyboard('{Meta>}k{/Meta}');
+    await screen.findByPlaceholderText('Type to search...');
+
+    // The overlay covers the frameless window's drag region (app header), so
+    // both layers must carve themselves out — otherwise clicks in the top
+    // band drag the window instead of dismissing the palette.
+    const overlay = document.querySelector('[cmdk-overlay]');
+    expect(overlay?.className).toContain('[-webkit-app-region:no-drag]');
+    const content = document.querySelector('[cmdk-dialog]');
+    expect(content?.className).toContain('[-webkit-app-region:no-drag]');
+  });
+});

--- a/packages/ui/src/__tests__/config-sharing.test.tsx
+++ b/packages/ui/src/__tests__/config-sharing.test.tsx
@@ -45,6 +45,14 @@ describe('BundleSummaryCard', () => {
 });
 
 describe('ShareConfigDialog', () => {
+  it('opts the modal out of window drag regions', () => {
+    renderWithApi(new MockCostApi(), <ShareConfigDialog onClose={() => undefined} />);
+    // The overlay covers the frameless window's drag region (app header), so
+    // it must carve itself out — otherwise backdrop clicks in the top band
+    // drag the window instead of dismissing the modal.
+    expect(screen.getByRole('dialog').className).toContain('[-webkit-app-region:no-drag]');
+  });
+
   it('exports to a file and shows the saved path', async () => {
     const api = new MockCostApi();
     const exportSpy = vi.spyOn(api, 'exportConfigBundle');

--- a/packages/ui/src/__tests__/confirm-modal.test.tsx
+++ b/packages/ui/src/__tests__/confirm-modal.test.tsx
@@ -44,6 +44,16 @@ describe('ConfirmModal', () => {
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
+  it('opts the modal out of window drag regions', () => {
+    render(
+      <ConfirmModal title="Test" message="msg" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+    // The overlay covers the frameless window's drag region (app header), so
+    // it must carve itself out — otherwise backdrop clicks in the top band
+    // drag the window instead of dismissing the modal.
+    expect(screen.getByRole('dialog').className).toContain('[-webkit-app-region:no-drag]');
+  });
+
   it('applies destructive styling when destructive prop is true', () => {
     render(
       <ConfirmModal title="Delete" message="msg" destructive onConfirm={vi.fn()} onCancel={vi.fn()} />,

--- a/packages/ui/src/__tests__/dialog.test.tsx
+++ b/packages/ui/src/__tests__/dialog.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Dialog, DialogContent, DialogTitle } from '../components/ui/dialog.js';
+
+afterEach(cleanup);
+
+describe('Dialog', () => {
+  it('opts the overlay and content out of window drag regions', () => {
+    render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined}>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    // The overlay covers the frameless window's drag region (app header), so
+    // both layers must carve themselves out — otherwise clicks in the top
+    // band drag the window instead of reaching the dialog.
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('[-webkit-app-region:no-drag]');
+    const overlay = content.previousElementSibling;
+    expect(overlay?.className).toContain('[-webkit-app-region:no-drag]');
+  });
+});

--- a/packages/ui/src/__tests__/view-yaml-modal.test.tsx
+++ b/packages/ui/src/__tests__/view-yaml-modal.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ViewYamlModal } from '../components/view-yaml-modal.js';
+
+afterEach(cleanup);
+
+describe('ViewYamlModal', () => {
+  it('opts the modal out of window drag regions', () => {
+    render(
+      <ViewYamlModal mode="import" existingIds={new Set()} onImport={vi.fn()} onClose={vi.fn()} />,
+    );
+    // The overlay covers the frameless window's drag region (app header), so
+    // it must carve itself out — otherwise backdrop clicks in the top band
+    // drag the window instead of dismissing the modal.
+    expect(screen.getByRole('dialog').className).toContain('[-webkit-app-region:no-drag]');
+  });
+});

--- a/packages/ui/src/components/command-palette.tsx
+++ b/packages/ui/src/components/command-palette.tsx
@@ -52,8 +52,8 @@ export function CommandPalette({ items, onNavigate }: CommandPaletteProps) {
       onOpenChange={setOpen}
       label="Command palette"
       loop
-      overlayClassName="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm"
-      contentClassName="fixed left-1/2 top-[20%] z-[100] w-full max-w-lg -translate-x-1/2 rounded-xl border border-border bg-bg-secondary shadow-2xl"
+      overlayClassName="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm [-webkit-app-region:no-drag]"
+      contentClassName="fixed left-1/2 top-[20%] z-[100] w-full max-w-lg -translate-x-1/2 rounded-xl border border-border bg-bg-secondary shadow-2xl [-webkit-app-region:no-drag]"
     >
       <div className="flex items-center gap-2 border-b border-border px-3">
         <Search className="h-4 w-4 shrink-0 text-text-secondary" />

--- a/packages/ui/src/components/config-sharing.tsx
+++ b/packages/ui/src/components/config-sharing.tsx
@@ -101,7 +101,7 @@ function SharingModal({ title, onClose, children, dismissable = true }: Readonly
   }, [onClose, dismissable]);
 
   return (
-    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
+    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none [-webkit-app-region:no-drag]" aria-modal="true">
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         {...(dismissable ? { onClick: onClose } : {})}

--- a/packages/ui/src/components/confirm-modal.tsx
+++ b/packages/ui/src/components/confirm-modal.tsx
@@ -32,7 +32,7 @@ export function ConfirmModal({
   }, [onCancel]);
 
   return (
-    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
+    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none [-webkit-app-region:no-drag]" aria-modal="true">
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onCancel}

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ export const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm [-webkit-app-region:no-drag] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -35,7 +35,7 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 flex max-h-[90vh] w-full max-w-md translate-x-[-50%] translate-y-[-50%] flex-col overflow-y-auto rounded-xl border border-border bg-bg-secondary p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        'fixed left-[50%] top-[50%] z-50 flex max-h-[90vh] w-full max-w-md translate-x-[-50%] translate-y-[-50%] flex-col overflow-y-auto rounded-xl border border-border bg-bg-secondary p-6 shadow-2xl duration-200 [-webkit-app-region:no-drag] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/view-yaml-modal.tsx
+++ b/packages/ui/src/components/view-yaml-modal.tsx
@@ -83,7 +83,7 @@ export function ViewYamlModal(props: ViewYamlModalProps): React.JSX.Element {
   const isExport = props.mode === 'export';
 
   return (
-    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none" aria-modal="true">
+    <dialog open className="fixed inset-0 z-[100] flex items-center justify-center bg-transparent m-0 p-0 max-w-none max-h-none w-full h-full border-none [-webkit-app-region:no-drag]" aria-modal="true">
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={props.onClose}


### PR DESCRIPTION
## Problem

The window uses `titleBarStyle: 'hiddenInset'` and the app header is a `[-webkit-app-region:drag]` region. Chromium computes drag regions **geometrically, ignoring z-order** — so when a full-viewport overlay opens above the header, clicks in the top ~90px band still hit the drag region instead of the overlay. Backdrop click-to-dismiss silently drags the window there instead of closing the modal.

Some chrome already carried `[-webkit-app-region:no-drag]` for this reason (debug panel header, scheduler controls, sharing banner), but the full-viewport overlays did not.

## Fix

Add `[-webkit-app-region:no-drag]` to every full-viewport overlay root:

- **ConfirmModal** (`confirm-modal.tsx`) — `<dialog>` root
- **SharingModal** (`config-sharing.tsx`) — `<dialog>` root (shared chrome for Share/Import config dialogs)
- **ViewYamlModal** (`view-yaml-modal.tsx`) — `<dialog>` root
- **Radix Dialog** (`ui/dialog.tsx`) — both `DialogOverlay` and `DialogContent`
- **CommandPalette** (`command-palette.tsx`) — cmdk overlay and content

Since the drag-region computation is a geometric union-minus-subtraction, a full-viewport `no-drag` element carves the whole window out of the drag region while the overlay is open. The trade-off is intended: while a modal is open, clicks in the header band dismiss the modal rather than drag the window.

## Tests

One test per component asserting the class on the rendered overlay root(s): extended `confirm-modal.test.tsx` and `config-sharing.test.tsx`, added `dialog.test.tsx`, `command-palette.test.tsx`, and `view-yaml-modal.test.tsx`.

`npm run check` passes (tsc + eslint + 951 tests).

Discovered during review of #500 / #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)